### PR TITLE
Add private chat rooms with invites and rework room commands

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: late.sh - Terminal Clubhouse for Developers
 - Primary audience: LLM agents working on this codebase, human contributors
-- Last updated: 2026-04-19
+- Last updated: 2026-04-20
 - Status: Active
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change often.
 
@@ -525,7 +525,7 @@ late-sh/
 - **Open access:** `LATE_SSH_OPEN=true` enables auth, but only public-key auth is accepted; password and keyboard-interactive are always rejected
 - **User scoping:** Votes are scoped to `user_id` (FK to `users.id`)
 - **Chat scoping:** Rooms visible via membership (`ChatRoom::list_for_user`, `ChatRoomMember`)
-- **Auto-join:** Public rooms with `auto_join=true` are joined on first connection (`auto_join_public_rooms`); `/create` makes auto-join rooms everyone can leave, `/create-room` (admin) makes permanent rooms nobody can leave
+- **Auto-join:** Public rooms with `auto_join=true` are seeded for a user only when the user record is first created; reconnecting does not re-add rooms the user already left. Permanent/admin room creation still bulk-adds all existing users when the room is created/promoted.
 - **Multi-tenant isolation:** All user data queries filter by `user_id`; no cross-user reads
 
 ### 4.3 Data model and key enums
@@ -776,11 +776,11 @@ Currently the SSH app assumes a single process. These in-memory structures would
 6. Failure: `IgnoreFailed { user_id, message }` for self-target, unknown username, already-ignored, or not-currently-ignored — surfaced as a red banner.
 
 **Chat roster/help overlay flow:**
-1. Trigger: User submits `/help`, `/active`, or `/list` in the composer
-2. Processing: `ChatState::submit_composer()` intercepts these before any message send. `/help` opens a static overlay, `/active` snapshots the shared in-memory `active_users` registry, and `/list` spawns `ChatService::list_room_members_task` for the selected non-auto-join room.
-3. Side effects: `/active` renders usernames in an overlay immediately and annotates repeated SSH sessions as `(<n> sessions)`. `/list` resolves `chat_room_members` to `users.username` and opens a room-member overlay when the async event arrives.
-4. Guardrail: `/list` is only allowed for the product's "private" rooms, defined in the TUI as `auto_join = false` and `kind != 'dm'`; it is rejected in `general`, permanent/public auto-join rooms, and DMs.
-5. Failure: `/list` on the wrong room shows a red banner; DB/service errors surface via `RoomMembersListFailed`.
+1. Trigger: User submits `/help`, `/active`, `/members`, or `/list` in the composer
+2. Processing: `ChatState::submit_composer()` intercepts these before any message send. `/help` opens a static overlay, `/active` snapshots the shared in-memory `active_users` registry, `/members` spawns `ChatService::list_room_members_task` for the selected room, and `/list` spawns `ChatService::list_public_rooms_task`.
+3. Side effects: `/active` renders usernames in an overlay immediately and annotates repeated SSH sessions as `(<n> sessions)`. `/members` resolves `chat_room_members` to `users.username` and opens a room-member overlay when the async event arrives. `/list` opens a simple public-room overlay with member counts.
+4. Guardrail: `/members` still requires a real selected room; DMs are allowed and render a generic `DM Members` title.
+5. Failure: Missing room selection or DB/service errors surface as chat banners via `RoomMembersListFailed` / `PublicRoomsListFailed`.
 
 **Chat reply flow:**
 1. Trigger: User selects a message (`j`/`k`) and presses `r`
@@ -814,7 +814,7 @@ Currently the SSH app assumes a single process. These in-memory structures would
 - **Chat message navigation is selection-first:** `selected_message_id` is the source of truth on both the dashboard general card and the chat screen (they share one storage). Mouse wheel, arrows, paging, and `j/k` all move selection; when no message is selected, the viewport falls back to newest-at-bottom.
 - **Chat display names are intentionally plain:** transcript author labels, DM labels, and member labels render the stored username without a leading `@` and without an appended country badge. `@` still exists in composer mentions, mention autocomplete, and command syntax (`/dm @user`, `/ignore @user`, etc.), so display formatting and mention syntax are deliberately different.
 - **Chat wrapping is word-aware:** Shared wrapping prefers breaking on whitespace for regular messages, reply quote lines, news-card text, and the composer. Hard splits are only valid for single words longer than the available width.
-- **Chat room list order is UI-defined:** The chat sidebar order is hardcoded as `core` (`general`, `announcements`, `suggestions`, any other permanent rooms, then synthetic `news`) → `public` → `private` → `dm`, with divider rows rendered in the UI. Here, "private" is a UI/product label for non-auto-join rooms (`auto_join = false`), not necessarily DB `visibility = 'private'`. The synthetic `news` row now carries its own unread badge sourced from `article_feed_reads`, not `chat_room_members`.
+- **Chat room list order is UI-defined:** The chat sidebar order is hardcoded as `core` (`general`, `announcements`, `suggestions`, any other permanent rooms, then synthetic `news`) → `public` → `private` → `dm`, with divider rows rendered in the UI. Public/private sections now map directly to DB `visibility = 'public' | 'private'` for non-permanent, non-DM rooms. The synthetic `news` row now carries its own unread badge sourced from `article_feed_reads`, not `chat_room_members`.
 - **Transcript render cost is cache-sensitive:** every member room keeps a warm tail (broadcast-driven, hard-capped at 1000 messages per room). The chat UI caches wrapped transcript rows for the dashboard general card and the active room; invalidation must track width, message content/order, usernames, badges, and bonsai glyphs. Only the selected room and general are fetched from DB on snapshot refresh — other rooms warm up from broadcasts and pull a one-shot backfill via `request_list` on first open per session.
 - **Composer render cost is cache-sensitive:** The chat composer caches wrapped `ComposerRow`s in `ChatState`; any change to composer text or width must invalidate that cache before render/cursor-up/down.
 - **Icon picker is chat-composer-only:** `Ctrl+]` (byte `0x1D`) opens `app::icon_picker` as a modal overlay, lazy-loads the catalog on first open (two sections each for Emoji and Nerd Font — no Unicode tab, no `unicode_names2` dep), and auto-starts `ChatState::start_composing` if the user isn't already composing. Selected icons are only ever pushed into `app.chat.composer`; Profile and news composers are intentionally not targets. The picker intercepts all input via an early return in `handle_parsed_input`, so while it is open nothing else on screen receives keys.
@@ -1015,9 +1015,9 @@ Use narrower crate-specific `cargo test` / `cargo nextest run` commands ad hoc w
 | Screen | Key | Status | Description |
 |--------|-----|--------|-------------|
 | **Dashboard** | 1 | Active | Now playing + vibe voting + `/music` hint + dashboard chat (The Lounge Hub) |
-| **Chat** | 2 | Active | Full room-list chat screen (`/dm @user`, `/join #room`, `/create #room`, `/leave`, `/active`, `/list`, `/ignore [@user]`, `/unignore [@user]`, `/music`, `/help`) with grouped room sections and a synthetic `news` entry in the room list |
+| **Chat** | 2 | Active | Full room-list chat screen (`/dm @user`, `/public #room`, `/private #room`, `/invite @user`, `/members`, `/leave`, `/active`, `/list`, `/ignore [@user]`, `/unignore [@user]`, `/music`, `/profile`, `/help`) with grouped room sections and a synthetic `news` entry in the room list |
 | **Games** | 3 | Active | The Arcade Lobby + leaderboard sidebar (champions, streaks, all-time high scores, chip leaders, info): persisted high-score games (`2048`, `Tetris`), daily games (`Sudoku`, `Nonograms`, `Minesweeper`, `Solitaire`), and admin-gated shared-table Blackjack. Game list auto-scrolls (top-third anchor); ASCII header hides on small screens |
