### PR TITLE
Fix chat scroll by excluding mouse events from paste detection, and refine bonsai sway

### DIFF
--- a/late-ssh/src/app/bonsai/ui.rs
+++ b/late-ssh/src/app/bonsai/ui.rs
@@ -66,23 +66,47 @@ pub fn draw_bonsai(frame: &mut Frame, area: Rect, state: &BonsaiState, beat: f32
         theme::AMBER
     };
 
-    // Sway: slow sine oscillation kicked by detected beats, top lines sway most
+    // Sway: slow sine oscillation kicked by detected beats, canopy lines only
+    let has_canopy = matches!(
+        stage,
+        Stage::Young | Stage::Mature | Stage::Ancient | Stage::Blossom
+    );
     let sway_time = SystemTime::UNIX_EPOCH
         .elapsed()
         .unwrap_or_default()
         .as_secs_f64();
     let sway_base = (sway_time * 2.0).sin(); // ~3s period
-    let sway_amplitude = beat.clamp(0.0, 1.0) as f64 * 3.0;
+    let sway_amplitude = beat.clamp(0.0, 1.0) as f64 * 1.5;
     let w = inner.width as usize;
 
-    for (i, art_line) in tree_art.iter().enumerate() {
-        // Top of canopy sways most, trunk/pot stay fixed
-        let line_factor = if tree_height <= 1 {
-            0.0
+    // Count canopy lines (contain @, #, or *) for per-line falloff
+    let canopy_count = if has_canopy {
+        tree_art
+            .iter()
+            .filter(|l| l.chars().any(|c| matches!(c, '@' | '#' | '*')))
+            .count()
+    } else {
+        0
+    };
+
+    for (_i, art_line) in tree_art.iter().enumerate() {
+        // Only canopy lines sway; top of canopy sways most
+        let is_canopy = has_canopy && art_line.chars().any(|c| matches!(c, '@' | '#' | '*'));
+        let offset = if is_canopy && canopy_count > 0 {
+            // Find this line's position within canopy lines (0 = topmost)
+            let canopy_idx = tree_art[.._i]
+                .iter()
+                .filter(|l| l.chars().any(|c| matches!(c, '@' | '#' | '*')))
+                .count();
+            let line_factor = if canopy_count <= 1 {
+                1.0
+            } else {
+                1.0 - (canopy_idx as f64 / (canopy_count - 1) as f64)
+            };
+            (sway_base * sway_amplitude * line_factor).round() as i32
         } else {
-            1.0 - (i as f64 / (tree_height - 1) as f64)
+            0
         };
-        let offset = (sway_base * sway_amplitude * line_factor).round() as i32;
 
         let mut spans = Vec::new();
         for ch in art_line.chars() {

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -334,7 +334,7 @@ pub fn handle(app: &mut App, data: &[u8]) {
     // paste markers, it's almost certainly pasted text. Without this, each
     // byte is processed as a key — newlines submit messages mid-paste and
     // remaining chars become navigation commands, causing chaos.
-    if !data.starts_with(b"\x1b[200~") && is_likely_paste(data) {
+    if !data.starts_with(b"\x1b[200~") && !data.starts_with(b"\x1b[<") && is_likely_paste(data) {
         handle_bracketed_paste(app, data);
         return;
     }


### PR DESCRIPTION
## Summary
- Mouse-driven scrolling in chat was broken because SGR mouse escape sequences (`\x1b[<...`) were misidentified as pasted text by the terminal paste heuristic, swallowing scroll and click events.
- The bonsai tree sway animation was too aggressive — the trunk and pot swayed along with the canopy, and the amplitude was high enough to look jittery.

## What changed
- **Paste detection**: Added an exclusion for SGR mouse event sequences (`\x1b[<`) in the `is_likely_paste` fast-path. These multi-byte sequences legitimately arrive in bulk and were incorrectly routed to `handle_bracketed_paste`, which consumed them silently. Chat scroll, click, and other mouse interactions now work correctly on terminals that use SGR mouse encoding.
- **Bonsai sway**: Sway is now limited to canopy lines only (those containing `@`, `#`, or `*`); trunk and pot lines stay fixed. The sway amplitude was halved (3.0 → 1.5) for a subtler effect, and falloff is calculated per-canopy-line rather than per-overall-tree-line.

## Behavior notes
- Terminals that send classic X10/normal mouse sequences were unaffected — this only fixes SGR-mode mouse reporting, which is the modern default for most terminals (kitty, alacritty, iTerm2, etc.).
- The bonsai visual change is cosmetic and applies to all growth stages that have a canopy (`Young`, `Mature`, `Ancient`, `Blossom`).

## Feature flags
None.

## Testing
- **Manual verification (paste detection)**: In an SGR-capable terminal, scroll the chat pane with the mouse wheel and confirm events are processed as scroll rather than being silently swallowed. Paste multi-line text and confirm it is still correctly handled as a paste.
- **Manual verification (bonsai)**: Observe the bonsai tree during music playback across growth stages. Confirm the trunk/pot remain stationary and only the canopy sways with beat detection.