### PR TITLE
Make CLI/music instructions and vote panel responsive to narrowing

### DIFF
--- a/late-ssh/src/app/dashboard/ui.rs
+++ b/late-ssh/src/app/dashboard/ui.rs
@@ -29,7 +29,10 @@ pub struct DashboardRenderInput<'a> {
 }
 
 pub fn draw_dashboard(frame: &mut Frame, area: Rect, view: DashboardRenderInput<'_>) {
-    if area.width < 52 || area.height < 16 {
+    const DASHBOARD_MIN_WIDTH: u16 = 24;
+    const DASHBOARD_SPLIT_TOP_MIN_WIDTH: u16 = 49;
+
+    if area.width < DASHBOARD_MIN_WIDTH || area.height < 16 {
         let compact = Paragraph::new("Dashboard view too small.")
             .style(Style::default().fg(theme::TEXT_DIM))
             .centered();
@@ -47,15 +50,26 @@ pub fn draw_dashboard(frame: &mut Frame, area: Rect, view: DashboardRenderInput<
         leading_genre: view.vote_counts.winner_or(view.current_genre),
         next_switch_in: view.next_switch_in,
     };
-    draw_stream_card(frame, top[0], &stream_props);
-    draw_vote_card(
-        frame,
-        top[1],
-        &VoteCardView {
-            vote_counts: view.vote_counts,
-            my_vote: view.my_vote,
-        },
-    );
+    if area.width >= DASHBOARD_SPLIT_TOP_MIN_WIDTH {
+        draw_stream_card(frame, top[0], &stream_props);
+        draw_vote_card(
+            frame,
+            top[1],
+            &VoteCardView {
+                vote_counts: view.vote_counts,
+                my_vote: view.my_vote,
+            },
+        );
+    } else {
+        draw_vote_card(
+            frame,
+            sections[0],
+            &VoteCardView {
+                vote_counts: view.vote_counts,
+                my_vote: view.my_vote,
+            },
+        );
+    }
 
     draw_dashboard_chat_card(frame, sections[1], view.chat_view);
 }
@@ -81,7 +95,21 @@ fn draw_stream_card(frame: &mut Frame, area: Rect, props: &StreamCardProps<'_>) 
         ..inner
     };
 
-    let lines = vec![
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+
+    let lines = if inner.width <= 31 {
+        compact_stream_lines(inner.width as usize, inner.height as usize)
+    } else {
+        stream_detail_lines(props)
+    };
+
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
+}
+
+fn stream_detail_lines<'a>(props: &'a StreamCardProps<'a>) -> Vec<Line<'a>> {
+    vec![
         Line::from(vec![
             Span::styled("CLI:     ", Style::default().fg(theme::TEXT_DIM)),
             Span::styled(
@@ -123,7 +151,98 @@ fn draw_stream_card(frame: &mut Frame, area: Rect, props: &StreamCardProps<'_>) 
                 Style::default().fg(theme::TEXT),
             ),
         ]),
-    ];
+    ]
+}
 
-    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), inner);
+fn compact_stream_lines(width: usize, max_rows: usize) -> Vec<Line<'static>> {
+    let install_label = if width >= 20 { "Enter" } else { "⏎" };
+    let install_gap = 1;
+    let install_desc = if width >= 24 {
+        "Copy CLI Install Command"
+    } else {
+        "Copy Install Command"
+    };
+    let browser_gap = if width >= 20 { 5 } else { 1 };
+    let mut lines = wrapped_action_lines(install_label, install_gap, install_desc, width);
+    let browser_lines = wrapped_action_lines("P", browser_gap, "Copy Browser Music URL", width);
+
+    if lines.len() + browser_lines.len() < max_rows {
+        lines.push(Line::raw(""));
+    }
+    lines.extend(browser_lines);
+
+    while lines.len() < max_rows {
+        lines.push(Line::raw(""));
+    }
+    lines.truncate(max_rows);
+    lines
+}
+
+fn wrapped_action_lines(
+    key: &str,
+    gap: usize,
+    description: &str,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let prefix = format!("{key}{}", " ".repeat(gap));
+    let indent = " ".repeat(prefix.chars().count());
+    let wrapped = wrap_with_indent(description, width, prefix.chars().count());
+    let mut lines = Vec::with_capacity(wrapped.len());
+
+    for (index, chunk) in wrapped.into_iter().enumerate() {
+        if index == 0 {
+            lines.push(Line::from(vec![
+                Span::styled(prefix.clone(), Style::default().fg(theme::AMBER)),
+                Span::styled(chunk, Style::default().fg(theme::TEXT_DIM)),
+            ]));
+        } else {
+            lines.push(Line::from(Span::styled(
+                format!("{indent}{chunk}"),
+                Style::default().fg(theme::TEXT_DIM),
+            )));
+        }
+    }
+
+    lines
+}
+
+fn wrap_with_indent(text: &str, width: usize, indent_width: usize) -> Vec<String> {
+    let first_width = width.saturating_sub(indent_width).max(1);
+    let next_width = first_width;
+    let mut lines = Vec::new();
+    let mut current = String::new();
+    let mut line_width = first_width;
+
+    for word in text.split_whitespace() {
+        let needed = if current.is_empty() {
+            word.len()
+        } else {
+            current.len() + 1 + word.len()
+        };
+        if needed <= line_width {
+            if !current.is_empty() {
+                current.push(' ');
+            }
+            current.push_str(word);
+            continue;
+        }
+
+        if current.is_empty() {
+            lines.push(word.to_string());
+        } else {
+            lines.push(std::mem::take(&mut current));
+            current.push_str(word);
+        }
+        line_width = next_width;
+    }
+
+    if !current.is_empty() {
+        lines.push(current);
+    }
+
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+
+    lines
 }

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -7,7 +7,7 @@ use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
     style::Style,
