### PR TITLE
Mark rooms read based on what's actually visible; drop bot active-member prompt context

### DIFF
--- a/late-core/src/models/user.rs
+++ b/late-core/src/models/user.rs
@@ -22,15 +22,6 @@ crate::model! {
 
 pub const USERNAME_MAX_LEN: usize = 32;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct PromptProfileContext {
-    pub username: String,
-    pub bio: String,
-    pub country: Option<String>,
-    pub timezone: Option<String>,
-    pub is_bot: bool,
-}
-
 const IGNORED_USER_IDS_KEY: &str = "ignored_user_ids";
 const THEME_ID_KEY: &str = "theme_id";
 const NOTIFY_KINDS_KEY: &str = "notify_kinds";
@@ -136,43 +127,6 @@ impl User {
             }
         }
         Ok(map)
-    }
-
-    pub async fn list_prompt_profile_context_by_ids(
-        client: &Client,
-        user_ids: &[Uuid],
-    ) -> Result<HashMap<Uuid, PromptProfileContext>> {
-        if user_ids.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let rows = client
-            .query(
-                "SELECT id, username, settings
-                 FROM users
-                 WHERE id = ANY($1)",
-                &[&user_ids],
-            )
-            .await?;
-
-        let mut contexts = HashMap::with_capacity(rows.len());
-        for row in rows {
-            let settings: Value = row.get("settings");
-            contexts.insert(
-                row.get("id"),
-                PromptProfileContext {
-                    username: row.get("username"),
-                    bio: extract_bio(&settings),
-                    country: extract_country(&settings),
-                    timezone: extract_timezone(&settings),
-                    is_bot: settings
-                        .get("bot")
-                        .and_then(Value::as_bool)
-                        .unwrap_or(false),
-                },
-            );
-        }
-        Ok(contexts)
     }
 
     pub async fn find_by_username(client: &Client, username: &str) -> Result<Option<Self>> {

--- a/late-core/tests/user.rs
+++ b/late-core/tests/user.rs
@@ -1,4 +1,4 @@
-use late_core::models::user::{PromptProfileContext, User, UserParams};
+use late_core::models::user::{User, UserParams};
 use late_core::test_utils::{TestDb, test_db};
 use serde_json::json;
 use tokio::time::{Duration, sleep};
@@ -296,59 +296,4 @@ async fn ignored_user_ids_require_existing_user() {
         .await
         .expect_err("expected missing user error");
     assert!(err.to_string().to_ascii_lowercase().contains("not found"));
-}
-
-#[tokio::test]
-async fn list_prompt_profile_context_by_ids_reads_profile_fields_from_settings() {
-    let (client, _test_db) = setup_db().await;
-
-    let alice = User::create(
-        &client,
-        UserParams {
-            fingerprint: "fp-prompt-alice".to_string(),
-            username: "alice".to_string(),
-            settings: json!({
-                "bio": "shipping rust + postgres",
-                "country": " pl ",
-                "timezone": " Europe/Warsaw ",
-            }),
-        },
-    )
-    .await
-    .expect("create alice");
-    let bob = User::create(
-        &client,
-        UserParams {
-            fingerprint: "fp-prompt-bob".to_string(),
-            username: "bob".to_string(),
-            settings: json!({}),
-        },
-    )
-    .await
-    .expect("create bob");
-
-    let contexts = User::list_prompt_profile_context_by_ids(&client, &[alice.id, bob.id])
-        .await
-        .expect("list prompt profile context");
-
-    assert_eq!(
-        contexts.get(&alice.id),
-        Some(&PromptProfileContext {
-            username: "alice".to_string(),
-            bio: "shipping rust + postgres".to_string(),
-            country: Some("PL".to_string()),
-            timezone: Some("Europe/Warsaw".to_string()),
-            is_bot: false,
-        })
-    );
-    assert_eq!(
-        contexts.get(&bob.id),
-        Some(&PromptProfileContext {
-            username: "bob".to_string(),
-            bio: String::new(),
-            country: None,
-            timezone: None,
-            is_bot: false,
-        })
-    );
 }

--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -982,7 +982,6 @@ impl TinyRng {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
 
     #[test]
     fn merge_ghost_settings_preserves_existing_profile_fields() {

--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -7,7 +7,7 @@ use late_core::{
         chat_room::ChatRoom,
         chat_room_member::ChatRoomMember,
         profile::{Profile, ProfileParams},
-        user::{PromptProfileContext, User, UserParams},
+        user::{User, UserParams},
     },
 };
 use serde_json::json;
@@ -42,8 +42,6 @@ struct BotUser {
 const BOT_FINGERPRINT: &str = "bot-fp-000";
 const BOT_USERNAME: &str = "bot";
 const BOT_COOLDOWN: Duration = Duration::from_secs(30);
-const BOT_ACTIVE_ROOM_MEMBER_LIMIT: usize = 20;
-const BOT_ACTIVE_ROOM_MEMBER_BIO_MAX_CHARS: usize = 96;
 pub const BOT_TIP_INTERVAL: Duration = Duration::from_secs(60 * 120); // 2 hours
 const BOT_TIP_PHASE_OFFSET: Duration = Duration::from_secs(60 * 120); // 2 hours
 pub const BOT_TIP_MIN_NEW_MESSAGES: usize = 10;
@@ -285,9 +283,6 @@ impl GhostService {
         let mut author_ids: Vec<Uuid> = messages.iter().map(|m| m.user_id).collect();
         author_ids.push(trigger_message.user_id);
         let usernames = User::list_usernames_by_ids(&client, &author_ids).await?;
-        let active_room_members = self
-            .build_active_room_member_context(&client, trigger_message.room_id, bot.id)
-            .await?;
 
         let mut history_str = String::from("CHAT HISTORY:\n");
         for msg in messages.into_iter().rev() {
@@ -296,11 +291,6 @@ impl GhostService {
                 .map(String::as_str)
                 .unwrap_or("unknown");
             history_str.push_str(&format!("{author}: {}\n", msg.body));
-        }
-        if let Some(active_room_members) = active_room_members {
-            history_str.push('\n');
-            history_str.push_str(&active_room_members);
-            history_str.push('\n');
         }
         history_str.push_str(
             "---\nThe latest message explicitly mentioned @bot. Reply with only your message content.",
@@ -318,7 +308,6 @@ impl GhostService {
             Use the extra space when the question benefits from a clearer answer.\n\
             You can answer questions about late.sh features, product positioning, and high-level architecture.\n\
             Prefer concrete facts from the provided app context over generic guesses.\n\
-            Use the active room member context when it materially helps, but do not dump it back verbatim.\n\
             Do NOT use markdown code fences.\n\
             Do NOT prefix with your own username.\n\
             If unsure, ask exactly one short clarifying question.\n\
@@ -807,33 +796,6 @@ impl GhostService {
 
         Ok(())
     }
-
-    async fn build_active_room_member_context(
-        &self,
-        client: &tokio_postgres::Client,
-        room_id: Uuid,
-        bot_user_id: Uuid,
-    ) -> Result<Option<String>> {
-        let room_member_ids = ChatRoomMember::list_user_ids(client, room_id).await?;
-        let active_room_member_ids = {
-            let active_users = self.active_users.lock_recover();
-            room_member_ids
-                .into_iter()
-                .filter(|user_id| *user_id != bot_user_id && active_users.contains_key(user_id))
-                .collect::<Vec<_>>()
-        };
-
-        if active_room_member_ids.is_empty() {
-            return Ok(None);
-        }
-
-        let profiles =
-            User::list_prompt_profile_context_by_ids(client, &active_room_member_ids).await?;
-        Ok(format_active_room_member_context(
-            &active_room_member_ids,
-            &profiles,
-        ))
-    }
 }
 
 fn merge_ghost_settings(existing: &serde_json::Value) -> serde_json::Value {
@@ -892,71 +854,6 @@ fn sanitize_mention_handle(input: &str) -> String {
 fn short_user_id(user_id: Uuid) -> String {
     let id = user_id.to_string();
     id[..id.len().min(8)].to_string()
-}
-
-fn format_active_room_member_context(
-    ordered_user_ids: &[Uuid],
-    profiles: &HashMap<Uuid, PromptProfileContext>,
-) -> Option<String> {
-    let mut lines = Vec::new();
-    for user_id in ordered_user_ids
-        .iter()
-        .take(BOT_ACTIVE_ROOM_MEMBER_LIMIT)
-        .copied()
-    {
-        let Some(profile) = profiles.get(&user_id) else {
-            continue;
-        };
-        if profile.is_bot {
-            continue;
-        }
-
-        let handle = profile
-            .username
-            .trim()
-            .strip_prefix('@')
-            .unwrap_or(profile.username.trim());
-        let handle = if handle.is_empty() {
-            short_user_id(user_id)
-        } else {
-            handle.to_string()
-        };
-
-        let mut parts = vec![format!("@{handle}")];
-        if let Some(country) = profile.country.as_deref() {
-            parts.push(format!("country={country}"));
-        }
-        if let Some(timezone) = profile.timezone.as_deref() {
-            parts.push(format!("timezone={timezone}"));
-        }
-        if !profile.bio.is_empty() {
-            parts.push(format!(
-                "bio={}",
-                truncate_for_prompt(&profile.bio, BOT_ACTIVE_ROOM_MEMBER_BIO_MAX_CHARS)
-            ));
-        }
-
-        lines.push(format!("- {}", parts.join(" | ")));
-    }
-
-    if lines.is_empty() {
-        return None;
-    }
-
-    Some(format!(
-        "ROOM ACTIVE MEMBERS (online now):\n{}",
-        lines.join("\n")
-    ))
-}
-
-fn truncate_for_prompt(input: &str, max_chars: usize) -> String {
-    if input.chars().count() <= max_chars {
-        return input.to_string();
-    }
-
-    let mut truncated = input.chars().take(max_chars).collect::<String>();
-    truncated.push_str("...");
-    truncated
 }
 
 fn contains_mention(text: &str, target_handle: &str) -> bool {
@@ -1210,63 +1107,5 @@ mod tests {
         let user_id = Uuid::from_u128(0x0123_4567_89ab_cdef_1111_2222_3333_4444);
         assert_eq!(mention_target_for_user(Some(""), user_id), "@01234567");
         assert_eq!(mention_target_for_user(Some("!!!"), user_id), "@01234567");
-    }
-
-    #[test]
-    fn format_active_room_member_context_includes_profile_fields() {
-        let alice = Uuid::from_u128(1);
-        let bob = Uuid::from_u128(2);
-        let mut profiles = HashMap::new();
-        profiles.insert(
-            alice,
-            PromptProfileContext {
-                username: "alice".to_string(),
-                bio: "rust backend dev".to_string(),
-                country: Some("PL".to_string()),
-                timezone: Some("Europe/Warsaw".to_string()),
-                is_bot: false,
-            },
-        );
-        profiles.insert(
-            bob,
-            PromptProfileContext {
-                username: "bob".to_string(),
-                bio: String::new(),
-                country: None,
-                timezone: None,
-                is_bot: false,
-            },
-        );
-
-        let context = format_active_room_member_context(&[alice, bob], &profiles).expect("context");
-        assert!(context.contains("ROOM ACTIVE MEMBERS (online now):"));
-        assert!(
-            context.contains("@alice | country=PL | timezone=Europe/Warsaw | bio=rust backend dev")
-        );
-        assert!(context.contains("- @bob"));
-    }
-
-    #[test]
-    fn truncate_for_prompt_adds_ellipsis_when_needed() {
-        assert_eq!(truncate_for_prompt("short", 12), "short");
-        assert_eq!(truncate_for_prompt("123456", 5), "12345...");
-    }
-
-    #[test]
-    fn format_active_room_member_context_skips_bot_profiles() {
-        let bot = Uuid::from_u128(3);
-        let mut profiles = HashMap::new();
-        profiles.insert(
-            bot,
-            PromptProfileContext {
-                username: "graybeard".to_string(),
-                bio: "noisy".to_string(),
-                country: None,
-                timezone: None,
-                is_bot: true,
-            },
-        );
-
-        assert_eq!(format_active_room_member_context(&[bot], &profiles), None);
     }
 }

--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -77,11 +77,15 @@ pub fn handle_compose_input(
         // text and cursor survive. Shadows ratatui-textarea's cursor-
         // down/up, which is rarely useful in a chat composer.
         0x0E if allow_room_switch => {
-            app.chat.switch_room_preserving_draft(1);
+            if app.chat.switch_room_preserving_draft(1) {
+                app.sync_visible_chat_room();
+            }
             app.chat.update_autocomplete();
         }
         0x10 if allow_room_switch => {
-            app.chat.switch_room_preserving_draft(-1);
+            if app.chat.switch_room_preserving_draft(-1) {
+                app.sync_visible_chat_room();
+            }
             app.chat.update_autocomplete();
         }
         b => {
@@ -138,7 +142,7 @@ pub fn handle_scroll_in_room(app: &mut App, room_id: Uuid, delta: isize) {
 fn switch_room(app: &mut App, delta: isize) {
     if app.chat.move_selection(delta) {
         app.chat.reset_composer();
-        app.chat.mark_selected_room_read();
+        app.sync_visible_chat_room();
         app.chat.request_list();
     }
 }
@@ -316,7 +320,7 @@ pub fn handle_byte(app: &mut App, byte: u8) -> bool {
                 let changed = app.chat.handle_room_jump_key(byte);
                 if changed {
                     app.chat.reset_composer();
-                    app.chat.mark_selected_room_read();
+                    app.sync_visible_chat_room();
                     app.chat.request_list();
                 }
                 return true;

--- a/late-ssh/src/app/chat/notifications/input.rs
+++ b/late-ssh/src/app/chat/notifications/input.rs
@@ -49,7 +49,7 @@ fn jump_to_selected(app: &mut App) {
     app.chat.selected_room_id = Some(room_id);
     app.chat.selected_message_id = Some(message_id);
     app.chat.highlighted_message_id = Some(message_id);
+    app.sync_visible_chat_room();
     app.chat.request_list();
-    app.chat.mark_selected_room_read();
     app.banner = Some(Banner::success(&format!("Jumped to {room_label}")));
 }

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -70,6 +70,7 @@ pub struct ChatState {
     overlay: Option<Overlay>,
     pub(crate) unread_counts: HashMap<Uuid, i64>,
     pending_read_rooms: HashSet<Uuid>,
+    visible_room_id: Option<Uuid>,
     room_tx: watch::Sender<Option<Uuid>>,
     pub(crate) selected_room_id: Option<Uuid>,
     pub(crate) room_jump_active: bool,
@@ -147,6 +148,7 @@ impl ChatState {
             overlay: None,
             unread_counts: HashMap::new(),
             pending_read_rooms: HashSet::new(),
+            visible_room_id: None,
             room_tx,
             selected_room_id: None,
             room_jump_active: false,
@@ -222,14 +224,26 @@ impl ChatState {
         self.selected_room_id = Some(self.rooms[0].0.id);
     }
 
+    pub fn mark_room_read(&mut self, room_id: Uuid) {
+        self.pending_read_rooms.insert(room_id);
+        self.unread_counts.insert(room_id, 0);
+        self.service.mark_room_read_task(self.user_id, room_id);
+    }
+
     pub fn mark_selected_room_read(&mut self) {
         let Some(room_id) = self.selected_room_id else {
             return;
         };
 
-        self.pending_read_rooms.insert(room_id);
-        self.unread_counts.insert(room_id, 0);
-        self.service.mark_room_read_task(self.user_id, room_id);
+        self.mark_room_read(room_id);
+    }
+
+    pub fn visible_room_id(&self) -> Option<Uuid> {
+        self.visible_room_id
+    }
+
+    pub fn set_visible_room_id(&mut self, room_id: Option<Uuid>) {
+        self.visible_room_id = room_id;
     }
 
     /// Returns visible messages for the given room.
@@ -638,7 +652,8 @@ impl ChatState {
         self.reply_target = None;
         self.edited_message_id = None;
         self.composer_room_id = Some(next_room_id);
-        self.mark_selected_room_read();
+        self.visible_room_id = Some(next_room_id);
+        self.mark_room_read(next_room_id);
         self.request_list();
         true
     }
@@ -1466,7 +1481,7 @@ impl ChatState {
             return;
         }
 
-        let is_viewing_room = Some(message.room_id) == self.selected_room_id;
+        let is_viewing_room = Some(message.room_id) == self.visible_room_id;
 
         let Some((_, messages)) = self
             .rooms

--- a/late-ssh/src/app/dashboard/input.rs
+++ b/late-ssh/src/app/dashboard/input.rs
@@ -19,6 +19,7 @@ pub fn handle_key(app: &mut App, byte: u8) -> bool {
         app.dashboard_g_prefix_armed = false;
         if (b'1'..=b'9').contains(&byte) {
             app.jump_dashboard_favorite((byte - b'1') as usize);
+            app.sync_visible_chat_room();
             return true;
         }
         // Any non-digit disarms and continues through normal handling so
@@ -32,14 +33,17 @@ pub fn handle_key(app: &mut App, byte: u8) -> bool {
 
     if byte == b'[' {
         app.cycle_dashboard_favorite(-1);
+        app.sync_visible_chat_room();
         return true;
     }
     if byte == b']' {
         app.cycle_dashboard_favorite(1);
+        app.sync_visible_chat_room();
         return true;
     }
     if byte == b',' {
         app.toggle_dashboard_last_favorite();
+        app.sync_visible_chat_room();
         return true;
     }
 

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -544,8 +544,8 @@ fn handle_parsed_input(app: &mut App, event: ParsedInput) {
             if app.screen == Screen::Chat {
                 app.chat.request_list();
                 app.chat.sync_selection();
-                app.chat.mark_selected_room_read();
             }
+            app.sync_visible_chat_room();
             app.chat.clear_message_selection();
         }
         // Page keys mirror Ctrl-U / Ctrl-D. Signs follow the existing scheme:
@@ -1079,19 +1079,21 @@ fn handle_global_key(app: &mut App, ctx: InputContext, byte: u8) -> bool {
         b'1' => {
             reset_composers_for_page_change(app);
             app.screen = Screen::Dashboard;
+            app.sync_visible_chat_room();
             true
         }
         b'2' => {
             reset_composers_for_page_change(app);
             app.chat.request_list();
             app.chat.sync_selection();
-            app.chat.mark_selected_room_read();
             app.screen = Screen::Chat;
+            app.sync_visible_chat_room();
             true
         }
         b'3' => {
             reset_composers_for_page_change(app);
             app.screen = Screen::Games;
+            app.sync_visible_chat_room();
             true
         }
         b'\t' => {
@@ -1102,10 +1104,10 @@ fn handle_global_key(app: &mut App, ctx: InputContext, byte: u8) -> bool {
                 Screen::Chat => {
                     app.chat.request_list();
                     app.chat.sync_selection();
-                    app.chat.mark_selected_room_read();
                 }
                 Screen::Games => {}
             }
+            app.sync_visible_chat_room();
             true
         }
         b'P' => {

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -285,6 +285,23 @@ impl App {
         }
     }
 
+    fn current_visible_chat_room_id(&self) -> Option<Uuid> {
+        match self.screen {
+            Screen::Dashboard => self.dashboard_active_room_id(),
+            Screen::Chat => self.chat.selected_room_id,
+            _ => None,
+        }
+    }
+
+    pub(crate) fn sync_visible_chat_room(&mut self) {
+        let visible_room_id = self.current_visible_chat_room_id();
+        let changed = self.chat.visible_room_id() != visible_room_id;
+        self.chat.set_visible_room_id(visible_room_id);
+        if changed && let Some(room_id) = visible_room_id {
+            self.chat.mark_room_read(room_id);
+        }
+    }
+
     /// Pins to render in the dashboard quick-switch strip. `None` when fewer
     /// than two favorites are pinned — there's nothing to switch between, so
     /// the strip is hidden entirely.
@@ -528,7 +545,7 @@ impl App {
             settings_modal::ui::MODAL_WIDTH,
         );
 
-        Ok(Self {
+        let mut app = Self {
             running: true,
             size: (cols, rows),
             screen: Screen::Dashboard,
@@ -607,7 +624,9 @@ impl App {
             icon_picker_state: super::icon_picker::IconPickerState::default(),
             icon_catalog: None,
             last_terminal_bg: None,
-        })
+        };
+        app.sync_visible_chat_room();
+        Ok(app)
     }
 
     pub fn resize(&mut self, cols: u16, rows: u16) -> Result<(), io::Error> {

--- a/late-ssh/src/app/tick.rs
+++ b/late-ssh/src/app/tick.rs
@@ -24,13 +24,17 @@ impl App {
             }
         }
 
+        self.sync_visible_chat_room();
+
         // Services
         if let Some(b) = self.chat.tick() {
             self.banner = Some(b);
         }
+        self.sync_visible_chat_room();
         if self.chat.pending_chat_screen_switch {
             self.chat.pending_chat_screen_switch = false;
             self.screen = Screen::Chat;
+            self.sync_visible_chat_room();
         }
         if let Some(b) = self.vote.tick() {
             self.banner = Some(b);

--- a/late-ssh/tests/app_dashboard_flow.rs
+++ b/late-ssh/tests/app_dashboard_flow.rs
@@ -3,7 +3,8 @@
 mod helpers;
 
 use helpers::{
-    make_app, make_app_with_paired_client, new_test_db, wait_for_render_contains, wait_until,
+    make_app, make_app_with_paired_client, new_test_db, render_plain, wait_for_render_contains,
+    wait_until,
 };
 use late_core::models::{
     chat_message::{ChatMessage, ChatMessageParams},
@@ -233,4 +234,94 @@ async fn dashboard_lazy_primes_favorite_histories_without_opening_chat() {
 
     app.handle_input(b"]");
     wait_for_render_contains(&mut app, "beta backlog").await;
+}
+
+#[tokio::test]
+async fn dashboard_switching_to_favorite_clears_strip_unread_count() {
+    let test_db = new_test_db().await;
+    let user = create_test_user(&test_db.db, "dashboard-unread-user-it").await;
+    let author = create_test_user(&test_db.db, "dashboard-unread-author-it").await;
+    let client = test_db.db.get().await.expect("db client");
+    let general = ChatRoom::ensure_general(&client)
+        .await
+        .expect("ensure general room");
+    let alpha = ChatRoom::get_or_create_public_room(&client, "alpha-unread")
+        .await
+        .expect("create alpha room");
+    let beta = ChatRoom::get_or_create_public_room(&client, "beta-unread")
+        .await
+        .expect("create beta room");
+
+    for room in [general.id, alpha.id, beta.id] {
+        ChatRoomMember::join(&client, room, user.id)
+            .await
+            .expect("join viewer");
+        ChatRoomMember::join(&client, room, author.id)
+            .await
+            .expect("join author");
+    }
+
+    ChatMessage::create(
+        &client,
+        ChatMessageParams {
+            room_id: beta.id,
+            user_id: author.id,
+            body: "beta unread seed".to_string(),
+        },
+    )
+    .await
+    .expect("create beta message");
+
+    Profile::update(
+        &client,
+        user.id,
+        ProfileParams {
+            username: "dashboard-unread-user-it".to_string(),
+            bio: String::new(),
+            country: None,
+            timezone: None,
+            notify_kinds: Vec::new(),
+            notify_bell: false,
+            notify_cooldown_mins: 0,
+            notify_format: None,
+            theme_id: Some("late".to_string()),
+            enable_background_color: false,
+            show_dashboard_header: true,
+            show_right_sidebar: true,
+            show_games_sidebar: true,
+            favorite_room_ids: vec![alpha.id, beta.id],
+        },
+    )
+    .await
+    .expect("update favorites");
+
+    let mut app = make_app(test_db.db.clone(), user.id, "dashboard-unread-flow-it");
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut saw_unread = false;
+    while Instant::now() < deadline {
+        if render_plain(&mut app).contains("2:#beta-unread (1)") {
+            saw_unread = true;
+            break;
+        }
+        sleep(Duration::from_millis(30)).await;
+    }
+    assert!(
+        saw_unread,
+        "dashboard strip should show beta unread count before switching"
+    );
+
+    app.handle_input(b"]");
+
+    let deadline = Instant::now() + Duration::from_secs(3);
+    let mut cleared = false;
+    while Instant::now() < deadline {
+        let plain = render_plain(&mut app);
+        if plain.contains("2:#beta-unread") && !plain.contains("2:#beta-unread (1)") {
+            cleared = true;
+            break;
+        }
+        sleep(Duration::from_millis(30)).await;
+    }
+    assert!(cleared, "dashboard switch should clear beta unread count");
 }


### PR DESCRIPTION
## Summary
- Fixes a bug where switching between favorites on the Dashboard left unread counts stale in the strip: the old selection-based read tracking only fired from the Chat screen, so Dashboard-driven room changes never cleared unread counts.
- Introduces a `visible_room_id` concept in chat state that reflects the room the user is actually looking at (Dashboard favorite, Chat selection, or none), and centralises read-marking through it.
- Removes the experimental "active room members" context that the bot was injecting into its prompt, along with its supporting database query, model type, and tests.

## What changed
- `ChatState` now tracks a separate `visible_room_id`, exposed via `visible_room_id()` / `set_visible_room_id()`. A new `mark_room_read(room_id)` helper backs `mark_selected_room_read()` and the new sync path.
- `App::sync_visible_chat_room()` resolves the currently visible room from the active screen (Dashboard favourite vs. Chat selection) and marks it read when it changes. It is invoked from every path that can change what the user sees: screen switches (`1`/`2`/`3`/`Tab`), Dashboard favourite jumps (`1`-`9`, `[`, `]`, `,`), Chat room switches (`Ctrl-N`/`Ctrl-P`, room-jump, message-selection clear), notifications jump-to-message, tick, and app construction.
- Incoming-message handling now compares against `visible_room_id` instead of `selected_room_id`, so a message arriving for the Dashboard-visible room is correctly treated as "being viewed".
- Removed `PromptProfileContext`, `User::list_prompt_profile_context_by_ids`, `GhostService::build_active_room_member_context`, `format_active_room_member_context`, `truncate_for_prompt`, and the corresponding unit/integration tests and prompt language. The bot prompt no longer lists online room members with bios/country/timezone.

## Behavior notes
- Unread counts in the Dashboard favourite strip now clear as soon as you land on that favourite (including on initial app load), matching Chat behaviour.
- A side effect of the bot change: replies will no longer reference other online members' profiles. If this was relied on in staging, note that it is gone.

## Feature flags
- None.

## Screenshots / Video
- UI change is limited to the Dashboard favourite strip's unread badge clearing on switch; no screenshot attached. A video of `]`/`[` cycling through favourites and watching the `(N)` badges disappear should be attached before review if visual confirmation is wanted.

## Testing
- Automated: new `late-ssh/tests/app_dashboard_flow.rs::dashboard_switching_to_favorite_clears_strip_unread_count` seeds an unread message in a favourite, asserts the strip shows `2:#beta-unread (1)`, presses `]`, and asserts the count clears.
- Automated: removed now-obsolete `list_prompt_profile_context_by_ids_reads_profile_fields_from_settings`, `format_active_room_member_context_*`, and `truncate_for_prompt_*` tests alongside the deleted code.
- Manual: cycle favourites with `]` / `[` / digit jumps / `,` toggle on Dashboard and confirm strip badges clear; switch screens with `1`/`2`/`3`/`Tab` and confirm the room under focus is marked read; trigger a notification jump and confirm the jumped-to room's badge clears.