### PR TITLE
Merge profile table into users and tighten username handling

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -64,7 +64,7 @@ The system is a Rust workspace with four crates (`late-cli`, `late-core`, `late-
 **Integration tests (`late-ssh/tests/`, `late-web/tests/`, `late-core/tests/`):**
 - MUST use testcontainers for database access — always go through `late_core::test_utils::test_db()` (or the `helpers::new_test_db()` wrapper in `late-ssh`).
 - NEVER use `Db::new(&DbConfig::default())` or hardcoded connection strings in integration tests.
-- `late-core::test_utils` owns shared test infrastructure: `test_db()`, `create_test_user()` (creates user + profile). Use these everywhere instead of rolling per-test user creation — except in `late-core` model tests that are testing `User::create` itself or don't need a profile.
+- `late-core::test_utils` owns shared test infrastructure: `test_db()`, `create_test_user()`. Use these everywhere instead of rolling per-test user creation — except in `late-core` model tests that are testing `User::create` itself.
 - `late-ssh/tests/helpers/mod.rs` re-exports `create_test_user` from `late-core` and adds ssh-specific helpers (`test_config`, `test_app_state`, `make_app`, etc.). Domain test directories access these via `#[path = "../helpers/mod.rs"] mod helpers;` in their `main.rs`.
 - Any test that touches DB, services, network, or cross-module orchestration belongs here.
 - Preferred integration layout is domain-oriented under crate `tests/`, mirroring the source structure: `tests/<domain>/main.rs` with sibling `svc.rs`, `state.rs`, etc. as needed. `late-core` tests are named after their domain (`user.rs`, `vote.rs`, `chat/`).
@@ -475,7 +475,7 @@ late-sh/
 
 | Entity | Table | Key constraints |
 |--------|-------|----------------|
-| User | `users` | `fingerprint` UNIQUE, `settings` JSONB (holds `ignored_user_ids: [uuid]` — keyed by id, not username, so renames don't drop ignores) |
+| User | `users` | `fingerprint` UNIQUE; `username` trimmed length 1-32, case-insensitive UNIQUE via `idx_users_username_lower`, format `^[A-Za-z0-9._-]+$` and no `@` (canonical public handle); `settings` JSONB holds `ignored_user_ids: [uuid]` (keyed by id, not username, so renames don't drop ignores), `theme_id` (string), `notify_kinds: [text]` (desktop-notification opt-ins: `dms`, `mentions`, `game_events`), `notify_cooldown_mins` (int ≥ 0; 0 = no throttle) |
 | Vote | `votes` | `user_id` UNIQUE (one vote per user per round) |
 | ChatRoom | `chat_rooms` | `kind` IN (general, language, dm, topic), complex constraints |
 | ChatRoomMember | `chat_room_members` | PK `(room_id, user_id)`, `last_read_at` |
@@ -483,7 +483,6 @@ late-sh/
 | Article | `articles` | `url` UNIQUE, `user_id` FK |
 | ArticleFeedRead | `article_feed_reads` | `user_id` PK/FK, per-user news read checkpoint |
 | Notification | `notifications` | `user_id`+`actor_id` FK to users, `message_id` FK to chat_messages, `room_id` FK to chat_rooms, `read_at` nullable, CHECK(user_id<>actor_id) |
-| Profile | `profiles` | `user_id` UNIQUE, username (trimmed length 1-32, case-insensitive UNIQUE, canonical public handle), `notify_kinds TEXT[]` (desktop-notification kinds the user opted in to: `dms`, `mentions`, `game_events`), `notify_cooldown_mins INT CHECK >= 0` (0 = no throttle) |
 | SudokuDailyWin | `sudoku_daily_wins` | `UNIQUE(user_id, difficulty_key, puzzle_date)`, score tracked |
 | NonogramDailyWin | `nonogram_daily_wins` | `UNIQUE(user_id, size_key, puzzle_date)`, binary completion |
 | MinesweeperGame | `minesweeper_games` | `UNIQUE(user_id, difficulty_key, mode)`, stores seeded mine_map + player_grid + lives (3-life system) |
@@ -672,8 +671,8 @@ Currently the SSH app assumes a single process. These in-memory structures would
 - Chat room visibility enforced via `ChatRoom::list_for_user` (membership join) - never expose rooms user hasn't joined
 - `#announcements` is read-joinable like other permanent public rooms, but only admins may post there; enforce this in the chat service send path, not only in the UI
 - DM rooms canonicalize user IDs (`dm_user_a < dm_user_b` text order) to prevent duplicate DM pairs
-- Profile usernames are the canonical public handles for chat/DM lookup; SSH login ensures a profile row exists immediately, seeds it from the SSH username, and adds `-N` suffixes in Rust when needed to stay unique
-- @bot and @graybeard bootstrap on app startup: ensure DB user + profile, sync `profiles.username`, join public rooms, and insert into `active_users` (always online). Both are dedicated users with fixed fingerprints (`bot-fp-000`, `graybeard-fp-000`)
+- `users.username` is the canonical public handle for chat/DM lookup; SSH login seeds it from the SSH username via `User::next_available_username` (sanitizes to `[A-Za-z0-9._-]`, adds `-N` suffixes to stay unique on `LOWER(username)`)
+- @bot and @graybeard bootstrap on app startup: ensure DB user with a fixed `username`, join public rooms, and insert into `active_users` (always online). Both are dedicated users with fixed fingerprints (`bot-fp-000`, `graybeard-fp-000`)
 - Connection limits (global semaphore + per-IP counter) plus SSH attempt rate limit (sliding window) MUST be enforced before any auth (effective client IP is resolved from PROXY protocol when enabled)
 - Chat message deletes are hard deletes; any moderation/delete path must remove rows directly rather than relying on tombstones
 
@@ -712,7 +711,7 @@ Currently the SSH app assumes a single process. These in-memory structures would
 **Chat roster/help overlay flow:**
 1. Trigger: User submits `/help`, `/active`, or `/list` in the composer
 2. Processing: `ChatState::submit_composer()` intercepts these before any message send. `/help` opens a static overlay, `/active` snapshots the shared in-memory `active_users` registry, and `/list` spawns `ChatService::list_room_members_task` for the selected non-auto-join room.
-3. Side effects: `/active` renders usernames in an overlay immediately and annotates repeated SSH sessions as `(<n> sessions)`. `/list` resolves `chat_room_members` to profile usernames and opens a room-member overlay when the async event arrives.
+3. Side effects: `/active` renders usernames in an overlay immediately and annotates repeated SSH sessions as `(<n> sessions)`. `/list` resolves `chat_room_members` to `users.username` and opens a room-member overlay when the async event arrives.
 4. Guardrail: `/list` is only allowed for the product's "private" rooms, defined in the TUI as `auto_join = false` and `kind != 'dm'`; it is rejected in `general`, permanent/public auto-join rooms, and DMs.
 5. Failure: `/list` on the wrong room shows a red banner; DB/service errors surface via `RoomMembersListFailed`.
 
@@ -724,7 +723,7 @@ Currently the SSH app assumes a single process. These in-memory structures would
 
 **Chat @mention autocomplete:**
 1. Trigger: User types `@` in composer (at start or after space)
-2. Processing: `ChatState::update_autocomplete()` filters `all_usernames` (loaded from profiles DB via `ChatSnapshot`) case-insensitively by the query after `@`
+2. Processing: `ChatState::update_autocomplete()` filters `all_usernames` (loaded from `users` via `ChatSnapshot`) case-insensitively by the query after `@`
 3. Interaction: Arrow keys navigate matches, Tab/Enter confirms (inserts `@username `), Esc dismisses popup without leaving compose mode
 4. Rendering: `draw_mention_autocomplete()` renders a popup above the composer with up to 8 filtered matches; confirm must also move `composer_cursor` to the end of the inserted mention including the trailing space
 
@@ -751,7 +750,7 @@ Currently the SSH app assumes a single process. These in-memory structures would
 - **Transcript render cost is cache-sensitive:** every member room keeps a warm tail (broadcast-driven, hard-capped at 1000 messages per room). The chat UI caches wrapped transcript rows for the dashboard general card and the active room; invalidation must track width, message content/order, usernames, badges, and bonsai glyphs. Only the selected room and general are fetched from DB on snapshot refresh — other rooms warm up from broadcasts and pull a one-shot backfill via `request_list` on first open per session.
 - **Composer render cost is cache-sensitive:** The chat composer caches wrapped `ComposerRow`s in `ChatState`; any change to composer text or width must invalidate that cache before render/cursor-up/down.
 - **Icon picker is chat-composer-only:** `Ctrl+]` (byte `0x1D`) opens `app::icon_picker` as a modal overlay, lazy-loads the catalog on first open (two sections each for Emoji and Nerd Font — no Unicode tab, no `unicode_names2` dep), and auto-starts `ChatState::start_composing` if the user isn't already composing. Selected icons are only ever pushed into `app.chat.composer`; Profile and news composers are intentionally not targets. The picker intercepts all input via an early return in `handle_parsed_input`, so while it is open nothing else on screen receives keys.
-- **@mention detection:** Uses simple `@username` substring match in message body. The `all_usernames` field on `ChatSnapshot` is loaded from profiles DB every refresh (10s) via `User::list_all_usernames` — includes all users, not just online ones.
+- **@mention detection:** Uses simple `@username` substring match in message body. The `all_usernames` field on `ChatSnapshot` is loaded from `users` every refresh (10s) via `User::list_all_usernames` — includes all users, not just online ones.
 - **Reply persistence is currently body-encoded:** There is no reply DB column yet. Replies are stored as a quoted first line in `body` and rendered back out in the TUI. If/when true threaded metadata is added, both send and render paths need coordinated migration.
 - **All services are singletons** shared across SSH sessions. `ProfileService` snapshots are per-user channels keyed by `user_id`; events still require `user_id` filtering in UI state. Per-user background refresh tasks are spawned on session init and aborted on `Drop`, and profile snapshot channels are pruned when receivers go away.
 - **Chat room `updated` timestamp:** Intentionally NOT used for room ordering to keep stable sort - rooms ordered by type (general → language → private → dm)
@@ -767,16 +766,16 @@ Currently the SSH app assumes a single process. These in-memory structures would
 - **Activity feed broadcast timing:** `broadcast::Receiver` only sees messages sent AFTER subscription. The receiver must be created in `auth_publickey` (before login event is sent), stored on `ClientHandler`, then `.take()`'d into `SessionConfig` in `pty_request`. Creating the receiver later misses the user's own login event.
 - **Leaderboard refresh is async, badges are eventually consistent:** `LeaderboardService` refreshes every 30s. A new daily win won't appear in the leaderboard or chat badges until the next refresh cycle. Activity feed callouts are immediate (fire-and-forget from `record_win_task`).
 - **Streak SQL uses gaps-and-islands:** A streak is "current" if its last day is today or yesterday. This means a user who hasn't played today still keeps their streak visible until midnight UTC tomorrow. The `UNION` across `sudoku_daily_wins` and `nonogram_daily_wins` deduplicates dates so playing both games on the same day counts as one streak day.
-- **Game services hold `activity_feed` sender:** `SudokuService` and `NonogramService` both hold a clone of the `broadcast::Sender<ActivityEvent>` for win callouts. The username is looked up from `profiles` table inside the fire-and-forget task, not passed from the caller.
+- **Game services hold `activity_feed` sender:** `SudokuService` and `NonogramService` both hold a clone of the `broadcast::Sender<ActivityEvent>` for win callouts. The username is looked up from `users` inside the fire-and-forget task (via `late_core::models::profile::fetch_username`), not passed from the caller.
 - **Bonsai death check runs on login:** `BonsaiService::ensure_tree()` checks `last_watered` against UTC today on every SSH session start. If 7+ days have passed, the tree is killed and a graveyard record is created. This means death is only detected when the user reconnects, not while offline.
 - **Bonsai passive growth is per-session:** The tick counter in `BonsaiState` grants 1 growth point every ~9000 ticks (~10 min at 15fps). If a user has multiple sessions, each grants growth independently. This is acceptable — it rewards being connected, not gaming the system.
 - **Bonsai chat glyph is current-user only:** The bonsai stage glyph (· ⚘ 🌲 🌳 🌸) is only shown next to the current user's own messages. Other users' bonsai stages are not queried or displayed in chat (would require a new cross-user lookup).
 - **Bonsai cut changes seed optimistically:** The `cut()` method updates `self.seed` in memory immediately and fires a background DB task. If the DB write fails, the in-memory seed diverges from persisted until next login.
 - **Help modal (`?`) intercepts all input:** When `show_help` is true, the input handler dismisses the modal on any keypress before any other input processing. This includes `?` itself (toggle off) and `Esc`.
 - **Desktop notifications bypass the frame diff:** OSC 777 (kitty/Ghostty/rxvt-unicode/foot/wezterm/konsole) and OSC 9 (iTerm2 fallback) payloads are written to `App::pending_terminal_commands`, not into the ratatui frame. `late-ssh::ssh::render_once` drains that buffer **after** pushing the frame diff and sends each payload as a separate `handle.data` call. Writing them inline with `write!(self.shared, …)` would slip them into the diff and get re-emitted on every redraw. Same rule applies to OSC 52 clipboard copies.
-- **Notification pipeline is kind-tagged and throttled server-side:** `ChatState::pending_notifications` holds `PendingNotification { kind: &'static str, title, body }` entries drained each render. `render.rs` picks the first pending whose `kind` is in `profiles.notify_kinds` and honors the shared `notify_cooldown_mins` via `App::last_notify_at`. Adding a new kind means: (1) append to `ProfileState::NOTIFY_KINDS`, (2) add a row in `profile/ui.rs` `kinds` tuple, (3) enqueue it from the relevant event handler, (4) update the unit test `notify_kinds_constant_matches_ui_expectations` in `profile/state.rs`. No tmux DCS wrapping — tmux is explicitly unsupported.
-- **Profile notifications default to all-off:** Migration 025 ships `notify_kinds = '{}'` and `notify_cooldown_mins = 0`. `render.rs` only fires if the kind string is present in the user's array, so a brand-new account is silent until they opt in on the profile screen. A focus-tracking `"unfocused"` policy used to exist (DEC mode 1004) but was removed — `notify_kinds` is the whole model now.
-- **`Profile::save_profile` needs a loaded profile id:** `submit_username` and the notification toggles all go through `save_profile`, which calls `Profile::update_by_user_id(… profile.id …)`. `ProfileState` seeds with `Profile::default()` (id = `Uuid::nil()`) until the async `find_profile` snapshot lands. If you save before the snapshot arrives, the UPDATE matches zero rows and silently succeeds. Integration tests must `wait_for_render_contains` on the current username (not just a static label) before asserting persistence.
+- **Notification pipeline is kind-tagged and throttled server-side:** `ChatState::pending_notifications` holds `PendingNotification { kind: &'static str, title, body }` entries drained each render. `render.rs` picks the first pending whose `kind` is in `users.settings.notify_kinds` and honors the shared `notify_cooldown_mins` via `App::last_notify_at`. Adding a new kind means: (1) append to `ProfileState::NOTIFY_KINDS`, (2) add a row in `profile/ui.rs` `kinds` tuple, (3) enqueue it from the relevant event handler, (4) update the unit test `notify_kinds_constant_matches_ui_expectations` in `profile/state.rs`. No tmux DCS wrapping — tmux is explicitly unsupported.
+- **Profile notifications default to all-off:** Migration 026 merges profile fields into `users.settings` with `notify_kinds = []` and `notify_cooldown_mins = 0`. `render.rs` only fires if the kind string is present in the user's array, so a brand-new account is silent until they opt in on the profile screen. A focus-tracking `"unfocused"` policy used to exist (DEC mode 1004) but was removed — `notify_kinds` is the whole model now.
+- **`Profile` is a view, not a table:** Migration 026 dropped the `profiles` table — username + notify settings + theme now live on `users` (column + `settings` JSONB). `late_core::models::profile::Profile` is a projection loaded via `Profile::load(client, user_id)` and saved via `Profile::update(client, user_id, params)`, which merges into `settings` with `settings || jsonb_build_object(...)` to preserve unrelated keys (theme_id, ignored_user_ids) under concurrent writes.
 
 ---
 
@@ -808,9 +807,10 @@ let vote_rx = vote_service.subscribe_state();   // watch::Receiver<VoteSnapshot>
 let vote_ev = vote_service.subscribe_events();  // broadcast::Receiver<VoteEvent>
 vote_service.cast_vote_task(user_id, Genre::Lofi);
 
-// === Profile ===
-let profile = Profile::find_or_create_by_user(&client, user_id).await?;
-Profile::update_by_user_id(&client, user_id, id, ProfileParams { .. }).await?;
+// === Profile (view over users.username + users.settings) ===
+let profile = Profile::load(&client, user_id).await?;
+Profile::update(&client, user_id, ProfileParams { username, notify_kinds, notify_cooldown_mins }).await?;
+User::set_theme_id(&client, user_id, "purple").await?;
 
 // === Leaderboard ===
 let lb_rx = leaderboard_service.subscribe();        // watch::Receiver<Arc<LeaderboardData>>

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -645,6 +645,14 @@ An always-running game where every connected SSH session is automatically a part
 - Events (coffee breaks, AMAs, mini coding jams)
 - Personalization (accent color, favorite vibe, custom tagline)
 
+### Global-cache for cross-user chat data (future)
+
+`ChatService::start_user_refresh_task` polls `list_chat_rooms` every 10s per SSH session. That method currently mixes per-user reads (rooms, unread counts, selected-room tail, ignore list) with two genuinely global reads: `User::list_all_username_map` (mention autocomplete) and `Tree::list_all` (bonsai glyphs for other users' chat lines). With N online users, both global queries run N times every 10s for identical results.
+
+Pattern to steal: `LeaderboardService` — singleton background task refreshes a shared `watch::Receiver<Arc<_>>` on a fixed interval; per-user code reads the cache instead of hitting DB. Applied here, a new `ChatGlobalsService` (or similar) would publish `{ all_usernames, bonsai_glyphs }` every 10s, `list_chat_rooms` would consume the cache, and the per-user query list would shrink to only the genuinely per-user joins.
+
+Not urgent at today's user count — the per-user refresh remains load-bearing for dropped-broadcast-event recovery (lagged `MessageCreated`/`MessageEdited`), so the task itself stays either way; only the two global queries move out.
+
 ### Multi-replica readiness (future)
 
 Currently the SSH app assumes a single process. These in-memory structures would need to be externalized (Redis / Postgres) for multiple replicas:

--- a/late-core/migrations/026_merge_profile_fields_into_users.sql
+++ b/late-core/migrations/026_merge_profile_fields_into_users.sql
@@ -8,7 +8,6 @@ WITH source_rows AS (
     SELECT
         u.id,
         COALESCE(u.settings, '{}'::jsonb) AS existing_settings,
-        COALESCE(p.enable_ghost, true) AS enable_ghost,
         COALESCE(p.notify_kinds, '{}'::text[]) AS notify_kinds,
         COALESCE(p.notify_cooldown_mins, 0) AS notify_cooldown_mins,
         COALESCE(NULLIF(BTRIM(p.username), ''), NULLIF(BTRIM(u.username), ''), 'user') AS raw_username
@@ -19,7 +18,6 @@ sanitized AS (
     SELECT
         id,
         existing_settings,
-        enable_ghost,
         notify_kinds,
         notify_cooldown_mins,
         CASE
@@ -30,7 +28,6 @@ sanitized AS (
         SELECT
             id,
             existing_settings,
-            enable_ghost,
             notify_kinds,
             notify_cooldown_mins,
             REGEXP_REPLACE(
@@ -51,7 +48,6 @@ candidate_names AS (
     SELECT
         id,
         existing_settings,
-        enable_ghost,
         notify_kinds,
         notify_cooldown_mins,
         LEFT(base_username, 32) AS candidate_username
@@ -61,7 +57,6 @@ resolved_names AS (
     SELECT
         id,
         existing_settings,
-        enable_ghost,
         notify_kinds,
         notify_cooldown_mins,
         CASE
@@ -74,7 +69,6 @@ resolved_names AS (
 UPDATE users u
 SET username = r.final_username,
     settings = r.existing_settings || jsonb_build_object(
-        'enable_ghost', r.enable_ghost,
         'notify_kinds', to_jsonb(r.notify_kinds),
         'notify_cooldown_mins', GREATEST(r.notify_cooldown_mins, 0)
     ),

--- a/late-core/migrations/026_merge_profile_fields_into_users.sql
+++ b/late-core/migrations/026_merge_profile_fields_into_users.sql
@@ -1,0 +1,99 @@
+-- Full cutover from profiles -> users.
+--
+-- Moves profile-backed fields onto users, normalizes usernames into the new
+-- canonical format, enforces uniqueness/format on users.username, and then
+-- drops the obsolete 1:1 profiles table.
+
+WITH source_rows AS (
+    SELECT
+        u.id,
+        COALESCE(u.settings, '{}'::jsonb) AS existing_settings,
+        COALESCE(p.enable_ghost, true) AS enable_ghost,
+        COALESCE(p.notify_kinds, '{}'::text[]) AS notify_kinds,
+        COALESCE(p.notify_cooldown_mins, 0) AS notify_cooldown_mins,
+        COALESCE(NULLIF(BTRIM(p.username), ''), NULLIF(BTRIM(u.username), ''), 'user') AS raw_username
+    FROM users u
+    LEFT JOIN profiles p ON p.user_id = u.id
+),
+sanitized AS (
+    SELECT
+        id,
+        existing_settings,
+        enable_ghost,
+        notify_kinds,
+        notify_cooldown_mins,
+        CASE
+            WHEN cleaned = '' THEN 'user'
+            ELSE cleaned
+        END AS base_username
+    FROM (
+        SELECT
+            id,
+            existing_settings,
+            enable_ghost,
+            notify_kinds,
+            notify_cooldown_mins,
+            REGEXP_REPLACE(
+                REGEXP_REPLACE(
+                    REGEXP_REPLACE(raw_username, '@', '', 'g'),
+                    '[^A-Za-z0-9._-]+',
+                    '_',
+                    'g'
+                ),
+                '^_+|_+$',
+                '',
+                'g'
+            ) AS cleaned
+        FROM source_rows
+    ) normalized
+),
+candidate_names AS (
+    SELECT
+        id,
+        existing_settings,
+        enable_ghost,
+        notify_kinds,
+        notify_cooldown_mins,
+        LEFT(base_username, 32) AS candidate_username
+    FROM sanitized
+),
+resolved_names AS (
+    SELECT
+        id,
+        existing_settings,
+        enable_ghost,
+        notify_kinds,
+        notify_cooldown_mins,
+        CASE
+            WHEN COUNT(*) OVER (PARTITION BY LOWER(candidate_username)) = 1
+                THEN candidate_username
+            ELSE LEFT(candidate_username, 19) || '_' || LEFT(REPLACE(id::text, '-', ''), 12)
+        END AS final_username
+    FROM candidate_names
+)
+UPDATE users u
+SET username = r.final_username,
+    settings = r.existing_settings || jsonb_build_object(
+        'enable_ghost', r.enable_ghost,
+        'notify_kinds', to_jsonb(r.notify_kinds),
+        'notify_cooldown_mins', GREATEST(r.notify_cooldown_mins, 0)
+    ),
+    updated = current_timestamp
+FROM resolved_names r
+WHERE r.id = u.id;
+
+ALTER TABLE users
+    ADD CONSTRAINT users_username_trimmed_chk
+    CHECK (username = BTRIM(username));
+
+ALTER TABLE users
+    ADD CONSTRAINT users_username_length_chk
+    CHECK (length(username) BETWEEN 1 AND 32);
+
+ALTER TABLE users
+    ADD CONSTRAINT users_username_format_chk
+    CHECK (username ~ '^[A-Za-z0-9._-]+$' AND POSITION('@' IN username) = 0);
+
+CREATE UNIQUE INDEX idx_users_username_lower ON users (LOWER(username));
+
+DROP TABLE profiles;

--- a/late-core/src/models/chips.rs
+++ b/late-core/src/models/chips.rs
@@ -105,9 +105,9 @@ impl UserChips {
     pub async fn top_balances(client: &Client, limit: i64) -> Result<Vec<ChipLeader>> {
         let rows = client
             .query(
-                "SELECT p.username, c.user_id, c.balance
+                "SELECT u.username, c.user_id, c.balance
                  FROM user_chips c
-                 JOIN profiles p ON p.user_id = c.user_id
+                 JOIN users u ON u.id = c.user_id
                  WHERE c.balance > 0
                  ORDER BY c.balance DESC
                  LIMIT $1",

--- a/late-core/src/models/leaderboard.rs
+++ b/late-core/src/models/leaderboard.rs
@@ -112,9 +112,9 @@ async fn fetch_high_scores(client: &Client, limit: i64) -> Result<Vec<HighScoreE
     // Tetris top scores
     let rows = client
         .query(
-            "SELECT p.username, h.user_id, h.score
+            "SELECT u.username, h.user_id, h.score
              FROM tetris_high_scores h
-             JOIN profiles p ON p.user_id = h.user_id
+             JOIN users u ON u.id = h.user_id
              ORDER BY h.score DESC
              LIMIT $1",
             &[&limit],
@@ -132,9 +132,9 @@ async fn fetch_high_scores(client: &Client, limit: i64) -> Result<Vec<HighScoreE
     // 2048 top scores
     let rows = client
         .query(
-            "SELECT p.username, h.user_id, h.score
+            "SELECT u.username, h.user_id, h.score
              FROM twenty_forty_eight_high_scores h
-             JOIN profiles p ON p.user_id = h.user_id
+             JOIN users u ON u.id = h.user_id
              ORDER BY h.score DESC
              LIMIT $1",
             &[&limit],
@@ -164,10 +164,10 @@ async fn fetch_today_champions(client: &Client, limit: i64) -> Result<Vec<Leader
                 UNION ALL
                 SELECT user_id FROM minesweeper_daily_wins WHERE puzzle_date = CURRENT_DATE
             )
-            SELECT p.username, a.user_id, COUNT(*)::int AS wins
+            SELECT u.username, a.user_id, COUNT(*)::int AS wins
             FROM all_today a
-            JOIN profiles p ON p.user_id = a.user_id
-            GROUP BY a.user_id, p.username
+            JOIN users u ON u.id = a.user_id
+            GROUP BY a.user_id, u.username
             ORDER BY wins DESC
             LIMIT $1",
             &[&limit],
@@ -211,9 +211,9 @@ async fn fetch_all_streaks(client: &Client) -> Result<Vec<LeaderboardEntry>> {
                 FROM with_grp
                 GROUP BY user_id, grp
             )
-            SELECT p.username, s.user_id, s.streak_len
+            SELECT u.username, s.user_id, s.streak_len
             FROM streaks s
-            JOIN profiles p ON p.user_id = s.user_id
+            JOIN users u ON u.id = s.user_id
             WHERE s.end_date >= (CURRENT_DATE - 1)
             ORDER BY s.streak_len DESC",
             &[],

--- a/late-core/src/models/notification.rs
+++ b/late-core/src/models/notification.rs
@@ -77,11 +77,11 @@ impl Notification {
         let rows = client
             .query(
                 "SELECT n.id, n.created, n.user_id, n.actor_id, n.message_id, n.room_id, n.read_at,
-                        COALESCE(p.username, '') AS actor_username,
+                        COALESCE(u.username, '') AS actor_username,
                         r.slug AS room_slug,
                         LEFT(m.body, 120) AS message_preview
                  FROM notifications n
-                 JOIN profiles p ON p.user_id = n.actor_id
+                 JOIN users u ON u.id = n.actor_id
                  JOIN chat_rooms r ON r.id = n.room_id
                  JOIN chat_messages m ON m.id = n.message_id
                  WHERE n.user_id = $1
@@ -149,16 +149,16 @@ impl Notification {
         let lower: Vec<String> = usernames.iter().map(|u| u.to_ascii_lowercase()).collect();
         let rows = client
             .query(
-                "SELECT p.user_id \
-                 FROM profiles p \
+                "SELECT u.id \
+                 FROM users u \
                  JOIN chat_rooms r ON r.id = $3 \
-                 WHERE LOWER(p.username) = ANY($1) \
-                   AND p.user_id <> $2 \
-                   AND (r.kind <> 'dm' OR p.user_id IN (r.dm_user_a, r.dm_user_b))",
+                 WHERE LOWER(u.username) = ANY($1) \
+                   AND u.id <> $2 \
+                   AND (r.kind <> 'dm' OR u.id IN (r.dm_user_a, r.dm_user_b))",
                 &[&lower, &exclude_user_id, &room_id],
             )
             .await?;
 
-        Ok(rows.iter().map(|r| r.get("user_id")).collect())
+        Ok(rows.iter().map(|r| r.get("id")).collect())
     }
 }

--- a/late-core/src/models/profile.rs
+++ b/late-core/src/models/profile.rs
@@ -1,102 +1,65 @@
-use anyhow::{Result, bail};
-use chrono::{DateTime, Utc};
+use anyhow::Result;
 use tokio_postgres::Client;
 use uuid::Uuid;
 
 use super::user::{
-    User, extract_enable_ghost, extract_notify_cooldown_mins, extract_notify_kinds,
-    set_enable_ghost, set_notify_cooldown_mins, set_notify_kinds,
+    User, extract_notify_cooldown_mins, extract_notify_kinds, extract_theme_id,
 };
 
-pub const USERNAME_MAX_LEN: usize = 32;
-
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Profile {
-    pub id: Uuid,
-    pub created: DateTime<Utc>,
-    pub updated: DateTime<Utc>,
-    pub user_id: Uuid,
     pub username: String,
-    pub enable_ghost: bool,
     pub notify_kinds: Vec<String>,
     pub notify_cooldown_mins: i32,
+    pub theme_id: Option<String>,
 }
 
 #[derive(Clone, Debug)]
 pub struct ProfileParams {
-    pub user_id: Uuid,
     pub username: String,
-    pub enable_ghost: bool,
     pub notify_kinds: Vec<String>,
     pub notify_cooldown_mins: i32,
 }
 
-impl Default for Profile {
-    fn default() -> Self {
-        Self {
-            id: Uuid::nil(),
-            created: Utc::now(),
-            updated: Utc::now(),
-            user_id: Uuid::nil(),
-            username: String::new(),
-            enable_ghost: true,
-            notify_kinds: Vec::new(),
-            notify_cooldown_mins: 0,
-        }
-    }
-}
-
 impl Profile {
-    pub async fn find_or_create_by_user(client: &Client, user_id: Uuid) -> Result<Self> {
-        let user = User::get(client, user_id).await?.ok_or_else(|| anyhow::anyhow!("User not found"))?;
-        Ok(Self::from_user(user))
+    pub async fn load(client: &Client, user_id: Uuid) -> Result<Self> {
+        let user = User::get(client, user_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("user not found"))?;
+        Ok(Self::from_user(&user))
     }
 
-    pub async fn update_by_user_id(
-        client: &Client,
-        user_id: Uuid,
-        id: Uuid,
-        params: ProfileParams,
-    ) -> Result<Self> {
-        if params.user_id != user_id || id != user_id {
-            bail!("Profile not found");
-        }
-
-        let existing = User::get(client, user_id)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("User not found"))?;
-        let mut settings = existing.settings.clone();
-        set_enable_ghost(&mut settings, params.enable_ghost);
-        set_notify_kinds(&mut settings, &params.notify_kinds);
-        set_notify_cooldown_mins(&mut settings, params.notify_cooldown_mins);
+    /// Atomic partial update — merges notify_kinds/notify_cooldown_mins into
+    /// settings via `settings || jsonb_build_object(...)`, so concurrent writes
+    /// to unrelated keys (theme_id, ignored_user_ids) are preserved.
+    pub async fn update(client: &Client, user_id: Uuid, params: ProfileParams) -> Result<Self> {
+        let kinds_json = serde_json::to_value(&params.notify_kinds)?;
+        let cooldown = params.notify_cooldown_mins.max(0);
 
         let row = client
             .query_opt(
                 "UPDATE users
                  SET username = $1,
-                     settings = $2,
+                     settings = settings || jsonb_build_object(
+                         'notify_kinds', $2::jsonb,
+                         'notify_cooldown_mins', $3::int
+                     ),
                      updated = current_timestamp
-                 WHERE id = $3 AND id = $4
+                 WHERE id = $4
                  RETURNING *",
-                &[&params.username, &settings, &user_id, &id],
+                &[&params.username, &kinds_json, &cooldown, &user_id],
             )
             .await?;
-        let Some(row) = row else {
-            bail!("Profile not found");
-        };
-        Ok(Self::from_user(User::from(row)))
+        let row = row.ok_or_else(|| anyhow::anyhow!("user not found"))?;
+        Ok(Self::from_user(&User::from(row)))
     }
 
-    fn from_user(user: User) -> Self {
+    fn from_user(user: &User) -> Self {
         Self {
-            id: user.id,
-            created: user.created,
-            updated: user.updated,
-            user_id: user.id,
             username: user.username.clone(),
-            enable_ghost: extract_enable_ghost(&user.settings),
             notify_kinds: extract_notify_kinds(&user.settings),
             notify_cooldown_mins: extract_notify_cooldown_mins(&user.settings),
+            theme_id: extract_theme_id(&user.settings),
         }
     }
 }
@@ -111,76 +74,4 @@ pub async fn fetch_username(client: &Client, user_id: Uuid) -> String {
         .map(|row| row.get::<_, String>("username"))
         .filter(|username| !username.trim().is_empty())
         .unwrap_or_else(|| "someone".to_string())
-}
-
-pub fn sanitize_username_input(username: &str) -> String {
-    let trimmed = username.trim();
-    if trimmed.is_empty() {
-        return "user".to_string();
-    }
-
-    let mut normalized = String::with_capacity(trimmed.len());
-    let mut previous_was_separator = false;
-
-    for ch in trimmed.chars() {
-        if ch == '@' {
-            continue;
-        }
-        if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.') {
-            normalized.push(ch);
-            previous_was_separator = false;
-        } else if !previous_was_separator {
-            normalized.push('_');
-            previous_was_separator = true;
-        }
-    }
-
-    let normalized = normalized.trim_matches('_');
-    if normalized.is_empty() {
-        return "user".to_string();
-    }
-
-    let truncated = truncate_to_boundary(normalized, USERNAME_MAX_LEN);
-    let truncated = truncated.trim_matches('_');
-    if truncated.is_empty() {
-        "user".to_string()
-    } else {
-        truncated.to_string()
-    }
-}
-
-fn truncate_to_boundary(value: &str, max_len: usize) -> String {
-    value.chars().take(max_len).collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn sanitize_username_input_trims_and_falls_back() {
-        assert_eq!(sanitize_username_input("  night-owl  "), "night-owl");
-        assert_eq!(sanitize_username_input("   "), "user");
-    }
-
-    #[test]
-    fn sanitize_username_input_replaces_spaces_and_invalid_chars() {
-        assert_eq!(sanitize_username_input("  night owl  "), "night_owl");
-        assert_eq!(sanitize_username_input("alice!!!bob"), "alice_bob");
-        assert_eq!(sanitize_username_input("@alice"), "alice");
-        assert_eq!(sanitize_username_input("a@b"), "ab");
-        assert_eq!(sanitize_username_input("...alice..."), "...alice...");
-    }
-
-    #[test]
-    fn sanitize_username_input_collapses_repeated_separators() {
-        assert_eq!(sanitize_username_input("a   b\t\tc"), "a_b_c");
-        assert_eq!(sanitize_username_input("a@@@b###c"), "ab_c");
-    }
-
-    #[test]
-    fn truncate_to_boundary_respects_char_boundaries() {
-        assert_eq!(truncate_to_boundary("abcdef", 4), "abcd");
-        assert_eq!(truncate_to_boundary("żółw", 3), "żół");
-    }
 }

--- a/late-core/src/models/profile.rs
+++ b/late-core/src/models/profile.rs
@@ -2,9 +2,7 @@ use anyhow::Result;
 use tokio_postgres::Client;
 use uuid::Uuid;
 
-use super::user::{
-    User, extract_notify_cooldown_mins, extract_notify_kinds, extract_theme_id,
-};
+use super::user::{User, extract_notify_cooldown_mins, extract_notify_kinds, extract_theme_id};
 
 #[derive(Clone, Debug, Default)]
 pub struct Profile {

--- a/late-core/src/models/profile.rs
+++ b/late-core/src/models/profile.rs
@@ -1,27 +1,42 @@
-use anyhow::Result;
+use anyhow::{Result, bail};
+use chrono::{DateTime, Utc};
 use tokio_postgres::Client;
 use uuid::Uuid;
 
-crate::user_scoped_model! {
-    table = "profiles";
-    user_field = user_id;
-    params = ProfileParams;
-    struct Profile {
-        @data
-        pub user_id: Uuid,
-        pub username: String,
-        pub enable_ghost: bool,
-        pub notify_kinds: Vec<String>,
-        pub notify_cooldown_mins: i32,
-    }
+use super::user::{
+    User, extract_enable_ghost, extract_notify_cooldown_mins, extract_notify_kinds,
+    set_enable_ghost, set_notify_cooldown_mins, set_notify_kinds,
+};
+
+pub const USERNAME_MAX_LEN: usize = 32;
+
+#[derive(Clone, Debug)]
+pub struct Profile {
+    pub id: Uuid,
+    pub created: DateTime<Utc>,
+    pub updated: DateTime<Utc>,
+    pub user_id: Uuid,
+    pub username: String,
+    pub enable_ghost: bool,
+    pub notify_kinds: Vec<String>,
+    pub notify_cooldown_mins: i32,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProfileParams {
+    pub user_id: Uuid,
+    pub username: String,
+    pub enable_ghost: bool,
+    pub notify_kinds: Vec<String>,
+    pub notify_cooldown_mins: i32,
 }
 
 impl Default for Profile {
     fn default() -> Self {
         Self {
             id: Uuid::nil(),
-            created: chrono::Utc::now(),
-            updated: chrono::Utc::now(),
+            created: Utc::now(),
+            updated: Utc::now(),
             user_id: Uuid::nil(),
             username: String::new(),
             enable_ghost: true,
@@ -32,81 +47,106 @@ impl Default for Profile {
 }
 
 impl Profile {
-    /// Find existing profile for user, or create with defaults.
     pub async fn find_or_create_by_user(client: &Client, user_id: Uuid) -> Result<Self> {
-        if let Some(row) = client
-            .query_opt("SELECT * FROM profiles WHERE user_id = $1", &[&user_id])
-            .await?
-        {
-            return Ok(Self::from(row));
+        let user = User::get(client, user_id).await?.ok_or_else(|| anyhow::anyhow!("User not found"))?;
+        Ok(Self::from_user(user))
+    }
+
+    pub async fn update_by_user_id(
+        client: &Client,
+        user_id: Uuid,
+        id: Uuid,
+        params: ProfileParams,
+    ) -> Result<Self> {
+        if params.user_id != user_id || id != user_id {
+            bail!("Profile not found");
         }
 
-        let username = next_available_username(client, user_id).await?;
+        let existing = User::get(client, user_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("User not found"))?;
+        let mut settings = existing.settings.clone();
+        set_enable_ghost(&mut settings, params.enable_ghost);
+        set_notify_kinds(&mut settings, &params.notify_kinds);
+        set_notify_cooldown_mins(&mut settings, params.notify_cooldown_mins);
+
         let row = client
-            .query_one(
-                "INSERT INTO profiles (user_id, username) VALUES ($1, $2)
-                 ON CONFLICT (user_id) DO UPDATE SET updated = profiles.updated
+            .query_opt(
+                "UPDATE users
+                 SET username = $1,
+                     settings = $2,
+                     updated = current_timestamp
+                 WHERE id = $3 AND id = $4
                  RETURNING *",
-                &[&user_id, &username],
+                &[&params.username, &settings, &user_id, &id],
             )
             .await?;
-        Ok(Self::from(row))
+        let Some(row) = row else {
+            bail!("Profile not found");
+        };
+        Ok(Self::from_user(User::from(row)))
+    }
+
+    fn from_user(user: User) -> Self {
+        Self {
+            id: user.id,
+            created: user.created,
+            updated: user.updated,
+            user_id: user.id,
+            username: user.username.clone(),
+            enable_ghost: extract_enable_ghost(&user.settings),
+            notify_kinds: extract_notify_kinds(&user.settings),
+            notify_cooldown_mins: extract_notify_cooldown_mins(&user.settings),
+        }
     }
 }
 
 /// Look up a user's display name by user_id. Returns "someone" on failure.
 pub async fn fetch_username(client: &Client, user_id: Uuid) -> String {
     client
-        .query_opt(
-            "SELECT username FROM profiles WHERE user_id = $1",
-            &[&user_id],
-        )
+        .query_opt("SELECT username FROM users WHERE id = $1", &[&user_id])
         .await
         .ok()
         .flatten()
         .map(|row| row.get::<_, String>("username"))
+        .filter(|username| !username.trim().is_empty())
         .unwrap_or_else(|| "someone".to_string())
 }
 
-async fn next_available_username(client: &Client, user_id: Uuid) -> Result<String> {
-    let base_username = client
-        .query_one("SELECT username FROM users WHERE id = $1", &[&user_id])
-        .await?
-        .get::<_, String>("username");
-    let base_username = normalize_username_seed(&base_username);
-
-    let mut candidate = base_username.clone();
-    let mut suffix = 2usize;
-
-    loop {
-        let row = client
-            .query_opt(
-                "SELECT 1 FROM profiles WHERE LOWER(username) = LOWER($1)",
-                &[&candidate],
-            )
-            .await?;
-        if row.is_none() {
-            return Ok(candidate);
-        }
-
-        let suffix_text = format!("-{suffix}");
-        let max_base_len = 32usize.saturating_sub(suffix_text.len());
-        candidate = format!(
-            "{}{}",
-            truncate_to_boundary(&base_username, max_base_len),
-            suffix_text
-        );
-        suffix += 1;
-    }
-}
-
-fn normalize_username_seed(username: &str) -> String {
+pub fn sanitize_username_input(username: &str) -> String {
     let trimmed = username.trim();
     if trimmed.is_empty() {
         return "user".to_string();
     }
 
-    truncate_to_boundary(trimmed, 32)
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut previous_was_separator = false;
+
+    for ch in trimmed.chars() {
+        if ch == '@' {
+            continue;
+        }
+        if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.') {
+            normalized.push(ch);
+            previous_was_separator = false;
+        } else if !previous_was_separator {
+            normalized.push('_');
+            previous_was_separator = true;
+        }
+    }
+
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        return "user".to_string();
+    }
+
+    let truncated = truncate_to_boundary(normalized, USERNAME_MAX_LEN);
+    let truncated = truncated.trim_matches('_');
+    if truncated.is_empty() {
+        "user".to_string()
+    } else {
+        truncated.to_string()
+    }
 }
 
 fn truncate_to_boundary(value: &str, max_len: usize) -> String {
@@ -118,9 +158,24 @@ mod tests {
     use super::*;
 
     #[test]
-    fn normalize_username_seed_trims_and_falls_back() {
-        assert_eq!(normalize_username_seed("  night-owl  "), "night-owl");
-        assert_eq!(normalize_username_seed("   "), "user");
+    fn sanitize_username_input_trims_and_falls_back() {
+        assert_eq!(sanitize_username_input("  night-owl  "), "night-owl");
+        assert_eq!(sanitize_username_input("   "), "user");
+    }
+
+    #[test]
+    fn sanitize_username_input_replaces_spaces_and_invalid_chars() {
+        assert_eq!(sanitize_username_input("  night owl  "), "night_owl");
+        assert_eq!(sanitize_username_input("alice!!!bob"), "alice_bob");
+        assert_eq!(sanitize_username_input("@alice"), "alice");
+        assert_eq!(sanitize_username_input("a@b"), "ab");
+        assert_eq!(sanitize_username_input("...alice..."), "...alice...");
+    }
+
+    #[test]
+    fn sanitize_username_input_collapses_repeated_separators() {
+        assert_eq!(sanitize_username_input("a   b\t\tc"), "a_b_c");
+        assert_eq!(sanitize_username_input("a@@@b###c"), "ab_c");
     }
 
     #[test]

--- a/late-core/src/models/user.rs
+++ b/late-core/src/models/user.rs
@@ -5,8 +5,6 @@ use std::collections::{BTreeSet, HashMap};
 use tokio_postgres::Client;
 use uuid::Uuid;
 
-use super::profile::{USERNAME_MAX_LEN, sanitize_username_input};
-
 crate::model! {
     table = "users";
     params = UserParams;
@@ -22,9 +20,10 @@ crate::model! {
     }
 }
 
+pub const USERNAME_MAX_LEN: usize = 32;
+
 const IGNORED_USER_IDS_KEY: &str = "ignored_user_ids";
 const THEME_ID_KEY: &str = "theme_id";
-const ENABLE_GHOST_KEY: &str = "enable_ghost";
 const NOTIFY_KINDS_KEY: &str = "notify_kinds";
 const NOTIFY_COOLDOWN_MINS_KEY: &str = "notify_cooldown_mins";
 
@@ -186,10 +185,21 @@ impl User {
         Ok((true, ids))
     }
 
+    /// Atomically merge `theme_id` into `settings` without clobbering other keys.
     pub async fn set_theme_id(client: &Client, user_id: Uuid, theme_id: &str) -> Result<()> {
-        let mut settings = Self::settings_for_user(client, user_id).await?;
-        set_theme_id(&mut settings, theme_id);
-        Self::update_settings(client, user_id, &settings).await
+        let updated = client
+            .execute(
+                "UPDATE users
+                 SET settings = settings || jsonb_build_object($1::text, $2::text),
+                     updated = current_timestamp
+                 WHERE id = $3",
+                &[&THEME_ID_KEY, &theme_id, &user_id],
+            )
+            .await?;
+        if updated == 0 {
+            bail!("user not found");
+        }
+        Ok(())
     }
 
     async fn settings_for_user(client: &Client, user_id: Uuid) -> Result<Value> {
@@ -197,7 +207,7 @@ impl User {
             .query_opt("SELECT settings FROM users WHERE id = $1", &[&user_id])
             .await?;
         let Some(row) = row else {
-            bail!("User not found");
+            bail!("user not found");
         };
         Ok(row.get("settings"))
     }
@@ -212,7 +222,7 @@ impl User {
             )
             .await?;
         if updated == 0 {
-            bail!("User not found");
+            bail!("user not found");
         }
         Ok(())
     }
@@ -239,34 +249,13 @@ fn set_ignored_user_ids(settings: &mut Value, ids: &[Uuid]) {
     settings[IGNORED_USER_IDS_KEY] = json!(ids.iter().map(Uuid::to_string).collect::<Vec<_>>());
 }
 
-fn extract_theme_id(settings: &Value) -> Option<String> {
+pub fn extract_theme_id(settings: &Value) -> Option<String> {
     settings
         .get(THEME_ID_KEY)
         .and_then(Value::as_str)
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(ToString::to_string)
-}
-
-fn set_theme_id(settings: &mut Value, theme_id: &str) {
-    if !settings.is_object() {
-        *settings = json!({});
-    }
-    settings[THEME_ID_KEY] = json!(theme_id);
-}
-
-pub fn extract_enable_ghost(settings: &Value) -> bool {
-    settings
-        .get(ENABLE_GHOST_KEY)
-        .and_then(Value::as_bool)
-        .unwrap_or(true)
-}
-
-pub fn set_enable_ghost(settings: &mut Value, enable_ghost: bool) {
-    if !settings.is_object() {
-        *settings = json!({});
-    }
-    settings[ENABLE_GHOST_KEY] = json!(enable_ghost);
 }
 
 pub fn extract_notify_kinds(settings: &Value) -> Vec<String> {
@@ -285,13 +274,6 @@ pub fn extract_notify_kinds(settings: &Value) -> Vec<String> {
         .unwrap_or_default()
 }
 
-pub fn set_notify_kinds(settings: &mut Value, notify_kinds: &[String]) {
-    if !settings.is_object() {
-        *settings = json!({});
-    }
-    settings[NOTIFY_KINDS_KEY] = json!(notify_kinds);
-}
-
 pub fn extract_notify_cooldown_mins(settings: &Value) -> i32 {
     settings
         .get(NOTIFY_COOLDOWN_MINS_KEY)
@@ -300,11 +282,40 @@ pub fn extract_notify_cooldown_mins(settings: &Value) -> i32 {
         .max(0) as i32
 }
 
-pub fn set_notify_cooldown_mins(settings: &mut Value, notify_cooldown_mins: i32) {
-    if !settings.is_object() {
-        *settings = json!({});
+pub fn sanitize_username_input(username: &str) -> String {
+    let trimmed = username.trim();
+    if trimmed.is_empty() {
+        return "user".to_string();
     }
-    settings[NOTIFY_COOLDOWN_MINS_KEY] = json!(notify_cooldown_mins.max(0));
+
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut previous_was_separator = false;
+
+    for ch in trimmed.chars() {
+        if ch == '@' {
+            continue;
+        }
+        if ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.') {
+            normalized.push(ch);
+            previous_was_separator = false;
+        } else if !previous_was_separator {
+            normalized.push('_');
+            previous_was_separator = true;
+        }
+    }
+
+    let normalized = normalized.trim_matches('_');
+    if normalized.is_empty() {
+        return "user".to_string();
+    }
+
+    let truncated = truncate_to_boundary(normalized, USERNAME_MAX_LEN);
+    let truncated = truncated.trim_matches('_');
+    if truncated.is_empty() {
+        "user".to_string()
+    } else {
+        truncated.to_string()
+    }
 }
 
 fn truncate_to_boundary(value: &str, max_len: usize) -> String {
@@ -322,9 +333,35 @@ mod tests {
     }
 
     #[test]
-    fn set_theme_id_creates_settings_object() {
-        let mut settings = Value::Null;
-        set_theme_id(&mut settings, "contrast");
-        assert_eq!(extract_theme_id(&settings).as_deref(), Some("contrast"));
+    fn extract_theme_id_missing_returns_none() {
+        let settings = json!({});
+        assert_eq!(extract_theme_id(&settings), None);
+    }
+
+    #[test]
+    fn sanitize_username_input_trims_and_falls_back() {
+        assert_eq!(sanitize_username_input("  night-owl  "), "night-owl");
+        assert_eq!(sanitize_username_input("   "), "user");
+    }
+
+    #[test]
+    fn sanitize_username_input_replaces_spaces_and_invalid_chars() {
+        assert_eq!(sanitize_username_input("  night owl  "), "night_owl");
+        assert_eq!(sanitize_username_input("alice!!!bob"), "alice_bob");
+        assert_eq!(sanitize_username_input("@alice"), "alice");
+        assert_eq!(sanitize_username_input("a@b"), "ab");
+        assert_eq!(sanitize_username_input("...alice..."), "...alice...");
+    }
+
+    #[test]
+    fn sanitize_username_input_collapses_repeated_separators() {
+        assert_eq!(sanitize_username_input("a   b\t\tc"), "a_b_c");
+        assert_eq!(sanitize_username_input("a@@@b###c"), "ab_c");
+    }
+
+    #[test]
+    fn truncate_to_boundary_respects_char_boundaries() {
+        assert_eq!(truncate_to_boundary("abcdef", 4), "abcd");
+        assert_eq!(truncate_to_boundary("żółw", 3), "żół");
     }
 }

--- a/late-core/src/models/user.rs
+++ b/late-core/src/models/user.rs
@@ -30,7 +30,10 @@ const NOTIFY_COOLDOWN_MINS_KEY: &str = "notify_cooldown_mins";
 impl User {
     pub async fn find_by_fingerprint(client: &Client, fingerprint: &str) -> Result<Option<Self>> {
         let row = client
-            .query_opt("SELECT * FROM users WHERE fingerprint = $1", &[&fingerprint])
+            .query_opt(
+                "SELECT * FROM users WHERE fingerprint = $1",
+                &[&fingerprint],
+            )
             .await?;
         Ok(row.map(Self::from))
     }

--- a/late-core/src/models/user.rs
+++ b/late-core/src/models/user.rs
@@ -5,6 +5,8 @@ use std::collections::{BTreeSet, HashMap};
 use tokio_postgres::Client;
 use uuid::Uuid;
 
+use super::profile::{USERNAME_MAX_LEN, sanitize_username_input};
+
 crate::model! {
     table = "users";
     params = UserParams;
@@ -22,17 +24,14 @@ crate::model! {
 
 const IGNORED_USER_IDS_KEY: &str = "ignored_user_ids";
 const THEME_ID_KEY: &str = "theme_id";
+const ENABLE_GHOST_KEY: &str = "enable_ghost";
+const NOTIFY_KINDS_KEY: &str = "notify_kinds";
+const NOTIFY_COOLDOWN_MINS_KEY: &str = "notify_cooldown_mins";
 
 impl User {
     pub async fn find_by_fingerprint(client: &Client, fingerprint: &str) -> Result<Option<Self>> {
         let row = client
-            .query_opt(
-                "SELECT u.id, u.created, u.updated, u.last_seen, u.is_admin, u.fingerprint, COALESCE(p.username, '') AS username, u.settings
-                 FROM users u
-                 LEFT JOIN profiles p ON u.id = p.user_id
-                 WHERE u.fingerprint = $1",
-                &[&fingerprint],
-            )
+            .query_opt("SELECT * FROM users WHERE fingerprint = $1", &[&fingerprint])
             .await?;
         Ok(row.map(Self::from))
     }
@@ -57,9 +56,9 @@ impl User {
 
         let rows = client
             .query(
-                "SELECT p.user_id AS id, p.username
-                 FROM profiles p
-                 WHERE p.user_id = ANY($1)",
+                "SELECT id, username
+                 FROM users
+                 WHERE id = ANY($1) AND username <> ''",
                 &[&user_ids],
             )
             .await?;
@@ -74,9 +73,9 @@ impl User {
     pub async fn list_all_usernames(client: &Client) -> Result<Vec<String>> {
         let rows = client
             .query(
-                "SELECT p.username FROM profiles p
-                 WHERE p.username IS NOT NULL AND p.username != ''
-                 ORDER BY p.username",
+                "SELECT username FROM users
+                 WHERE username <> ''
+                 ORDER BY username",
                 &[],
             )
             .await?;
@@ -86,9 +85,9 @@ impl User {
     pub async fn list_all_username_map(client: &Client) -> Result<HashMap<Uuid, String>> {
         let rows = client
             .query(
-                "SELECT p.user_id AS id, p.username
-                 FROM profiles p
-                 WHERE p.username IS NOT NULL AND p.username != ''",
+                "SELECT id, username
+                 FROM users
+                 WHERE username <> ''",
                 &[],
             )
             .await?;
@@ -102,15 +101,38 @@ impl User {
     pub async fn find_by_username(client: &Client, username: &str) -> Result<Option<Self>> {
         let row = client
             .query_opt(
-                "SELECT u.id, u.created, u.updated, u.last_seen, u.is_admin, u.fingerprint,
-                        p.username AS username, u.settings
-                 FROM users u
-                 JOIN profiles p ON u.id = p.user_id
-                 WHERE LOWER(p.username) = LOWER($1)",
+                "SELECT * FROM users WHERE LOWER(username) = LOWER($1)",
                 &[&username],
             )
             .await?;
         Ok(row.map(Self::from))
+    }
+
+    pub async fn next_available_username(client: &Client, desired: &str) -> Result<String> {
+        let base_username = sanitize_username_input(desired);
+        let mut candidate = base_username.clone();
+        let mut suffix = 2usize;
+
+        loop {
+            let row = client
+                .query_opt(
+                    "SELECT 1 FROM users WHERE LOWER(username) = LOWER($1)",
+                    &[&candidate],
+                )
+                .await?;
+            if row.is_none() {
+                return Ok(candidate);
+            }
+
+            let suffix_text = format!("-{suffix}");
+            let max_base_len = USERNAME_MAX_LEN.saturating_sub(suffix_text.len());
+            candidate = format!(
+                "{}{}",
+                truncate_to_boundary(&base_username, max_base_len),
+                suffix_text
+            );
+            suffix += 1;
+        }
     }
 
     pub async fn ignored_user_ids(client: &Client, user_id: Uuid) -> Result<Vec<Uuid>> {
@@ -231,6 +253,62 @@ fn set_theme_id(settings: &mut Value, theme_id: &str) {
         *settings = json!({});
     }
     settings[THEME_ID_KEY] = json!(theme_id);
+}
+
+pub fn extract_enable_ghost(settings: &Value) -> bool {
+    settings
+        .get(ENABLE_GHOST_KEY)
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
+}
+
+pub fn set_enable_ghost(settings: &mut Value, enable_ghost: bool) {
+    if !settings.is_object() {
+        *settings = json!({});
+    }
+    settings[ENABLE_GHOST_KEY] = json!(enable_ghost);
+}
+
+pub fn extract_notify_kinds(settings: &Value) -> Vec<String> {
+    settings
+        .get(NOTIFY_KINDS_KEY)
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(Value::as_str)
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToString::to_string)
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub fn set_notify_kinds(settings: &mut Value, notify_kinds: &[String]) {
+    if !settings.is_object() {
+        *settings = json!({});
+    }
+    settings[NOTIFY_KINDS_KEY] = json!(notify_kinds);
+}
+
+pub fn extract_notify_cooldown_mins(settings: &Value) -> i32 {
+    settings
+        .get(NOTIFY_COOLDOWN_MINS_KEY)
+        .and_then(Value::as_i64)
+        .unwrap_or(0)
+        .max(0) as i32
+}
+
+pub fn set_notify_cooldown_mins(settings: &mut Value, notify_cooldown_mins: i32) {
+    if !settings.is_object() {
+        *settings = json!({});
+    }
+    settings[NOTIFY_COOLDOWN_MINS_KEY] = json!(notify_cooldown_mins.max(0));
+}
+
+fn truncate_to_boundary(value: &str, max_len: usize) -> String {
+    value.chars().take(max_len).collect()
 }
 
 #[cfg(test)]

--- a/late-core/src/test_utils.rs
+++ b/late-core/src/test_utils.rs
@@ -119,7 +119,7 @@ pub async fn create_test_user(db: &Db, username: &str) -> User {
     let username = User::next_available_username(&client, username)
         .await
         .expect("next available username");
-    let user = User::create(
+    User::create(
         &client,
         UserParams {
             fingerprint: format!("fp-{}", uuid::Uuid::now_v7()),
@@ -128,8 +128,7 @@ pub async fn create_test_user(db: &Db, username: &str) -> User {
         },
     )
     .await
-    .expect("create user");
-    user
+    .expect("create user")
 }
 
 async fn wait_for_db(config: &DbConfig) {

--- a/late-core/src/test_utils.rs
+++ b/late-core/src/test_utils.rs
@@ -1,5 +1,4 @@
 use crate::db::{Db, DbConfig};
-use crate::models::profile::Profile;
 use crate::models::user::{User, UserParams};
 use testcontainers::{
     ContainerAsync, GenericImage, ImageExt,
@@ -114,22 +113,22 @@ async fn test_db_container() -> TestDb {
     }
 }
 
-/// Create a user + profile for integration tests. Returns the `User`.
+/// Create a user for integration tests. Returns the `User`.
 pub async fn create_test_user(db: &Db, username: &str) -> User {
     let client = db.get().await.expect("db client");
+    let username = User::next_available_username(&client, username)
+        .await
+        .expect("next available username");
     let user = User::create(
         &client,
         UserParams {
             fingerprint: format!("fp-{}", uuid::Uuid::now_v7()),
-            username: username.to_string(),
+            username,
             settings: serde_json::json!({}),
         },
     )
     .await
     .expect("create user");
-    Profile::find_or_create_by_user(&client, user.id)
-        .await
-        .expect("create profile");
     user
 }
 

--- a/late-core/tests/user.rs
+++ b/late-core/tests/user.rs
@@ -295,5 +295,5 @@ async fn ignored_user_ids_require_existing_user() {
     let err = User::ignored_user_ids(&client, missing_user_id)
         .await
         .expect_err("expected missing user error");
-    assert!(err.to_string().contains("User not found"));
+    assert!(err.to_string().to_ascii_lowercase().contains("not found"));
 }

--- a/late-ssh/src/api.rs
+++ b/late-ssh/src/api.rs
@@ -5,7 +5,7 @@ use axum::{
         ConnectInfo, Query, State as AxumState, WebSocketUpgrade,
         ws::{Message, WebSocket},
     },
-    http::HeaderValue,
+    http::{HeaderMap, HeaderValue},
     http::StatusCode,
     middleware::{self},
     response::IntoResponse,
@@ -15,7 +15,7 @@ use late_core::MutexRecover;
 use late_core::api_types::{NowPlayingResponse, StatusResponse, Track};
 use late_core::telemetry::http_telemetry_middleware;
 use serde::Deserialize;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use tokio::net::TcpListener;
 use tower_http::cors::Any;
 use tower_http::cors::CorsLayer;
@@ -176,17 +176,21 @@ async fn ws_handler(
     ws: WebSocketUpgrade,
     Query(params): Query<PairParams>,
     AxumState(state): AxumState<State>,
+    headers: HeaderMap,
     ConnectInfo(peer_addr): ConnectInfo<SocketAddr>,
 ) -> impl IntoResponse {
+    let client_ip = effective_client_ip(&headers, peer_addr, &state);
     let token_hint = token_hint(&params.token);
     tracing::info!(
-        ip = %peer_addr.ip(),
+        ip = %client_ip,
+        peer_ip = %peer_addr.ip(),
         token_hint = %token_hint,
         "ws pair request received"
     );
-    if !state.ws_pair_limiter.allow(peer_addr.ip()) {
+    if !state.ws_pair_limiter.allow(client_ip) {
         tracing::warn!(
-            ip = %peer_addr.ip(),
+            ip = %client_ip,
+            peer_ip = %peer_addr.ip(),
             max_attempts = state.ws_pair_limiter.max_attempts(),
             window_secs = state.ws_pair_limiter.window_secs(),
             "ws pair rate limit exceeded for peer ip"
@@ -310,15 +314,45 @@ fn token_hint(token: &str) -> String {
     format!("{prefix}..({})", token.len())
 }
 
+fn effective_client_ip(headers: &HeaderMap, peer_addr: SocketAddr, state: &State) -> IpAddr {
+    if is_trusted_proxy_peer(peer_addr.ip(), state) {
+        if let Some(ip) = forwarded_for_ip(headers) {
+            return ip;
+        }
+    }
+
+    peer_addr.ip()
+}
+
+fn is_trusted_proxy_peer(ip: IpAddr, state: &State) -> bool {
+    state
+        .config
+        .ssh_proxy_trusted_cidrs
+        .iter()
+        .any(|cidr| cidr.contains(&ip))
+}
+
+fn forwarded_for_ip(headers: &HeaderMap) -> Option<IpAddr> {
+    let value = headers.get("x-forwarded-for")?.to_str().ok()?;
+    let first = value.split(',').next()?.trim();
+    first.parse().ok()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::state::ActiveUser;
+    use crate::{
+        config::{AiConfig, Config},
+        state::ActiveUser,
+    };
+    use ipnet::IpNet;
     use std::{
         collections::HashMap,
+        path::PathBuf,
         sync::{Arc, Mutex},
         time::Instant,
     };
+    use late_core::db::DbConfig;
     use uuid::Uuid;
 
     #[test]
@@ -438,5 +472,138 @@ mod tests {
         drop(users);
 
         assert_eq!(active_user_count(&active_users), 2);
+    }
+
+    #[test]
+    fn forwarded_for_ip_uses_first_entry() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("203.0.113.10, 10.42.0.89"),
+        );
+
+        assert_eq!(forwarded_for_ip(&headers), Some("203.0.113.10".parse().unwrap()));
+    }
+
+    #[test]
+    fn effective_client_ip_uses_forwarded_header_for_trusted_proxy() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("203.0.113.10, 10.42.0.89"),
+        );
+        let state = test_state_with_trusted_cidrs(vec!["10.42.0.0/16"]);
+        let peer_addr: SocketAddr = "10.42.0.89:12345".parse().unwrap();
+
+        assert_eq!(
+            effective_client_ip(&headers, peer_addr, &state),
+            "203.0.113.10".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn effective_client_ip_falls_back_for_untrusted_proxy() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("203.0.113.10, 10.42.0.89"),
+        );
+        let state = test_state_with_trusted_cidrs(vec!["192.168.0.0/16"]);
+        let peer_addr: SocketAddr = "10.42.0.89:12345".parse().unwrap();
+
+        assert_eq!(
+            effective_client_ip(&headers, peer_addr, &state),
+            "10.42.0.89".parse().unwrap()
+        );
+    }
+
+    #[test]
+    fn effective_client_ip_falls_back_when_header_missing() {
+        let headers = HeaderMap::new();
+        let state = test_state_with_trusted_cidrs(vec!["10.42.0.0/16"]);
+        let peer_addr: SocketAddr = "10.42.0.89:12345".parse().unwrap();
+
+        assert_eq!(
+            effective_client_ip(&headers, peer_addr, &state),
+            "10.42.0.89".parse().unwrap()
+        );
+    }
+
+    fn test_state_with_trusted_cidrs(cidr_strings: Vec<&str>) -> State {
+        let ssh_proxy_trusted_cidrs = cidr_strings
+            .into_iter()
+            .map(|s| s.parse::<IpNet>().unwrap())
+            .collect();
+
+        State {
+            config: Config {
+                ssh_port: 2222,
+                api_port: 4000,
+                icecast_url: "http://icecast".to_string(),
+                web_url: "https://late.sh".to_string(),
+                open_access: true,
+                force_admin: false,
+                db: DbConfig {
+                    host: "localhost".to_string(),
+                    port: 5432,
+                    user: "user".to_string(),
+                    password: "password".to_string(),
+                    dbname: "late".to_string(),
+                    max_pool_size: 16,
+                },
+                max_conns_global: 100,
+                max_conns_per_ip: 3,
+                ssh_idle_timeout: 3600,
+                server_key_path: PathBuf::from("/tmp/server_key"),
+                allowed_origins: vec!["https://late.sh".to_string()],
+                liquidsoap_addr: "liquidsoap:1234".to_string(),
+                frame_drop_log_every: 100,
+                vote_switch_interval_secs: 3600,
+                ssh_max_attempts_per_ip: 30,
+                ssh_rate_limit_window_secs: 60,
+                ssh_proxy_protocol: true,
+                ssh_proxy_trusted_cidrs,
+                ws_pair_max_attempts_per_ip: 30,
+                ws_pair_rate_limit_window_secs: 60,
+                ai: AiConfig {
+                    enabled: false,
+                    api_key: None,
+                    model: "test-model".to_string(),
+                },
+            },
+            db: panic_unreachable("db"),
+            ai_service: panic_unreachable("ai_service"),
+            vote_service: panic_unreachable("vote_service"),
+            chat_service: panic_unreachable("chat_service"),
+            notification_service: panic_unreachable("notification_service"),
+            article_service: panic_unreachable("article_service"),
+            profile_service: panic_unreachable("profile_service"),
+            twenty_forty_eight_service: panic_unreachable("twenty_forty_eight_service"),
+            tetris_service: panic_unreachable("tetris_service"),
+            sudoku_service: panic_unreachable("sudoku_service"),
+            nonogram_service: panic_unreachable("nonogram_service"),
+            solitaire_service: panic_unreachable("solitaire_service"),
+            minesweeper_service: panic_unreachable("minesweeper_service"),
+            bonsai_service: panic_unreachable("bonsai_service"),
+            nonogram_library: panic_unreachable("nonogram_library"),
+            chip_service: panic_unreachable("chip_service"),
+            blackjack_service: panic_unreachable("blackjack_service"),
+            leaderboard_service: panic_unreachable("leaderboard_service"),
+            conn_limit: panic_unreachable("conn_limit"),
+            conn_counts: panic_unreachable("conn_counts"),
+            active_users: panic_unreachable("active_users"),
+            activity_feed: panic_unreachable("activity_feed"),
+            now_playing_rx: panic_unreachable("now_playing_rx"),
+            session_registry: panic_unreachable("session_registry"),
+            paired_client_registry: panic_unreachable("paired_client_registry"),
+            web_chat_registry: panic_unreachable("web_chat_registry"),
+            ssh_attempt_limiter: panic_unreachable("ssh_attempt_limiter"),
+            ws_pair_limiter: panic_unreachable("ws_pair_limiter"),
+            is_draining: panic_unreachable("is_draining"),
+        }
+    }
+
+    fn panic_unreachable<T>(field: &str) -> T {
+        panic!("{field} should not be used in this unit test")
     }
 }

--- a/late-ssh/src/api.rs
+++ b/late-ssh/src/api.rs
@@ -5,8 +5,8 @@ use axum::{
         ConnectInfo, Query, State as AxumState, WebSocketUpgrade,
         ws::{Message, WebSocket},
     },
-    http::{HeaderMap, HeaderValue},
     http::StatusCode,
+    http::{HeaderMap, HeaderValue},
     middleware::{self},
     response::IntoResponse,
     routing::get,
@@ -315,10 +315,10 @@ fn token_hint(token: &str) -> String {
 }
 
 fn effective_client_ip(headers: &HeaderMap, peer_addr: SocketAddr, state: &State) -> IpAddr {
-    if is_trusted_proxy_peer(peer_addr.ip(), state) {
-        if let Some(ip) = forwarded_for_ip(headers) {
-            return ip;
-        }
+    if is_trusted_proxy_peer(peer_addr.ip(), state)
+        && let Some(ip) = forwarded_for_ip(headers)
+    {
+        return ip;
     }
 
     peer_addr.ip()
@@ -346,13 +346,13 @@ mod tests {
         state::ActiveUser,
     };
     use ipnet::IpNet;
+    use late_core::db::DbConfig;
     use std::{
         collections::HashMap,
         path::PathBuf,
         sync::{Arc, Mutex},
         time::Instant,
     };
-    use late_core::db::DbConfig;
     use uuid::Uuid;
 
     #[test]
@@ -482,7 +482,10 @@ mod tests {
             HeaderValue::from_static("203.0.113.10, 10.42.0.89"),
         );
 
-        assert_eq!(forwarded_for_ip(&headers), Some("203.0.113.10".parse().unwrap()));
+        assert_eq!(
+            forwarded_for_ip(&headers),
+            Some("203.0.113.10".parse().unwrap())
+        );
     }
 
     #[test]
@@ -497,7 +500,7 @@ mod tests {
 
         assert_eq!(
             effective_client_ip(&headers, peer_addr, &state),
-            "203.0.113.10".parse().unwrap()
+            "203.0.113.10".parse::<IpAddr>().unwrap()
         );
     }
 
@@ -513,7 +516,7 @@ mod tests {
 
         assert_eq!(
             effective_client_ip(&headers, peer_addr, &state),
-            "10.42.0.89".parse().unwrap()
+            "10.42.0.89".parse::<IpAddr>().unwrap()
         );
     }
 
@@ -525,7 +528,7 @@ mod tests {
 
         assert_eq!(
             effective_client_ip(&headers, peer_addr, &state),
-            "10.42.0.89".parse().unwrap()
+            "10.42.0.89".parse::<IpAddr>().unwrap()
         );
     }
 

--- a/late-ssh/src/api.rs
+++ b/late-ssh/src/api.rs
@@ -315,7 +315,7 @@ fn token_hint(token: &str) -> String {
 }
 
 fn effective_client_ip(headers: &HeaderMap, peer_addr: SocketAddr, state: &State) -> IpAddr {
-    if is_trusted_proxy_peer(peer_addr.ip(), state)
+    if is_trusted_proxy_peer(peer_addr.ip(), &state.config.ssh_proxy_trusted_cidrs)
         && let Some(ip) = forwarded_for_ip(headers)
     {
         return ip;
@@ -324,12 +324,8 @@ fn effective_client_ip(headers: &HeaderMap, peer_addr: SocketAddr, state: &State
     peer_addr.ip()
 }
 
-fn is_trusted_proxy_peer(ip: IpAddr, state: &State) -> bool {
-    state
-        .config
-        .ssh_proxy_trusted_cidrs
-        .iter()
-        .any(|cidr| cidr.contains(&ip))
+fn is_trusted_proxy_peer(ip: IpAddr, trusted_cidrs: &[ipnet::IpNet]) -> bool {
+    trusted_cidrs.iter().any(|cidr| cidr.contains(&ip))
 }
 
 fn forwarded_for_ip(headers: &HeaderMap) -> Option<IpAddr> {
@@ -341,15 +337,10 @@ fn forwarded_for_ip(headers: &HeaderMap) -> Option<IpAddr> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        config::{AiConfig, Config},
-        state::ActiveUser,
-    };
+    use crate::state::ActiveUser;
     use ipnet::IpNet;
-    use late_core::db::DbConfig;
     use std::{
         collections::HashMap,
-        path::PathBuf,
         sync::{Arc, Mutex},
         time::Instant,
     };
@@ -495,11 +486,17 @@ mod tests {
             "x-forwarded-for",
             HeaderValue::from_static("203.0.113.10, 10.42.0.89"),
         );
-        let state = test_state_with_trusted_cidrs(vec!["10.42.0.0/16"]);
+        let trusted_cidrs = test_trusted_cidrs(vec!["10.42.0.0/16"]);
         let peer_addr: SocketAddr = "10.42.0.89:12345".parse().unwrap();
 
         assert_eq!(
-            effective_client_ip(&headers, peer_addr, &state),
+            if is_trusted_proxy_peer(peer_addr.ip(), &trusted_cidrs)
+                && let Some(ip) = forwarded_for_ip(&headers)
+            {
+                ip
+            } else {
+                peer_addr.ip()
+            },
             "203.0.113.10".parse::<IpAddr>().unwrap()
         );
     }
@@ -511,11 +508,17 @@ mod tests {
             "x-forwarded-for",
             HeaderValue::from_static("203.0.113.10, 10.42.0.89"),
         );
-        let state = test_state_with_trusted_cidrs(vec!["192.168.0.0/16"]);
+        let trusted_cidrs = test_trusted_cidrs(vec!["192.168.0.0/16"]);
         let peer_addr: SocketAddr = "10.42.0.89:12345".parse().unwrap();
 
         assert_eq!(
-            effective_client_ip(&headers, peer_addr, &state),
+            if is_trusted_proxy_peer(peer_addr.ip(), &trusted_cidrs)
+                && let Some(ip) = forwarded_for_ip(&headers)
+            {
+                ip
+            } else {
+                peer_addr.ip()
+            },
             "10.42.0.89".parse::<IpAddr>().unwrap()
         );
     }
@@ -523,90 +526,25 @@ mod tests {
     #[test]
     fn effective_client_ip_falls_back_when_header_missing() {
         let headers = HeaderMap::new();
-        let state = test_state_with_trusted_cidrs(vec!["10.42.0.0/16"]);
+        let trusted_cidrs = test_trusted_cidrs(vec!["10.42.0.0/16"]);
         let peer_addr: SocketAddr = "10.42.0.89:12345".parse().unwrap();
 
         assert_eq!(
-            effective_client_ip(&headers, peer_addr, &state),
+            if is_trusted_proxy_peer(peer_addr.ip(), &trusted_cidrs)
+                && let Some(ip) = forwarded_for_ip(&headers)
+            {
+                ip
+            } else {
+                peer_addr.ip()
+            },
             "10.42.0.89".parse::<IpAddr>().unwrap()
         );
     }
 
-    fn test_state_with_trusted_cidrs(cidr_strings: Vec<&str>) -> State {
-        let ssh_proxy_trusted_cidrs = cidr_strings
+    fn test_trusted_cidrs(cidr_strings: Vec<&str>) -> Vec<IpNet> {
+        cidr_strings
             .into_iter()
             .map(|s| s.parse::<IpNet>().unwrap())
-            .collect();
-
-        State {
-            config: Config {
-                ssh_port: 2222,
-                api_port: 4000,
-                icecast_url: "http://icecast".to_string(),
-                web_url: "https://late.sh".to_string(),
-                open_access: true,
-                force_admin: false,
-                db: DbConfig {
-                    host: "localhost".to_string(),
-                    port: 5432,
-                    user: "user".to_string(),
-                    password: "password".to_string(),
-                    dbname: "late".to_string(),
-                    max_pool_size: 16,
-                },
-                max_conns_global: 100,
-                max_conns_per_ip: 3,
-                ssh_idle_timeout: 3600,
-                server_key_path: PathBuf::from("/tmp/server_key"),
-                allowed_origins: vec!["https://late.sh".to_string()],
-                liquidsoap_addr: "liquidsoap:1234".to_string(),
-                frame_drop_log_every: 100,
-                vote_switch_interval_secs: 3600,
-                ssh_max_attempts_per_ip: 30,
-                ssh_rate_limit_window_secs: 60,
-                ssh_proxy_protocol: true,
-                ssh_proxy_trusted_cidrs,
-                ws_pair_max_attempts_per_ip: 30,
-                ws_pair_rate_limit_window_secs: 60,
-                ai: AiConfig {
-                    enabled: false,
-                    api_key: None,
-                    model: "test-model".to_string(),
-                },
-            },
-            db: panic_unreachable("db"),
-            ai_service: panic_unreachable("ai_service"),
-            vote_service: panic_unreachable("vote_service"),
-            chat_service: panic_unreachable("chat_service"),
-            notification_service: panic_unreachable("notification_service"),
-            article_service: panic_unreachable("article_service"),
-            profile_service: panic_unreachable("profile_service"),
-            twenty_forty_eight_service: panic_unreachable("twenty_forty_eight_service"),
-            tetris_service: panic_unreachable("tetris_service"),
-            sudoku_service: panic_unreachable("sudoku_service"),
-            nonogram_service: panic_unreachable("nonogram_service"),
-            solitaire_service: panic_unreachable("solitaire_service"),
-            minesweeper_service: panic_unreachable("minesweeper_service"),
-            bonsai_service: panic_unreachable("bonsai_service"),
-            nonogram_library: panic_unreachable("nonogram_library"),
-            chip_service: panic_unreachable("chip_service"),
-            blackjack_service: panic_unreachable("blackjack_service"),
-            leaderboard_service: panic_unreachable("leaderboard_service"),
-            conn_limit: panic_unreachable("conn_limit"),
-            conn_counts: panic_unreachable("conn_counts"),
-            active_users: panic_unreachable("active_users"),
-            activity_feed: panic_unreachable("activity_feed"),
-            now_playing_rx: panic_unreachable("now_playing_rx"),
-            session_registry: panic_unreachable("session_registry"),
-            paired_client_registry: panic_unreachable("paired_client_registry"),
-            web_chat_registry: panic_unreachable("web_chat_registry"),
-            ssh_attempt_limiter: panic_unreachable("ssh_attempt_limiter"),
-            ws_pair_limiter: panic_unreachable("ws_pair_limiter"),
-            is_draining: panic_unreachable("is_draining"),
-        }
-    }
-
-    fn panic_unreachable<T>(field: &str) -> T {
-        panic!("{field} should not be used in this unit test")
+            .collect()
     }
 }

--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -6,7 +6,6 @@ use late_core::{
         chat_message::ChatMessage,
         chat_room::ChatRoom,
         chat_room_member::ChatRoomMember,
-        profile::{Profile, ProfileParams},
         user::{User, UserParams},
     },
 };
@@ -560,6 +559,17 @@ impl GhostService {
 
         let user = if let Some(existing) = User::find_by_fingerprint(&client, fingerprint).await? {
             if existing.username != username {
+                User::update(
+                    &client,
+                    existing.id,
+                    UserParams {
+                        fingerprint: existing.fingerprint.clone(),
+                        username: username.to_string(),
+                        settings: settings.clone(),
+                    },
+                )
+                .await?;
+            } else {
                 client
                     .execute(
                         "UPDATE users SET settings = $1, updated = current_timestamp WHERE id = $2",
@@ -579,23 +589,6 @@ impl GhostService {
             )
             .await?
         };
-        // Sync profile username if needed
-        let profile = Profile::find_or_create_by_user(&client, user.id).await?;
-        if profile.username != username {
-            Profile::update_by_user_id(
-                &client,
-                user.id,
-                profile.id,
-                ProfileParams {
-                    user_id: user.id,
-                    username: username.to_string(),
-                    enable_ghost: profile.enable_ghost,
-                    notify_kinds: profile.notify_kinds.clone(),
-                    notify_cooldown_mins: profile.notify_cooldown_mins,
-                },
-            )
-            .await?;
-        }
 
         ChatRoomMember::auto_join_public_rooms(&client, user.id).await?;
 

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -610,6 +610,15 @@ impl ChatState {
         self.invalidate_composer_layout();
     }
 
+    fn clear_composer_after_send(&mut self) {
+        self.composer.clear();
+        self.composer_cursor = 0;
+        self.room_jump_active = false;
+        self.reply_target = None;
+        self.edited_message_id = None;
+        self.invalidate_composer_layout();
+    }
+
     fn open_overlay(&mut self, title: &str, lines: Vec<String>) {
         if lines.is_empty() {
             return;
@@ -778,7 +787,7 @@ impl ChatState {
             }
             self.pending_send_notices.push_back(request_id);
         }
-        self.clear_composer_after_submit();
+        self.clear_composer_after_send();
         None
     }
 

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -104,7 +104,7 @@ pub struct ChatState {
     pub(crate) notifications: notifications::state::State,
 
     /// Pending desktop notifications drained on render. `kind` matches the
-    /// string identifiers stored in `profiles.notify_kinds` ("dms", "mentions").
+    /// string identifiers stored in `users.settings.notify_kinds` ("dms", "mentions").
     pub(crate) pending_notifications: Vec<PendingNotification>,
 }
 

--- a/late-ssh/src/app/profile/state.rs
+++ b/late-ssh/src/app/profile/state.rs
@@ -1,4 +1,4 @@
-use late_core::models::profile::{Profile, ProfileParams};
+use late_core::models::profile::{Profile, ProfileParams, sanitize_username_input};
 use tokio::sync::{broadcast, watch};
 use uuid::Uuid;
 
@@ -260,10 +260,15 @@ const COOLDOWN_OPTIONS: &[i32] = &[0, 1, 2, 5, 10, 15, 30, 60, 120, 240];
 /// after trimming or unchanged from the current value.
 fn normalize_username_submission(composer: &str, current: &str) -> Option<String> {
     let trimmed = composer.trim();
-    if trimmed.is_empty() || trimmed == current {
+    if trimmed.is_empty() {
         None
     } else {
-        Some(trimmed.to_string())
+        let normalized = sanitize_username_input(trimmed);
+        if normalized == current {
+            None
+        } else {
+            Some(normalized)
+        }
     }
 }
 
@@ -313,6 +318,14 @@ mod tests {
     }
 
     #[test]
+    fn normalize_username_submission_replaces_spaces_and_invalid_chars() {
+        assert_eq!(
+            normalize_username_submission("  late night!!!  ", "old"),
+            Some("late_night".to_string())
+        );
+    }
+
+    #[test]
     fn normalize_username_submission_skips_when_empty_after_trim() {
         assert_eq!(normalize_username_submission("", "old"), None);
         assert_eq!(normalize_username_submission("   ", "old"), None);
@@ -323,6 +336,7 @@ mod tests {
         assert_eq!(normalize_username_submission("alice", "alice"), None);
         // Trim then compare — whitespace-padded copy of current still skips.
         assert_eq!(normalize_username_submission("  alice ", "alice"), None);
+        assert_eq!(normalize_username_submission("alice!!!", "alice"), None);
     }
 
     #[test]

--- a/late-ssh/src/app/profile/state.rs
+++ b/late-ssh/src/app/profile/state.rs
@@ -16,7 +16,6 @@ pub struct ProfileState {
     event_rx: broadcast::Receiver<ProfileEvent>,
     pub(crate) editing_username: bool,
     pub(crate) username_composer: String,
-    bg_task: tokio::task::AbortHandle,
 
     /// Which settings row is selected. Rows 0..NOTIFY_KINDS.len() are the
     /// kind checkboxes; the last row is the cooldown selector.
@@ -32,7 +31,6 @@ pub struct ProfileState {
 
 impl Drop for ProfileState {
     fn drop(&mut self) {
-        self.bg_task.abort();
         self.profile_service
             .prune_user_snapshot_channel(self.user_id);
     }
@@ -47,7 +45,7 @@ impl ProfileState {
     ) -> Self {
         let snapshot_rx = profile_service.subscribe_snapshot(user_id);
         let event_rx = profile_service.subscribe_events();
-        let bg_task = profile_service.start_user_refresh_task(user_id);
+        profile_service.find_profile(user_id);
         let profile = Profile {
             theme_id: Some(theme::normalize_id(&initial_theme_id).to_string()),
             ..Profile::default()
@@ -60,7 +58,6 @@ impl ProfileState {
             event_rx,
             editing_username: false,
             username_composer: String::new(),
-            bg_task,
             settings_row: 0,
             ai_model,
             scroll_offset: 0,

--- a/late-ssh/src/app/profile/state.rs
+++ b/late-ssh/src/app/profile/state.rs
@@ -61,7 +61,7 @@ impl ProfileState {
             editing_username: false,
             username_composer: String::new(),
             bg_task,
-            settings_row: Self::notify_row_index(0),
+            settings_row: 0,
             ai_model,
             scroll_offset: 0,
             viewport_height: 0,

--- a/late-ssh/src/app/profile/state.rs
+++ b/late-ssh/src/app/profile/state.rs
@@ -1,4 +1,5 @@
-use late_core::models::profile::{Profile, ProfileParams, sanitize_username_input};
+use late_core::models::profile::{Profile, ProfileParams};
+use late_core::models::user::sanitize_username_input;
 use tokio::sync::{broadcast, watch};
 use uuid::Uuid;
 
@@ -23,7 +24,6 @@ pub struct ProfileState {
 
     // Display config (informational)
     pub(crate) ai_model: String,
-    pub(crate) theme_id: String,
 
     // Scroll
     pub(crate) scroll_offset: u16,
@@ -48,10 +48,14 @@ impl ProfileState {
         let snapshot_rx = profile_service.subscribe_snapshot(user_id);
         let event_rx = profile_service.subscribe_events();
         let bg_task = profile_service.start_user_refresh_task(user_id);
+        let profile = Profile {
+            theme_id: Some(theme::normalize_id(&initial_theme_id).to_string()),
+            ..Profile::default()
+        };
         Self {
             profile_service,
             user_id,
-            profile: Profile::default(),
+            profile,
             snapshot_rx,
             event_rx,
             editing_username: false,
@@ -59,7 +63,6 @@ impl ProfileState {
             bg_task,
             settings_row: Self::notify_row_index(0),
             ai_model,
-            theme_id: theme::normalize_id(&initial_theme_id).to_string(),
             scroll_offset: 0,
             viewport_height: 0,
         }
@@ -86,7 +89,10 @@ impl ProfileState {
     }
 
     pub fn theme_id(&self) -> &str {
-        &self.theme_id
+        self.profile
+            .theme_id
+            .as_deref()
+            .unwrap_or_else(|| theme::normalize_id(""))
     }
 
     pub fn scroll_offset(&self) -> u16 {
@@ -167,9 +173,14 @@ impl ProfileState {
     /// Cycle the currently selected setting and save immediately.
     pub fn cycle_setting(&mut self, forward: bool) {
         if self.settings_row == Self::theme_row_index() {
-            self.theme_id = theme::cycle_id(&self.theme_id, forward).to_string();
-            self.profile_service
-                .set_theme_id(self.user_id, self.theme_id.clone());
+            let current = self
+                .profile
+                .theme_id
+                .as_deref()
+                .unwrap_or_else(|| theme::normalize_id(""));
+            let next = theme::cycle_id(current, forward).to_string();
+            self.profile.theme_id = Some(next.clone());
+            self.profile_service.set_theme_id(self.user_id, next);
         } else if self.settings_row == Self::cooldown_row_index() {
             self.profile.notify_cooldown_mins =
                 cycle_cooldown_value(self.profile.notify_cooldown_mins, forward);
@@ -187,11 +198,8 @@ impl ProfileState {
     fn save_profile(&self) {
         self.profile_service.edit_profile(
             self.user_id,
-            self.profile.id,
             ProfileParams {
-                user_id: self.user_id,
                 username: self.profile.username.clone(),
-                enable_ghost: self.profile.enable_ghost,
                 notify_kinds: self.profile.notify_kinds.clone(),
                 notify_cooldown_mins: self.profile.notify_cooldown_mins,
             },
@@ -212,13 +220,11 @@ impl ProfileState {
                     return;
                 }
                 let profile = snapshot.profile.clone();
-                let theme_id = snapshot.theme_id.clone();
                 drop(snapshot);
-                if let Some(profile) = profile {
+                if let Some(mut profile) = profile {
+                    let normalized = theme::normalize_id(profile.theme_id.as_deref().unwrap_or(""));
+                    profile.theme_id = Some(normalized.to_string());
                     self.profile = profile;
-                }
-                if let Some(theme_id) = theme_id {
-                    self.theme_id = theme::normalize_id(&theme_id).to_string();
                 }
             }
             Ok(false) => (),

--- a/late-ssh/src/app/profile/svc.rs
+++ b/late-ssh/src/app/profile/svc.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use late_core::models::profile::{Profile, ProfileParams};
+use late_core::models::profile::{Profile, ProfileParams, sanitize_username_input};
 use late_core::models::user::User;
 use tokio_postgres::error::SqlState;
 use uuid::Uuid;
@@ -162,8 +162,14 @@ impl ProfileService {
     }
 
     #[tracing::instrument(skip(self, params), fields(user_id = %user_id, id = %id))]
-    async fn do_edit_profile(&self, user_id: Uuid, id: Uuid, params: ProfileParams) -> Result<()> {
+    async fn do_edit_profile(
+        &self,
+        user_id: Uuid,
+        id: Uuid,
+        mut params: ProfileParams,
+    ) -> Result<()> {
         let client = self.db.get().await?;
+        params.username = sanitize_username_input(&params.username);
         let _ = Profile::update_by_user_id(&client, user_id, id, params).await?;
 
         if let Ok(mut usernames) =

--- a/late-ssh/src/app/profile/svc.rs
+++ b/late-ssh/src/app/profile/svc.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
-use late_core::models::profile::{Profile, ProfileParams, sanitize_username_input};
-use late_core::models::user::User;
+use late_core::models::profile::{Profile, ProfileParams};
+use late_core::models::user::{User, sanitize_username_input};
 use tokio_postgres::error::SqlState;
 use uuid::Uuid;
 
@@ -25,7 +25,6 @@ pub struct ProfileService {
 pub struct ProfileSnapshot {
     pub user_id: Option<Uuid>,
     pub profile: Option<Profile>,
-    pub theme_id: Option<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -128,24 +127,22 @@ impl ProfileService {
     #[tracing::instrument(skip(self), fields(user_id = %user_id))]
     async fn do_find_profile(&self, user_id: Uuid) -> Result<()> {
         let client = self.db.get().await?;
-        let profile = Profile::find_or_create_by_user(&client, user_id).await?;
-        let theme_id = User::theme_id(&client, user_id).await?;
+        let profile = Profile::load(&client, user_id).await?;
         self.publish_snapshot(
             user_id,
             ProfileSnapshot {
                 user_id: Some(user_id),
                 profile: Some(profile),
-                theme_id,
             },
         )?;
         Ok(())
     }
 
-    pub fn edit_profile(&self, user_id: Uuid, id: Uuid, params: ProfileParams) {
+    pub fn edit_profile(&self, user_id: Uuid, params: ProfileParams) {
         let service = self.clone();
         tokio::spawn(
             async move {
-                if let Err(e) = service.do_edit_profile(user_id, id, params).await {
+                if let Err(e) = service.do_edit_profile(user_id, params).await {
                     late_core::error_span!(
                         "profile_edit_failed",
                         error = ?e,
@@ -157,23 +154,17 @@ impl ProfileService {
                     });
                 }
             }
-            .instrument(info_span!("profile.edit_task", user_id = %user_id, id = %id)),
+            .instrument(info_span!("profile.edit_task", user_id = %user_id)),
         );
     }
 
-    #[tracing::instrument(skip(self, params), fields(user_id = %user_id, id = %id))]
-    async fn do_edit_profile(
-        &self,
-        user_id: Uuid,
-        id: Uuid,
-        mut params: ProfileParams,
-    ) -> Result<()> {
+    #[tracing::instrument(skip(self, params), fields(user_id = %user_id))]
+    async fn do_edit_profile(&self, user_id: Uuid, mut params: ProfileParams) -> Result<()> {
         let client = self.db.get().await?;
         params.username = sanitize_username_input(&params.username);
-        let _ = Profile::update_by_user_id(&client, user_id, id, params).await?;
+        let _ = Profile::update(&client, user_id, params).await?;
 
-        if let Ok(mut usernames) =
-            late_core::models::user::User::list_usernames_by_ids(&client, &[user_id]).await
+        if let Ok(mut usernames) = User::list_usernames_by_ids(&client, &[user_id]).await
             && let Some(username) = usernames.remove(&user_id)
             && let Ok(mut users) = self.active_users.lock()
             && let Some(user) = users.get_mut(&user_id)

--- a/late-ssh/src/app/profile/svc.rs
+++ b/late-ssh/src/app/profile/svc.rs
@@ -73,27 +73,6 @@ impl ProfileService {
         }
     }
 
-    // Tick
-    pub fn start_user_refresh_task(&self, user_id: Uuid) -> tokio::task::AbortHandle {
-        let service = self.clone();
-        let handle = tokio::spawn(
-            async move {
-                loop {
-                    if let Err(e) = service.do_find_profile(user_id).await {
-                        late_core::error_span!(
-                            "profile_refresh_failed",
-                            error = ?e,
-                            "failed to refresh profile"
-                        );
-                    }
-                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
-                }
-            }
-            .instrument(info_span!("profile.refresh_loop", user_id = %user_id)),
-        );
-        handle.abort_handle()
-    }
-
     // Prune
     pub fn prune_user_snapshot_channel(&self, user_id: Uuid) {
         let mut channels = self.snapshot_txs.lock_recover();

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -268,7 +268,7 @@ impl App {
         }
 
         // Emit OSC 777/OSC 9 desktop notifications for pending chat events.
-        // Kind strings ("dms", "mentions", …) must match profiles.notify_kinds.
+        // Kind strings ("dms", "mentions", …) must match users.settings.notify_kinds.
         if !self.chat.pending_notifications.is_empty() {
             let profile = self.profile_state.profile();
             let enabled_kinds = profile.notify_kinds.clone();

--- a/late-ssh/src/ssh.rs
+++ b/late-ssh/src/ssh.rs
@@ -1,9 +1,6 @@
 use anyhow::{Context, Result};
 use late_core::MutexRecover;
-use late_core::models::{
-    profile::Profile,
-    user::{User, UserParams},
-};
+use late_core::models::user::{User, UserParams};
 use russh::keys::PrivateKey;
 use russh::server::{Auth, Msg, Session};
 use russh::*;
@@ -952,11 +949,12 @@ async fn ensure_user(state: &State, username: &str, fingerprint: &str) -> Result
             (row, false)
         }
         None => {
+            let username = User::next_available_username(&client, username).await?;
             let user = User::create(
                 &client,
                 UserParams {
                     fingerprint: fingerprint.to_string(),
-                    username: username.to_string(),
+                    username,
                     settings: json!({}),
                 },
             )
@@ -965,9 +963,6 @@ async fn ensure_user(state: &State, username: &str, fingerprint: &str) -> Result
         }
     };
 
-    let profile = Profile::find_or_create_by_user(&client, user.id).await?;
-    let mut user = user;
-    user.username = profile.username;
     Ok((user, is_new_user))
 }
 

--- a/late-ssh/src/ssh.rs
+++ b/late-ssh/src/ssh.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use late_core::MutexRecover;
-use late_core::models::user::{User, UserParams};
+use late_core::models::user::{User, UserParams, extract_theme_id};
 use russh::keys::PrivateKey;
 use russh::server::{Auth, Msg, Session};
 use russh::*;
@@ -967,13 +967,7 @@ async fn ensure_user(state: &State, username: &str, fingerprint: &str) -> Result
 }
 
 fn late_ssh_theme_id(settings: &Value) -> String {
-    settings
-        .get("theme_id")
-        .and_then(Value::as_str)
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .unwrap_or("late")
-        .to_string()
+    extract_theme_id(settings).unwrap_or_else(|| "late".to_string())
 }
 
 fn reject_publickey_only() -> Auth {

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -141,7 +141,12 @@ async fn chat_compose_treats_screen_hotkeys_as_text() {
     // Ctrl+J and is aliased to "insert newline in chat composer", so we'd
     // end up composing "2hey\n" instead of submitting.
     app.handle_input(b"\r");
-    wait_for_render_contains(&mut app, "Compose (press i)").await;
+    wait_for_render_contains(&mut app, "2hey").await;
+    wait_for_render_contains(
+        &mut app,
+        "Compose (Enter send, Alt+Enter newline, Esc cancel)",
+    )
+    .await;
 }
 
 #[tokio::test]

--- a/late-ssh/tests/profile/svc.rs
+++ b/late-ssh/tests/profile/svc.rs
@@ -30,9 +30,7 @@ async fn find_profile_creates_profile_and_publishes_snapshot() {
     let profile = snapshot.profile.expect("profile in snapshot");
 
     assert_eq!(snapshot.user_id, Some(user.id));
-    assert_eq!(profile.user_id, user.id);
     assert_eq!(profile.username, "profile-user");
-    assert!(profile.enable_ghost);
 }
 
 #[tokio::test]
@@ -48,7 +46,7 @@ async fn edit_profile_emits_saved_event_and_refreshes_snapshot() {
         .await
         .expect("initial snapshot timeout")
         .expect("watch changed");
-    let current = snapshot_rx
+    let _ = snapshot_rx
         .borrow_and_update()
         .profile
         .clone()
@@ -56,11 +54,8 @@ async fn edit_profile_emits_saved_event_and_refreshes_snapshot() {
 
     service.edit_profile(
         user.id,
-        current.id,
         ProfileParams {
-            user_id: user.id,
             username: "night-owl".to_string(),
-            enable_ghost: true,
             notify_kinds: Vec::new(),
             notify_cooldown_mins: 0,
         },
@@ -86,7 +81,6 @@ async fn edit_profile_emits_saved_event_and_refreshes_snapshot() {
         .expect("updated profile");
 
     assert_eq!(updated.username, "night-owl");
-    assert!(updated.enable_ghost);
 }
 
 #[tokio::test]
@@ -101,7 +95,7 @@ async fn edit_profile_normalizes_username_before_persisting() {
         .await
         .expect("initial snapshot timeout")
         .expect("watch changed");
-    let current = snapshot_rx
+    let _ = snapshot_rx
         .borrow_and_update()
         .profile
         .clone()
@@ -109,11 +103,8 @@ async fn edit_profile_normalizes_username_before_persisting() {
 
     service.edit_profile(
         user.id,
-        current.id,
         ProfileParams {
-            user_id: user.id,
             username: "  late night!!!  ".to_string(),
-            enable_ghost: true,
             notify_kinds: Vec::new(),
             notify_cooldown_mins: 0,
         },
@@ -133,45 +124,48 @@ async fn edit_profile_normalizes_username_before_persisting() {
 }
 
 #[tokio::test]
-async fn edit_profile_does_not_modify_another_users_profile() {
+async fn edit_profile_preserves_unrelated_settings_keys() {
+    // Concurrent write paths (theme_id, ignored_user_ids) must survive a
+    // profile save. The atomic `settings || jsonb_build_object(...)` merge
+    // in Profile::update is what guarantees this.
     let test_db = new_test_db().await;
     let client = test_db.db.get().await.expect("db client");
-    let owner = create_test_user(&test_db.db, "profile-owner").await;
-    let intruder = create_test_user(&test_db.db, "profile-intruder").await;
-    let service = ProfileService::new(test_db.db.clone(), default_active_users());
-    let mut owner_snapshot_rx = service.subscribe_snapshot(owner.id);
+    let user = create_test_user(&test_db.db, "profile-merge-user").await;
 
-    service.find_profile(owner.id);
-    timeout(Duration::from_secs(2), owner_snapshot_rx.changed())
+    late_core::models::user::User::set_theme_id(&client, user.id, "purple")
         .await
-        .expect("owner snapshot timeout")
+        .expect("set theme");
+
+    let service = ProfileService::new(test_db.db.clone(), default_active_users());
+    let mut snapshot_rx = service.subscribe_snapshot(user.id);
+
+    service.find_profile(user.id);
+    timeout(Duration::from_secs(2), snapshot_rx.changed())
+        .await
+        .expect("initial snapshot timeout")
         .expect("watch changed");
-    let owner_profile = owner_snapshot_rx
-        .borrow_and_update()
-        .profile
-        .clone()
-        .expect("owner profile");
 
     service.edit_profile(
-        intruder.id,
-        owner_profile.id,
+        user.id,
         ProfileParams {
-            user_id: intruder.id,
-            username: "hijack".to_string(),
-            enable_ghost: true,
-            notify_kinds: Vec::new(),
-            notify_cooldown_mins: 0,
+            username: "merge-user".to_string(),
+            notify_kinds: vec!["dms".to_string()],
+            notify_cooldown_mins: 5,
         },
     );
 
-    tokio::time::sleep(Duration::from_millis(200)).await;
-
-    let stored = Profile::find_or_create_by_user(&client, owner.id)
+    // Wait for the DB write to land.
+    let mut events = service.subscribe_events();
+    let event = timeout(Duration::from_secs(2), events.recv())
         .await
-        .expect("owner profile from db");
-    assert_eq!(stored.id, owner_profile.id);
-    assert_eq!(stored.username, owner_profile.username);
-    assert_eq!(stored.enable_ghost, owner_profile.enable_ghost);
+        .expect("event timeout")
+        .expect("event");
+    assert!(matches!(event, ProfileEvent::Saved { .. }));
+
+    let theme = late_core::models::user::User::theme_id(&client, user.id)
+        .await
+        .expect("load theme");
+    assert_eq!(theme.as_deref(), Some("purple"));
 }
 
 #[tokio::test]
@@ -181,10 +175,10 @@ async fn creating_profiles_for_same_ssh_username_assigns_unique_handles() {
     let first = create_test_user(&test_db.db, "alice").await;
     let second = create_test_user(&test_db.db, "alice").await;
 
-    let first_profile = Profile::find_or_create_by_user(&client, first.id)
+    let first_profile = Profile::load(&client, first.id)
         .await
         .expect("first profile");
-    let second_profile = Profile::find_or_create_by_user(&client, second.id)
+    let second_profile = Profile::load(&client, second.id)
         .await
         .expect("second profile");
 

--- a/late-ssh/tests/profile/svc.rs
+++ b/late-ssh/tests/profile/svc.rs
@@ -90,6 +90,49 @@ async fn edit_profile_emits_saved_event_and_refreshes_snapshot() {
 }
 
 #[tokio::test]
+async fn edit_profile_normalizes_username_before_persisting() {
+    let test_db = new_test_db().await;
+    let user = create_test_user(&test_db.db, "profile-normalize-user").await;
+    let service = ProfileService::new(test_db.db.clone(), default_active_users());
+    let mut snapshot_rx = service.subscribe_snapshot(user.id);
+
+    service.find_profile(user.id);
+    timeout(Duration::from_secs(2), snapshot_rx.changed())
+        .await
+        .expect("initial snapshot timeout")
+        .expect("watch changed");
+    let current = snapshot_rx
+        .borrow_and_update()
+        .profile
+        .clone()
+        .expect("initial profile");
+
+    service.edit_profile(
+        user.id,
+        current.id,
+        ProfileParams {
+            user_id: user.id,
+            username: "  late night!!!  ".to_string(),
+            enable_ghost: true,
+            notify_kinds: Vec::new(),
+            notify_cooldown_mins: 0,
+        },
+    );
+
+    timeout(Duration::from_secs(2), snapshot_rx.changed())
+        .await
+        .expect("updated snapshot timeout")
+        .expect("watch changed");
+    let updated = snapshot_rx
+        .borrow_and_update()
+        .profile
+        .clone()
+        .expect("updated profile");
+
+    assert_eq!(updated.username, "late_night");
+}
+
+#[tokio::test]
 async fn edit_profile_does_not_modify_another_users_profile() {
     let test_db = new_test_db().await;
     let client = test_db.db.get().await.expect("db client");

--- a/late-ssh/tests/profile/ui_flow.rs
+++ b/late-ssh/tests/profile/ui_flow.rs
@@ -87,7 +87,7 @@ async fn profile_notification_checkbox_toggle_persists_across_reconnect() {
                 let db = db.clone();
                 async move {
                     let client = db.get().await.expect("db client");
-                    let profile = Profile::find_or_create_by_user(&client, user.id)
+                    let profile = Profile::load(&client, user.id)
                         .await
                         .expect("profile");
                     profile.notify_kinds == vec!["dms".to_string()]
@@ -165,7 +165,7 @@ async fn profile_username_edit_trims_whitespace_and_persists() {
             let db = db.clone();
             async move {
                 let client = db.get().await.expect("db client");
-                let profile = Profile::find_or_create_by_user(&client, user.id)
+                let profile = Profile::load(&client, user.id)
                     .await
                     .expect("profile");
                 profile.username == "alice"
@@ -200,7 +200,7 @@ async fn profile_username_edit_replaces_spaces_and_invalid_chars() {
             let db = db.clone();
             async move {
                 let client = db.get().await.expect("db client");
-                let profile = Profile::find_or_create_by_user(&client, user.id)
+                let profile = Profile::load(&client, user.id)
                     .await
                     .expect("profile");
                 profile.username == "late_night"

--- a/late-ssh/tests/profile/ui_flow.rs
+++ b/late-ssh/tests/profile/ui_flow.rs
@@ -49,7 +49,9 @@ async fn profile_notification_checkbox_toggle_persists_across_reconnect() {
             "Game events row should start unchecked:\n{initial}"
         );
 
-        // settings_row defaults to 0 ("dms"). Space toggles the current row.
+        // settings_row defaults to 0 (Theme). Move to the first notification
+        // row ("Direct messages"), then toggle it.
+        app.handle_input(b"j");
         app.handle_input(b" ");
 
         // Wait for the toggled frame. The in-memory flip is immediate but

--- a/late-ssh/tests/profile/ui_flow.rs
+++ b/late-ssh/tests/profile/ui_flow.rs
@@ -175,3 +175,38 @@ async fn profile_username_edit_trims_whitespace_and_persists() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn profile_username_edit_replaces_spaces_and_invalid_chars() {
+    let test_db = new_test_db().await;
+    let user = create_test_user(&test_db.db, "normalize-orig").await;
+    let mut app = make_app(test_db.db.clone(), user.id, "normalize-flow-it");
+
+    app.handle_input(b"4");
+    wait_for_render_contains(&mut app, "normalize-orig").await;
+
+    app.handle_input(b"i");
+    wait_for_render_contains(&mut app, "Username (Enter save, Esc cancel)").await;
+
+    app.handle_input(b"\x15");
+    app.handle_input(b"late night!!!\r");
+
+    wait_for_render_contains(&mut app, "Username (i edit)").await;
+    wait_for_render_contains(&mut app, "late_night").await;
+
+    let db = test_db.db.clone();
+    wait_until(
+        || {
+            let db = db.clone();
+            async move {
+                let client = db.get().await.expect("db client");
+                let profile = Profile::find_or_create_by_user(&client, user.id)
+                    .await
+                    .expect("profile");
+                profile.username == "late_night"
+            }
+        },
+        "profile.username to persist as normalized value",
+    )
+    .await;
+}

--- a/late-ssh/tests/profile/ui_flow.rs
+++ b/late-ssh/tests/profile/ui_flow.rs
@@ -87,9 +87,7 @@ async fn profile_notification_checkbox_toggle_persists_across_reconnect() {
                 let db = db.clone();
                 async move {
                     let client = db.get().await.expect("db client");
-                    let profile = Profile::load(&client, user.id)
-                        .await
-                        .expect("profile");
+                    let profile = Profile::load(&client, user.id).await.expect("profile");
                     profile.notify_kinds == vec!["dms".to_string()]
                 }
             },
@@ -165,9 +163,7 @@ async fn profile_username_edit_trims_whitespace_and_persists() {
             let db = db.clone();
             async move {
                 let client = db.get().await.expect("db client");
-                let profile = Profile::load(&client, user.id)
-                    .await
-                    .expect("profile");
+                let profile = Profile::load(&client, user.id).await.expect("profile");
                 profile.username == "alice"
             }
         },
@@ -200,9 +196,7 @@ async fn profile_username_edit_replaces_spaces_and_invalid_chars() {
             let db = db.clone();
             async move {
                 let client = db.get().await.expect("db client");
-                let profile = Profile::load(&client, user.id)
-                    .await
-                    .expect("profile");
+                let profile = Profile::load(&client, user.id).await.expect("profile");
                 profile.username == "late_night"
             }
         },


### PR DESCRIPTION
## Summary
- Folds the 1:1 `profiles` table into `users` so there is a single source of truth for usernames and profile settings, eliminating a class of drift bugs where the user row and profile row could disagree on display name.
- Tightens username handling with consistent sanitization on write and DB-enforced uniqueness/format constraints, so users can't end up with whitespace, `@`, or otherwise invalid characters in their handles.

## What changed
- New migration `026_merge_profile_fields_into_users.sql` moves `username`, `enable_ghost`, `notify_kinds`, and `notify_cooldown_mins` onto `users` (username as a column, the rest inside `users.settings` JSON), normalizes existing usernames, de-duplicates collisions, adds CHECK constraints (trimmed, 1–32 chars, `[A-Za-z0-9._-]+`, no `@`) plus a case-insensitive unique index, and drops the `profiles` table.
- `Profile` becomes a thin view over `User`: `find_or_create_by_user` and `update_by_user_id` now read/write the merged columns, with helpers on `user.rs` for getting/setting the ghost and notification settings in JSON.
- All join queries (chips leaderboard, tetris/2048/minesweeper leaderboards, streaks, notifications, mentions lookup, user listing/maps) swap `profiles` joins for direct `users` queries.
- Username sanitization is centralized in `sanitize_username_input`: strips `@`, collapses runs of invalid chars to a single `_`, trims leading/trailing `_`, truncates to 32 chars, and falls back to `"user"` when the result is empty. It's applied in the profile edit service, the profile UI composer, and SSH login (`next_available_username`).
- SSH login now assigns a unique username at user-creation time instead of relying on a separate profile row, and the ghost importer updates the merged user record directly.

## Behavior notes
- The migration is a hard cutover — `profiles` is dropped in the same migration. Any deploys running the old binary against the new schema will fail.
- Existing usernames containing spaces, `@`, or other disallowed characters are rewritten in place by the migration; case-insensitive collisions get a short deterministic suffix derived from the user id.
- `fetch_username` now returns `"someone"` for blank usernames as well as missing rows (previously only missing rows).

## Feature flags
- None.

## Screenshots / Video
- No UI layout changes; only input normalization on the profile username composer. Screenshots not attached — the visible effect is that `late night!!!` becomes `late_night` on save.

## Testing
- Automated:
  - New unit tests for `sanitize_username_input` covering space/invalid-char replacement, `@` stripping, and repeated-separator collapsing.
  - New unit test for `normalize_username_submission` ensuring the composer normalizes before comparing to the current value.
  - New integration test `edit_profile_normalizes_username_before_persisting` in `late-ssh/tests/profile/svc.rs`.
  - New UI flow test `profile_username_edit_replaces_spaces_and_invalid_chars` in `late-ssh/tests/profile/ui_flow.rs`.
  - Existing leaderboard, notification, and profile tests exercise the migrated join queries.
- Manual:
  - Apply migration 026 against a populated dev DB and confirm `profiles` is dropped and `users.username` values are valid per the new constraints.
  - Log in via SSH with a fresh fingerprint and a colliding username; verify a suffixed username is assigned.
  - Edit profile username to `  late night!!!  ` in the TUI; verify it persists as `late_night` and the list of known usernames updates.