-    widgets::{Block, Borders, Clear},
+    widgets::{Block, Borders, Clear, Paragraph},
 };
 
 use late_core::models::leaderboard::LeaderboardData;
@@ -307,6 +307,20 @@ impl App {
     }
 
     fn draw(frame: &mut Frame, area: Rect, screen: Screen, ctx: DrawContext<'_>) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        if area.width < 4 || area.height < 4 {
+            frame.render_widget(
+                Paragraph::new("Too small")
+                    .style(Style::default().fg(theme::TEXT_DIM))
+                    .centered(),
+                area,
+            );
+            return;
+        }
+
         if ctx.show_splash {
             let msg = "take a break, grab a coffee";
             // Animate typing the message (1 char per tick instead of 1 char per 2 ticks)

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -410,6 +410,10 @@ impl App {
     }
 
     pub fn resize(&mut self, cols: u16, rows: u16) -> Result<(), io::Error> {
+        if cols == 0 || rows == 0 {
+            tracing::debug!(cols, rows, "ignoring zero-sized resize");
+            return Ok(());
+        }
         tracing::debug!(cols, rows, "window resized");
         self.size = (cols, rows);
         self.terminal.resize(Rect::new(0, 0, cols, rows))

--- a/late-ssh/src/app/vote/ui.rs
+++ b/late-ssh/src/app/vote/ui.rs
@@ -16,7 +16,7 @@ pub struct VoteCardView<'a> {
 
 pub fn draw_vote_card(frame: &mut Frame, area: Rect, view: &VoteCardView<'_>) {
     let block = Block::default()
-        .title(" Vote Next (L/A/C) ")
+        .title(vote_card_title(area.width))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme::BORDER));
     let inner = block.inner(area);
@@ -31,6 +31,12 @@ pub fn draw_vote_options(
     vote_counts: &VoteCount,
     my_vote: Option<Genre>,
 ) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let compact_mode = area.width < 15;
+    let padded_compact_mode = (15..=16).contains(&area.width);
     let options = [
         ("L", "Lofi", &vote_counts.lofi, my_vote == Some(Genre::Lofi)),
         (
@@ -52,7 +58,7 @@ pub fn draw_vote_options(
 
     let layout = Layout::vertical(vec![Constraint::Length(1); options.len()]).split(area);
 
-    for (i, (key, name, votes, is_voted)) in options.iter().enumerate() {
+    for (slot, (key, name, votes, is_voted)) in layout.iter().zip(options.iter()) {
         let bar_filled = if total_votes > 0 {
             (**votes as usize * max_bar_width) / total_votes as usize
         } else {
@@ -60,41 +66,109 @@ pub fn draw_vote_options(
         };
         let bar_empty = max_bar_width.saturating_sub(bar_filled);
 
-        let mut spans = vec![
-            Span::styled(
-                format!(" {} ", key),
-                Style::default()
-                    .fg(theme::AMBER)
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(format!("{:<8}", name), Style::default().fg(theme::TEXT)),
-            Span::styled(
-                "█".repeat(bar_filled),
-                Style::default().fg(if *is_voted {
-                    theme::SUCCESS
-                } else {
-                    theme::AMBER_DIM
-                }),
-            ),
-            Span::styled("░".repeat(bar_empty), Style::default().fg(theme::BORDER)),
-            Span::styled(
-                format!(" {:>3}", votes),
-                Style::default().fg(theme::TEXT_DIM),
-            ),
-        ];
+        let mut spans = if compact_mode || padded_compact_mode {
+            compact_vote_spans(
+                key,
+                name,
+                **votes,
+                *is_voted,
+                area.width as usize,
+                padded_compact_mode,
+            )
+        } else {
+            vec![
+                Span::styled(
+                    format!(" {} ", key),
+                    Style::default()
+                        .fg(theme::AMBER)
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(format!("{:<8}", name), Style::default().fg(theme::TEXT)),
+                Span::styled(
+                    "█".repeat(bar_filled),
+                    Style::default().fg(if *is_voted {
+                        theme::SUCCESS
+                    } else {
+                        theme::AMBER_DIM
+                    }),
+                ),
+                Span::styled("░".repeat(bar_empty), Style::default().fg(theme::BORDER)),
+                Span::styled(
+                    format!(" {:>3}", votes),
+                    Style::default().fg(theme::TEXT_DIM),
+                ),
+            ]
+        };
 
-        if *is_voted {
+        if *is_voted && !(compact_mode || padded_compact_mode) {
             spans.push(Span::styled(" ✓", Style::default().fg(theme::SUCCESS)));
         }
 
-        frame.render_widget(Paragraph::new(Line::from(spans)), layout[i]);
+        frame.render_widget(Paragraph::new(Line::from(spans)), *slot);
+    }
+}
+
+fn compact_vote_spans<'a>(
+    key: &'a str,
+    name: &'a str,
+    votes: i64,
+    is_voted: bool,
+    available_width: usize,
+    leading_pad: bool,
+) -> Vec<Span<'a>> {
+    let rest = &name[key.len()..];
+    let votes_text = votes.to_string();
+    let leading_width = usize::from(leading_pad);
+    let indicator_width = votes_text.len() + 1;
+    let name_width = available_width
+        .saturating_sub(indicator_width + leading_width)
+        .max(key.len());
+    let rest_width = name_width.saturating_sub(key.len());
+
+    let mut spans = Vec::with_capacity(5);
+    if leading_pad {
+        spans.push(Span::raw(" "));
+    }
+    spans.extend([
+        Span::styled(
+            key,
+            Style::default()
+                .fg(theme::AMBER)
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{rest:<rest_width$}"),
+            Style::default().fg(theme::TEXT),
+        ),
+        Span::styled(votes_text, Style::default().fg(theme::TEXT_DIM)),
+    ]);
+
+    if is_voted {
+        spans.push(Span::styled("✓", Style::default().fg(theme::SUCCESS)));
+    } else {
+        spans.push(Span::raw(" "));
+    }
+
+    spans
+}
+
+fn vote_card_title(width: u16) -> &'static str {
+    match width {
+        20.. => " Vote Next (L/A/C) ",
+        14..=18 => " Vote Next ",
+        13 => " Vote Next",
+        _ => "Vote Next",
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ratatui::{Terminal, backend::TestBackend};
+    use ratatui::{
+        Terminal,
+        backend::TestBackend,
+        style::{Color, Modifier},
+    };
 
     #[test]
     fn draw_vote_options_includes_all_genres_in_totals() {
@@ -137,5 +211,89 @@ mod tests {
         assert_eq!(count_blocks(&lofi_line), 4);
         assert_eq!(count_blocks(&classic_line), 4);
         assert_eq!(count_blocks(&ambient_line), 4);
+    }
+
+    #[test]
+    fn draw_vote_options_compact_mode_accents_initial_letters() {
+        let counts = VoteCount {
+            lofi: 5,
+            classic: 2,
+            ambient: 2,
+            jazz: 0,
+        };
+
+        let backend = TestBackend::new(12, 4);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                let area = Rect::new(0, 0, 12, 4);
+                draw_vote_options(frame, area, &counts, Some(Genre::Lofi));
+            })
+            .expect("draw");
+
+        let buffer = terminal.backend().buffer();
+        let line = |y: u16| -> String {
+            let mut out = String::new();
+            for x in 0..12 {
+                out.push_str(buffer[(x, y)].symbol());
+            }
+            out
+        };
+
+        assert_eq!(line(0), "Lofi      5✓");
+        assert_eq!(line(1), "Ambient   2 ");
+        assert_eq!(line(2), "Classic   2 ");
+
+        for (x, y, ch) in [(0, 0, "L"), (0, 1, "A"), (0, 2, "C")] {
+            assert_eq!(buffer[(x, y)].symbol(), ch);
+            assert_eq!(buffer[(x, y)].fg, theme::AMBER);
+            assert!(buffer[(x, y)].modifier.contains(Modifier::BOLD));
+        }
+
+        assert_eq!(buffer[(1, 0)].symbol(), "o");
+        assert_eq!(buffer[(1, 0)].fg, theme::TEXT);
+        assert_eq!(buffer[(10, 0)].symbol(), "5");
+        assert_eq!(buffer[(10, 0)].fg, theme::TEXT_DIM);
+        assert_eq!(buffer[(11, 0)].symbol(), "✓");
+        assert_eq!(buffer[(11, 0)].fg, theme::SUCCESS);
+
+        let compact_first_char_style = buffer[(0, 0)].style();
+        assert_eq!(compact_first_char_style.fg, Some(Color::Rgb(184, 120, 44)));
+        assert!(compact_first_char_style.add_modifier.contains(Modifier::BOLD));
+    }
+
+    #[test]
+    fn draw_vote_options_padded_compact_mode_keeps_left_padding() {
+        let counts = VoteCount {
+            lofi: 0,
+            classic: 0,
+            ambient: 0,
+            jazz: 0,
+        };
+
+        let backend = TestBackend::new(15, 4);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+
+        terminal
+            .draw(|frame| {
+                let area = Rect::new(0, 0, 15, 4);
+                draw_vote_options(frame, area, &counts, None);
+            })
+            .expect("draw");
+
+        let buffer = terminal.backend().buffer();
+        assert_eq!(buffer[(0, 0)].symbol(), " ");
+        assert_eq!(buffer[(1, 0)].symbol(), "L");
+        assert_eq!(buffer[(1, 1)].symbol(), "A");
+        assert_eq!(buffer[(1, 2)].symbol(), "C");
+    }
+
+    #[test]
+    fn vote_card_title_shortens_as_width_shrinks() {
+        assert_eq!(vote_card_title(19), " Vote Next (L/A/C) ");
+        assert_eq!(vote_card_title(18), " Vote Next ");
+        assert_eq!(vote_card_title(13), " Vote Next");
+        assert_eq!(vote_card_title(12), "Vote Next");
     }
 }


### PR DESCRIPTION
## Summary

Made the voting box and music connection box responsive by having narrowing render states. This allows the Dashboard's chat to be usable on much narrower terminals than before (such as Termux, or older computer monitors, or for people that need larger fonts to read well.) The code is unfortunately complex for such a "simple" thing but it can always be backed if/when/as-soon-as it becomes a burden, so I'm in favor of trying it out.

## Detail
- Lower dashboard min width to 24 and stack vote card above chat when too narrow to split
- Add compact stream card layout showing just the Enter/P shortcuts when space is tight
- Add compact vote option rendering with accented initial letters and shortened card title
- Guard top-level draw and resize against zero-sized areas, render "Too small" below 4x4