### PR TITLE
Gracefully handle exec requests + Ghostty ssh-terminfo

### DIFF
--- a/late-ssh/src/ssh.rs
+++ b/late-ssh/src/ssh.rs
@@ -720,6 +720,28 @@ impl russh::server::Handler for ClientHandler {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self, data, session), fields(peer = ?self.peer_addr, transport = ?self.transport_peer_addr, len = data.len()))]
+    async fn exec_request(
+        &mut self,
+        channel: ChannelId,
+        data: &[u8],
+        session: &mut Session,
+    ) -> Result<(), Self::Error> {
+        let command = String::from_utf8_lossy(data);
+        let preview: String = command.chars().take(128).collect();
+        tracing::info!(
+            command = %preview,
+            "rejecting exec request; only interactive shell is supported"
+        );
+        if let Err(e) = session.channel_failure(channel) {
+            tracing::error!(error = ?e, "exec channel_failure failed");
+        }
+        if let Err(e) = session.close(channel) {
+            tracing::error!(error = ?e, "exec channel close failed");
+        }
+        Ok(())
+    }
+
     #[tracing::instrument(skip(self, session), fields(peer = ?self.peer_addr, transport = ?self.transport_peer_addr))]
     async fn shell_request(
         &mut self,


### PR DESCRIPTION
Reject `exec` SSH requests with `channel_failure` + close instead of accepting the channel and going silent.

Without a handler, any client that sent an `exec` (automation, IDE remote integrations, terminfo installers, scanner probes) just hung

### Ghostty

Particularly helps Ghostty users. On first connect Ghostty may run its [ssh-terminfo integration](https://ghostty.org/docs/help/terminfo#ssh), roughly:

```
infocmp -x xterm-ghostty | ssh YOUR-SERVER -- tic -x -
```

With no exec handler that call hung and `ssh late.sh` never reached the TUI. Now the exec is rejected, and Ghostty falls back to a normal pty + shell with `TERM=xterm-256color`. TUI loads fine.

Server logs from a Ghostty connect:

```
late-ssh         | 2026-04-17T00:10:59.442035Z  INFO auth_publickey{user="yawner" peer=Some(192.168.97.1:59252) transport=Some(192.168.97.1:59252)}: late_ssh::ssh: late-ssh/src/ssh.rs:436: user connected username=yawner fingerprint=SHA256:REDACTED
late-ssh         | 2026-04-17T00:10:59.447776Z DEBUG channel_open_session{peer=Some(192.168.97.1:59252) transport=Some(192.168.97.1:59252)}: late_ssh::ssh: late-ssh/src/ssh.rs:478: session channel opened
late-ssh         | 2026-04-17T00:10:59.451656Z DEBUG env_request{channel=ChannelId(2) variable_name="TERM_PROGRAM" variable_value="ghostty" peer=Some(192.168.97.1:59252) transport=Some(192.168.97.1:59252)}: late_ssh::ssh: late-ssh/src/ssh.rs:717: env channel_success sent variable_name="TERM_PROGRAM"
late-ssh         | 2026-04-17T00:10:59.452294Z DEBUG env_request{channel=ChannelId(2) variable_name="TERM" variable_value="xterm-ghostty" peer=Some(192.168.97.1:59252) transport=Some(192.168.97.1:59252)}: late_ssh::ssh: late-ssh/src/ssh.rs:717: env channel_success sent variable_name="TERM"
late-ssh         | 2026-04-17T00:10:59.453176Z  INFO exec_request{channel=ChannelId(2) peer=Some(192.168.97.1:59252) transport=Some(192.168.97.1:59252) len=320}: late_ssh::ssh: late-ssh/src/ssh.rs:732: rejecting exec request; only interactive shell is supported command=
late-ssh         |                                 infocmp xterm-ghostty >/dev/null 2>&1 && exit 0
late-ssh         |                                 command -v tic
late-ssh         | 2026-04-17T00:10:59.454591Z DEBUG data{channel=ChannelId(2) peer=Some(192.168.97.1:59252) len=3969}: late_ssh::ssh: late-ssh/src/ssh.rs:813: received input data len=3969
late-ssh         | 2026-04-17T00:10:59.460543Z DEBUG channel_eof{channel=ChannelId(2) peer=Some(192.168.97.1:59252) transport=Some(192.168.97.1:59252)}: late_ssh::ssh: late-ssh/src/ssh.rs:835: client sent channel EOF channel=ChannelId(2)
late-ssh         | 2026-04-17T00:10:59.463722Z DEBUG channel_close{channel=ChannelId(2) peer=Some(192.168.97.1:59252) transport=Some(192.168.97.1:59252)}: late_ssh::ssh: late-ssh/src/ssh.rs:849: client closed channel channel=ChannelId(2)
late-ssh         | 2026-04-17T00:11:02.753851Z  INFO auth_publickey{user="yawner" peer=Some(192.168.97.1:59268) transport=Some(192.168.97.1:59268)}: late_ssh::ssh: late-ssh/src/ssh.rs:436: user connected username=yawner fingerprint=SHA256:REDACTED
late-ssh         | 2026-04-17T00:11:02.756439Z DEBUG channel_open_session{peer=Some(192.168.97.1:59268) transport=Some(192.168.97.1:59268)}: late_ssh::ssh: late-ssh/src/ssh.rs:478: session channel opened
late-ssh         | 2026-04-17T00:11:02.757807Z DEBUG pty_request{channel=ChannelId(2) term="xterm-256color" col_width=245 row_height=57 _pix_width=3440 _pix_height=2014 peer=Some(192.168.97.1:59268) transport=Some(192.168.97.1:59268)}: late_ssh::ssh: late-ssh/src/ssh.rs:499: pty requested term="xterm-256color" col_width=245 row_height=57
late-ssh         | 2026-04-17T00:11:02.826734Z DEBUG pty_request{channel=ChannelId(2) term="xterm-256color" col_width=245 row_height=57 _pix_width=3440 _pix_height=2014 peer=Some(192.168.97.1:59268) transport=Some(192.168.97.1:59268)}: late_ssh::ssh: late-ssh/src/ssh.rs:695: pty channel_success sent
late-ssh         | 2026-04-17T00:11:02.827180Z DEBUG env_request{channel=ChannelId(2) variable_name="TERM" variable_value="xterm-256color" peer=Some(192.168.97.1:59268) transport=Some(192.168.97.1:59268)}: late_ssh::ssh: late-ssh/src/ssh.rs:717: env channel_success sent variable_name="TERM"
late-ssh         | 2026-04-17T00:11:02.827586Z DEBUG shell_request{channel=ChannelId(2) peer=Some(192.168.97.1:59268) transport=Some(192.168.97.1:59268)}: late_ssh::ssh: late-ssh/src/ssh.rs:751: shell requested
late-ssh         | 2026-04-17T00:11:02.827612Z DEBUG shell_request{channel=ChannelId(2) peer=Some(192.168.97.1:59268) transport=Some(192.168.97.1:59268)}: late_ssh::ssh: late-ssh/src/ssh.rs:753: shell channel_success sent
```