-| **Profile** | 4 | Active | Read-only public identity card: username, country, timezone, optional `Current time` (derived from timezone when parseable), bio, Your Stats (streak + badge, chips, high scores), @bot/@graybeard info. Bio is wrapped at the same width the modal editor uses (`welcome_modal::ui::bio_text_width(MODAL_WIDTH)`) via `build_composer_rows`, so pasted URLs fold instead of running off-screen. All editing happens in the **welcome/profile modal** (auto-opens on first login, reopen via Profile's edit action) — sectioned into Identity / Appearance / Notifications / Location, with a Save CTA and a `?` callout that opens the help modal on top. Bio is an inline full-width bordered editor under the Identity heading (encouraging people to share site / GitHub / socials); it accepts bracketed-paste so URLs drop in whole. Theme + background color preview live from the draft while the modal is open. Selecting a chat message and pressing `p` opens a separate read-only **profile modal** for that author; it shows the same public identity summary, supports `j/k` or arrows for scroll, and is slightly wider than the first revision. |
+| **Profile** | 4 | Active | Read-only public identity card: username, country, timezone, optional `Current time` (derived from timezone when parseable), bio, Your Stats (streak + badge, chips, high scores), @bot/@graybeard info. Bio is wrapped at the same width the modal editor uses (`settings_modal::ui::bio_text_width(MODAL_WIDTH)`) via `build_composer_rows`, so pasted URLs fold instead of running off-screen. All editing happens in the **profile/settings modal** (auto-opens on first login, reopen via Profile's edit action or `/profile`) — sectioned into Identity / Appearance / Notifications / Location, with a Save CTA and a `?` callout that opens the help modal on top. Bio is an inline full-width bordered editor under the Identity heading (encouraging people to share site / GitHub / socials); it accepts bracketed-paste so URLs drop in whole. Theme + background color preview live from the draft while the modal is open. Selecting a chat message and pressing `p` opens a separate read-only **profile modal** for that author; it shows the same public identity summary, supports `j/k` or arrows for scroll, and is slightly wider than the first revision. |
 
 ### Layout
 
@@ -1048,17 +1048,17 @@ Use narrower crate-specific `cargo test` / `cargo nextest run` commands ad hoc w
 └────────────────────────────────────────────────────────────────────┘
 ```
 
-Toast notification is hidden by default (0 rows). When active, it appears as a 3-row bordered block (green for success, red for error) at the **top-right** of the content area. Welcome overlay renders on top of the toast.
+Toast notification is hidden by default (0 rows). When active, it appears as a 3-row bordered block (green for success, red for error) at the **top-right** of the content area. The profile/settings overlay renders on top of the toast.
 
 ### Keyboard shortcuts
 
 | Key | Context | Action |
 |-----|---------|--------|
 | `q` / `Q` / `Ctrl+C` | Global | Quit |
-| `?` | Global (not composing) | Open help modal (multi-slide guide). Also works inside the welcome/profile modal, which renders help on top while keeping the draft intact. |
+| `?` | Global (not composing) | Open help modal (multi-slide guide). Also works inside the profile/settings modal, which renders help on top while keeping the draft intact. |
 | `h` / `l` / `←` / `→` | Help modal | Switch slides (Overview / Chat / Music / News / Arcade / Bonsai / Profile / Architecture) |
 | `j` / `k` / `↑` / `↓` | Help modal | Scroll current slide (uncapped — past the last line is blank space) |
-| `?` / `q` / `Esc` | Help modal | Close (returns to underlying screen, including welcome modal if it was open) |
+| `?` / `q` / `Esc` | Help modal | Close (returns to underlying screen, including the profile/settings modal if it was open) |
 | `Tab` | Global | Cycle screens |
 | `1` | Global | Jump to Dashboard |
 | `2` | Global | Jump to Chat |
@@ -1118,16 +1118,17 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `/active` | Chat composer | List active SSH users from the in-memory session registry |
 | `/list` | Chat composer | List users in the selected non-auto-join ("private") room |
 | `/music` | Chat composer | Open music setup instructions in the same scrollable overlay flow as `/help` |
+| `/profile` | Chat composer | Open the profile/settings modal |
 | `/ignore [@user]` | Chat composer | Mute a user, or list muted users when no arg |
 | `/unignore [@user]` | Chat composer | Remove a user from your ignore list |
 | `j` / `k` / arrows | Chat overlay (`/help`, ignore list) | Scroll overlay |
 | `q` / `Esc` | Chat overlay (`/help`, ignore list) | Close overlay |
-| `Enter` | Profile screen | Open the welcome/profile modal to edit |
-| `↑` / `↓` / `j` / `k` | Welcome/profile modal | Move between rows (Username, Bio, Theme, Background, DMs, @mentions, Game events, Bell, Cooldown, Country, Timezone, Save) |
-| `←` / `→` | Welcome/profile modal | Cycle the current row's setting (theme, toggles, cooldown) |
-| `Space` / `Enter` / `e` | Welcome/profile modal | Activate row — edit username/bio, cycle a setting, open country/timezone picker, or fire Save |
-| `Alt+Enter` | Welcome/profile modal (bio editing) | Insert newline |
-| `?` | Welcome/profile modal | Open help modal on top |
+| `Enter` | Profile screen | Open the profile/settings modal to edit |
+| `↑` / `↓` / `j` / `k` | Profile/settings modal | Move between rows (Username, Bio, Theme, Background, DMs, @mentions, Game events, Bell, Cooldown, Country, Timezone, Save) |
+| `←` / `→` | Profile/settings modal | Cycle the current row's setting (theme, toggles, cooldown) |
+| `Space` / `Enter` / `e` | Profile/settings modal | Activate row — edit username/bio, cycle a setting, open country/timezone picker, or fire Save |
+| `Alt+Enter` | Profile/settings modal (bio editing) | Insert newline |
+| `?` | Profile/settings modal | Open help modal on top |
 | `j` / `k` / `↑` / `↓` | Read-only profile modal | Scroll |
 | `q` / `Esc` | Read-only profile modal | Close |
 | `Esc` | Any modal | Close/cancel |
@@ -1147,7 +1148,7 @@ When modifying any keybinding, update **all** of the following:
 
 1. **Input handler** — the actual `match byte` in the relevant `input.rs` (screen-specific or `app/input.rs` for globals)
 2. **Help modal** — `app/help_modal/data.rs` (slide copy, e.g. Overview "This modal" section) and `app/help_modal/ui.rs` `draw_footer()` keybind line
-3. **Welcome modal** — `app/welcome_modal/ui.rs` `draw_footer()` keybind line and the bordered help callout in `draw_help_callout()`
+3. **Settings modal** — `app/settings_modal/ui.rs` `draw_footer()` keybind line and the bordered help callout in `draw_help_callout()`
 4. **Sidebar hints** — `app/common/sidebar.rs`, e.g. the volume/mute hint line in Now Playing
 5. **Game guard** — `app/input.rs` `handle_global_key()`, the `!matches!(byte, ...)` allowlist for keys that pass through during active games
 6. **This table** — the keyboard shortcuts table above in CONTEXT.md

--- a/MUSIC.md
+++ b/MUSIC.md
@@ -3,13 +3,13 @@
 This file tracks the local music catalog used by `late.sh` radio.
 
 - Runtime source of truth for playback order is the `.m3u` files in `infra/liquidsoap/`.
-- Source of truth for reproducible fetching is `scripts/fetch_cc_music.py`.
+- Source of truth for reproducible fetching is `scripts/fetch_cc_music.py` plus `scripts/fetch_ambient_refresh.py` for the expanded ambient catalog.
 - `CONTEXT.md` should keep only high-signal status and point here for detailed track inventories.
 
 ## Library Status
 
 - `lofi`: done, 50 tracks, mixed `CC0` and `CC-BY 4.0`
-- `ambient`: done, 14 tracks, all `CC-BY 4.0`
+- `ambient`: done, 93 tracks, mixed `CC0` and `CC-BY 4.0`
 - `classic`: done, 40 tracks, public domain via Musopen / Internet Archive
 - `jazz`: pending
 
@@ -72,20 +72,99 @@ This file tracks the local music catalog used by `late.sh` radio.
 
 | # | Artist | Title | License | Source URL |
 |---|--------|-------|---------|------------|
-| 1 | Amarent | Swirling Snowflakes - Finale | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/swirling-snowflakes-finale/ |
-| 2 | Amarent | Sweet Dreams (Middle-Eastern Remix) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/sweet-dreams-middle-eastern-remix/ |
-| 3 | Amarent | Salt Lake Swerve (Chillout Remix) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/salt-lake-swerve-chillout-remix/ |
-| 4 | Amarent | Cathay Lounge | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/cathay-lounge/ |
-| 5 | Amarent | A Better World | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/a-better-world/ |
-| 6 | Amarent | Sweet Dreams | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/sweet-dreams-2/ |
-| 7 | Amarent | Sweet Love (Chill Remix) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/sweet-love-chill-remix/ |
-| 8 | Amarent | Outer Space | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-atmospheric-music/outer-space/ |
-| 9 | Amarent | Tuesday Night | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-atmospheric-music/tuesday-night/ |
-| 10 | Amarent | Tuesday Night (Radio Edit) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-atmospheric-music/tuesday-night-radio-edit/ |
-| 11 | Amarent | Ethereal | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-atmospheric-music/ethereal-2/ |
-| 12 | Ketsa | Meditation | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/modern-meditations/meditation-5/ |
-| 13 | Ketsa | Morning Stillness | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/modern-meditations/morning-stillness/ |
-| 14 | Ketsa | Patterns | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/modern-meditations/patterns-1/ |
+| 1 | 1000 Handz | Alchemist | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/alchemist/ |
+| 2 | 1000 Handz | Astral Longing | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/astral-longing/ |
+| 3 | 1000 Handz | Astral | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/astral-1/ |
+| 4 | 1000 Handz | Avatar | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/avatar/ |
+| 5 | 1000 Handz | Cosmos | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodic-rap-instrumentals-vol-2/cosmos-3/ |
+| 6 | 1000 Handz | Cross Rhodes | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/cross-rhodes/ |
+| 7 | 1000 Handz | Dance Hall | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/dance-hall/ |
+| 8 | 1000 Handz | Dark Side of the Moon | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodic-rap-instrumentals-vol-2/dark-side-of-the-moon-1/ |
+| 9 | 1000 Handz | Download | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/download/ |
+| 10 | 1000 Handz | Galactic | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-electronicgaming-instrumentals/galactic/ |
+| 11 | 1000 Handz | Giza | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/giza-2/ |
+| 12 | 1000 Handz | Guild | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/guild/ |
+| 13 | 1000 Handz | Hopeful | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/hopeful-3/ |
+| 14 | 1000 Handz | Isles | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/isles/ |
+| 15 | 1000 Handz | Kraken | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-electronicgaming-instrumentals/kraken/ |
+| 16 | 1000 Handz | Lilies | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/lilies/ |
+| 17 | 1000 Handz | Magneto | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/magneto/ |
+| 18 | 1000 Handz | Misunderstood | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/misunderstood-4/ |
+| 19 | 1000 Handz | Monaco | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/monaco/ |
+| 20 | 1000 Handz | Motherboard | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-electronicgaming-instrumentals/motherboard-1/ |
+| 21 | 1000 Handz | Mystery | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/mystery-2/ |
+| 22 | 1000 Handz | Orbitol | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/orbitol/ |
+| 23 | 1000 Handz | Orion (no drums) | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/orion-no-drums/ |
+| 24 | 1000 Handz | Phantomm | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-electronicgaming-instrumentals/phantomm/ |
+| 25 | 1000 Handz | Potential | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/potential/ |
+| 26 | 1000 Handz | Saturn ft. ADG | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-electronicgaming-instrumentals/saturn-ft-adg/ |
+| 27 | 1000 Handz | Shatter | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodic-rap-instrumentals-vol-2/shatter-1/ |
+| 28 | 1000 Handz | Silense | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/silense/ |
+| 29 | 1000 Handz | Stories | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/stories-2/ |
+| 30 | 1000 Handz | Tea | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/tea/ |
+| 31 | 1000 Handz | The Muse | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/the-muse/ |
+| 32 | 1000 Handz | The Shire | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/the-shire/ |
+| 33 | 1000 Handz | The Well | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/the-well/ |
+| 34 | 1000 Handz | Through The Stars | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/through-the-stars-1/ |
+| 35 | 1000 Handz | Throughout | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/throughout/ |
+| 36 | 1000 Handz | Tundra | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/tundra/ |
+| 37 | 1000 Handz | Unlimited | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-electronicgaming-instrumentals/unlimited/ |
+| 38 | 1000 Handz | Wednesday | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-ambientbackground-scores/wednesday-1/ |
+| 39 | 1000 Handz | World Is Yourz | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/world-is-yourz/ |
+| 40 | 1000 Handz | Xperience | CC-BY 4.0 | https://freemusicarchive.org/music/1000-handz/cc-by-free-to-use-melodiessamples-no-drums/xperience/ |
+| 41 | Holizna (Synthetic People) | A Lonely Asteroid Headed Towards Earth | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 42 | Holizna (Synthetic People) | A Small Town On Pluto (Family Vacation) | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 43 | Holizna (Synthetic People) | A Small Town On Pluto (The Grocery Store) | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 44 | Holizna (Synthetic People) | Astronaut (Part 2) | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 45 | Holizna (Synthetic People) | Astronaut (Part 3) | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 46 | Holizna (Synthetic People) | Astronaut | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 47 | Holizna (Synthetic People) | Before The Big Bang | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 48 | Holizna (Synthetic People) | Fomalhaut b, Iota Draconis-b, Mu Arae c, WASP 17b, and 51 Pegasi b, This is for You! | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 49 | Holizna (Synthetic People) | Saturn In A Meteor Shower | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 50 | Holizna (Synthetic People) | Space Hospitals | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 51 | Holizna (Synthetic People) | The Milky Way | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 52 | Holizna (Synthetic People) | Tiny Plastic Video Games For Long Anxious Space Travel | CC0 | https://holiznacc0.bandcamp.com/album/an-ocean-in-outer-space |
+| 53 | Holizna | A Cloud Dog Named Sky | CC0 | https://holiznacc0.bandcamp.com/album/make-shift-salvation |
+| 54 | Holizna | A Small Town On Pluto | CC0 | https://holiznacc0.bandcamp.com/album/a-small-town-on-pluto |
+| 55 | Holizna | Cold Feet | CC0 | https://holiznacc0.bandcamp.com/album/a-small-town-on-pluto |
+| 56 | Holizna | Goodbye Good Times | CC0 | https://holiznacc0.bandcamp.com/album/make-shift-salvation |
+| 57 | Holizna | Iron Skies | CC0 | https://holiznacc0.bandcamp.com/album/make-shift-salvation |
+| 58 | Holizna | Last Train To Earth | CC0 | https://holiznacc0.bandcamp.com/album/a-small-town-on-pluto |
+| 59 | Holizna | Make-Shift Salvation | CC0 | https://holiznacc0.bandcamp.com/album/make-shift-salvation |
+| 60 | Holizna | The Edge Of Nowhere | CC0 | https://holiznacc0.bandcamp.com/album/make-shift-salvation |
+| 61 | Holizna | The Only Store In Town | CC0 | https://holiznacc0.bandcamp.com/album/a-small-town-on-pluto |
+| 62 | Holizna | The Wind That Whistled Through The Wicker Chair | CC0 | https://holiznacc0.bandcamp.com/album/make-shift-salvation |
+| 63 | Almusic34 | Deep Space Ambient | CC-BY 4.0 | https://freemusicarchive.org/music/almusic34/single/deep-space-ambientmp3/ |
+| 64 | Almusic34 | Space Ambient Mix 4 | CC-BY 4.0 | https://freemusicarchive.org/music/almusic34/single/space-ambient-mix-4mp3/ |
+| 65 | Almusic34 | Space Ambient Mix | CC-BY 4.0 | https://freemusicarchive.org/music/almusic34/single/space-ambient-mixmp3 |
+| 66 | Amarent | A Better World | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/a-better-world/ |
+| 67 | Amarent | At the Heart of It Is Just Me and You (Instrumental) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/instrumental-versions/at-the-heart-of-it-is-just-me-and-you-instrumental/ |
+| 68 | Amarent | Cathay Lounge | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/cathay-lounge/ |
+| 69 | Amarent | Ethereal | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-atmospheric-music/ethereal-2/ |
+| 70 | Amarent | Never Let Go (Instrumental) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/instrumental-versions/never-let-go-instrumental/ |
+| 71 | Amarent | Outer Space | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-atmospheric-music/outer-space/ |
+| 72 | Amarent | Salt Lake Swerve (Chillout Remix) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/salt-lake-swerve-chillout-remix/ |
+| 73 | Amarent | Sweet Dreams (Middle-Eastern Remix) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/sweet-dreams-middle-eastern-remix/ |
+| 74 | Amarent | Sweet Dreams | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/sweet-dreams-2/ |
+| 75 | Amarent | Sweet Love (Chill Remix) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/sweet-love-chill-remix/ |
+| 76 | Amarent | Swirling Snowflakes - Finale | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-ambient-music/swirling-snowflakes-finale/ |
+| 77 | Amarent | To the Moon (Instrumental) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/instrumental-versions/to-the-moon-instrumental/ |
+| 78 | Amarent | Tuesday Night (Radio Edit) | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-atmospheric-music/tuesday-night-radio-edit/ |
+| 79 | Amarent | Tuesday Night | CC-BY 4.0 | https://freemusicarchive.org/music/amarent/free-atmospheric-music/tuesday-night/ |
+| 80 | Ketsa | Around the Corner | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/cc-by-free-to-use-for-anything/around-the-corner/ |
+| 81 | Ketsa | Harmony | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/cc-by-free-to-use-for-anything/harmony-4/ |
+| 82 | Ketsa | Machine Ghosts | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/cc-by-free-to-use-for-anything/machine-ghosts/ |
+| 83 | Ketsa | Meditation | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/modern-meditations/meditation-5/ |
+| 84 | Ketsa | Morning Stillness | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/modern-meditations/morning-stillness/ |
+| 85 | Ketsa | Patterns | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/modern-meditations/patterns-1/ |
+| 86 | Ketsa | Still Dreams | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/cc-by-free-to-use-for-anything/still-dreams/ |
+| 87 | Ketsa | Surroundings are Green | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/cc-by-free-to-use-for-anything/surroundings-are-green/ |
+| 88 | Ketsa | Where Dreams Drift | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/cc-by-free-to-use-for-anything/where-dreams-drift/ |
+| 89 | Sergey Cheremisinov | Last Moon Last Stars | CC-BY 4.0 | https://freemusicarchive.org/music/Sergey_Cheremisinov/metamorphoses/last-moon-last-stars/ |
+| 90 | Sergey Cheremisinov | Metamorphoses | CC-BY 4.0 | https://freemusicarchive.org/music/Sergey_Cheremisinov/metamorphoses/metamorphoses/ |
+| 91 | Sergey Cheremisinov | Mindful Choice | CC-BY 4.0 | https://freemusicarchive.org/music/Sergey_Cheremisinov/metamorphoses/mindful-choice/ |
+| 92 | Splashkabona | Dreamy Ambient Positive Moments in Time | CC-BY 4.0 | https://freemusicarchive.org/music/splashkabona/single/dreamy-ambient-positive-moments-in-time/ |
+| 93 | Vlad Annenkov | Emotional Cinematic Ambient "Gentle Memory" | CC-BY 4.0 | https://freemusicarchive.org/music/vlad-annenkov/single/emotional-cinematic-ambient-gentle-memorymp3/ |
 
 ## Classic
 

--- a/MUSIC.md
+++ b/MUSIC.md
@@ -9,7 +9,7 @@ This file tracks the local music catalog used by `late.sh` radio.
 ## Library Status
 
 - `lofi`: done, 50 tracks, mixed `CC0` and `CC-BY 4.0`
-- `ambient`: done, 20 tracks, all `CC-BY 4.0`
+- `ambient`: done, 14 tracks, all `CC-BY 4.0`
 - `classic`: done, 40 tracks, public domain via Musopen / Internet Archive
 - `jazz`: pending
 
@@ -86,12 +86,6 @@ This file tracks the local music catalog used by `late.sh` radio.
 | 12 | Ketsa | Meditation | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/modern-meditations/meditation-5/ |
 | 13 | Ketsa | Morning Stillness | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/modern-meditations/morning-stillness/ |
 | 14 | Ketsa | Patterns | CC-BY 4.0 | https://freemusicarchive.org/music/Ketsa/modern-meditations/patterns-1/ |
-| 15 | The Imperfectionist | White Noise Part 1 | CC-BY 4.0 | https://freemusicarchive.org/music/the-imperfectionist/white-noise/1-white-noise-part1mp3/ |
-| 16 | The Imperfectionist | White Noise Part 2 | CC-BY 4.0 | https://freemusicarchive.org/music/the-imperfectionist/white-noise/2-white-noise-part2mp3/ |
-| 17 | The Imperfectionist | White Noise Part 3 | CC-BY 4.0 | https://freemusicarchive.org/music/the-imperfectionist/white-noise/3-white-noise-part3mp3/ |
-| 18 | The Imperfectionist | White Noise Part 4 | CC-BY 4.0 | https://freemusicarchive.org/music/the-imperfectionist/white-noise/4-white-noise-part4mp3/ |
-| 19 | The Imperfectionist | White Noise Part 5 | CC-BY 4.0 | https://freemusicarchive.org/music/the-imperfectionist/white-noise/5-white-noise-part5mp3/ |
-| 20 | The Imperfectionist | White Noise Part 6 | CC-BY 4.0 | https://freemusicarchive.org/music/the-imperfectionist/white-noise/6-white-noise-part6mp3/ |
 
 ## Classic
 

--- a/infra/liquidsoap/ambient.m3u
+++ b/infra/liquidsoap/ambient.m3u
@@ -1,20 +1,93 @@
-annotate:artist="Amarent",title="Swirling Snowflakes - Finale",duration="183":/music/ambient/amarent-swirling-snowflakes-finale.mp3
-annotate:artist="Amarent",title="Sweet Dreams",duration="219":/music/ambient/amarent-sweet-dreams-middle-eastern-remix.mp3
-annotate:artist="Amarent",title="Salt Lake Swerve (Chill Remix)",duration="251":/music/ambient/amarent-salt-lake-swerve-chillout-remix.mp3
-annotate:artist="Amarent",title="Cathay Lounge",duration="312":/music/ambient/amarent-cathay-lounge.mp3
+annotate:artist="1000 Handz",title="Alchemist",duration="216":/music/ambient/1000-handz-alchemist.mp3
+annotate:artist="1000 Handz",title="Astral Longing",duration="142":/music/ambient/1000-handz-astral-longing.mp3
+annotate:artist="1000 Handz",title="Astral",duration="137":/music/ambient/1000-handz-astral.mp3
+annotate:artist="1000 Handz",title="Avatar",duration="137":/music/ambient/1000-handz-avatar.mp3
+annotate:artist="1000 Handz",title="Cosmos",duration="156":/music/ambient/1000-handz-cosmos.mp3
+annotate:artist="1000 Handz",title="Cross Rhodes",duration="258":/music/ambient/1000-handz-cross-rhodes.mp3
+annotate:artist="1000 Handz",title="Dance Hall",duration="164":/music/ambient/1000-handz-dance-hall.mp3
+annotate:artist="1000 Handz",title="Dark Side of the Moon",duration="175":/music/ambient/1000-handz-dark-side-of-the-moon.mp3
+annotate:artist="1000 Handz",title="Download",duration="137":/music/ambient/1000-handz-download.mp3
+annotate:artist="1000 Handz",title="Galactic",duration="236":/music/ambient/1000-handz-galactic.mp3
+annotate:artist="1000 Handz",title="Giza",duration="195":/music/ambient/1000-handz-giza.mp3
+annotate:artist="1000 Handz",title="Guild",duration="163":/music/ambient/1000-handz-guild.mp3
+annotate:artist="1000 Handz",title="Hopeful",duration="163":/music/ambient/1000-handz-hopeful.mp3
+annotate:artist="1000 Handz",title="Isles",duration="129":/music/ambient/1000-handz-isles.mp3
+annotate:artist="1000 Handz",title="Kraken",duration="261":/music/ambient/1000-handz-kraken.mp3
+annotate:artist="1000 Handz",title="Lilies",duration="189":/music/ambient/1000-handz-lilies.mp3
+annotate:artist="1000 Handz",title="Magneto",duration="151":/music/ambient/1000-handz-magneto.mp3
+annotate:artist="1000 Handz",title="Misunderstood",duration="189":/music/ambient/1000-handz-misunderstood.mp3
+annotate:artist="1000 Handz",title="Monaco",duration="71":/music/ambient/1000-handz-monaco.mp3
+annotate:artist="1000 Handz",title="Motherboard",duration="116":/music/ambient/1000-handz-motherboard.mp3
+annotate:artist="1000 Handz",title="Mystery",duration="201":/music/ambient/1000-handz-mystery.mp3
+annotate:artist="1000 Handz",title="Orbitol",duration="110":/music/ambient/1000-handz-orbitol.mp3
+annotate:artist="1000 Handz",title="Orion (no drums)",duration="112":/music/ambient/1000-handz-orion-no-drums.mp3
+annotate:artist="1000 Handz",title="Phantomm",duration="140":/music/ambient/1000-handz-phantomm.mp3
+annotate:artist="1000 Handz",title="Potential",duration="575":/music/ambient/1000-handz-potential.mp3
+annotate:artist="1000 Handz",title="Saturn ft. ADG",duration="203":/music/ambient/1000-handz-saturn-ft-adg.mp3
+annotate:artist="1000 Handz",title="Shatter",duration="160":/music/ambient/1000-handz-shatter.mp3
+annotate:artist="1000 Handz",title="Silense",duration="118":/music/ambient/1000-handz-silense.mp3
+annotate:artist="1000 Handz",title="Stories",duration="105":/music/ambient/1000-handz-stories.mp3
+annotate:artist="1000 Handz",title="Tea",duration="147":/music/ambient/1000-handz-tea.mp3
+annotate:artist="1000 Handz",title="The Muse",duration="148":/music/ambient/1000-handz-the-muse.mp3
+annotate:artist="1000 Handz",title="The Shire",duration="193":/music/ambient/1000-handz-the-shire.mp3
+annotate:artist="1000 Handz",title="The Well",duration="85":/music/ambient/1000-handz-the-well.mp3
+annotate:artist="1000 Handz",title="Through The Stars",duration="167":/music/ambient/1000-handz-through-the-stars.mp3
+annotate:artist="1000 Handz",title="Throughout",duration="165":/music/ambient/1000-handz-throughout.mp3
+annotate:artist="1000 Handz",title="Tundra",duration="153":/music/ambient/1000-handz-tundra.mp3
+annotate:artist="1000 Handz",title="Unlimited",duration="261":/music/ambient/1000-handz-unlimited.mp3
+annotate:artist="1000 Handz",title="Wednesday",duration="157":/music/ambient/1000-handz-wednesday.mp3
+annotate:artist="1000 Handz",title="World Is Yourz",duration="135":/music/ambient/1000-handz-world-is-yourz.mp3
+annotate:artist="1000 Handz",title="Xperience",duration="117":/music/ambient/1000-handz-xperience.mp3
+annotate:artist="Holizna (Synthetic People)",title="A Lonely Asteroid Headed Towards Earth",duration="76":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - A Lonely Asteroid Headed Towards Earth.mp3
+annotate:artist="Holizna (Synthetic People)",title="A Small Town On Pluto (Family Vacation)",duration="409":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - A Small Town On Pluto (Family Vacation).mp3
+annotate:artist="Holizna (Synthetic People)",title="A Small Town On Pluto (The Grocery Store)",duration="232":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - A Small Town On Pluto (The Grocery Store).mp3
+annotate:artist="Holizna (Synthetic People)",title="Astronaut (Part 2)",duration="318":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - Astronaut (Part 2).mp3
+annotate:artist="Holizna (Synthetic People)",title="Astronaut (Part 3)",duration="260":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - Astronaut (Part 3).mp3
+annotate:artist="Holizna (Synthetic People)",title="Astronaut",duration="126":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - Astronaut.mp3
+annotate:artist="Holizna (Synthetic People)",title="Before The Big Bang",duration="256":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - Before The Big Bang.mp3
+annotate:artist="Holizna (Synthetic People)",title="Fomalhaut b, Iota Draconis-b, Mu Arae c, WASP 17b, and 51 Pegasi b, This is for You!",duration="349":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - Fomalhaut b, Iota Draconis-b, Mu Arae c, WASP 17b, and 51 Pegasi b, This is for You!.mp3
+annotate:artist="Holizna (Synthetic People)",title="Saturn In A Meteor Shower",duration="185":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - Saturn In A Meteor Shower.mp3
+annotate:artist="Holizna (Synthetic People)",title="Space Hospitals",duration="215":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - Space Hospitals.mp3
+annotate:artist="Holizna (Synthetic People)",title="The Milky Way",duration="292":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - The Milky Way.mp3
+annotate:artist="Holizna (Synthetic People)",title="Tiny Plastic Video Games For Long Anxious Space Travel",duration="107":/music/ambient/Holizna (Synthetic People)---Holizna (Synthetic People) - Tiny Plastic Video Games For Long Anxious Space Travel.mp3
+annotate:artist="Holizna",title="A Cloud Dog Named Sky",duration="411":/music/ambient/Holizna---Holizna - A Cloud Dog Named Sky.mp3
+annotate:artist="Holizna",title="A Small Town On Pluto",duration="189":/music/ambient/Holizna---Holizna - A Small Town On Pluto.mp3
+annotate:artist="Holizna",title="Cold Feet",duration="306":/music/ambient/Holizna---Holizna - Cold Feet.mp3
+annotate:artist="Holizna",title="Goodbye Good Times",duration="223":/music/ambient/Holizna---Holizna - Goodbye Good Times.mp3
+annotate:artist="Holizna",title="Iron Skies",duration="296":/music/ambient/Holizna---Holizna - Iron Skies.mp3
+annotate:artist="Holizna",title="Last Train To Earth",duration="371":/music/ambient/Holizna---Holizna - Last Train To Earth.mp3
+annotate:artist="Holizna",title="Make-Shift Salvation",duration="401":/music/ambient/Holizna---Holizna - Make-Shift Salvation.mp3
+annotate:artist="Holizna",title="The Edge Of Nowhere",duration="377":/music/ambient/Holizna---Holizna - The Edge Of Nowhere.mp3
+annotate:artist="Holizna",title="The Only Store In Town",duration="265":/music/ambient/Holizna---Holizna - The Only Store In Town.mp3
+annotate:artist="Holizna",title="The Wind That Whistled Through The Wicker Chair",duration="280":/music/ambient/Holizna---Holizna - The Wind That Whistled Through The Wicker Chair.mp3
+annotate:artist="Almusic34",title="Deep Space Ambient",duration="898":/music/ambient/almusic34-deep-space-ambientmp3.mp3
+annotate:artist="Almusic34",title="Space Ambient Mix 4",duration="1625":/music/ambient/almusic34-space-ambient-mix-4mp3.mp3
+annotate:artist="Almusic34",title="Space Ambient Mix",duration="2651":/music/ambient/almusic34-space-ambient-mixmp3.mp3
 annotate:artist="Amarent",title="A Better World",duration="275":/music/ambient/amarent-a-better-world.mp3
-annotate:artist="Amarent",title="Sweet Dreams (Mellow Synth Version)",duration="219":/music/ambient/amarent-sweet-dreams.mp3
-annotate:artist="Amarent",title="Sweet Love",duration="222":/music/ambient/amarent-sweet-love-chill-remix.mp3
-annotate:artist="Amarent",title="Outer Space",duration="254":/music/ambient/amarent-outer-space.mp3
-annotate:artist="Amarent",title="Tuesday Night (Original)",duration="625":/music/ambient/amarent-tuesday-night.mp3
-annotate:artist="Amarent",title="Tuesday Night",duration="531":/music/ambient/amarent-tuesday-night-radio-edit.mp3
+annotate:artist="Amarent",title="At the Heart of It Is Just Me and You (Instrumental)",duration="251":/music/ambient/amarent-at-the-heart-of-it-is-just-me-and-you-instrumental.mp3
+annotate:artist="Amarent",title="Cathay Lounge",duration="312":/music/ambient/amarent-cathay-lounge.mp3
 annotate:artist="Amarent",title="Ethereal",duration="397":/music/ambient/amarent-ethereal.mp3
+annotate:artist="Amarent",title="Never Let Go (Instrumental)",duration="180":/music/ambient/amarent-never-let-go-instrumental.mp3
+annotate:artist="Amarent",title="Outer Space",duration="254":/music/ambient/amarent-outer-space.mp3
+annotate:artist="Amarent",title="Salt Lake Swerve (Chillout Remix)",duration="251":/music/ambient/amarent-salt-lake-swerve-chillout-remix.mp3
+annotate:artist="Amarent",title="Sweet Dreams (Middle-Eastern Remix)",duration="219":/music/ambient/amarent-sweet-dreams-middle-eastern-remix.mp3
+annotate:artist="Amarent",title="Sweet Dreams",duration="219":/music/ambient/amarent-sweet-dreams.mp3
+annotate:artist="Amarent",title="Sweet Love (Chill Remix)",duration="222":/music/ambient/amarent-sweet-love-chill-remix.mp3
+annotate:artist="Amarent",title="Swirling Snowflakes - Finale",duration="183":/music/ambient/amarent-swirling-snowflakes-finale.mp3
+annotate:artist="Amarent",title="To the Moon (Instrumental)",duration="256":/music/ambient/amarent-to-the-moon-instrumental.mp3
+annotate:artist="Amarent",title="Tuesday Night (Radio Edit)",duration="531":/music/ambient/amarent-tuesday-night-radio-edit.mp3
+annotate:artist="Amarent",title="Tuesday Night",duration="625":/music/ambient/amarent-tuesday-night.mp3
+annotate:artist="Ketsa",title="Around the Corner",duration="192":/music/ambient/ketsa-around-the-corner.mp3
+annotate:artist="Ketsa",title="Harmony",duration="204":/music/ambient/ketsa-harmony.mp3
+annotate:artist="Ketsa",title="Machine Ghosts",duration="213":/music/ambient/ketsa-machine-ghosts.mp3
 annotate:artist="Ketsa",title="Meditation",duration="272":/music/ambient/ketsa-meditation.mp3
 annotate:artist="Ketsa",title="Morning Stillness",duration="232":/music/ambient/ketsa-morning-stillness.mp3
 annotate:artist="Ketsa",title="Patterns",duration="288":/music/ambient/ketsa-patterns.mp3
-annotate:artist="The Imperfectionist",title="White Noise Part 1",duration="246":/music/ambient/the-imperfectionist-1-white-noise-part1mp3.mp3
-annotate:artist="The Imperfectionist",title="White Noise Part 2",duration="147":/music/ambient/the-imperfectionist-2-white-noise-part2mp3.mp3
-annotate:artist="The Imperfectionist",title="White Noise Part 3",duration="525":/music/ambient/the-imperfectionist-3-white-noise-part3mp3.mp3
-annotate:artist="The Imperfectionist",title="White Noise Part 4",duration="270":/music/ambient/the-imperfectionist-4-white-noise-part4mp3.mp3
-annotate:artist="The Imperfectionist",title="White Noise Part 5",duration="315":/music/ambient/the-imperfectionist-5-white-noise-part5mp3.mp3
-annotate:artist="The Imperfectionist",title="White Noise Part 6",duration="311":/music/ambient/the-imperfectionist-6-white-noise-part6mp3.mp3
+annotate:artist="Ketsa",title="Still Dreams",duration="188":/music/ambient/ketsa-still-dreams.mp3
+annotate:artist="Ketsa",title="Surroundings are Green",duration="199":/music/ambient/ketsa-surroundings-are-green.mp3
+annotate:artist="Ketsa",title="Where Dreams Drift",duration="211":/music/ambient/ketsa-where-dreams-drift.mp3
+annotate:artist="Sergey Cheremisinov",title="Last Moon Last Stars",duration="80":/music/ambient/sergey-cheremisinov-last-moon-last-stars.mp3
+annotate:artist="Sergey Cheremisinov",title="Metamorphoses",duration="244":/music/ambient/sergey-cheremisinov-metamorphoses.mp3
+annotate:artist="Sergey Cheremisinov",title="Mindful Choice",duration="322":/music/ambient/sergey-cheremisinov-mindful-choice.mp3
+annotate:artist="Splashkabona",title="Dreamy Ambient Positive Moments in Time",duration="320":/music/ambient/splashkabona-dreamy-ambient-positive-moments-in-time.mp3
+annotate:artist="Vlad Annenkov",title="Emotional Cinematic Ambient 'Gentle Memory'",duration="153":/music/ambient/vlad-annenkov-emotional-cinematic-ambient-gentle-memorymp3.mp3

--- a/late-core/migrations/028_topic_room_visibility_uniqueness.sql
+++ b/late-core/migrations/028_topic_room_visibility_uniqueness.sql
@@ -1,0 +1,11 @@
+-- Topic rooms are now unique per visibility bucket (public/private), not
+-- globally by slug, and default to opt-in unless explicitly marked auto-join.
+
+ALTER TABLE chat_rooms
+    ALTER COLUMN auto_join SET DEFAULT false;
+
+DROP INDEX IF EXISTS uq_chat_rooms_topic_slug;
+
+CREATE UNIQUE INDEX uq_chat_rooms_topic_visibility_slug
+ON chat_rooms (visibility, slug)
+WHERE kind = 'topic';

--- a/late-core/src/models/chat_room.rs
+++ b/late-core/src/models/chat_room.rs
@@ -102,27 +102,21 @@ impl ChatRoom {
     pub async fn create_private_room(client: &Client, slug: &str) -> Result<Self> {
         let slug = normalize_topic_slug(slug)?;
 
-        let existing = client
-            .query_opt(
-                "SELECT id
-                 FROM chat_rooms
-                 WHERE kind = 'topic' AND visibility = 'private' AND slug = $1",
-                &[&slug],
-            )
-            .await?;
-        if existing.is_some() {
-            bail!("private room #{slug} already exists");
-        }
-
         let row = client
-            .query_one(
+            .query_opt(
                 "INSERT INTO chat_rooms (kind, visibility, auto_join, slug)
                  VALUES ('topic', 'private', false, $1)
+                 ON CONFLICT (visibility, slug) WHERE kind = 'topic'
+                 DO NOTHING
                  RETURNING *",
                 &[&slug],
             )
             .await?;
-        Ok(Self::from(row))
+
+        match row {
+            Some(row) => Ok(Self::from(row)),
+            None => bail!("private room #{slug} already exists"),
+        }
     }
 
     pub async fn get_or_create_room(client: &Client, slug: &str) -> Result<Self> {

--- a/late-core/src/models/chat_room.rs
+++ b/late-core/src/models/chat_room.rs
@@ -52,10 +52,14 @@ impl ChatRoom {
 
         let row = client
             .query_one(
-                "INSERT INTO chat_rooms (kind, slug, language_code)
-                 VALUES ('language', $1, $2)
+                "INSERT INTO chat_rooms (kind, visibility, auto_join, slug, language_code)
+                 VALUES ('language', 'public', false, $1, $2)
                  ON CONFLICT (language_code) WHERE kind = 'language'
-                 DO UPDATE SET slug = EXCLUDED.slug, updated = current_timestamp
+                 DO UPDATE
+                    SET visibility = 'public',
+                        auto_join = false,
+                        slug = EXCLUDED.slug,
+                        updated = current_timestamp
                  RETURNING *",
                 &[&slug, &language_code],
             )
@@ -63,26 +67,66 @@ impl ChatRoom {
         Ok(Self::from(row))
     }
 
-    pub async fn get_or_create_room(client: &Client, slug: &str) -> Result<Self> {
-        let slug = slug.trim().to_lowercase();
-        if slug.is_empty() {
-            bail!("room name cannot be empty");
-        }
-        if slug == "general" {
-            bail!("cannot create room with reserved name 'general'");
-        }
+    pub async fn find_topic_room(
+        client: &Client,
+        visibility: &str,
+        slug: &str,
+    ) -> Result<Option<Self>> {
+        let slug = normalize_topic_slug(slug)?;
+        let row = client
+            .query_opt(
+                "SELECT *
+                 FROM chat_rooms
+                 WHERE kind = 'topic' AND visibility = $1 AND slug = $2",
+                &[&visibility, &slug],
+            )
+            .await?;
+        Ok(row.map(Self::from))
+    }
 
+    pub async fn get_or_create_public_room(client: &Client, slug: &str) -> Result<Self> {
+        let slug = normalize_topic_slug(slug)?;
         let row = client
             .query_one(
                 "INSERT INTO chat_rooms (kind, visibility, auto_join, slug)
                  VALUES ('topic', 'public', false, $1)
-                 ON CONFLICT (slug) WHERE kind = 'topic'
+                 ON CONFLICT (visibility, slug) WHERE kind = 'topic'
                  DO UPDATE SET updated = current_timestamp
                  RETURNING *",
                 &[&slug],
             )
             .await?;
         Ok(Self::from(row))
+    }
+
+    pub async fn create_private_room(client: &Client, slug: &str) -> Result<Self> {
+        let slug = normalize_topic_slug(slug)?;
+
+        let existing = client
+            .query_opt(
+                "SELECT id
+                 FROM chat_rooms
+                 WHERE kind = 'topic' AND visibility = 'private' AND slug = $1",
+                &[&slug],
+            )
+            .await?;
+        if existing.is_some() {
+            bail!("private room #{slug} already exists");
+        }
+
+        let row = client
+            .query_one(
+                "INSERT INTO chat_rooms (kind, visibility, auto_join, slug)
+                 VALUES ('topic', 'private', false, $1)
+                 RETURNING *",
+                &[&slug],
+            )
+            .await?;
+        Ok(Self::from(row))
+    }
+
+    pub async fn get_or_create_room(client: &Client, slug: &str) -> Result<Self> {
+        Self::get_or_create_public_room(client, slug).await
     }
 
     pub async fn get_or_create_dm(client: &Client, user_a: Uuid, user_b: Uuid) -> Result<Self> {
@@ -172,7 +216,9 @@ impl ChatRoom {
 
         let existing = client
             .query_opt(
-                "SELECT id FROM chat_rooms WHERE slug = $1 AND kind = 'topic'",
+                "SELECT id
+                 FROM chat_rooms
+                 WHERE slug = $1 AND kind = 'topic' AND visibility = 'public'",
                 &[&slug],
             )
             .await?;
@@ -204,7 +250,9 @@ impl ChatRoom {
 
         let existing = client
             .query_opt(
-                "SELECT id FROM chat_rooms WHERE slug = $1 AND kind = 'topic'",
+                "SELECT id
+                 FROM chat_rooms
+                 WHERE slug = $1 AND kind = 'topic' AND visibility = 'public'",
                 &[&slug],
             )
             .await?;
@@ -258,6 +306,17 @@ pub fn canonical_dm_pair(user_a: Uuid, user_b: Uuid) -> (Uuid, Uuid) {
     } else {
         (user_b, user_a)
     }
+}
+
+fn normalize_topic_slug(slug: &str) -> Result<String> {
+    let slug = slug.trim().to_lowercase();
+    if slug.is_empty() {
+        bail!("room name cannot be empty");
+    }
+    if slug == "general" {
+        bail!("cannot create room with reserved name 'general'");
+    }
+    Ok(slug)
 }
 
 #[cfg(test)]

--- a/late-core/src/models/notification.rs
+++ b/late-core/src/models/notification.rs
@@ -133,9 +133,8 @@ impl Notification {
     /// Resolve @usernames to user IDs, excluding the actor.
     ///
     /// For DM rooms, only resolves usernames that belong to one of the two DM
-    /// participants — mentioning a third party in a DM is silently dropped.
-    /// For non-DM rooms (including private rooms), no membership check is
-    /// performed.
+    /// participants. For private rooms, only resolves usernames that are
+    /// members of the room. Public rooms resolve against all users.
     pub async fn resolve_mentioned_user_ids(
         client: &Client,
         usernames: &[String],
@@ -152,9 +151,15 @@ impl Notification {
                 "SELECT u.id \
                  FROM users u \
                  JOIN chat_rooms r ON r.id = $3 \
+                 LEFT JOIN chat_room_members m \
+                   ON m.room_id = r.id AND m.user_id = u.id \
                  WHERE LOWER(u.username) = ANY($1) \
                    AND u.id <> $2 \
-                   AND (r.kind <> 'dm' OR u.id IN (r.dm_user_a, r.dm_user_b))",
+                   AND (
+                        (r.kind = 'dm' AND u.id IN (r.dm_user_a, r.dm_user_b))
+                        OR (r.kind <> 'dm' AND r.visibility = 'private' AND m.user_id IS NOT NULL)
+                        OR (r.kind <> 'dm' AND r.visibility = 'public')
+                   )",
                 &[&lower, &exclude_user_id, &room_id],
             )
             .await?;

--- a/late-core/tests/chat/room.rs
+++ b/late-core/tests/chat/room.rs
@@ -28,6 +28,37 @@ async fn test_chat_room_general_and_language() {
     assert_eq!(lang.kind, "language");
     assert_eq!(lang.language_code.as_deref(), Some("es"));
     assert_eq!(lang.slug.as_deref(), Some("lang-es"));
+    assert_eq!(lang.visibility, "public");
+    assert!(!lang.auto_join);
+}
+
+#[tokio::test]
+async fn test_chat_room_public_and_private_topics() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+
+    let public_room = ChatRoom::get_or_create_public_room(&client, "side")
+        .await
+        .expect("create public room");
+    let public_room_again = ChatRoom::get_or_create_public_room(&client, "side")
+        .await
+        .expect("get public room");
+    let private_room = ChatRoom::create_private_room(&client, "side")
+        .await
+        .expect("create private room");
+
+    assert_eq!(public_room.id, public_room_again.id);
+    assert_eq!(public_room.visibility, "public");
+    assert!(!public_room.auto_join);
+    assert_eq!(private_room.visibility, "private");
+    assert!(!private_room.auto_join);
+    assert_ne!(public_room.id, private_room.id);
+
+    let duplicate_private = ChatRoom::create_private_room(&client, "side").await;
+    assert!(
+        duplicate_private.is_err(),
+        "expected duplicate private room to fail"
+    );
 }
 
 #[tokio::test]

--- a/late-ssh/assets/splash_tips/new_and_returning_users_tip_pool.json
+++ b/late-ssh/assets/splash_tips/new_and_returning_users_tip_pool.json
@@ -1,7 +1,7 @@
 [
   "Try our games! ~Rank up on the leaderboards~",
   "Water your bonsai once a day with the w key",
-  "You can create your own room with /create #room",
+  "You can open a public room with /public #room",
   "Vote for the next music genre by using the L or A or C keys",
   "Configure your notification preferences on screen 4",
   "Press ? outside of chat to see available hotkeys",
@@ -19,7 +19,7 @@
   "Use m, - and = to mute, quiet, or louden the music",
   "Type /active in chat to see who is online",
   "Shared ASCII art board coming soon!",
-  "Use /list in a private room to see who's in it",
+  "Use /members to see who's in the current room",
   "Select a chat message with j/k and press r to reply to it",
   "Solve a daily puzzle every day to build a streak and earn badges",
   "Log in daily for free Late Chips, and earn more by solving daily puzzles",

--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -43,7 +43,7 @@ const BOT_USERNAME: &str = "bot";
 const BOT_COOLDOWN: Duration = Duration::from_secs(30);
 pub const BOT_TIP_INTERVAL: Duration = Duration::from_secs(60 * 120); // 2 hours
 const BOT_TIP_PHASE_OFFSET: Duration = Duration::from_secs(60 * 120); // 2 hours
-pub const BOT_TIP_MIN_NEW_MESSAGES: usize = 3;
+pub const BOT_TIP_MIN_NEW_MESSAGES: usize = 10;
 const BOT_TIP_HISTORY_SIZE: i64 = 50;
 const GRAYBEARD_FINGERPRINT: &str = "graybeard-fp-000";
 const GRAYBEARD_USERNAME: &str = "graybeard";
@@ -87,7 +87,7 @@ pub const GRAYBEARD_CHAT_INTERVAL: Duration = Duration::from_secs(60 * 120); // 
 // Keep graybeard halfway between @bot's 2-hour tips.
 const GRAYBEARD_CHAT_PHASE_OFFSET: Duration = Duration::from_secs(60 * 60); // 1 hour
 pub const GRAYBEARD_MENTION_COOLDOWN: Duration = Duration::from_secs(60); // 1 min
-const GRAYBEARD_MIN_NEW_MESSAGES: usize = 3;
+const GRAYBEARD_MIN_NEW_MESSAGES: usize = 10;
 
 impl GhostService {
     pub fn new(
@@ -505,7 +505,7 @@ impl GhostService {
         }
     }
 
-    /// 30-min tick: check #general for new messages not from graybeard, then comment.
+    /// 2-hour tick: check #general for new messages not from graybeard, then comment.
     async fn graybeard_chat_tick(&self, gb: BotUser) -> Result<()> {
         let (general_room, messages) = {
             let client = self.db.get().await?;

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -428,7 +428,8 @@ impl ChatState {
     }
 
     /// Build the flat visual navigation order.
-    /// Order: core (general, announcements) → news → mentions → public rooms (alpha) → private (alpha) → DMs
+    /// Order: core (general, announcements) → news → mentions → public rooms
+    /// (alpha) → private rooms (alpha) → DMs
     pub(crate) fn visual_order(&self) -> Vec<RoomSlot> {
         let mut order = Vec::new();
 
@@ -459,20 +460,20 @@ impl ChatState {
         // Mentions / notifications
         order.push(RoomSlot::Notifications);
 
-        // Public rooms (auto_join, alpha by slug)
+        // Public rooms (non-DM, non-permanent, alpha by slug)
         let mut public: Vec<_> = self
             .rooms
             .iter()
-            .filter(|(r, _)| r.kind != "dm" && !r.permanent && r.auto_join)
+            .filter(|(r, _)| r.kind != "dm" && !r.permanent && r.visibility == "public")
             .collect();
         public.sort_by(|(a, _), (b, _)| a.slug.cmp(&b.slug));
         order.extend(public.iter().map(|(r, _)| RoomSlot::Room(r.id)));
 
-        // Private rooms (!auto_join, alpha by slug)
+        // Private rooms (visibility=private, alpha by slug)
         let mut private: Vec<_> = self
             .rooms
             .iter()
-            .filter(|(r, _)| r.kind != "dm" && !r.permanent && !r.auto_join)
+            .filter(|(r, _)| r.kind != "dm" && !r.permanent && r.visibility == "private")
             .collect();
         private.sort_by(|(a, _), (b, _)| a.slug.cmp(&b.slug));
         order.extend(private.iter().map(|(r, _)| RoomSlot::Room(r.id)));
@@ -662,15 +663,18 @@ impl ChatState {
             return None;
         }
 
-        if body.trim() == "/list" {
+        if body.trim() == "/members" {
             self.clear_composer_after_submit();
-            let Some(room) = self.selected_room() else {
+            let Some(room_id) = self.selected_room_id else {
                 return Some(Banner::error("No room selected"));
             };
-            if !room_supports_member_list(room) {
-                return Some(Banner::error("/list only works in private rooms"));
-            }
-            self.service.list_room_members_task(self.user_id, room.id);
+            self.service.list_room_members_task(self.user_id, room_id);
+            return None;
+        }
+
+        if body.trim() == "/list" {
+            self.clear_composer_after_submit();
+            self.service.list_public_rooms_task(self.user_id);
             return None;
         }
 
@@ -701,10 +705,31 @@ impl ChatState {
             return Some(Banner::success(&format!("Opening DM with {target}...")));
         }
 
-        if let Some(room) = parse_join_command(&body) {
-            self.service.join_room_task(self.user_id, room.to_string());
+        if let Some(room) = parse_room_command(&body, "/public") {
+            self.service
+                .open_public_room_task(self.user_id, room.to_string());
             self.clear_composer_after_submit();
-            return Some(Banner::success(&format!("Joining #{room}...")));
+            return Some(Banner::success(&format!("Opening public #{room}...")));
+        }
+
+        if let Some(room) = parse_room_command(&body, "/private") {
+            self.clear_composer_after_submit();
+            self.service
+                .create_private_room_task(self.user_id, room.to_string());
+            return Some(Banner::success(&format!("Creating private #{room}...")));
+        }
+
+        if let Some(target) = parse_user_command(&body, "/invite") {
+            self.clear_composer_after_submit();
+            let Some(room_id) = self.selected_room_id else {
+                return Some(Banner::error("No room selected"));
+            };
+            let Some(target) = target else {
+                return Some(Banner::error("Usage: /invite @user"));
+            };
+            self.service
+                .invite_user_to_room_task(self.user_id, room_id, target.to_string());
+            return Some(Banner::success(&format!("Inviting @{target}...")));
         }
 
         if parse_leave_command(&body) {
@@ -726,13 +751,6 @@ impl ChatState {
             }
             self.service
                 .create_permanent_room_task(self.user_id, slug.to_string());
-            return Some(Banner::success(&format!("Creating #{slug}...")));
-        }
-
-        if let Some(slug) = parse_create_command(&body) {
-            self.clear_composer_after_submit();
-            self.service
-                .create_room_task(self.user_id, slug.to_string());
             return Some(Banner::success(&format!("Creating #{slug}...")));
         }
 
@@ -1105,8 +1123,14 @@ impl ChatState {
                 ChatEvent::LeaveFailed { user_id, message } if self.user_id == user_id => {
                     banner = Some(Banner::error(&message));
                 }
-                ChatEvent::RoomCreated { user_id, slug } if self.user_id == user_id => {
+                ChatEvent::RoomCreated {
+                    user_id,
+                    room_id,
+                    slug,
+                } if self.user_id == user_id => {
+                    self.selected_room_id = Some(room_id);
                     self.request_list();
+                    self.pending_dm_screen_switch = true;
                     banner = Some(Banner::success(&format!("Created #{slug}")));
                 }
                 ChatEvent::RoomCreateFailed { user_id, message } if self.user_id == user_id => {
@@ -1181,9 +1205,37 @@ impl ChatState {
                 } if self.user_id == user_id => {
                     self.open_overlay(&title, members);
                 }
+                ChatEvent::PublicRoomsListed {
+                    user_id,
+                    title,
+                    rooms,
+                } if self.user_id == user_id => {
+                    self.open_overlay(&title, rooms);
+                }
+                ChatEvent::InviteSucceeded {
+                    user_id,
+                    room_id,
+                    room_slug,
+                    username,
+                } if self.user_id == user_id => {
+                    if Some(room_id) == self.selected_room_id {
+                        self.request_list();
+                    }
+                    banner = Some(Banner::success(&format!(
+                        "Invited @{username} to #{room_slug}"
+                    )));
+                }
                 ChatEvent::RoomMembersListFailed { user_id, message }
                     if self.user_id == user_id =>
                 {
+                    banner = Some(Banner::error(&message));
+                }
+                ChatEvent::PublicRoomsListFailed { user_id, message }
+                    if self.user_id == user_id =>
+                {
+                    banner = Some(Banner::error(&message));
+                }
+                ChatEvent::InviteFailed { user_id, message } if self.user_id == user_id => {
                     banner = Some(Banner::error(&message));
                 }
                 _ => {}
@@ -1342,25 +1394,14 @@ fn parse_dm_command(input: &str) -> Option<&str> {
     Some(username)
 }
 
-/// Parse `/join #room` or `/join room` from the composer text.
-/// Returns the room slug if the input matches.
-fn parse_join_command(input: &str) -> Option<&str> {
-    let rest = input.strip_prefix("/join ")?.trim_start();
-    let room = rest.strip_prefix('#').unwrap_or(rest).trim();
-    if room.is_empty() {
-        return None;
-    }
-    Some(room)
-}
-
 /// Parse `/leave` from the composer text.
 fn parse_leave_command(input: &str) -> bool {
     input.trim() == "/leave"
 }
 
-/// Parse `/create <slug>` or `/create #slug` from the composer text.
-fn parse_create_command(input: &str) -> Option<&str> {
-    let rest = input.strip_prefix("/create ")?.trim_start();
+/// Parse `/public <slug>` or `/private <slug>` style commands.
+fn parse_room_command<'a>(input: &'a str, command: &str) -> Option<&'a str> {
+    let rest = input.strip_prefix(&format!("{command} "))?.trim_start();
     let slug = rest.strip_prefix('#').unwrap_or(rest).trim();
     if slug.is_empty() {
         return None;
@@ -1386,10 +1427,6 @@ fn parse_delete_room_command(input: &str) -> Option<&str> {
         return None;
     }
     Some(slug)
-}
-
-fn room_supports_member_list(room: &ChatRoom) -> bool {
-    room.kind != "dm" && !room.auto_join
 }
 
 fn online_username_set(active_users: Option<&ActiveUsers>) -> HashSet<String> {
@@ -1809,6 +1846,42 @@ mod tests {
     }
 
     #[test]
+    fn parse_public_room_with_hash() {
+        assert_eq!(
+            parse_room_command("/public #lobby", "/public"),
+            Some("lobby")
+        );
+    }
+
+    #[test]
+    fn parse_public_room_without_hash() {
+        assert_eq!(
+            parse_room_command("/public lobby", "/public"),
+            Some("lobby")
+        );
+    }
+
+    #[test]
+    fn parse_private_room_with_hash() {
+        assert_eq!(
+            parse_room_command("/private #hideout", "/private"),
+            Some("hideout")
+        );
+    }
+
+    #[test]
+    fn parse_private_room_empty() {
+        assert_eq!(parse_room_command("/private ", "/private"), None);
+        assert_eq!(parse_room_command("/private #", "/private"), None);
+    }
+
+    #[test]
+    fn parse_private_room_not_command() {
+        assert_eq!(parse_room_command("hello", "/private"), None);
+        assert_eq!(parse_room_command("/privates foo", "/private"), None);
+    }
+
+    #[test]
     fn parse_create_room_with_hash() {
         assert_eq!(
             parse_create_room_command("/create-room #announcements"),
@@ -1860,37 +1933,6 @@ mod tests {
     #[test]
     fn parse_delete_room_not_command() {
         assert_eq!(parse_delete_room_command("hello"), None);
-    }
-
-    #[test]
-    fn room_supports_member_list_only_for_non_auto_join_non_dm_rooms() {
-        let private_room = ChatRoom {
-            id: Uuid::now_v7(),
-            created: chrono::Utc::now(),
-            updated: chrono::Utc::now(),
-            kind: "topic".to_string(),
-            visibility: "public".to_string(),
-            auto_join: false,
-            permanent: false,
-            slug: Some("side".to_string()),
-            language_code: None,
-            dm_user_a: None,
-            dm_user_b: None,
-        };
-        assert!(room_supports_member_list(&private_room));
-
-        let public_room = ChatRoom {
-            auto_join: true,
-            ..private_room.clone()
-        };
-        assert!(!room_supports_member_list(&public_room));
-
-        let dm_room = ChatRoom {
-            kind: "dm".to_string(),
-            visibility: "dm".to_string(),
-            ..private_room
-        };
-        assert!(!room_supports_member_list(&dm_room));
     }
 
     #[test]

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -73,7 +73,7 @@ pub struct ChatState {
     pub(crate) composing: bool,
     composer_room_id: Option<Uuid>,
     pending_send_notices: VecDeque<Uuid>,
-    pub(crate) pending_dm_screen_switch: bool,
+    pub(crate) pending_chat_screen_switch: bool,
     pub(crate) mention_ac: MentionAutocomplete,
     pub(crate) all_usernames: Vec<String>,
     pub(crate) bonsai_glyphs: HashMap<Uuid, String>,
@@ -146,7 +146,7 @@ impl ChatState {
             composing: false,
             composer_room_id: None,
             pending_send_notices: VecDeque::new(),
-            pending_dm_screen_switch: false,
+            pending_chat_screen_switch: false,
             mention_ac: MentionAutocomplete::default(),
             all_usernames: Vec::new(),
             bonsai_glyphs: HashMap::new(),
@@ -1096,7 +1096,7 @@ impl ChatState {
                 ChatEvent::DmOpened { user_id, room_id } if self.user_id == user_id => {
                     self.selected_room_id = Some(room_id);
                     self.request_list();
-                    self.pending_dm_screen_switch = true;
+                    self.pending_chat_screen_switch = true;
                     banner = Some(Banner::success("DM opened"));
                 }
                 ChatEvent::DmFailed { user_id, message } if self.user_id == user_id => {
@@ -1109,7 +1109,7 @@ impl ChatState {
                 } if self.user_id == user_id => {
                     self.selected_room_id = Some(room_id);
                     self.request_list();
-                    self.pending_dm_screen_switch = true;
+                    self.pending_chat_screen_switch = true;
                     banner = Some(Banner::success(&format!("Joined #{slug}")));
                 }
                 ChatEvent::RoomFailed { user_id, message } if self.user_id == user_id => {
@@ -1130,7 +1130,7 @@ impl ChatState {
                 } if self.user_id == user_id => {
                     self.selected_room_id = Some(room_id);
                     self.request_list();
-                    self.pending_dm_screen_switch = true;
+                    self.pending_chat_screen_switch = true;
                     banner = Some(Banner::success(&format!("Created #{slug}")));
                 }
                 ChatEvent::RoomCreateFailed { user_id, message } if self.user_id == user_id => {

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -104,6 +104,7 @@ pub enum ChatEvent {
     },
     RoomCreated {
         user_id: Uuid,
+        room_id: Uuid,
         slug: String,
     },
     RoomCreateFailed {
@@ -141,11 +142,30 @@ pub enum ChatEvent {
         title: String,
         members: Vec<String>,
     },
+    PublicRoomsListed {
+        user_id: Uuid,
+        title: String,
+        rooms: Vec<String>,
+    },
+    InviteSucceeded {
+        user_id: Uuid,
+        room_id: Uuid,
+        room_slug: String,
+        username: String,
+    },
     IgnoreFailed {
         user_id: Uuid,
         message: String,
     },
     RoomMembersListFailed {
+        user_id: Uuid,
+        message: String,
+    },
+    PublicRoomsListFailed {
+        user_id: Uuid,
+        message: String,
+    },
+    InviteFailed {
         user_id: Uuid,
         message: String,
     },
@@ -654,13 +674,91 @@ impl ChatService {
                     .unwrap_or_else(|| format!("@<unknown:{}>", short_user_id(id)))
             })
             .collect();
-        let title = room
-            .slug
-            .as_deref()
-            .map(|slug| format!("#{slug} Members"))
-            .unwrap_or_else(|| "Room Members".to_string());
+        let title = if room.kind == "dm" {
+            "DM Members".to_string()
+        } else {
+            room.slug
+                .as_deref()
+                .map(|slug| format!("#{slug} Members"))
+                .unwrap_or_else(|| "Room Members".to_string())
+        };
 
         Ok((title, members))
+    }
+
+    pub fn list_public_rooms_task(&self, user_id: Uuid) {
+        let service = self.clone();
+        let span = info_span!("chat.list_public_rooms_task", user_id = %user_id);
+        tokio::spawn(
+            async move {
+                let event = match service.list_public_rooms().await {
+                    Ok((title, rooms)) => ChatEvent::PublicRoomsListed {
+                        user_id,
+                        title,
+                        rooms,
+                    },
+                    Err(e) => ChatEvent::PublicRoomsListFailed {
+                        user_id,
+                        message: e.to_string(),
+                    },
+                };
+                let _ = service.evt_tx.send(event);
+            }
+            .instrument(span),
+        );
+    }
+
+    async fn list_public_rooms(&self) -> Result<(String, Vec<String>)> {
+        let client = &self.db.get().await?;
+        let rows = client
+            .query(
+                "SELECT r.kind,
+                        r.slug,
+                        r.language_code,
+                        COUNT(m.user_id)::bigint AS member_count
+                 FROM chat_rooms r
+                 LEFT JOIN chat_room_members m ON m.room_id = r.id
+                 WHERE r.kind <> 'dm' AND r.visibility = 'public'
+                 GROUP BY r.id, r.kind, r.slug, r.language_code, r.permanent, r.created
+                 ORDER BY
+                    CASE
+                        WHEN r.kind = 'general' AND r.slug = 'general' THEN 0
+                        WHEN r.permanent THEN 1
+                        ELSE 2
+                    END ASC,
+                    COALESCE(r.slug, COALESCE(r.language_code, '')) ASC,
+                    r.created ASC,
+                    r.id ASC",
+                &[],
+            )
+            .await?;
+
+        let rooms: Vec<String> = rows
+            .into_iter()
+            .map(|row| {
+                let kind: String = row.get("kind");
+                let slug: Option<String> = row.get("slug");
+                let language_code: Option<String> = row.get("language_code");
+                let member_count: i64 = row.get("member_count");
+                let label = slug
+                    .map(|slug| format!("#{slug}"))
+                    .or_else(|| language_code.map(|code| format!("language:{code}")))
+                    .unwrap_or(kind);
+                let noun = if member_count == 1 {
+                    "member"
+                } else {
+                    "members"
+                };
+                format!("{label} ({member_count} {noun})")
+            })
+            .collect();
+        let rooms = if rooms.is_empty() {
+            vec!["No public rooms".to_string()]
+        } else {
+            rooms
+        };
+
+        Ok(("Public Rooms".to_string(), rooms))
     }
 
     pub fn ignore_user_task(&self, user_id: Uuid, target_username: String) {
@@ -747,12 +845,12 @@ impl ChatService {
         Ok((ids, format!("Unignored @{}", target.username)))
     }
 
-    pub fn join_room_task(&self, user_id: Uuid, slug: String) {
+    pub fn open_public_room_task(&self, user_id: Uuid, slug: String) {
         let service = self.clone();
-        let span = info_span!("chat.join_room_task", user_id = %user_id, slug = %slug);
+        let span = info_span!("chat.open_public_room_task", user_id = %user_id, slug = %slug);
         tokio::spawn(
             async move {
-                match service.join_room(user_id, &slug).await {
+                match service.open_public_room(user_id, &slug).await {
                     Ok(room_id) => {
                         let _ = service.evt_tx.send(ChatEvent::RoomJoined {
                             user_id,
@@ -772,9 +870,44 @@ impl ChatService {
         );
     }
 
-    async fn join_room(&self, user_id: Uuid, slug: &str) -> Result<Uuid> {
+    async fn open_public_room(&self, user_id: Uuid, slug: &str) -> Result<Uuid> {
         let client = &self.db.get().await?;
-        let room = ChatRoom::get_or_create_room(client, slug).await?;
+        let room = match ChatRoom::find_topic_room(client, "public", slug).await? {
+            Some(room) => room,
+            None => ChatRoom::get_or_create_public_room(client, slug).await?,
+        };
+        ChatRoomMember::join(client, room.id, user_id).await?;
+        Ok(room.id)
+    }
+
+    pub fn create_private_room_task(&self, user_id: Uuid, slug: String) {
+        let service = self.clone();
+        let span = info_span!("chat.create_private_room_task", user_id = %user_id, slug = %slug);
+        tokio::spawn(
+            async move {
+                match service.create_private_room(user_id, &slug).await {
+                    Ok(room_id) => {
+                        let _ = service.evt_tx.send(ChatEvent::RoomCreated {
+                            user_id,
+                            room_id,
+                            slug,
+                        });
+                    }
+                    Err(e) => {
+                        let _ = service.evt_tx.send(ChatEvent::RoomCreateFailed {
+                            user_id,
+                            message: e.to_string(),
+                        });
+                    }
+                }
+            }
+            .instrument(span),
+        );
+    }
+
+    async fn create_private_room(&self, user_id: Uuid, slug: &str) -> Result<Uuid> {
+        let client = &self.db.get().await?;
+        let room = ChatRoom::create_private_room(client, slug).await?;
         ChatRoomMember::join(client, room.id, user_id).await?;
         Ok(room.id)
     }
@@ -819,10 +952,12 @@ impl ChatService {
         tokio::spawn(
             async move {
                 match service.create_room(&slug).await {
-                    Ok(_) => {
-                        let _ = service
-                            .evt_tx
-                            .send(ChatEvent::RoomCreated { user_id, slug });
+                    Ok(room_id) => {
+                        let _ = service.evt_tx.send(ChatEvent::RoomCreated {
+                            user_id,
+                            room_id,
+                            slug,
+                        });
                     }
                     Err(e) => {
                         let _ = service.evt_tx.send(ChatEvent::RoomCreateFailed {
@@ -836,12 +971,12 @@ impl ChatService {
         );
     }
 
-    async fn create_room(&self, slug: &str) -> Result<()> {
+    async fn create_room(&self, slug: &str) -> Result<Uuid> {
         let client = &self.db.get().await?;
         let room = ChatRoom::ensure_auto_join(client, slug).await?;
         let added = ChatRoom::add_all_users(client, room.id).await?;
         tracing::info!(slug = %slug, room_id = %room.id, users_added = added, "room created");
-        Ok(())
+        Ok(room.id)
     }
 
     pub fn create_permanent_room_task(&self, user_id: Uuid, slug: String) {
@@ -873,6 +1008,67 @@ impl ChatService {
         let added = ChatRoom::add_all_users(client, room.id).await?;
         tracing::info!(slug = %slug, room_id = %room.id, users_added = added, "permanent room created");
         Ok(())
+    }
+
+    pub fn invite_user_to_room_task(&self, user_id: Uuid, room_id: Uuid, target_username: String) {
+        let service = self.clone();
+        let span = info_span!(
+            "chat.invite_user_to_room_task",
+            user_id = %user_id,
+            room_id = %room_id,
+            target = %target_username
+        );
+        tokio::spawn(
+            async move {
+                let event = match service
+                    .invite_user_to_room(user_id, room_id, &target_username)
+                    .await
+                {
+                    Ok((room_slug, username)) => ChatEvent::InviteSucceeded {
+                        user_id,
+                        room_id,
+                        room_slug,
+                        username,
+                    },
+                    Err(e) => ChatEvent::InviteFailed {
+                        user_id,
+                        message: e.to_string(),
+                    },
+                };
+                let _ = service.evt_tx.send(event);
+            }
+            .instrument(span),
+        );
+    }
+
+    async fn invite_user_to_room(
+        &self,
+        user_id: Uuid,
+        room_id: Uuid,
+        target_username: &str,
+    ) -> Result<(String, String)> {
+        let client = &self.db.get().await?;
+        let room = ChatRoom::get(client, room_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Room not found"))?;
+        if room.kind == "dm" {
+            anyhow::bail!("Cannot invite users to a DM");
+        }
+        let is_member = ChatRoomMember::is_member(client, room_id, user_id).await?;
+        if !is_member {
+            anyhow::bail!("You are not a member of this room");
+        }
+
+        let target = User::find_by_username(client, target_username)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("User '{}' not found", target_username))?;
+        if target.id == user_id {
+            anyhow::bail!("Cannot invite yourself");
+        }
+
+        ChatRoomMember::join(client, room_id, target.id).await?;
+        let room_slug = room.slug.clone().unwrap_or_else(|| room.kind.clone());
+        Ok((room_slug, target.username))
     }
 
     pub fn delete_permanent_room_task(&self, user_id: Uuid, slug: String) {

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -718,14 +718,12 @@ impl ChatService {
                         COUNT(m.user_id)::bigint AS member_count
                  FROM chat_rooms r
                  LEFT JOIN chat_room_members m ON m.room_id = r.id
-                 WHERE r.kind <> 'dm' AND r.visibility = 'public'
-                 GROUP BY r.id, r.kind, r.slug, r.language_code, r.permanent, r.created
+                 WHERE r.kind <> 'dm'
+                   AND r.visibility = 'public'
+                   AND r.permanent = false
+                 GROUP BY r.id, r.kind, r.slug, r.language_code, r.created
                  ORDER BY
-                    CASE
-                        WHEN r.kind = 'general' AND r.slug = 'general' THEN 0
-                        WHEN r.permanent THEN 1
-                        ELSE 2
-                    END ASC,
+                    member_count DESC,
                     COALESCE(r.slug, COALESCE(r.language_code, '')) ASC,
                     r.created ASC,
                     r.id ASC",

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -718,7 +718,7 @@ impl ChatService {
                         COUNT(m.user_id)::bigint AS member_count
                  FROM chat_rooms r
                  LEFT JOIN chat_room_members m ON m.room_id = r.id
-                 WHERE r.kind <> 'dm'
+                 WHERE r.kind = 'topic'
                    AND r.visibility = 'public'
                    AND r.permanent = false
                  GROUP BY r.id, r.kind, r.slug, r.language_code, r.created

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -850,7 +850,7 @@ pub fn draw_chat(frame: &mut Frame, area: Rect, view: ChatRenderInput<'_>) {
     public_rooms.sort_by(|(a, _), (b, _)| a.slug.cmp(&b.slug));
     if !public_rooms.is_empty() {
         room_lines.push(Line::from(""));
-        room_lines.push(section_divider("Rooms", rooms_width));
+        room_lines.push(section_divider("Public", rooms_width));
         for (room, _) in &public_rooms {
             let label = room
                 .slug

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -842,10 +842,10 @@ pub fn draw_chat(frame: &mut Frame, area: Rect, view: ChatRenderInput<'_>) {
         }
     }
 
-    // ── Rooms (public, via /create, alpha sorted) ──
+    // ── Rooms (public visibility, alpha sorted) ──
     let mut public_rooms: Vec<_> = chat_rooms
         .iter()
-        .filter(|(r, _)| r.kind != "dm" && !r.permanent && r.auto_join)
+        .filter(|(r, _)| r.kind != "dm" && !r.permanent && r.visibility == "public")
         .collect();
     public_rooms.sort_by(|(a, _), (b, _)| a.slug.cmp(&b.slug));
     if !public_rooms.is_empty() {
@@ -871,10 +871,10 @@ pub fn draw_chat(frame: &mut Frame, area: Rect, view: ChatRenderInput<'_>) {
         }
     }
 
-    // ── Private (via /join, alpha sorted) ──
+    // ── Private (private visibility, alpha sorted) ──
     let mut private_rooms: Vec<_> = chat_rooms
         .iter()
-        .filter(|(r, _)| r.kind != "dm" && !r.permanent && !r.auto_join)
+        .filter(|(r, _)| r.kind != "dm" && !r.permanent && r.visibility == "private")
         .collect();
     private_rooms.sort_by(|(a, _), (b, _)| a.slug.cmp(&b.slug));
     if !private_rooms.is_empty() {

--- a/late-ssh/src/app/common/overlay.rs
+++ b/late-ssh/src/app/common/overlay.rs
@@ -58,7 +58,10 @@ pub fn draw_overlay(frame: &mut Frame, anchor: Rect, overlay: &Overlay) {
     );
 
     let block = Block::default()
-        .title(format!(" {} (j/k scroll · q/Esc close) ", overlay.title))
+        .title(format!(
+            " {} (↑/↓ j/k scroll · Esc/q close) ",
+            overlay.title
+        ))
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme::BORDER_ACTIVE()));
 

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -94,12 +94,14 @@ pub fn bot_app_context() -> String {
 pub fn chat_help_lines() -> Vec<String> {
     [
         "Commands",
-        "  /join #room        join a room (creates it if new, solo)",
-        "  /create #room      create a room and add everyone",
+        "  /public #room      open or create a public room",
+        "  /private #room     create a private room",
+        "  /invite @user      add a user to the current room",
         "  /leave             leave the current room",
         "  /dm @user          open a direct message",
         "  /active            list active users",
-        "  /list              list users in this private room",
+        "  /members           list users in this room",
+        "  /list              list public rooms",
         "  /ignore [@user]    ignore a user, or list ignored users",
         "  /unignore [@user]  remove a user from your ignore list",
         "  /music             explain how music works",
@@ -151,7 +153,7 @@ pub fn chat_help_lines() -> Vec<String> {
         "  Esc                close",
         "",
         "Overlay windows",
-        "  q / Esc            close overlay",
+        "  Esc / q            close overlay",
         "  j / k              scroll overlay",
     ]
     .into_iter()

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -503,13 +503,33 @@ fn handle_vt_segment(app: &mut App, data: &[u8]) {
 }
 
 fn handle_overlay_input(app: &mut App, event: &ParsedInput) {
+    match overlay_input_action(event) {
+        Some(OverlayInputAction::Close) => app.chat.close_overlay(),
+        Some(OverlayInputAction::Scroll(delta)) => app.chat.scroll_overlay(delta),
+        None => {}
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OverlayInputAction {
+    Close,
+    Scroll(i16),
+}
+
+fn overlay_input_action(event: &ParsedInput) -> Option<OverlayInputAction> {
     match event {
-        ParsedInput::Byte(b'q' | b'Q') => app.chat.close_overlay(),
-        ParsedInput::Byte(b'j' | b'J') => app.chat.scroll_overlay(1),
-        ParsedInput::Byte(b'k' | b'K') => app.chat.scroll_overlay(-1),
-        ParsedInput::Arrow(b'B') => app.chat.scroll_overlay(1),
-        ParsedInput::Arrow(b'A') => app.chat.scroll_overlay(-1),
-        _ => {}
+        ParsedInput::Byte(b'q' | b'Q') | ParsedInput::Char('q' | 'Q') => {
+            Some(OverlayInputAction::Close)
+        }
+        ParsedInput::Byte(b'j' | b'J') | ParsedInput::Char('j' | 'J') => {
+            Some(OverlayInputAction::Scroll(1))
+        }
+        ParsedInput::Byte(b'k' | b'K') | ParsedInput::Char('k' | 'K') => {
+            Some(OverlayInputAction::Scroll(-1))
+        }
+        ParsedInput::Arrow(b'B') => Some(OverlayInputAction::Scroll(1)),
+        ParsedInput::Arrow(b'A') => Some(OverlayInputAction::Scroll(-1)),
+        _ => None,
     }
 }
 
@@ -1717,5 +1737,29 @@ mod tests {
             news_composing: false,
         };
         assert!(ctx.blocks_arrow_sequence());
+    }
+
+    #[test]
+    fn overlay_input_action_accepts_printable_chars_and_arrows() {
+        assert_eq!(
+            overlay_input_action(&ParsedInput::Char('j')),
+            Some(OverlayInputAction::Scroll(1))
+        );
+        assert_eq!(
+            overlay_input_action(&ParsedInput::Char('k')),
+            Some(OverlayInputAction::Scroll(-1))
+        );
+        assert_eq!(
+            overlay_input_action(&ParsedInput::Char('q')),
+            Some(OverlayInputAction::Close)
+        );
+        assert_eq!(
+            overlay_input_action(&ParsedInput::Arrow(b'B')),
+            Some(OverlayInputAction::Scroll(1))
+        );
+        assert_eq!(
+            overlay_input_action(&ParsedInput::Arrow(b'A')),
+            Some(OverlayInputAction::Scroll(-1))
+        );
     }
 }

--- a/late-ssh/src/app/settings_modal/ui.rs
+++ b/late-ssh/src/app/settings_modal/ui.rs
@@ -498,7 +498,7 @@ fn draw_save_cta(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
 fn draw_footer(frame: &mut Frame, area: Rect) {
     let footer = Line::from(vec![
         Span::raw("  "),
-        Span::styled("j/k ↑↓", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled("↑↓ j/k", Style::default().fg(theme::AMBER_DIM())),
         Span::styled(" navigate  ", Style::default().fg(theme::TEXT_DIM())),
         Span::styled("←→", Style::default().fg(theme::AMBER_DIM())),
         Span::styled(" cycle  ", Style::default().fg(theme::TEXT_DIM())),

--- a/late-ssh/src/app/tick.rs
+++ b/late-ssh/src/app/tick.rs
@@ -28,8 +28,8 @@ impl App {
         if let Some(b) = self.chat.tick() {
             self.banner = Some(b);
         }
-        if self.chat.pending_dm_screen_switch {
-            self.chat.pending_dm_screen_switch = false;
+        if self.chat.pending_chat_screen_switch {
+            self.chat.pending_chat_screen_switch = false;
             self.screen = Screen::Chat;
         }
         if let Some(b) = self.vote.tick() {

--- a/late-ssh/src/ssh.rs
+++ b/late-ssh/src/ssh.rs
@@ -581,19 +581,6 @@ impl russh::server::Handler for ClientHandler {
         };
 
         let user_id = user.id;
-        match self
-            .state
-            .chat_service
-            .auto_join_public_rooms(user_id)
-            .await
-        {
-            Ok(joined) => {
-                tracing::debug!(user_id = %user_id, joined, "auto-joined public chat rooms");
-            }
-            Err(e) => {
-                tracing::warn!(user_id = %user_id, error = ?e, "failed to auto-join public chat rooms");
-            }
-        }
 
         let my_vote = match self.state.vote_service.get_user_vote(user_id).await {
             Ok(v) => v,
@@ -1155,6 +1142,22 @@ async fn ensure_user(state: &State, username: &str, fingerprint: &str) -> Result
                 },
             )
             .await?;
+            match state.chat_service.auto_join_public_rooms(user.id).await {
+                Ok(joined) => {
+                    tracing::debug!(
+                        user_id = %user.id,
+                        joined,
+                        "seeded auto-join chat rooms for newly created user"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        user_id = %user.id,
+                        error = ?e,
+                        "failed to seed auto-join chat rooms for newly created user"
+                    );
+                }
+            }
             (user, true)
         }
     };

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -276,7 +276,7 @@ async fn help_command_renders_chat_feedback_without_persisting_message() {
 }
 
 #[tokio::test]
-async fn list_command_shows_private_room_members_without_persisting_message() {
+async fn members_command_shows_room_members_without_persisting_message() {
     let test_db = new_test_db().await;
     let viewer = create_test_user(&test_db.db, "list-flow-viewer").await;
     let target = create_test_user(&test_db.db, "list-flow-target").await;
@@ -288,7 +288,7 @@ async fn list_command_shows_private_room_members_without_persisting_message() {
         .await
         .expect("join viewer to general");
 
-    let private_room = ChatRoom::get_or_create_room(&client, "side")
+    let private_room = ChatRoom::create_private_room(&client, "side")
         .await
         .expect("create room");
     ChatRoomMember::join(&client, private_room.id, viewer.id)
@@ -302,11 +302,14 @@ async fn list_command_shows_private_room_members_without_persisting_message() {
 
     app.handle_input(b"2");
     wait_for_render_contains(&mut app, " Rooms (h/l)").await;
+    wait_for_render_contains(&mut app, "> general").await;
+    wait_for_render_contains(&mut app, " Private ").await;
+    wait_for_render_contains(&mut app, " side").await;
 
-    app.handle_input(b"i/join side\r");
-    wait_for_render_contains(&mut app, "Joined #side").await;
+    app.handle_input(b"lll");
+    wait_for_render_contains(&mut app, "> side").await;
 
-    app.handle_input(b"i/list\r");
+    app.handle_input(b"i/members\r");
     wait_for_render_contains(&mut app, "#side Members").await;
     wait_for_render_contains(&mut app, "@list-flow-viewer").await;
     wait_for_render_contains(&mut app, "@list-flow-target").await;
@@ -314,7 +317,7 @@ async fn list_command_shows_private_room_members_without_persisting_message() {
     let messages = ChatMessage::list_recent(&client, private_room.id, 20)
         .await
         .expect("list recent messages");
-    assert!(messages.is_empty(), "expected /list to stay client-side");
+    assert!(messages.is_empty(), "expected /members to stay client-side");
 }
 
 #[tokio::test]

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -306,7 +306,9 @@ async fn members_command_shows_room_members_without_persisting_message() {
     wait_for_render_contains(&mut app, " Private ").await;
     wait_for_render_contains(&mut app, " side").await;
 
-    app.handle_input(b"lll");
+    app.handle_input(b" ");
+    wait_for_render_contains(&mut app, "[f] side").await;
+    app.handle_input(b"f");
     wait_for_render_contains(&mut app, "> side").await;
 
     app.handle_input(b"i/members\r");


### PR DESCRIPTION
## Summary
- Introduces true private rooms alongside public topic rooms: the same `#slug` can now exist once as public and once as private, with private rooms requiring an explicit invite.
- Replaces the overloaded `/join` and `/create` composer flow with purpose-built `/public`, `/private`, `/invite`, `/members`, and `/list` commands so users can tell at a glance what each one does.
- Fixes the longstanding "left rooms keep coming back" paper cut — auto-join rooms are now seeded only when a user record is first created; reconnecting no longer re-adds rooms you already left.

## What changed
- **Private rooms**: `ChatRoom::create_private_room` and `ChatRoom::find_topic_room` plus migration `028_topic_room_visibility_uniqueness.sql`, which swaps the global `uq_chat_rooms_topic_slug` index for a `(visibility, slug)` unique index and flips `auto_join` default to `false`.
- **Composer commands**:
  - `/public #room` — open or create a public topic room (replaces `/join` for public rooms).
  - `/private #room` — create a new private topic room you can then invite people to.
  - `/invite @user` — add a user to the currently selected room.
  - `/members` — list members of the current room (DMs allowed, renders generic "DM Members" title).
  - `/list` — now lists all public rooms with member counts, instead of listing members of a private room.
- **Mention safety in private rooms**: `Notification::resolve_mentioned_user_ids` now only resolves `@usernames` that are members of the target private room, so you can't page a non-member by guessing their handle.
- **Room list grouping**: The sidebar's public/private sections map directly to DB `visibility` instead of the old `auto_join` proxy, matching the new first-class notion of private rooms.
- **Overlay UX**: `/help`, `/members`, `/list`, and similar overlays accept arrow keys and plain `j`/`k`/`q` characters for scroll/close; titles updated to `↑/↓ j/k scroll · Esc/q close`.
- **Docs + tips**: `CONTEXT.md`, help modal, and splash tips updated to the new command surface. Welcome modal references renamed to "profile/settings modal" (file move `welcome_modal` → `settings_modal` was landed separately; this branch updates the prose and a footer label to match).
- **Music library**: Drops six "White Noise" ambient tracks that no longer fit the curated set, bringing ambient to 14 CC-BY tracks; see `MUSIC.md`.

## Behavior notes
- Existing users keep their current room memberships; the auto-join seeding change only affects which rooms *new* users land in and means that leaving a public room is now sticky across reconnects.
- `get_or_create_room` is preserved as a thin alias over `get_or_create_public_room` so existing call sites (including admin `/create-room`) keep working.
- `/private #foo` fails loudly if a private room with that slug already exists; public and private rooms with the same slug are allowed and resolve independently.
- `RoomCreated` now carries the new `room_id` so the client can auto-select the newly created private room and trigger the chat screen switch.

## Feature flags
- None.

## Screenshots / Video
- UI-visible change (new commands, updated overlay titles, new `Public Rooms` overlay). Screenshots still need to be attached before review.

## Testing
- Automated:
  - `late-core` — new `test_chat_room_public_and_private_topics` covers public/private coexistence, idempotent public creation, and duplicate-private rejection; existing language-room test now asserts `visibility = 'public'` and `auto_join = false`.
  - `late-ssh` — new composer parser tests for `/public` and `/private` (with/without `#`, empty, non-matching); removed the now-obsolete `room_supports_member_list` test; `app_input_flow` end-to-end test rewritten to exercise `/members` in a private room created via `create_private_room`.
  - `overlay_input_action` unit test covers the new `ParsedInput::Char` + arrow handling.
- Manual verification still to run:
  - SSH in as a new user, confirm auto-join rooms are seeded once; leave one, reconnect, confirm it stays left.
  - `/public #foo`, leave, `/public #foo` again — should re-open the same public room.
  - `/private #foo` then `/invite @bob`; as `@bob`, confirm the room appears and `@mentions` from non-members don't notify.
  - `/members` in general, a private room, and a DM; `/list` shows member counts; overlays close with both `q` and `Esc` and scroll with arrows and `j`/`k`.