### PR TITLE
CONTEXT.md:remind that postgres+root errs are probably red herring

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1226,6 +1226,7 @@ Use narrower crate-specific `cargo test` / `cargo nextest run` commands ad hoc w
 6. Now-playing shows "Unknown" → Check Icecast `/status-json.xsl`, metadata format: `"Artist - Title | Duration"` (duration is absent for internet streams — this is expected)
 7. Liquidsoap debugging → `docker run --rm savonet/liquidsoap:v2.4.0 liquidsoap -h <topic>`
 8. Music missing from PVC → Re-run infra deploy to trigger `sync_music` job (syncs from R2). For manual recovery: `aws s3 sync s3://$MUSIC_BUCKET/ ./music/ --endpoint-url $S3_ENDPOINT` then `kubectl cp` each genre dir individually into the pod.
+9. Repeated Postgres `role "root" does not exist` lines in GitHub Actions are often service-log noise, not the failure. They’re misleading because Actions prints service container logs after a job fails. Generally check for other errors before stopping to try and fix this probable red-herring.
 
 ## 11. TUI Screens Reference [STABLE]
 


### PR DESCRIPTION
Keep getting distracted by repeated Postgres `role "root" does not exist` lines in GitHub Actions logs when trying to troubleshoot something else. Reminder to not get stuck on this error when the cause could very well be something else.