### PR TITLE
Fix cargo target dir guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-target
+target/
 node_modules
 .env
 .claude

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: late.sh - Terminal Clubhouse for Developers
 - Primary audience: LLM agents working on this codebase, human contributors
-- Last updated: 2026-04-10 (Music stack cleaned to local playlists only)
+- Last updated: 2026-04-12 (Cargo target-dir guidance aligned with Cargo defaults)
 - Status: Active
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change often.
 
@@ -118,9 +118,7 @@ cargo nextest run --workspace --all-targets
 - Some integration/smoke tests require Docker/testcontainers and may fail in restricted sandboxes.
 - If a feature area is intentionally WIP, temporary lint/test gaps are acceptable only when explicitly documented and tracked for cleanup.
 - **Tool bootstrap:** The repo now includes `.mise.toml` with `rust`, `mold`, and `cargo-nextest`. Prefer `mise install` before local development so the expected toolchain and test runner are available.
-- **Cargo environment setup:** The workspace requires specific directories for Cargo to avoid permission issues. Always set these environment variables when running `cargo` commands:
-  - `CARGO_TARGET_DIR=/target`
-  - `CARGO_HOME=$HOME/.cargo`
+- **Cargo environment setup:** For local host development, use Cargo's normal defaults, including the standard repo-local `target/` directory. Docker/dev containers still use `/app/target` via container configuration. `CARGO_HOME=$HOME/.cargo` remains a valid override when an environment needs it, but it is not a repo-wide requirement.
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Docker
 ####################################################
 
-# --- General ---
+# --- General (Docker/dev containers) ---
 RUST_LOG ?= info,late_web=debug,late_ssh=debug,late_core=debug
 CARGO_TARGET_DIR ?= /app/target
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,11 @@ cargo run -p late-ssh
 cargo run -p late-web
 ```
 
-Cargo in this repo expects:
+Local host development can use Cargo's normal defaults, including the standard
+repo-local `target/` directory. The `/app/target` path is only for Docker/dev
+containers.
 
 ```bash
-export CARGO_TARGET_DIR=/target
 export CARGO_HOME=$HOME/.cargo
 ```
 


### PR DESCRIPTION
## Summary
- stop telling local host developers to export `CARGO_TARGET_DIR=/target`
- document that local development can use Cargo's default repo-local `target/`
- clarify that `/app/target` is the Docker/dev-container path
- explicitly ignore `target/` in the workspace root

## Notes
- no code behavior changes
- docs/config guidance only