### PR TITLE
Swap h/l room navigation for LTR-friendly ordering

### DIFF
--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -79,11 +79,11 @@ pub fn handle_byte(app: &mut App, byte: u8) -> bool {
     if app.chat.notifications_selected {
         match byte {
             b'h' | b'H' => {
-                switch_room(app, 1);
+                switch_room(app, -1);
                 return true;
             }
             b'l' | b'L' => {
-                switch_room(app, -1);
+                switch_room(app, 1);
                 return true;
             }
             _ => return super::notifications::input::handle_byte(app, byte),
@@ -94,11 +94,11 @@ pub fn handle_byte(app: &mut App, byte: u8) -> bool {
         // h/l still switch rooms even when news is selected
         match byte {
             b'h' | b'H' => {
-                switch_room(app, 1);
+                switch_room(app, -1);
                 return true;
             }
             b'l' | b'L' => {
-                switch_room(app, -1);
+                switch_room(app, 1);
                 return true;
             }
             _ => return super::news::input::handle_byte(app, byte),
@@ -136,11 +136,11 @@ pub fn handle_byte(app: &mut App, byte: u8) -> bool {
             true
         }
         b'h' | b'H' => {
-            switch_room(app, 1);
+            switch_room(app, -1);
             true
         }
         b'l' | b'L' => {
-            switch_room(app, -1);
+            switch_room(app, 1);
             true
         }
         b'i' | b'I' | b'\r' | b'\n' => {

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -479,7 +479,7 @@ impl ChatState {
                     "/dm @user — open a direct message\n",
                     "/help — show this message\n",
                     "\n",
-                    "⌨ Keys: h/l switch rooms · j/k select msg · r reply · d delete · i compose · @user mention",
+                    "⌨ Keys: l/h switch rooms · j/k select msg · r reply · d delete · i compose · @user mention",
                 );
                 let request_id = Uuid::now_v7();
                 self.service.send_message_task(

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -683,7 +683,7 @@ pub fn draw_chat(frame: &mut Frame, area: Rect, view: ChatRenderInput<'_>) {
     )));
 
     let rooms_block = Block::default()
-        .title(" Rooms (h/l) ")
+        .title(" Rooms (l/h) ")
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme::BORDER));
     let rooms_paragraph = Paragraph::new(room_lines).block(rooms_block);

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -38,7 +38,7 @@ async fn screen_number_keys_switch_between_dashboard_games_and_chat() {
     let mut app = make_app(test_db.db.clone(), user.id, "screen-flow-it");
 
     app.handle_input(b"2");
-    wait_for_render_contains(&mut app, " Rooms (h/l)").await;
+    wait_for_render_contains(&mut app, " Rooms (l/h)").await;
 
     app.handle_input(b"3");
     wait_for_render_contains(&mut app, " The Arcade ").await;
@@ -89,7 +89,7 @@ async fn chat_compose_treats_screen_hotkeys_as_text() {
     let mut app = make_app(test_db.db.clone(), user.id, "chat-compose-flow-it");
 
     app.handle_input(b"2");
-    wait_for_render_contains(&mut app, " Rooms (h/l)").await;
+    wait_for_render_contains(&mut app, " Rooms (l/h)").await;
 
     app.handle_input(b"i2hey");
     wait_for_render_contains(&mut app, "2hey").await;


### PR DESCRIPTION
## Summary
- Swap the direction of `h` and `l` for room switching: `l` now moves to the next room (down the list) and `h` moves to the previous room (up the list)
- Update all hint texts from `h/l` to `l/h` to reflect the new ordering

## Motivation
In vim (the inspiration for hjkl movement), l = right and h = left.  For LTR language readers (the majority of late.sh users), "right" intuitively means "next" and "left" means "previous". When working with a horizontal room list whose selection starts at the top, `l` (right) makes more sense to go "down" to the next room ordinally, and `h` (left) to go back to the previous one.

## Test plan
- [ ] Verify `l`/`L` moves to the next room in the list
- [ ] Verify `h`/`H` moves to the previous room in the list
- [ ] Confirm hint text reads `l/h` in the Rooms block title, `/help` output, and test assertions
- [ ] Check room switching still works from notifications and news views