### PR TITLE
fix(chat): prioritize online users in @ mention picker

### DIFF
--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -830,6 +830,28 @@ impl ChatState {
         self.invalidate_composer_layout();
     }
 
+    pub fn composer_delete_right(&mut self) {
+        let char_count = self.composer.chars().count();
+        if self.composer_cursor >= char_count {
+            return;
+        }
+
+        let byte_pos = self
+            .composer
+            .char_indices()
+            .nth(self.composer_cursor)
+            .map(|(i, _)| i)
+            .unwrap_or(self.composer.len());
+        let next_byte = self
+            .composer
+            .char_indices()
+            .nth(self.composer_cursor + 1)
+            .map(|(i, _)| i)
+            .unwrap_or(self.composer.len());
+        self.composer.replace_range(byte_pos..next_byte, "");
+        self.invalidate_composer_layout();
+    }
+
     pub fn composer_delete_word_right(&mut self) {
         let chars: Vec<char> = self.composer.chars().collect();
         let len = chars.len();
@@ -1066,8 +1088,10 @@ impl ChatState {
 
         let query = &self.composer[offset + 1..];
         let query_lower = query.to_ascii_lowercase();
-        let online = online_username_set(self.active_users.as_ref());
-        let matches = rank_mention_matches(&self.all_usernames, &query_lower, &online);
+        let active_users = self.active_users.as_ref();
+        let matches = rank_mention_matches(&self.all_usernames, &query_lower, || {
+            online_username_set(active_users)
+        });
 
         if matches.is_empty() {
             self.mention_ac.active = false;
@@ -1620,28 +1644,42 @@ fn online_username_set(active_users: Option<&ActiveUsers>) -> HashSet<String> {
 pub(crate) fn rank_mention_matches(
     all_usernames: &[String],
     query_lower: &str,
-    online: &HashSet<String>,
+    online_set: impl FnOnce() -> HashSet<String>,
 ) -> Vec<MentionMatch> {
-    let mut matches: Vec<MentionMatch> = all_usernames
+    // Lowercase each candidate once and keep it paired with the original
+    // display name; reused for the prefix filter, the online lookup, and the
+    // alphabetical tie-breaker.
+    let mut filtered: Vec<(String, String)> = all_usernames
         .iter()
-        .filter(|name| name.to_ascii_lowercase().starts_with(query_lower))
-        .map(|name| {
+        .filter_map(|name| {
             let lower = name.to_ascii_lowercase();
-            let is_online = online.contains(&lower);
-            MentionMatch {
-                name: name.clone(),
-                online: is_online,
-            }
+            lower
+                .starts_with(query_lower)
+                .then(|| (lower, name.clone()))
         })
         .collect();
-    matches.sort_by(|a, b| {
-        b.online.cmp(&a.online).then_with(|| {
-            a.name
-                .to_ascii_lowercase()
-                .cmp(&b.name.to_ascii_lowercase())
+    if filtered.is_empty() {
+        return Vec::new();
+    }
+
+    let online = online_set();
+    let mut matches: Vec<(String, MentionMatch)> = filtered
+        .drain(..)
+        .map(|(lower, name)| {
+            let is_online = online.contains(&lower);
+            (
+                lower,
+                MentionMatch {
+                    name,
+                    online: is_online,
+                },
+            )
         })
+        .collect();
+    matches.sort_by(|(a_lower, a), (b_lower, b)| {
+        b.online.cmp(&a.online).then_with(|| a_lower.cmp(b_lower))
     });
-    matches
+    matches.into_iter().map(|(_, m)| m).collect()
 }
 
 fn format_active_user_lines(active_users: Option<&ActiveUsers>) -> Vec<String> {
@@ -1751,6 +1789,10 @@ mod tests {
         matches.iter().map(|m| m.name.as_str()).collect()
     }
 
+    fn online(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|n| n.to_string()).collect()
+    }
+
     #[test]
     fn rank_mention_matches_orders_online_before_offline() {
         let all = vec![
@@ -1759,38 +1801,93 @@ mod tests {
             "carol".to_string(),
             "dave".to_string(),
         ];
-        let online: HashSet<String> = ["bob".to_string(), "dave".to_string()]
-            .into_iter()
-            .collect();
-        let ranked = rank_mention_matches(&all, "", &online);
+        let ranked = rank_mention_matches(&all, "", || online(&["bob", "dave"]));
         assert_eq!(names(&ranked), vec!["bob", "dave", "alice", "carol"]);
         assert!(ranked[0].online && ranked[1].online);
         assert!(!ranked[2].online && !ranked[3].online);
     }
 
     #[test]
+    fn rank_mention_matches_prefix_filter_groups_online_first() {
+        // "@a" with two online and one offline 'a'-prefixed users:
+        // online 'a' names come first (alphabetically), then offline.
+        let all = vec![
+            "alice".to_string(),
+            "alex".to_string(),
+            "albert".to_string(),
+            "bob".to_string(),
+        ];
+        let ranked = rank_mention_matches(&all, "a", || online(&["alice", "alex"]));
+        assert_eq!(names(&ranked), vec!["alex", "alice", "albert"]);
+        assert!(ranked[0].online && ranked[1].online);
+        assert!(!ranked[2].online);
+    }
+
+    #[test]
     fn rank_mention_matches_applies_prefix_filter() {
         let all = vec!["alice".to_string(), "albert".to_string(), "bob".to_string()];
-        let online: HashSet<String> = ["bob".to_string()].into_iter().collect();
-        let ranked = rank_mention_matches(&all, "al", &online);
+        let ranked = rank_mention_matches(&all, "al", || online(&["bob"]));
         assert_eq!(names(&ranked), vec!["albert", "alice"]);
     }
 
     #[test]
     fn rank_mention_matches_prefix_is_case_insensitive() {
         let all = vec!["Alice".to_string(), "alBert".to_string()];
-        let online = HashSet::new();
-        let ranked = rank_mention_matches(&all, "al", &online);
+        let ranked = rank_mention_matches(&all, "al", HashSet::new);
         assert_eq!(names(&ranked), vec!["alBert", "Alice"]);
     }
 
     #[test]
     fn rank_mention_matches_falls_back_to_alpha_when_no_online_info() {
         let all = vec!["zed".to_string(), "alice".to_string(), "bob".to_string()];
-        let online = HashSet::new();
-        let ranked = rank_mention_matches(&all, "", &online);
+        let ranked = rank_mention_matches(&all, "", HashSet::new);
         assert_eq!(names(&ranked), vec!["alice", "bob", "zed"]);
         assert!(ranked.iter().all(|m| !m.online));
+    }
+
+    #[test]
+    fn rank_mention_matches_skips_online_set_when_prefix_excludes_all() {
+        // When the query filters everyone out, the online-set supplier must
+        // not be invoked — it's the expensive path (locks ActiveUsers).
+        let all = vec!["alice".to_string(), "bob".to_string()];
+        let ranked = rank_mention_matches(&all, "zz", || {
+            panic!("online_set should not be built when prefix filter is empty")
+        });
+        assert!(ranked.is_empty());
+    }
+
+    #[test]
+    fn online_username_set_returns_empty_for_none() {
+        assert!(online_username_set(None).is_empty());
+    }
+
+    #[test]
+    fn online_username_set_lowercases_active_usernames() {
+        use crate::state::ActiveUser;
+        use std::sync::{Arc, Mutex};
+        use std::time::Instant;
+
+        let mut users: HashMap<Uuid, ActiveUser> = HashMap::new();
+        users.insert(
+            Uuid::now_v7(),
+            ActiveUser {
+                username: "Alice".to_string(),
+                connection_count: 1,
+                last_login_at: Instant::now(),
+            },
+        );
+        users.insert(
+            Uuid::now_v7(),
+            ActiveUser {
+                username: "BOB".to_string(),
+                connection_count: 2,
+                last_login_at: Instant::now(),
+            },
+        );
+        let active: ActiveUsers = Arc::new(Mutex::new(users));
+
+        let set = online_username_set(Some(&active));
+        assert_eq!(set, online(&["alice", "bob"]));
     }
 
     #[test]

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -1,6 +1,9 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
-use late_core::models::{chat_message::ChatMessage, chat_room::ChatRoom};
+use late_core::{
+    MutexRecover,
+    models::{chat_message::ChatMessage, chat_room::ChatRoom},
+};
 use tokio::sync::watch;
 use uuid::Uuid;
 
@@ -36,12 +39,18 @@ The stream is 128kbps MP3 from Icecast, fed by Liquidsoap playlists of CC0/CC-BY
 
 pub(crate) const ROOM_JUMP_KEYS: &[u8] = b"asdfghjklqwertyuiopzxcvbnm1234567890";
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MentionMatch {
+    pub name: String,
+    pub online: bool,
+}
+
 #[derive(Default)]
 pub(crate) struct MentionAutocomplete {
     pub active: bool,
     pub query: String,
     pub trigger_offset: usize,
-    pub matches: Vec<String>,
+    pub matches: Vec<MentionMatch>,
     pub selected: usize,
 }
 
@@ -1044,12 +1053,8 @@ impl ChatState {
 
         let query = &self.composer[offset + 1..];
         let query_lower = query.to_ascii_lowercase();
-        let matches: Vec<String> = self
-            .all_usernames
-            .iter()
-            .filter(|name| name.to_ascii_lowercase().starts_with(&query_lower))
-            .cloned()
-            .collect();
+        let online = online_username_set(self.active_users.as_ref());
+        let matches = rank_mention_matches(&self.all_usernames, &query_lower, &online);
 
         if matches.is_empty() {
             self.mention_ac.active = false;
@@ -1079,7 +1084,7 @@ impl ChatState {
         if !self.mention_ac.active || self.mention_ac.matches.is_empty() {
             return;
         }
-        let username = self.mention_ac.matches[self.mention_ac.selected].clone();
+        let username = self.mention_ac.matches[self.mention_ac.selected].name.clone();
         self.composer.truncate(self.mention_ac.trigger_offset);
         self.composer.push('@');
         self.composer.push_str(&username);
@@ -1585,12 +1590,48 @@ fn room_supports_member_list(room: &ChatRoom) -> bool {
     room.kind != "dm" && !room.auto_join
 }
 
+fn online_username_set(active_users: Option<&ActiveUsers>) -> HashSet<String> {
+    let Some(active_users) = active_users else {
+        return HashSet::new();
+    };
+    let guard = active_users.lock_recover();
+    guard
+        .values()
+        .map(|u| u.username.to_ascii_lowercase())
+        .collect()
+}
+
+pub(crate) fn rank_mention_matches(
+    all_usernames: &[String],
+    query_lower: &str,
+    online: &HashSet<String>,
+) -> Vec<MentionMatch> {
+    let mut matches: Vec<MentionMatch> = all_usernames
+        .iter()
+        .filter(|name| name.to_ascii_lowercase().starts_with(query_lower))
+        .map(|name| {
+            let lower = name.to_ascii_lowercase();
+            let is_online = online.contains(&lower);
+            MentionMatch {
+                name: name.clone(),
+                online: is_online,
+            }
+        })
+        .collect();
+    matches.sort_by(|a, b| {
+        b.online
+            .cmp(&a.online)
+            .then_with(|| a.name.to_ascii_lowercase().cmp(&b.name.to_ascii_lowercase()))
+    });
+    matches
+}
+
 fn format_active_user_lines(active_users: Option<&ActiveUsers>) -> Vec<String> {
     let Some(active_users) = active_users else {
         return vec!["Active user list unavailable".to_string()];
     };
 
-    let guard = active_users.lock().expect("active users lock poisoned");
+    let guard = active_users.lock_recover();
     if guard.is_empty() {
         return vec!["No active users".to_string()];
     }
@@ -1687,6 +1728,56 @@ fn reply_preview_text(body: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn names(matches: &[MentionMatch]) -> Vec<&str> {
+        matches.iter().map(|m| m.name.as_str()).collect()
+    }
+
+    #[test]
+    fn rank_mention_matches_orders_online_before_offline() {
+        let all = vec![
+            "alice".to_string(),
+            "bob".to_string(),
+            "carol".to_string(),
+            "dave".to_string(),
+        ];
+        let online: HashSet<String> = ["bob".to_string(), "dave".to_string()]
+            .into_iter()
+            .collect();
+        let ranked = rank_mention_matches(&all, "", &online);
+        assert_eq!(names(&ranked), vec!["bob", "dave", "alice", "carol"]);
+        assert!(ranked[0].online && ranked[1].online);
+        assert!(!ranked[2].online && !ranked[3].online);
+    }
+
+    #[test]
+    fn rank_mention_matches_applies_prefix_filter() {
+        let all = vec![
+            "alice".to_string(),
+            "albert".to_string(),
+            "bob".to_string(),
+        ];
+        let online: HashSet<String> = ["bob".to_string()].into_iter().collect();
+        let ranked = rank_mention_matches(&all, "al", &online);
+        assert_eq!(names(&ranked), vec!["albert", "alice"]);
+    }
+
+    #[test]
+    fn rank_mention_matches_prefix_is_case_insensitive() {
+        let all = vec!["Alice".to_string(), "alBert".to_string()];
+        let online = HashSet::new();
+        let ranked = rank_mention_matches(&all, "al", &online);
+        assert_eq!(names(&ranked), vec!["alBert", "Alice"]);
+    }
+
+    #[test]
+    fn rank_mention_matches_falls_back_to_alpha_when_no_online_info() {
+        let all = vec!["zed".to_string(), "alice".to_string(), "bob".to_string()];
+        let online = HashSet::new();
+        let ranked = rank_mention_matches(&all, "", &online);
+        assert_eq!(names(&ranked), vec!["alice", "bob", "zed"]);
+        assert!(ranked.iter().all(|m| !m.online));
+    }
 
     #[test]
     fn reply_preview_text_uses_message_body_for_nested_replies() {

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -1084,7 +1084,9 @@ impl ChatState {
         if !self.mention_ac.active || self.mention_ac.matches.is_empty() {
             return;
         }
-        let username = self.mention_ac.matches[self.mention_ac.selected].name.clone();
+        let username = self.mention_ac.matches[self.mention_ac.selected]
+            .name
+            .clone();
         self.composer.truncate(self.mention_ac.trigger_offset);
         self.composer.push('@');
         self.composer.push_str(&username);
@@ -1619,9 +1621,11 @@ pub(crate) fn rank_mention_matches(
         })
         .collect();
     matches.sort_by(|a, b| {
-        b.online
-            .cmp(&a.online)
-            .then_with(|| a.name.to_ascii_lowercase().cmp(&b.name.to_ascii_lowercase()))
+        b.online.cmp(&a.online).then_with(|| {
+            a.name
+                .to_ascii_lowercase()
+                .cmp(&b.name.to_ascii_lowercase())
+        })
     });
     matches
 }
@@ -1752,11 +1756,7 @@ mod tests {
 
     #[test]
     fn rank_mention_matches_applies_prefix_filter() {
-        let all = vec![
-            "alice".to_string(),
-            "albert".to_string(),
-            "bob".to_string(),
-        ];
+        let all = vec!["alice".to_string(), "albert".to_string(), "bob".to_string()];
         let online: HashSet<String> = ["bob".to_string()].into_iter().collect();
         let ranked = rank_mention_matches(&all, "al", &online);
         assert_eq!(names(&ranked), vec!["albert", "alice"]);

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -24,7 +24,7 @@ pub use super::ui_text::ComposerRow;
 pub(super) use super::ui_text::build_composer_rows;
 pub(crate) use super::ui_text::{composer_cursor_scroll_for_rows, composer_line_count_for_rows};
 
-use super::state::ROOM_JUMP_KEYS;
+use super::state::{MentionMatch, ROOM_JUMP_KEYS};
 use super::ui_text::{
     build_composer_lines, build_composer_lines_from_rows, composer_line_count,
     wrap_chat_entry_to_lines,
@@ -52,7 +52,7 @@ pub struct DashboardChatView<'a> {
     pub composer_cursor: usize,
     pub composing: bool,
     pub cursor_visible: bool,
-    pub mention_matches: &'a [String],
+    pub mention_matches: &'a [MentionMatch],
     pub mention_selected: usize,
     pub mention_active: bool,
     pub reply_author: Option<&'a str>,
@@ -71,7 +71,7 @@ pub(super) struct ComposerBlockView<'a> {
     pub reply_author: Option<&'a str>,
     pub is_editing: bool,
     pub mention_active: bool,
-    pub mention_matches: &'a [String],
+    pub mention_matches: &'a [MentionMatch],
     pub mention_selected: usize,
 }
 
@@ -526,7 +526,12 @@ fn dm_label(
 
 // ── Mention autocomplete popup ──────────────────────────────
 
-fn draw_mention_autocomplete(frame: &mut Frame, anchor: Rect, matches: &[String], selected: usize) {
+fn draw_mention_autocomplete(
+    frame: &mut Frame,
+    anchor: Rect,
+    matches: &[MentionMatch],
+    selected: usize,
+) {
     if matches.is_empty() {
         return;
     }
@@ -549,7 +554,7 @@ fn draw_mention_autocomplete(frame: &mut Frame, anchor: Rect, matches: &[String]
         .iter()
         .enumerate()
         .take(8)
-        .map(|(i, name)| {
+        .map(|(i, m)| {
             let style = if i == selected {
                 Style::default()
                     .fg(theme::AMBER())
@@ -558,7 +563,7 @@ fn draw_mention_autocomplete(frame: &mut Frame, anchor: Rect, matches: &[String]
                 Style::default().fg(theme::TEXT())
             };
             let prefix = if i == selected { " > " } else { "   " };
-            Line::from(Span::styled(format!("{prefix}@{name}"), style))
+            Line::from(Span::styled(format!("{prefix}@{}", m.name), style))
         })
         .collect();
 
@@ -590,7 +595,7 @@ pub struct ChatRenderInput<'a> {
     pub composing: bool,
     pub current_user_id: Uuid,
     pub cursor_visible: bool,
-    pub mention_matches: &'a [String],
+    pub mention_matches: &'a [MentionMatch],
     pub mention_selected: usize,
     pub mention_active: bool,
     pub reply_author: Option<&'a str>,

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -555,14 +555,15 @@ fn draw_mention_autocomplete(
         .enumerate()
         .take(8)
         .map(|(i, m)| {
-            let style = if i == selected {
-                Style::default()
+            let is_selected = i == selected;
+            let style = match (is_selected, m.online) {
+                (true, _) => Style::default()
                     .fg(theme::AMBER())
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default().fg(theme::TEXT())
+                    .add_modifier(Modifier::BOLD),
+                (false, true) => Style::default().fg(theme::TEXT()),
+                (false, false) => Style::default().fg(theme::TEXT_FAINT()),
             };
-            let prefix = if i == selected { " > " } else { "   " };
+            let prefix = if is_selected { " > " } else { "   " };
             Line::from(Span::styled(format!("{prefix}@{}", m.name), style))
         })
         .collect();

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -50,6 +50,7 @@ enum ParsedInput {
     Byte(u8),
     Arrow(u8),
     CtrlArrow(u8),
+    Delete,
     CtrlBackspace,
     CtrlDelete,
     Scroll(isize),
@@ -226,6 +227,9 @@ impl Perform for VtCollector {
             }
             '~' if p0 == Some(3) && p1 == Some(5) => {
                 self.events.push(ParsedInput::CtrlDelete);
+            }
+            '~' if p0 == Some(3) => {
+                self.events.push(ParsedInput::Delete);
             }
             '~' if p0 == Some(8) && p1 == Some(5) => {
                 self.events.push(ParsedInput::CtrlBackspace);
@@ -503,6 +507,13 @@ fn handle_parsed_input(app: &mut App, event: ParsedInput) {
             }
             handle_scroll_for_screen(app, ctx.screen, isize::MIN)
         }
+        ParsedInput::Delete
+            if (ctx.screen == Screen::Chat || ctx.screen == Screen::Dashboard)
+                && ctx.chat_composing =>
+        {
+            app.chat.composer_delete_right();
+            app.chat.update_autocomplete();
+        }
         ParsedInput::CtrlBackspace
             if (ctx.screen == Screen::Chat || ctx.screen == Screen::Dashboard)
                 && ctx.chat_composing =>
@@ -538,7 +549,10 @@ fn handle_parsed_input(app: &mut App, event: ParsedInput) {
                 app.chat.composer_cursor_word_left();
             }
         }
-        ParsedInput::CtrlArrow(_) | ParsedInput::CtrlBackspace | ParsedInput::CtrlDelete => {}
+        ParsedInput::Delete
+        | ParsedInput::CtrlArrow(_)
+        | ParsedInput::CtrlBackspace
+        | ParsedInput::CtrlDelete => {}
         ParsedInput::Arrow(key) => {
             if ctx.screen == Screen::Chat && app.chat.room_jump_active {
                 let _ = chat::input::handle_arrow(app, key);
@@ -1215,6 +1229,7 @@ mod tests {
             vec![ParsedInput::CtrlArrow(b'C')]
         );
         assert_eq!(parser.feed(b"\x1b[5D"), vec![ParsedInput::CtrlArrow(b'D')]);
+        assert_eq!(parser.feed(b"\x1b[3~"), vec![ParsedInput::Delete]);
         assert_eq!(parser.feed(b"\x1b[3;5~"), vec![ParsedInput::CtrlDelete]);
         assert_eq!(
             parser.feed(b"\x1b[127;5u"),


### PR DESCRIPTION
Closes #29.

`@` mention picker now ranks online users first and dims offline rows so the useful names are where you look first.

## What changed

- **Ranking** -- sort candidates by `(online desc, name asc)`. Online set built once from `ActiveUsers`
- **Visual affordance**:
  - selected → `AMBER` + `BOLD` (unchanged)
  - online → `TEXT`
  - offline → `TEXT_FAINT`

## Result

In a room with a few online + many offline members, typing `@` now shows the online folks on top in bright text, with the offline roster greyed underneath. Cursor still moves through both groups so you can `@` an offline user when you want to.

## Screenshots

_Before:_

<img width="1715" height="1049" alt="image" src="https://github.com/user-attachments/assets/01fad855-74bc-4360-bee0-fa9348984b46" />

_After:_

<img width="1715" height="1049" alt="image" src="https://github.com/user-attachments/assets/c5563f8a-a542-4f7f-8a9e-55e390dc9b92" />

## Tests

- Unit tests inline in `state.rs`:

## Repro with:

```fish
# Bump LATE_MAX_CONNS_PER_IP 
function lssh
    ssh -o IdentitiesOnly=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 2222 $argv
end

for u in alice bob carol
    ssh-keygen -t ed25519 -f ~/.ssh/late_$u -N "" -C $u
    lssh -i ~/.ssh/late_$u $u@localhost   # first-login creates user row; `q` to quit
end


# Keep alice + bob connected, leave carol offline. In alice's composer: `c` → `i` → `@`.
# Expected: bob + alice on top, carol faint at bottom.
```


