### PR TITLE
feat(ssh): Shift-Tab cycles screens backward

### DIFF
--- a/late-ssh/src/app/common/primitives.rs
+++ b/late-ssh/src/app/common/primitives.rs
@@ -63,6 +63,15 @@ impl Screen {
             Screen::Profile => Screen::Dashboard,
         }
     }
+
+    pub fn prev(self) -> Self {
+        match self {
+            Screen::Dashboard => Screen::Profile,
+            Screen::Chat => Screen::Dashboard,
+            Screen::Games => Screen::Chat,
+            Screen::Profile => Screen::Games,
+        }
+    }
 }
 
 pub fn genre_label(genre: Genre) -> &'static str {
@@ -145,6 +154,14 @@ mod tests {
         assert_eq!(Screen::Chat.next(), Screen::Games);
         assert_eq!(Screen::Games.next(), Screen::Profile);
         assert_eq!(Screen::Profile.next(), Screen::Dashboard);
+    }
+
+    #[test]
+    fn screen_prev_cycles_all_screens() {
+        assert_eq!(Screen::Dashboard.prev(), Screen::Profile);
+        assert_eq!(Screen::Chat.prev(), Screen::Dashboard);
+        assert_eq!(Screen::Games.prev(), Screen::Chat);
+        assert_eq!(Screen::Profile.prev(), Screen::Games);
     }
 
     #[test]

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -477,7 +477,32 @@ fn handle_parsed_input(app: &mut App, event: ParsedInput) {
         ParsedInput::Scroll(delta) => handle_scroll_for_screen(app, ctx.screen, delta),
         // Mouse clicks only matter inside the icon picker today; ignore here.
         ParsedInput::MousePress { .. } => {}
-        ParsedInput::BackTab => {}
+        ParsedInput::BackTab => {
+            if ctx.screen == Screen::Chat && app.chat.room_jump_active {
+                return;
+            }
+            if (ctx.screen == Screen::Dashboard || ctx.screen == Screen::Chat) && ctx.chat_composing
+            {
+                return;
+            }
+            if ctx.screen == Screen::Chat && ctx.news_composing {
+                return;
+            }
+            if ctx.screen == Screen::Profile && ctx.profile_composing {
+                return;
+            }
+            if ctx.screen == Screen::Games && app.is_playing_game {
+                return;
+            }
+            reset_composers_for_page_change(app);
+            app.screen = ctx.screen.prev();
+            if app.screen == Screen::Chat {
+                app.chat.request_list();
+                app.chat.sync_selection();
+                app.chat.mark_selected_room_read();
+            }
+            app.chat.clear_message_selection();
+        }
         // Page keys mirror Ctrl-U / Ctrl-D. Signs follow the existing scheme:
         // positive = toward older/top, negative = toward newer/bottom. See
         // `app.chat.select_message` — its `delta` is in MESSAGES, not rows,
@@ -1195,6 +1220,12 @@ mod tests {
     fn vt_parser_reads_ss3_arrow_sequence() {
         let mut parser = VtInputParser::default();
         assert_eq!(parser.feed(b"\x1bOD"), vec![ParsedInput::Arrow(b'D')]);
+    }
+
+    #[test]
+    fn vt_parser_reads_backtab_sequence() {
+        let mut parser = VtInputParser::default();
+        assert_eq!(parser.feed(b"\x1b[Z"), vec![ParsedInput::BackTab]);
     }
 
     #[test]

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -580,7 +580,7 @@ fn draw_help_overlay(
         Line::from(""),
         section("Global"),
         divider(col_w),
-        key("Tab", "next screen"),
+        key("Tab / S-Tab", "next / prev screen"),
         key("1-4", "jump to screen"),
         key("m", "mute paired"),
         key("+ / -", "volume"),

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -72,6 +72,32 @@ async fn screen_number_keys_switch_between_dashboard_games_and_chat() {
 }
 
 #[tokio::test]
+async fn shift_tab_cycles_screens_backwards() {
+    let test_db = new_test_db().await;
+    let user = create_test_user(&test_db.db, "screen-backtab-it").await;
+    let client = test_db.db.get().await.expect("db client");
+    let general = ChatRoom::ensure_general(&client)
+        .await
+        .expect("ensure general room");
+    ChatRoomMember::join(&client, general.id, user.id)
+        .await
+        .expect("join general room");
+    let mut app = make_app(test_db.db.clone(), user.id, "screen-backtab-flow-it");
+
+    app.handle_input(b"\x1b[Z");
+    wait_for_render_contains(&mut app, " Profile ").await;
+
+    app.handle_input(b"\x1b[Z");
+    wait_for_render_contains(&mut app, " The Arcade ").await;
+
+    app.handle_input(b"\x1b[Z");
+    wait_for_render_contains(&mut app, " Rooms (h/l)").await;
+
+    app.handle_input(b"\x1b[Z");
+    wait_for_render_contains(&mut app, " Dashboard ").await;
+}
+
+#[tokio::test]
 async fn active_game_blocks_screen_number_hotkeys() {
     let test_db = new_test_db().await;
     let user = create_test_user(&test_db.db, "games-hotkey-it").await;


### PR DESCRIPTION
It keeps getting requested repeatedly in the suggestions  channel, so I thought -- let's just do it.

## Summary
- Adds `Screen::prev()` and wires Shift-Tab (xterm `CSI Z`) to cycle screens in reverse: Dashboard → Profile → Games → Chat → Dashboard.
- Mirrors Tab's blocked set — inert while composing chat/news/profile, during room-jump mode, and with an active game — so Shift-Tab is allowed iff Tab's screen-switch is allowed.
- Updates `/help` global section from `Tab` to `Tab / S-Tab`.

## Test plan
- [x] `cargo test -p late-ssh --lib` (covers `Screen::prev` and `\x1b[Z` parser)
- [x] `cargo test -p late-ssh --test app_input_flow shift_tab_cycles_screens_backwards`
- [ ] Manual: `ssh -p 2222 <user>@localhost`, Shift-Tab should cycle backward; verify it's inert while composing a message, in room-jump mode (space on Chat), and during an active game.