### PR TITLE
Support Utf8

### DIFF
--- a/late-cli/src/main.rs
+++ b/late-cli/src/main.rs
@@ -1575,10 +1575,8 @@ async fn run_viz_ws(
                     break;
                 };
                 match msg? {
-                    Message::Text(text) => {
-                        if apply_pair_control(&text, muted, volume_percent)? {
-                            send_client_state(&mut ws, muted, volume_percent).await?;
-                        }
+                    Message::Text(text) if apply_pair_control(&text, muted, volume_percent)? => {
+                        send_client_state(&mut ws, muted, volume_percent).await?;
                     }
                     Message::Close(_) => break,
                     _ => {}

--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -9,14 +9,14 @@ fn is_prev_room_key(byte: u8) -> bool {
     matches!(byte, b'h' | b'H' | 0x10)
 }
 
-pub fn handle_compose_input(app: &mut App, byte: u8) {
+pub fn handle_compose_input(app: &mut App, c: char) {
     if app.chat.is_autocomplete_active() {
-        match byte {
-            0x1B => {
+        match c {
+            '\x1B' => {
                 app.chat.ac_dismiss();
                 return;
             }
-            b'\t' | b'\r' | b'\n' => {
+            '\t' | '\r' | '\n' => {
                 app.chat.ac_confirm();
                 return;
             }
@@ -24,26 +24,26 @@ pub fn handle_compose_input(app: &mut App, byte: u8) {
         }
     }
 
-    match byte {
-        0x1B => {
+    match c {
+        '\x1B' => {
             app.chat.reset_composer();
         }
-        b'\r' | b'\n' => {
+        '\r' | '\n' => {
             if let Some(b) = app.chat.submit_composer(false) {
                 app.banner = Some(b);
             }
         }
-        0x15 => {
+        '\x15' => {
             // Ctrl-U: clear composer
             app.chat.composer_clear();
             app.chat.update_autocomplete();
         }
-        0x7F => {
+        '\x7F' => {
             app.chat.composer_backspace();
             app.chat.update_autocomplete();
         }
-        b if (32..127).contains(&b) => {
-            app.chat.composer_push(b as char);
+        c if !c.is_control() => {
+            app.chat.composer_push(c);
             app.chat.update_autocomplete();
         }
         _ => {}

--- a/late-ssh/src/app/chat/news/input.rs
+++ b/late-ssh/src/app/chat/news/input.rs
@@ -1,23 +1,23 @@
 use crate::app::state::App;
 
-pub fn handle_composer_input(app: &mut App, byte: u8) {
-    match byte {
-        0x1B => {
+pub fn handle_composer_input(app: &mut App, ch: char) {
+    match ch {
+        '\x1B' => {
             // Escape cancels composing and aborts any in-flight URL task.
             app.chat.news.stop_composing();
         }
-        b'\r' | b'\n' => {
+        '\r' | '\n' => {
             app.chat.news.submit_composer();
         }
-        0x15 => {
+        '\x15' => {
             // Ctrl-U: clear composer
             app.chat.news.composer_clear();
         }
-        0x7F | 0x08 => {
+        '\x7F' | '\x08' => {
             app.chat.news.composer_pop();
         }
-        b if (32..127).contains(&b) => {
-            app.chat.news.composer_push(b as char);
+        c if !c.is_control() => {
+            app.chat.news.composer_push(c);
         }
         _ => {}
     }

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -48,6 +48,8 @@ enum PasteTarget {
 #[derive(Clone, Debug, Eq, PartialEq)]
 enum ParsedInput {
     Byte(u8),
+    // For non ASCII characters
+    Char(char),
     Arrow(u8),
     CtrlArrow(u8),
     CtrlBackspace,
@@ -68,6 +70,15 @@ enum ParsedInput {
     End,
     FocusGained,
     FocusLost,
+}
+
+impl ParsedInput {
+    fn unwrap_byte(&self) -> u8 {
+        match self {
+            ParsedInput::Byte(b) => *b,
+            _ => panic!("unwrap_byte called on non-byte variant"),
+        }
+    }
 }
 
 /// Walk `data` and split it on inline `ESC` + `CR`/`LF` pairs (Alt+Enter).
@@ -426,9 +437,34 @@ fn handle_vt_segment(app: &mut App, data: &[u8]) {
     }
 
     let events = app.vt_input.feed(data);
-    for event in events {
+    for event in agg_input_bytes_into_char(events) {
         handle_parsed_input(app, event);
     }
+}
+
+fn agg_input_bytes_into_char(events: Vec<ParsedInput>) -> Vec<ParsedInput> {
+    // if all bytes are UTF-8, aggregate into a single char
+    if events.len() <= 4
+        && events
+            .iter()
+            .all(|i| matches!(i, ParsedInput::Byte(b) if *b & 128 != 0))
+    {
+        let mut buf = [0u8; 4];
+        for (i, event) in events.iter().enumerate() {
+            buf[i] = event.unwrap_byte();
+        }
+
+        if let Some(c) = std::str::from_utf8(&buf[..events.len()])
+            .ok()
+            .and_then(|x| x.chars().next())
+        {
+            return vec![ParsedInput::Char(c)];
+        } else {
+            return events;
+        }
+    }
+
+    events
 }
 
 fn handle_overlay_input(app: &mut App, event: &ParsedInput) {
@@ -584,7 +620,7 @@ fn handle_parsed_input(app: &mut App, event: ParsedInput) {
                 return;
             }
 
-            if handle_modal_input(app, ctx, byte) {
+            if handle_modal_input(app, ctx, byte as char) {
                 return;
             }
 
@@ -595,6 +631,8 @@ fn handle_parsed_input(app: &mut App, event: ParsedInput) {
 
             dispatch_screen_key(app, ctx.screen, byte);
         }
+        // keys are ASCII characters and will be handled by previous match arm
+        ParsedInput::Char(ch) => _ = handle_modal_input(app, ctx, ch),
     }
 }
 
@@ -609,7 +647,7 @@ fn dispatch_escape(app: &mut App) {
         app.chat.cancel_room_jump();
         return;
     }
-    if handle_modal_input(app, ctx, 0x1B) {
+    if handle_modal_input(app, ctx, '\x1B') {
         return;
     }
     if (ctx.screen == Screen::Chat || ctx.screen == Screen::Dashboard) && app.chat.has_overlay() {
@@ -725,19 +763,20 @@ fn handle_arrow_for_screen(app: &mut App, screen: Screen, key: u8) -> bool {
     }
 }
 
-fn handle_modal_input(app: &mut App, ctx: InputContext, byte: u8) -> bool {
+fn handle_modal_input(app: &mut App, ctx: InputContext, ch: char) -> bool {
     if (ctx.screen == Screen::Dashboard || ctx.screen == Screen::Chat) && ctx.chat_composing {
-        chat::input::handle_compose_input(app, byte);
+        chat::input::handle_compose_input(app, ch);
         return true;
     }
 
     if ctx.screen == Screen::Chat && ctx.news_composing {
-        chat::news::input::handle_composer_input(app, byte);
+        chat::news::input::handle_composer_input(app, ch);
         return true;
     }
 
-    if ctx.screen == Screen::Profile && ctx.profile_composing {
-        profile::input::handle_composer_input(app, byte);
+    // only allow ASCII for profile composer input
+    if ctx.screen == Screen::Profile && ctx.profile_composing && ch.is_ascii() {
+        profile::input::handle_composer_input(app, ch);
         return true;
     }
 
@@ -963,20 +1002,18 @@ fn handle_icon_picker_input(app: &mut App, event: ParsedInput) {
     match event {
         ParsedInput::Byte(b'\r') => apply_icon_selection(app, false),
         ParsedInput::AltEnter => apply_icon_selection(app, true),
-        ParsedInput::Byte(0x7f) => {
-            if app.icon_picker_state.search_cursor > 0 {
-                let byte_pos = app
-                    .icon_picker_state
-                    .search_query
-                    .char_indices()
-                    .nth(app.icon_picker_state.search_cursor - 1)
-                    .map(|(i, _)| i)
-                    .unwrap_or(0);
-                app.icon_picker_state.search_query.remove(byte_pos);
-                app.icon_picker_state.search_cursor -= 1;
-                app.icon_picker_state.selected_index = 0;
-                app.icon_picker_state.scroll_offset = 0;
-            }
+        ParsedInput::Byte(0x7f) if app.icon_picker_state.search_cursor > 0 => {
+            let byte_pos = app
+                .icon_picker_state
+                .search_query
+                .char_indices()
+                .nth(app.icon_picker_state.search_cursor - 1)
+                .map(|(i, _)| i)
+                .unwrap_or(0);
+            app.icon_picker_state.search_query.remove(byte_pos);
+            app.icon_picker_state.search_cursor -= 1;
+            app.icon_picker_state.selected_index = 0;
+            app.icon_picker_state.scroll_offset = 0;
         }
         ParsedInput::Arrow(b'A') => picker_move_selection(app, -1),
         ParsedInput::Arrow(b'B') => picker_move_selection(app, 1),
@@ -1418,5 +1455,125 @@ mod tests {
             profile_composing: false,
         };
         assert!(ctx.blocks_arrow_sequence());
+    }
+
+    // Pure ASCII alphanumeric: a single Byte event passes through unchanged.
+    #[test]
+    fn ascii_alpha_passthrough() {
+        let input = vec![ParsedInput::Byte(b'a')];
+        assert_eq!(
+            agg_input_bytes_into_char(input),
+            vec![ParsedInput::Byte(b'a')]
+        );
+    }
+
+    #[test]
+    fn ascii_digit_passthrough() {
+        let input = vec![ParsedInput::Byte(b'7')];
+        assert_eq!(
+            agg_input_bytes_into_char(input),
+            vec![ParsedInput::Byte(b'7')]
+        );
+    }
+
+    #[test]
+    fn ascii_uppercase_passthrough() {
+        let input = vec![ParsedInput::Byte(b'Z')];
+        assert_eq!(
+            agg_input_bytes_into_char(input),
+            vec![ParsedInput::Byte(b'Z')]
+        );
+    }
+
+    // ASCII control bytes: high bit is clear, so they pass through as Byte.
+    #[test]
+    fn ascii_ctrl_nul_passthrough() {
+        let input = vec![ParsedInput::Byte(0x00)];
+        assert_eq!(
+            agg_input_bytes_into_char(input),
+            vec![ParsedInput::Byte(0x00)]
+        );
+    }
+
+    #[test]
+    fn ascii_ctrl_escape_passthrough() {
+        let input = vec![ParsedInput::Byte(0x1B)];
+        assert_eq!(
+            agg_input_bytes_into_char(input),
+            vec![ParsedInput::Byte(0x1B)]
+        );
+    }
+
+    #[test]
+    fn ascii_ctrl_del_passthrough() {
+        // DEL (0x7F) has the high bit clear, so it is not aggregated.
+        let input = vec![ParsedInput::Byte(0x7F)];
+        assert_eq!(
+            agg_input_bytes_into_char(input),
+            vec![ParsedInput::Byte(0x7F)]
+        );
+    }
+
+    // Two-byte UTF-8 sequence (U+0142 LATIN SMALL LETTER L WITH STROKE, "ł").
+    #[test]
+    fn utf8_two_byte_aggregated_into_char() {
+        let bytes: Vec<u8> = 'ł'.to_string().into_bytes(); // [0xC5, 0x82]
+        let input = bytes.iter().copied().map(ParsedInput::Byte).collect();
+        assert_eq!(
+            agg_input_bytes_into_char(input),
+            vec![ParsedInput::Char('ł')]
+        );
+    }
+
+    // Three-byte UTF-8 sequence (U+4E2D CJK UNIFIED IDEOGRAPH, "中").
+    #[test]
+    fn utf8_three_byte_aggregated_into_char() {
+        let bytes: Vec<u8> = '中'.to_string().into_bytes(); // [0xE4, 0xB8, 0xAD]
+        let input = bytes.iter().copied().map(ParsedInput::Byte).collect();
+        assert_eq!(
+            agg_input_bytes_into_char(input),
+            vec![ParsedInput::Char('中')]
+        );
+    }
+
+    // Four-byte UTF-8 sequence (U+1F600 GRINNING FACE, "😀").
+    #[test]
+    fn utf8_four_byte_aggregated_into_char() {
+        let bytes: Vec<u8> = '😀'.to_string().into_bytes(); // [0xF0, 0x9F, 0x98, 0x80]
+        let input = bytes.iter().copied().map(ParsedInput::Byte).collect();
+        assert_eq!(
+            agg_input_bytes_into_char(input),
+            vec![ParsedInput::Char('😀')]
+        );
+    }
+
+    // A mix of event types (e.g. Arrow alongside Byte) is never aggregated,
+    // even when all Bytes happen to have their high bit set.
+    #[test]
+    fn mixed_event_types_passthrough_unchanged() {
+        let input = vec![ParsedInput::Arrow(b'A'), ParsedInput::Byte(0xC5)];
+        let expected = vec![ParsedInput::Arrow(b'A'), ParsedInput::Byte(0xC5)];
+        assert_eq!(agg_input_bytes_into_char(input), expected);
+    }
+
+    // Five or more high-bit bytes cannot form a valid UTF-8 scalar, so they
+    // pass through as-is.
+    #[test]
+    fn too_many_high_bit_bytes_passthrough() {
+        let input = vec![
+            ParsedInput::Byte(0x80),
+            ParsedInput::Byte(0x81),
+            ParsedInput::Byte(0x82),
+            ParsedInput::Byte(0x83),
+            ParsedInput::Byte(0x84),
+        ];
+        let expected = input.clone();
+        assert_eq!(agg_input_bytes_into_char(input), expected);
+    }
+
+    // An empty event list should come back empty.
+    #[test]
+    fn empty_input_returns_empty() {
+        assert_eq!(agg_input_bytes_into_char(vec![]), vec![]);
     }
 }

--- a/late-ssh/src/app/profile/input.rs
+++ b/late-ssh/src/app/profile/input.rs
@@ -43,45 +43,22 @@ pub fn handle_arrow(app: &mut App, key: u8) -> bool {
     }
 }
 
-pub fn handle_composer_input(app: &mut App, byte: u8) {
-    match byte {
-        b'\r' => app.profile_state.submit_username(),
-        0x1B => app.profile_state.cancel_username_edit(),
-        0x15 => app.profile_state.composer_clear(),
-        0x7F => app.profile_state.composer_backspace(),
-        b => {
-            if let Some(ch) = composer_char_from_byte(b) {
-                app.profile_state.composer_push(ch);
-            }
+pub fn handle_composer_input(app: &mut App, ch: char) {
+    match ch {
+        '\r' => app.profile_state.submit_username(),
+        '\x1B' => app.profile_state.cancel_username_edit(),
+        '\x15' => app.profile_state.composer_clear(),
+        '\x7F' => app.profile_state.composer_backspace(),
+        ch if !ch.is_control() => {
+            app.profile_state.composer_push(ch);
         }
-    }
-}
-
-fn composer_char_from_byte(byte: u8) -> Option<char> {
-    if byte.is_ascii_graphic() || byte == b' ' {
-        Some(byte as char)
-    } else {
-        None
+        _ => {}
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn composer_char_from_byte_accepts_graphics_and_space() {
-        assert_eq!(composer_char_from_byte(b'a'), Some('a'));
-        assert_eq!(composer_char_from_byte(b'9'), Some('9'));
-        assert_eq!(composer_char_from_byte(b' '), Some(' '));
-    }
-
-    #[test]
-    fn composer_char_from_byte_rejects_control_bytes() {
-        assert_eq!(composer_char_from_byte(0x00), None);
-        assert_eq!(composer_char_from_byte(0x1B), None);
-        assert_eq!(composer_char_from_byte(b'\n'), None);
-    }
 
     #[test]
     fn settings_row_delta_maps_jk_keys() {


### PR DESCRIPTION
Changes:
- Added a ParsedInput::Char that is used only for non ASCII character input. When handling vt input in `handle_vt_segment` we detect if the input is a single utf8 char and convert multiple ParsedInput::Byte into a single Char
- functions that handle input for composable fields now accept `char` instead of `u8` to handle utf8
- some match arms with single ifs inside were collapsed to satisfy cargo clippy when running `make check` because of if let guards stabilization (if you run `make check` on main you'll see the issues)


https://asciinema.org/a/mMlhrqbc5wzimHoa