### PR TITLE
Add flake.nix for local developement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@ node_modules
 .env
 .claude
 .codex
+result
+result-*
+.direnv
 late-ssh/assets/nonograms/.number-loom-validation/
 server_key
 server_key.pub

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,84 @@
+{
+  lib,
+  stdenv,
+  rustPlatform,
+  gitRev ? null,
+  pkg-config,
+  cmake,
+  perl,
+  alsa-lib,
+  mold,
+}: let
+  packageVersion = (builtins.fromTOML (builtins.readFile ./late-ssh/Cargo.toml)).package.version;
+  filterSrc = src: regexes:
+    lib.cleanSourceWith {
+      inherit src;
+      filter = path: type: let
+        relPath = lib.removePrefix (toString src + "/") (toString path);
+      in
+        lib.all (re: builtins.match re relPath == null) regexes;
+    };
+in
+  rustPlatform.buildRustPackage {
+    pname = "late-sh";
+    version = "${packageVersion}-unstable-${
+      if gitRev != null
+      then gitRev
+      else "dirty"
+    }";
+
+    # Build all deployable workspace binaries. late-web's CSS is a pre-built,
+    # committed asset; tailwind is not invoked at build time.
+    cargoBuildFlags = ["--workspace" "--bins"];
+    useNextest = true;
+
+    src = filterSrc ./. [
+      ".*\\.nix$"
+      "^.jj/"
+      "^.git/"
+      "^flake\\.lock$"
+      "^target/"
+      "^late-web/node_modules/"
+    ];
+
+    cargoLock.lockFile = ./Cargo.lock;
+
+    nativeBuildInputs =
+      [
+        pkg-config
+        cmake
+        perl
+        rustPlatform.bindgenHook
+      ]
+      ++ lib.optionals stdenv.isLinux [
+        mold
+      ];
+
+    buildInputs = lib.optionals stdenv.isLinux [
+      alsa-lib
+    ];
+
+    # Integration tests require a live postgres; skip by default.
+    doCheck = false;
+
+    env = {
+      RUST_BACKTRACE = 1;
+      CARGO_INCREMENTAL = "0"; # https://github.com/rust-lang/rust/issues/139110
+      RUSTFLAGS = lib.optionalString stdenv.isLinux "-C link-arg=-fuse-ld=mold";
+      NIX_LATE_GIT_HASH = gitRev;
+    };
+
+    meta = {
+      description = "Social SSH terminal — late.sh";
+      homepage = "https://github.com/mpiorowski/late-sh";
+      # Source-available under FSL-1.1-MIT (converts to MIT after 2 years).
+      license = {
+        shortName = "FSL-1.1-MIT";
+        fullName = "Functional Source License, Version 1.1, MIT Future License";
+        url = "https://fsl.software/";
+        free = true;
+        redistributable = true;
+      };
+      mainProgram = "late-ssh";
+    };
+  }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776222810,
+        "narHash": "sha256-5TD8MYqLMcJi9yV/9jq2dVUPtnu/lKZPD61esQCgvqs=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "4d6fee71fea68418a48992409b47f1183d0dd111",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,139 @@
+{
+  description = "late.sh — a social SSH terminal";
+
+  inputs = {
+    # For listing and iterating nix systems
+    flake-utils.url = "github:numtide/flake-utils";
+
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+    # For installing non-standard rustc versions
+    rust-overlay.url = "github:oxalica/rust-overlay";
+    rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    rust-overlay,
+  }:
+    {
+      overlays.default = final: prev: {
+        late-sh = self.packages.${final.stdenv.hostPlatform.system}.late-sh;
+      };
+    }
+    // (flake-utils.lib.eachSystem nixpkgs.lib.systems.flakeExposed (system: let
+      pkgs = import nixpkgs {
+        inherit system;
+        overlays = [
+          rust-overlay.overlays.default
+        ];
+      };
+
+      # When we're running in the shell, we want rustc with a bunch of extra
+      # bits so that rust-analyzer, clippy, rustfmt, etc. all work out of the
+      # box.
+      rustShellToolchain = pkgs.rust-bin.stable.latest.default.override {
+        # NOTE: explicitly add rust-src to the rustc compiler only in devShell.
+        # this in turn causes a dependency on the rust compiler src, which
+        # bloats the closure size by several GiB. but doing this here and not
+        # by default avoids the default flake install from including that
+        # dependency, so it's worth it.
+        extensions = [
+          "rust-src"
+          "rust-analyzer"
+          "llvm-tools-preview"
+        ];
+      };
+
+      # But, whenever we are running CI builds or checks, we want to use a
+      # smaller closure. This reduces the CI impact on fresh clones/VMs, etc.
+      rustMinimalPlatform = let
+        platform = pkgs.rust-bin.stable.latest.minimal;
+      in
+        pkgs.makeRustPlatform {
+          rustc = platform;
+          cargo = platform;
+        };
+    in {
+      formatter = pkgs.alejandra;
+
+      packages = {
+        late-sh = pkgs.callPackage ./default.nix {
+          rustPlatform = rustMinimalPlatform;
+          gitRev = self.rev or self.dirtyRev or null;
+        };
+        default = self.packages.${system}.late-sh;
+      };
+
+      checks.late-sh = self.packages.${system}.late-sh.overrideAttrs ({...}: {
+        # The default Rust infrastructure runs all builds in the release
+        # profile, which is significantly slower. Run this under the `test`
+        # profile instead
+        cargoBuildType = "test";
+        cargoCheckType = "test";
+        buildPhase = "true";
+        installPhase = "touch $out";
+      });
+
+      devShells.default = let
+        packages = with pkgs; [
+          rustShellToolchain
+          llvmPackages.llvm # for e.g. llvm-symbolizer
+
+          # Matches .mise.toml / CONTRIBUTING tooling
+          mold
+          cargo-nextest
+
+          # Commonly useful cargo helpers
+          cargo-llvm-cov
+          cargo-watch
+
+          # late-web frontend tooling
+          nodejs
+          tailwindcss_4
+
+          # Integration / infra tooling (docker-compose stack, migrations, etc.)
+          postgresql
+          docker-compose
+        ];
+
+        # on macOS and Linux, use faster parallel linkers that are much more
+        # efficient than the defaults. these noticeably improve link time even
+        # for medium sized rust projects.
+        rustLinkerFlags =
+          if pkgs.stdenv.isLinux
+          then ["-fuse-ld=mold" "-Wl,--compress-debug-sections=zstd"]
+          else if pkgs.stdenv.isDarwin
+          then
+            # on darwin, /usr/bin/ld actually looks at the environment variable
+            # $DEVELOPER_DIR, which is set by the nix stdenv, and if set,
+            # automatically uses it to route the `ld` invocation to the binary
+            # within. in the devShell though, that isn't what we want; it's
+            # functional, but Xcode's linker as of ~v15 (not yet open source)
+            # is ultra-fast and very shiny; it is enabled via -ld_new, and on by
+            # default as of v16+
+            ["--ld-path=$(unset DEVELOPER_DIR; /usr/bin/xcrun --find ld)" "-ld_new"]
+          else [];
+
+        rustLinkFlagsString =
+          pkgs.lib.concatStringsSep " "
+          (pkgs.lib.concatMap (x: ["-C" "link-arg=${x}"]) rustLinkerFlags);
+
+        # The `RUSTFLAGS` environment variable is set in `shellHook` instead of
+        # `env` to allow the `xcrun` command above to be interpreted by the
+        # shell.
+        shellHook = ''
+          export RUSTFLAGS="${rustLinkFlagsString}"
+        '';
+
+        late-sh = self.packages.${system}.late-sh;
+      in
+        pkgs.mkShell {
+          name = "late-sh";
+          packages = packages ++ late-sh.nativeBuildInputs ++ late-sh.buildInputs;
+          inherit shellHook;
+        };
+    }));
+}


