### PR TITLE
Clean up expired per-IP entries in `IpRateLimiter`

### DIFF
--- a/late-core/src/rate_limit.rs
+++ b/late-core/src/rate_limit.rs
@@ -30,6 +30,24 @@ impl IpRateLimiter {
         self.window.as_secs()
     }
 
+    pub fn entry_count(&self) -> usize {
+        self.attempts_by_ip.lock_recover().len()
+    }
+
+    pub fn cleanup(&self) {
+        let now = Instant::now();
+        let mut attempts_by_ip = self.attempts_by_ip.lock_recover();
+        attempts_by_ip.retain(|_, attempts| {
+            while let Some(first) = attempts.front() {
+                if now.duration_since(*first) <= self.window {
+                    break;
+                }
+                attempts.pop_front();
+            }
+            !attempts.is_empty()
+        });
+    }
+
     pub fn allow(&self, ip: IpAddr) -> bool {
         if self.max_attempts == 0 {
             return true;
@@ -99,5 +117,32 @@ mod tests {
         assert!(!limiter.allow(ip));
         sleep(Duration::from_millis(1100)).await;
         assert!(limiter.allow(ip));
+    }
+
+    #[tokio::test]
+    async fn cleanup_removes_expired_ip_entries() {
+        let limiter = IpRateLimiter::new(1, 1);
+        let ip: IpAddr = "10.0.0.1".parse().expect("parse ip");
+
+        limiter.allow(ip);
+        assert_eq!(limiter.entry_count(), 1);
+
+        sleep(Duration::from_millis(1100)).await;
+        limiter.cleanup();
+        assert_eq!(limiter.entry_count(), 0);
+    }
+
+    #[tokio::test]
+    async fn cleanup_retains_ips_with_active_timestamps() {
+        let limiter = IpRateLimiter::new(5, 1);
+        let stale_ip: IpAddr = "10.0.0.1".parse().expect("parse stale ip");
+        let active_ip: IpAddr = "10.0.0.2".parse().expect("parse active ip");
+
+        limiter.allow(stale_ip);
+        sleep(Duration::from_millis(1100)).await;
+        limiter.allow(active_ip);
+
+        limiter.cleanup();
+        assert_eq!(limiter.entry_count(), 1);
     }
 }

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -263,6 +263,24 @@ async fn main() -> anyhow::Result<()> {
         Ok(())
     });
 
+    let limiter_cleanup_shutdown = singleton_shutdown.clone();
+    let ssh_limiter = state.ssh_attempt_limiter.clone();
+    let ws_limiter = state.ws_pair_limiter.clone();
+    tasks.spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(300));
+        interval.tick().await; // skip immediate first tick
+        loop {
+            tokio::select! {
+                _ = limiter_cleanup_shutdown.cancelled() => break,
+                _ = interval.tick() => {
+                    ssh_limiter.cleanup();
+                    ws_limiter.cleanup();
+                }
+            }
+        }
+        Ok(())
+    });
+
     let vote_shutdown = singleton_shutdown.clone();
     tasks.spawn(async move {
         vote_service.start_background_task(vote_shutdown).await;


### PR DESCRIPTION
Hey, awesome project! I've been working on my own `ratatui` + `russh` app recently, so I was excited to dig into this.

While reading through the rate limiter, I noticed that expired per-IP entries can stick around indefinitely in the `HashMap`, which means scanner traffic can accumulate in the map until restart. This PR adds a periodic cleanup to remove those expired entries.

## Problem

`IpRateLimiter::allow()` prunes expired timestamps from the current IP's `VecDeque`, but it does not remove the IP key from the outer `HashMap` when that deque becomes empty.

That means IPs that hit the limiter once and never call `allow()` again can leave behind empty map entries indefinitely. For an internet-facing service, scanner traffic can make that map grow monotonically until restart.

## Impact

- Rate-limiting behavior is unchanged. Empty entries do not affect correctness.
- Memory usage can grow without bound as new source IPs accumulate.
- Both `ssh_attempt_limiter` and `ws_pair_limiter` are affected.

## Fix

Add a periodic background cleanup task that sweeps each limiter's `attempts_by_ip` map, removes expired timestamps, and drops IP entries whose queues become empty.

This keeps the `O(n)` sweep off the request path. Expired entries may remain until the next cleanup tick, but map growth is bounded instead of unbounded.

## Verification

- Added a unit test that confirms cleanup removes an IP entry after its timestamps expire.
- Added a unit test that confirms cleanup preserves IPs with active timestamps.