### PR DESCRIPTION
This flake strongly follows flake structure from [jj-vcs/jj](https://github.com/jj-vcs/jj) repo

 ## Changes

  - Add `flake.nix` with `packages.late-sh`, `checks.late-sh`, `devShells.default`, and `overlays.default`.
  - Add `default.nix` -- `rustPlatform.buildRustPackage` over the workspace, builds `late`, `late-ssh`, `late-web` bins. Stable rust via `rust-overlay`.
  - Extend `.gitignore` with nix outputs: `result`, `result-*`, `.direnv`.

  ## Notes

  - **`mold` + `RUSTFLAGS=-C link-arg=-fuse-ld=mold`** on Linux, matching `.cargo/config.toml` and `.mise.toml`.
  - **`gitRev`** threaded through `self.rev or self.dirtyRev or null`  ->  version suffix `-unstable-<rev>` / `-dirty`.
  - **devShell** mirrors `.mise.toml` (`rust`, `mold`, `cargo-nextest`) plus `docker-compose`, `nodejs`, `tailwindcss_4`, and shared `buildInputs`/`nativeBuildInputs` from the package.

  ## Testing

  - `nix flake check --no-build` on x86_64-linux'.
  - `nix build .#late-sh` -- produces `result/bin/{late,late-ssh,late-web}`.
  - `nix develop` + `make check` -- pass (fmt, clippy, nextest).