### PR TITLE
Artboard snapshot gallery for browsing daily and monthly archives

### DIFF
--- a/.github/workflows/deploy_cli.yml
+++ b/.github/workflows/deploy_cli.yml
@@ -85,7 +85,7 @@ jobs:
           TOOLCHAIN="$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64"
           case "${{ matrix.target }}" in
             aarch64-linux-android)
-              linker="$TOOLCHAIN/bin/aarch64-linux-android24-clang"
+              linker="$TOOLCHAIN/bin/aarch64-linux-android26-clang"
               echo "CARGO_TARGET_AARCH64_LINUX_ANDROID_LINKER=$linker" >> "$GITHUB_ENV"
               echo "CC_aarch64_linux_android=$linker" >> "$GITHUB_ENV"
               echo "AR_aarch64_linux_android=$TOOLCHAIN/bin/llvm-ar" >> "$GITHUB_ENV"
@@ -94,7 +94,7 @@ jobs:
               ln -sf "$TOOLCHAIN/bin/llvm-ar" "$TOOLCHAIN/bin/aarch64-linux-android-ar"
               ;;
             x86_64-linux-android)
-              linker="$TOOLCHAIN/bin/x86_64-linux-android24-clang"
+              linker="$TOOLCHAIN/bin/x86_64-linux-android26-clang"
               echo "CARGO_TARGET_X86_64_LINUX_ANDROID_LINKER=$linker" >> "$GITHUB_ENV"
               echo "CC_x86_64_linux_android=$linker" >> "$GITHUB_ENV"
               echo "AR_x86_64_linux_android=$TOOLCHAIN/bin/llvm-ar" >> "$GITHUB_ENV"

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -519,6 +519,7 @@ The artboard is keyboard-first, but it is not "just type into a grid". It layers
 
 - `view` mode: inspect the board, move the cursor/viewport, and keep global page switching (`1-4`, `Tab`, `Shift+Tab`) available.
 - `active` mode: edit the board. Single-key global shortcuts are suppressed so typing goes to the canvas/editor.
+- `snapshot` view: read-only historical daily/monthly archive view. `g` in Artboard view mode opens the snapshot browser; `j/k` or arrows move, `Enter` selects, the top row returns to the live board, and `g` exits an active historical snapshot back to live.
 
 ```text
 type chars -> draw directly
@@ -533,6 +534,7 @@ Key behaviors:
 - Artboard opens in `view` mode.
 - In `view` mode, arrows/Home/End/PageUp/PageDown move around the board without entering draw mode.
 - `i` or `Enter` enters `active` mode.
+- `g` in `view` mode opens daily/monthly snapshots; selected archives cannot enter `active` mode.
 - Plain typing draws directly at the cursor.
 - Typing space erases at the cursor.
 - `Shift+arrows` starts/extends a selection.
@@ -562,6 +564,7 @@ Mouse-specific extras:
 | Open Artboard | `4`, `Tab`, `Shift+Tab` | Dedicated top-level screen; entering it also connects a local client |
 | Move around in view mode | `←↑↓→`, `Home`, `End`, `PgUp`, `PgDn`, mouse wheel | Lets users inspect/pan without entering draw mode |
 | Enter active mode | `i`, `Enter` | Switches the screen from inspect to edit |
+| Snapshot browser | `g` | View daily/monthly archives read-only; `j/k` or arrows navigate, `Enter` selects, top row returns live |
 | Draw / erase in active mode | `<type>`, `Space`, `Backspace`, `Delete` | Plain typing edits the shared canvas |
 | Select | `Shift+arrows`, mouse drag | Local selection only |
 | Copy / cut to swatch | `Ctrl+C`, `Ctrl+X` | Fills swatch strip; does not sync to peers |
@@ -1279,7 +1282,7 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `?` | Global (not composing) | Open help modal (multi-slide guide). Also works inside the settings modal, which renders help on top while keeping the draft intact. |
 | `h` / `l` / `←` / `→` | Help modal | Switch slides (Overview / Chat / Music / News / Arcade / Bonsai / Settings / Architecture) |
 | `j` / `k` / `↑` / `↓` | Help modal | Scroll current slide (uncapped — past the last line is blank space) |
-| `?` / `q` / `Esc` | Help modal | Close (returns to the underlying screen, including the settings modal if it was open) |
+| `Esc` / `q` / `?` | Help modal | Close (returns to the underlying screen, including the settings modal if it was open) |
 | `Tab` | Global | Cycle screens |
 | `1` | Global | Jump to Dashboard |
 | `2` | Global | Jump to Chat |
@@ -1343,7 +1346,7 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `/ignore [@user]` | Chat composer | Mute a user, or list muted users when no arg |
 | `/unignore [@user]` | Chat composer | Remove a user from your ignore list |
 | `j` / `k` / arrows | Chat overlay (`/help`, ignore list) | Scroll overlay |
-| `q` / `Esc` | Chat overlay (`/help`, ignore list) | Close overlay |
+| `Esc` / `q` | Chat overlay (`/help`, ignore list) | Close overlay |
 | `Ctrl+O` | Global | Open the settings modal from anywhere |
 | `↑` / `↓` / `j` / `k` | Settings modal | Move between rows (Username, Theme, Background, Right sidebar, Games sidebar, Country, Timezone, DMs, @mentions, Game events, Bell, Cooldown, Format) |
 | `←` / `→` | Settings modal | Cycle the current row's setting (theme, toggles, cooldown, notification format) |
@@ -1351,7 +1354,7 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `Alt+Enter` | Settings modal (bio editing) | Insert newline |
 | `?` | Settings modal | Open help modal on top |
 | `j` / `k` / `↑` / `↓` | Read-only profile modal | Scroll |
-| `q` / `Esc` | Read-only profile modal | Close |
+| `Esc` / `q` | Read-only profile modal | Close |
 | `Esc` | Any modal | Close/cancel |
 | `c` | Chat (not composing) | Open web chat QR (copies URL + shows it as fallback) |
 | `Ctrl+]` | Dashboard / Chat | Open icon picker (emoji + nerd font). Auto-starts the composer if not already composing. Inserts into the chat composer only. |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -909,6 +909,7 @@ Currently the SSH app assumes a single process. These in-memory structures would
 - Chat room visibility enforced via `ChatRoom::list_for_user` (membership join) - never expose rooms user hasn't joined
 - `#announcements` is read-joinable like other permanent public rooms, but only admins may post there; enforce this in the chat service send path, not only in the UI
 - DM rooms canonicalize user IDs (`dm_user_a < dm_user_b` text order) to prevent duplicate DM pairs
+- DM room endpoints (`dm_user_a`, `dm_user_b`) are durable even when `chat_room_members` changes: if one participant leaves a DM, the next message from the other participant re-adds both endpoints before targeted delivery. Private topic rooms do not have durable endpoints and still require explicit invites/rejoins.
 - `users.username` is the canonical public handle for chat/DM lookup; SSH login seeds it from the SSH username via `User::next_available_username` (sanitizes to `[A-Za-z0-9._-]`, adds `-N` suffixes to stay unique on `LOWER(username)`)
 - @bot and @graybeard bootstrap on app startup: ensure DB user with a fixed `username`, join public rooms, and insert into `active_users` (always online). Both are dedicated users with fixed fingerprints (`bot-fp-000`, `graybeard-fp-000`)
 - Connection limits (global semaphore + per-IP counter) plus SSH attempt rate limit (sliding window) MUST be enforced before any auth (effective client IP is resolved from PROXY protocol when enabled)

--- a/late-ssh/src/app/artboard/input.rs
+++ b/late-ssh/src/app/artboard/input.rs
@@ -543,7 +543,7 @@ fn map_button(button: MouseButton) -> Option<AppPointerButton> {
 mod tests {
     use super::*;
     use crate::app::artboard::provenance::ArtboardProvenance;
-    use crate::app::artboard::svc::{DartboardService, DartboardSnapshot};
+    use crate::app::artboard::svc::{ArtboardSnapshotService, DartboardService, DartboardSnapshot};
     use dartboard_core::{Canvas, CellValue, RgbColor};
     use dartboard_editor::Clipboard;
 
@@ -1215,6 +1215,11 @@ mod tests {
             ..Default::default()
         };
         let svc = DartboardService::disconnected_for_tests(snapshot);
-        State::new(svc, "painter".to_string(), shared_provenance)
+        State::new(
+            svc,
+            ArtboardSnapshotService::disabled(),
+            "painter".to_string(),
+            shared_provenance,
+        )
     }
 }

--- a/late-ssh/src/app/artboard/page.rs
+++ b/late-ssh/src/app/artboard/page.rs
@@ -19,6 +19,10 @@ pub(crate) fn handle_key(app: &mut App, byte: u8) -> bool {
         return handle_action(app, action);
     }
 
+    if state.is_snapshot_browser_open() {
+        return handle_snapshot_browser_key(state, byte);
+    }
+
     if is_interacting {
         let action = super::input::handle_byte(state, size, byte);
         return handle_action(app, action);
@@ -34,7 +38,14 @@ pub(crate) fn handle_key(app: &mut App, byte: u8) -> bool {
             state.clear_pending_canvas_click();
             true
         }
+        b'g' | b'G' => {
+            state.toggle_snapshot_browser_or_live();
+            true
+        }
         b'i' | b'I' | b'\r' | b'\n' => {
+            if state.is_archive_view_active() {
+                return true;
+            }
             app.activate_artboard_interaction();
             true
         }
@@ -55,6 +66,10 @@ pub(crate) fn handle_arrow(app: &mut App, key: u8) -> bool {
 
     if is_interacting || state.is_help_open() || state.is_glyph_picker_open() {
         return super::input::handle_arrow(state, size, key);
+    }
+
+    if state.is_snapshot_browser_open() {
+        return handle_snapshot_browser_arrow(state, key);
     }
 
     match key {
@@ -88,6 +103,10 @@ pub(crate) fn handle_event(app: &mut App, event: &ParsedInput) -> bool {
     if is_interacting || state.is_help_open() || state.is_glyph_picker_open() {
         let action = super::input::handle_event(state, size, event);
         return handle_action(app, action);
+    }
+
+    if state.is_snapshot_browser_open() {
+        return handle_snapshot_browser_event(state, event);
     }
 
     match event {
@@ -143,7 +162,8 @@ pub(crate) fn handle_event(app: &mut App, event: &ParsedInput) -> bool {
                 && matches!(mouse.button, Some(MouseButton::Left))
                 && !mouse.modifiers.shift
                 && !mouse.modifiers.alt
-                && !mouse.modifiers.ctrl =>
+                && !mouse.modifiers.ctrl
+                && !state.is_archive_view_active() =>
         {
             if swatch_hit(size, state, mouse.x, mouse.y).is_some()
                 || info_hit(size, state, mouse.x, mouse.y)
@@ -159,6 +179,36 @@ pub(crate) fn handle_event(app: &mut App, event: &ParsedInput) -> bool {
         ParsedInput::Mouse(mouse) => handle_view_mode_mouse(state, size, mouse),
         _ => false,
     }
+}
+
+fn handle_snapshot_browser_key(state: &mut super::state::State, byte: u8) -> bool {
+    match byte {
+        b'g' | b'G' | b'q' | b'Q' | 0x1B => state.close_snapshot_browser(),
+        b'j' | b'J' => state.move_snapshot_browser_selection(1),
+        b'k' | b'K' => state.move_snapshot_browser_selection(-1),
+        b'\r' | b'\n' => state.activate_snapshot_browser_selection(),
+        _ => return false,
+    }
+    true
+}
+
+fn handle_snapshot_browser_arrow(state: &mut super::state::State, key: u8) -> bool {
+    match key {
+        b'A' => state.move_snapshot_browser_selection(-1),
+        b'B' => state.move_snapshot_browser_selection(1),
+        _ => return false,
+    }
+    true
+}
+
+fn handle_snapshot_browser_event(state: &mut super::state::State, event: &ParsedInput) -> bool {
+    match event {
+        ParsedInput::Home => state.snapshot_browser_home(),
+        ParsedInput::PageUp => state.snapshot_browser_page(-1),
+        ParsedInput::PageDown => state.snapshot_browser_page(1),
+        _ => return false,
+    }
+    true
 }
 
 fn handle_view_mode_mouse(
@@ -205,7 +255,7 @@ mod tests {
     use crate::app::artboard::{
         provenance::ArtboardProvenance,
         state::State,
-        svc::{DartboardService, DartboardSnapshot},
+        svc::{ArtboardSnapshotService, DartboardService, DartboardSnapshot},
     };
 
     #[test]
@@ -309,6 +359,11 @@ mod tests {
             ..Default::default()
         };
         let svc = DartboardService::disconnected_for_tests(snapshot);
-        State::new(svc, "viewer".to_string(), shared_provenance)
+        State::new(
+            svc,
+            ArtboardSnapshotService::disabled(),
+            "viewer".to_string(),
+            shared_provenance,
+        )
     }
 }

--- a/late-ssh/src/app/artboard/state.rs
+++ b/late-ssh/src/app/artboard/state.rs
@@ -12,14 +12,17 @@ use dartboard_editor::{
 };
 use dartboard_tui::{FloatingView, SelectionShape as TuiSelectionShape, SelectionView};
 use ratatui::layout::Rect;
-use std::time::Instant;
+use std::{cell::Cell, time::Instant};
 use tokio::sync::{
     broadcast::{self, error::TryRecvError},
-    watch,
+    mpsc as tokio_mpsc, watch,
 };
 
 use super::provenance::{SharedArtboardProvenance, apply_shared_op};
-use super::svc::{DartboardEvent, DartboardService, DartboardSnapshot};
+use super::svc::{
+    ArtboardArchiveResult, ArtboardArchiveSnapshot, ArtboardSnapshotService, DartboardEvent,
+    DartboardService, DartboardSnapshot,
+};
 use crate::app::icon_picker::{self, catalog::IconCatalogData};
 
 const DOUBLE_CLICK_WINDOW_MS: u128 = 400;
@@ -48,17 +51,23 @@ pub struct State {
     hover_pos: Option<Pos>,
     snapshot_rx: watch::Receiver<DartboardSnapshot>,
     event_rx: broadcast::Receiver<DartboardEvent>,
+    snapshot_service: ArtboardSnapshotService,
+    archive_rx: tokio_mpsc::UnboundedReceiver<ArtboardArchiveResult>,
+    archive_tx: tokio_mpsc::UnboundedSender<ArtboardArchiveResult>,
+    snapshot_browser: SnapshotBrowserState,
 }
 
 impl State {
     pub fn new(
         svc: DartboardService,
+        snapshot_service: ArtboardSnapshotService,
         username: String,
         shared_provenance: SharedArtboardProvenance,
     ) -> Self {
         let snapshot_rx = svc.subscribe_state();
         let snapshot = snapshot_rx.borrow().clone();
         let event_rx = svc.subscribe_events();
+        let (archive_tx, archive_rx) = tokio_mpsc::unbounded_channel();
         Self {
             snapshot,
             private_notice: None,
@@ -81,11 +90,17 @@ impl State {
             hover_pos: None,
             snapshot_rx,
             event_rx,
+            snapshot_service,
+            archive_rx,
+            archive_tx,
+            snapshot_browser: SnapshotBrowserState::default(),
         }
     }
 
     pub fn tick(&mut self) {
-        if self.snapshot_rx.has_changed().unwrap_or(false) {
+        self.drain_archive_results();
+
+        if !self.is_archive_view_active() && self.snapshot_rx.has_changed().unwrap_or(false) {
             self.snapshot = self.snapshot_rx.borrow_and_update().clone();
             self.editor.clamp_cursor(&self.snapshot.canvas);
             self.editor.clamp_viewport_origin(&self.snapshot.canvas);
@@ -671,11 +686,137 @@ impl State {
         self.last_canvas_click = None;
     }
 
+    pub fn is_snapshot_browser_open(&self) -> bool {
+        self.snapshot_browser.open
+    }
+
+    pub fn is_archive_view_active(&self) -> bool {
+        self.snapshot_browser.active.is_some()
+    }
+
+    pub fn active_archive_snapshot(&self) -> Option<&ArtboardArchiveSnapshot> {
+        self.snapshot_browser.active.as_ref()
+    }
+
+    pub fn snapshot_browser_items(&self) -> &[ArtboardArchiveSnapshot] {
+        &self.snapshot_browser.items
+    }
+
+    pub fn snapshot_browser_selected_index(&self) -> usize {
+        self.snapshot_browser.selected_index
+    }
+
+    pub fn snapshot_browser_scroll_offset(&self) -> usize {
+        self.snapshot_browser.scroll_offset
+    }
+
+    pub fn snapshot_browser_loading(&self) -> bool {
+        self.snapshot_browser.loading
+    }
+
+    pub fn snapshot_browser_error(&self) -> Option<&str> {
+        self.snapshot_browser.error.as_deref()
+    }
+
+    pub fn set_snapshot_browser_visible_height(&self, height: usize) {
+        self.snapshot_browser.visible_height.set(height);
+    }
+
+    pub fn toggle_snapshot_browser_or_live(&mut self) {
+        if self.snapshot_browser.open {
+            self.close_snapshot_browser();
+        } else if self.is_archive_view_active() {
+            self.exit_archive_view();
+        } else {
+            self.open_snapshot_browser();
+        }
+    }
+
+    pub fn open_snapshot_browser(&mut self) {
+        self.close_help();
+        self.close_glyph_picker();
+        self.clear_local_state();
+        self.snapshot_browser.open = true;
+        self.snapshot_browser.error = None;
+        self.snapshot_browser.loading = true;
+        self.snapshot_browser.selected_index = self
+            .snapshot_browser
+            .active
+            .as_ref()
+            .and_then(|active| {
+                self.snapshot_browser
+                    .items
+                    .iter()
+                    .position(|item| item.board_key == active.board_key)
+                    .map(|idx| idx + 1)
+            })
+            .unwrap_or(0);
+        self.clamp_snapshot_browser_selection();
+        self.snapshot_service
+            .list_archives_task(self.archive_tx.clone());
+    }
+
+    pub fn close_snapshot_browser(&mut self) {
+        self.snapshot_browser.open = false;
+    }
+
+    pub fn move_snapshot_browser_selection(&mut self, delta: isize) {
+        if !self.snapshot_browser.open {
+            return;
+        }
+        let last = self.snapshot_browser_option_count().saturating_sub(1) as isize;
+        self.snapshot_browser.selected_index =
+            (self.snapshot_browser.selected_index as isize + delta).clamp(0, last) as usize;
+        self.ensure_snapshot_browser_selection_visible();
+    }
+
+    pub fn snapshot_browser_home(&mut self) {
+        self.snapshot_browser.selected_index = 0;
+        self.snapshot_browser.scroll_offset = 0;
+    }
+
+    pub fn snapshot_browser_page(&mut self, delta_pages: isize) {
+        let page = self.snapshot_browser.visible_height.get().max(1) as isize;
+        self.move_snapshot_browser_selection(delta_pages.saturating_mul(page));
+    }
+
+    pub fn activate_snapshot_browser_selection(&mut self) {
+        if !self.snapshot_browser.open {
+            return;
+        }
+        if self.snapshot_browser.selected_index == 0 {
+            self.exit_archive_view();
+            self.snapshot_browser.open = false;
+            return;
+        }
+        let Some(item) = self
+            .snapshot_browser
+            .items
+            .get(self.snapshot_browser.selected_index - 1)
+            .cloned()
+        else {
+            return;
+        };
+        self.activate_archive_snapshot(item);
+        self.snapshot_browser.open = false;
+    }
+
+    pub fn exit_archive_view(&mut self) {
+        self.snapshot_browser.active = None;
+        self.snapshot = self.snapshot_rx.borrow_and_update().clone();
+        self.editor.clamp_cursor(&self.snapshot.canvas);
+        self.editor.clamp_viewport_origin(&self.snapshot.canvas);
+        self.clear_local_state();
+    }
+
     pub fn is_help_open(&self) -> bool {
         self.help_open
     }
 
     pub fn toggle_help(&mut self) {
+        if self.is_archive_view_active() {
+            return;
+        }
         self.help_open = !self.help_open;
     }
 
@@ -730,6 +871,9 @@ impl State {
     }
 
     pub fn open_glyph_picker(&mut self) {
+        if self.is_archive_view_active() {
+            return;
+        }
         // Enforce the "at most one of {selection, floating, picker}" invariant:
         // opening dismisses any floating preview and clears any selection.
         let _ = self.dismiss_floating();
@@ -836,6 +980,56 @@ impl State {
         true
     }
 
+    fn drain_archive_results(&mut self) {
+        while let Ok(result) = self.archive_rx.try_recv() {
+            self.snapshot_browser.loading = false;
+            match result {
+                ArtboardArchiveResult::Loaded(items) => {
+                    self.snapshot_browser.items = items;
+                    self.snapshot_browser.error = None;
+                    self.clamp_snapshot_browser_selection();
+                }
+                ArtboardArchiveResult::Failed(error) => {
+                    self.snapshot_browser.error = Some(error);
+                    self.clamp_snapshot_browser_selection();
+                }
+            }
+        }
+    }
+
+    fn snapshot_browser_option_count(&self) -> usize {
+        self.snapshot_browser.items.len() + 1
+    }
+
+    fn clamp_snapshot_browser_selection(&mut self) {
+        let last = self.snapshot_browser_option_count().saturating_sub(1);
+        self.snapshot_browser.selected_index = self.snapshot_browser.selected_index.min(last);
+        self.ensure_snapshot_browser_selection_visible();
+    }
+
+    fn ensure_snapshot_browser_selection_visible(&mut self) {
+        let visible = self.snapshot_browser.visible_height.get().max(1);
+        if self.snapshot_browser.selected_index < self.snapshot_browser.scroll_offset {
+            self.snapshot_browser.scroll_offset = self.snapshot_browser.selected_index;
+        } else if self.snapshot_browser.selected_index
+            >= self.snapshot_browser.scroll_offset + visible
+        {
+            self.snapshot_browser.scroll_offset =
+                self.snapshot_browser.selected_index + 1 - visible;
+        }
+    }
+
+    fn activate_archive_snapshot(&mut self, item: ArtboardArchiveSnapshot) {
+        self.clear_local_state();
+        self.snapshot.canvas = item.canvas.clone();
+        self.snapshot.provenance = item.provenance.clone();
+        self.snapshot.peers.clear();
+        self.snapshot.connect_rejected = None;
+        self.editor.clamp_cursor(&self.snapshot.canvas);
+        self.editor.clamp_viewport_origin(&self.snapshot.canvas);
+        self.snapshot_browser.active = Some(item);
+    }
+
     fn active_user_color(&self) -> RgbColor {
         self.snapshot
             .your_color
@@ -860,6 +1054,9 @@ impl State {
         &mut self,
         edit: impl FnOnce(&mut EditorSession, &mut Canvas, RgbColor) -> bool,
     ) -> bool {
+        if self.is_archive_view_active() {
+            return false;
+        }
         let before = self.snapshot.canvas.clone();
         let before_provenance = self.snapshot.provenance.clone();
         let color = self.active_user_color();
@@ -875,6 +1072,9 @@ impl State {
         before: Canvas,
         before_provenance: super::provenance::ArtboardProvenance,
     ) -> bool {
+        if self.is_archive_view_active() {
+            return false;
+        }
         let Some(op) = diff_canvas_op(&before, &self.snapshot.canvas, self.active_user_color())
         else {
             return false;
@@ -1057,6 +1257,18 @@ pub enum BrushMode {
     Glyph(char),
 }
 
+#[derive(Default)]
+struct SnapshotBrowserState {
+    open: bool,
+    loading: bool,
+    error: Option<String>,
+    items: Vec<ArtboardArchiveSnapshot>,
+    selected_index: usize,
+    scroll_offset: usize,
+    visible_height: Cell<usize>,
+    active: Option<ArtboardArchiveSnapshot>,
+}
+
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum HelpTab {
     #[default]
@@ -1194,7 +1406,7 @@ fn canvas_pos_for_screen_point(
 mod tests {
     use super::*;
     use crate::app::artboard::provenance::ArtboardProvenance;
-    use crate::app::artboard::svc::{DartboardService, DartboardSnapshot};
+    use crate::app::artboard::svc::{ArtboardSnapshotService, DartboardService, DartboardSnapshot};
     use dartboard_core::{CanvasOp, CellValue, RgbColor};
     use dartboard_editor::Clipboard;
 
@@ -1208,7 +1420,12 @@ mod tests {
             ..Default::default()
         };
         let svc = DartboardService::disconnected_for_tests(snapshot);
-        let mut state = State::new(svc, "painter".to_string(), shared_provenance);
+        let mut state = State::new(
+            svc,
+            ArtboardSnapshotService::disabled(),
+            "painter".to_string(),
+            shared_provenance,
+        );
         state.set_viewport_for_screen((80, 24));
         state
     }

--- a/late-ssh/src/app/artboard/state.rs
+++ b/late-ssh/src/app/artboard/state.rs
@@ -15,13 +15,13 @@ use ratatui::layout::Rect;
 use std::{cell::Cell, time::Instant};
 use tokio::sync::{
     broadcast::{self, error::TryRecvError},
-    mpsc as tokio_mpsc, watch,
+    watch,
 };
 
 use super::provenance::{SharedArtboardProvenance, apply_shared_op};
 use super::svc::{
-    ArtboardArchiveResult, ArtboardArchiveSnapshot, ArtboardSnapshotService, DartboardEvent,
-    DartboardService, DartboardSnapshot,
+    ArtboardArchiveLoader, ArtboardArchiveResult, ArtboardArchiveSnapshot, ArtboardSnapshotService,
+    DartboardEvent, DartboardService, DartboardSnapshot,
 };
 use crate::app::icon_picker::{self, catalog::IconCatalogData};
 
@@ -51,9 +51,7 @@ pub struct State {
     hover_pos: Option<Pos>,
     snapshot_rx: watch::Receiver<DartboardSnapshot>,
     event_rx: broadcast::Receiver<DartboardEvent>,
-    snapshot_service: ArtboardSnapshotService,
-    archive_rx: tokio_mpsc::UnboundedReceiver<ArtboardArchiveResult>,
-    archive_tx: tokio_mpsc::UnboundedSender<ArtboardArchiveResult>,
+    archive_loader: ArtboardArchiveLoader,
     snapshot_browser: SnapshotBrowserState,
 }
 
@@ -67,7 +65,7 @@ impl State {
         let snapshot_rx = svc.subscribe_state();
         let snapshot = snapshot_rx.borrow().clone();
         let event_rx = svc.subscribe_events();
-        let (archive_tx, archive_rx) = tokio_mpsc::unbounded_channel();
+        let archive_loader = ArtboardArchiveLoader::new(snapshot_service);
         Self {
             snapshot,
             private_notice: None,
@@ -90,9 +88,7 @@ impl State {
             hover_pos: None,
             snapshot_rx,
             event_rx,
-            snapshot_service,
-            archive_rx,
-            archive_tx,
+            archive_loader,
             snapshot_browser: SnapshotBrowserState::default(),
         }
     }
@@ -752,8 +748,7 @@ impl State {
             })
             .unwrap_or(0);
         self.clamp_snapshot_browser_selection();
-        self.snapshot_service
-            .list_archives_task(self.archive_tx.clone());
+        self.archive_loader.request_list();
     }
 
     pub fn close_snapshot_browser(&mut self) {
@@ -981,7 +976,7 @@ impl State {
     }
 
     fn drain_archive_results(&mut self) {
-        while let Ok(result) = self.archive_rx.try_recv() {
+        while let Some(result) = self.archive_loader.try_recv() {
             self.snapshot_browser.loading = false;
             match result {
                 ArtboardArchiveResult::Loaded(items) => {

--- a/late-ssh/src/app/artboard/svc.rs
+++ b/late-ssh/src/app/artboard/svc.rs
@@ -80,6 +80,27 @@ pub enum ArtboardArchiveResult {
     Failed(String),
 }
 
+pub struct ArtboardArchiveLoader {
+    service: ArtboardSnapshotService,
+    tx: tokio_mpsc::UnboundedSender<ArtboardArchiveResult>,
+    rx: tokio_mpsc::UnboundedReceiver<ArtboardArchiveResult>,
+}
+
+impl ArtboardArchiveLoader {
+    pub fn new(service: ArtboardSnapshotService) -> Self {
+        let (tx, rx) = tokio_mpsc::unbounded_channel();
+        Self { service, tx, rx }
+    }
+
+    pub fn request_list(&self) {
+        self.service.list_archives_task(self.tx.clone());
+    }
+
+    pub fn try_recv(&mut self) -> Option<ArtboardArchiveResult> {
+        self.rx.try_recv().ok()
+    }
+}
+
 #[derive(Clone)]
 pub struct ArtboardSnapshotService {
     db: Option<Db>,
@@ -94,7 +115,7 @@ impl ArtboardSnapshotService {
         Self { db: None }
     }
 
-    pub fn list_archives_task(&self, tx: tokio_mpsc::UnboundedSender<ArtboardArchiveResult>) {
+    fn list_archives_task(&self, tx: tokio_mpsc::UnboundedSender<ArtboardArchiveResult>) {
         let Some(db) = self.db.clone() else {
             let _ = tx.send(ArtboardArchiveResult::Loaded(Vec::new()));
             return;

--- a/late-ssh/src/app/artboard/svc.rs
+++ b/late-ssh/src/app/artboard/svc.rs
@@ -1,10 +1,12 @@
 use std::{sync::mpsc, thread, time::Duration};
 
+use anyhow::Context;
 use dartboard_core::{
     Canvas, CanvasOp, Client, ClientOpId, Peer, RgbColor, Seq, ServerMsg, UserId,
 };
 use dartboard_local::{ConnectOutcome, Hello, LocalClient, ServerHandle};
-use tokio::sync::{broadcast, watch};
+use late_core::{db::Db, models::artboard::Snapshot};
+use tokio::sync::{broadcast, mpsc as tokio_mpsc, watch};
 use uuid::Uuid;
 
 use super::provenance::{
@@ -48,11 +50,113 @@ pub enum DartboardEvent {
     },
 }
 
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum ArtboardSnapshotKind {
+    Daily,
+    Monthly,
+}
+
+impl ArtboardSnapshotKind {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Daily => "daily",
+            Self::Monthly => "monthly",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ArtboardArchiveSnapshot {
+    pub board_key: String,
+    pub kind: ArtboardSnapshotKind,
+    pub label: String,
+    pub canvas: Canvas,
+    pub provenance: ArtboardProvenance,
+}
+
+#[derive(Debug)]
+pub enum ArtboardArchiveResult {
+    Loaded(Vec<ArtboardArchiveSnapshot>),
+    Failed(String),
+}
+
+#[derive(Clone)]
+pub struct ArtboardSnapshotService {
+    db: Option<Db>,
+}
+
+impl ArtboardSnapshotService {
+    pub fn new(db: Db) -> Self {
+        Self { db: Some(db) }
+    }
+
+    pub fn disabled() -> Self {
+        Self { db: None }
+    }
+
+    pub fn list_archives_task(&self, tx: tokio_mpsc::UnboundedSender<ArtboardArchiveResult>) {
+        let Some(db) = self.db.clone() else {
+            let _ = tx.send(ArtboardArchiveResult::Loaded(Vec::new()));
+            return;
+        };
+        tokio::spawn(async move {
+            let result = list_archive_snapshots(&db).await;
+            let msg = match result {
+                Ok(snapshots) => ArtboardArchiveResult::Loaded(snapshots),
+                Err(error) => ArtboardArchiveResult::Failed(format!("{error:#}")),
+            };
+            let _ = tx.send(msg);
+        });
+    }
+}
+
 #[derive(Clone)]
 pub struct DartboardService {
     command_tx: mpsc::Sender<Command>,
     snapshot_rx: watch::Receiver<DartboardSnapshot>,
     event_tx: broadcast::Sender<DartboardEvent>,
+}
+
+async fn list_archive_snapshots(db: &Db) -> anyhow::Result<Vec<ArtboardArchiveSnapshot>> {
+    let client = db
+        .get()
+        .await
+        .context("failed to get db client for artboard snapshot list")?;
+    let mut snapshots = Vec::new();
+    for (prefix, kind) in [
+        ("daily:", ArtboardSnapshotKind::Daily),
+        ("monthly:", ArtboardSnapshotKind::Monthly),
+    ] {
+        let rows = Snapshot::list_by_board_key_prefix(&client, prefix)
+            .await
+            .with_context(|| format!("failed to list {prefix} artboard snapshots"))?;
+        for row in rows {
+            snapshots.push(decode_archive_snapshot(row, kind)?);
+        }
+    }
+    Ok(snapshots)
+}
+
+fn decode_archive_snapshot(
+    snapshot: Snapshot,
+    kind: ArtboardSnapshotKind,
+) -> anyhow::Result<ArtboardArchiveSnapshot> {
+    let label = snapshot
+        .board_key
+        .split_once(':')
+        .map(|(_, label)| label.to_string())
+        .unwrap_or_else(|| snapshot.board_key.clone());
+    let canvas =
+        serde_json::from_value(snapshot.canvas).context("failed to decode artboard canvas")?;
+    let provenance = serde_json::from_value(snapshot.provenance)
+        .context("failed to decode artboard provenance")?;
+    Ok(ArtboardArchiveSnapshot {
+        board_key: snapshot.board_key,
+        kind,
+        label,
+        canvas,
+        provenance,
+    })
 }
 
 enum Command {

--- a/late-ssh/src/app/artboard/ui.rs
+++ b/late-ssh/src/app/artboard/ui.rs
@@ -39,6 +39,9 @@ pub fn draw_game(frame: &mut Frame, area: Rect, state: &State, interacting: bool
     if state.is_help_open() {
         draw_help(frame, area, state);
     }
+    if state.is_snapshot_browser_open() {
+        draw_snapshot_browser(frame, area, state);
+    }
     if state.is_glyph_picker_open()
         && let Some(catalog) = state.glyph_catalog()
     {
@@ -77,19 +80,28 @@ fn draw_artboard_sidebar(frame: &mut Frame, info_area: Option<Rect>, info_lines:
 }
 
 fn artboard_info_lines(state: &State, interacting: bool) -> Vec<Line<'static>> {
-    let mut lines = vec![info_label_value(
-        "Mode",
-        if interacting {
-            "active".to_string()
-        } else {
-            "view".to_string()
-        },
-        if interacting {
-            theme::AMBER()
-        } else {
-            theme::TEXT_BRIGHT()
-        },
-    )];
+    let mode = if state.is_archive_view_active() {
+        "snapshot".to_string()
+    } else if interacting {
+        "active".to_string()
+    } else {
+        "view".to_string()
+    };
+    let mode_color = if state.is_archive_view_active() {
+        theme::SUCCESS()
+    } else if interacting {
+        theme::AMBER()
+    } else {
+        theme::TEXT_BRIGHT()
+    };
+    let mut lines = vec![info_label_value("Mode", mode, mode_color)];
+    if let Some(active) = state.active_archive_snapshot() {
+        lines.push(info_label_value(
+            "Archive",
+            format!("{} {}", active.kind.label(), active.label),
+            theme::TEXT_BRIGHT(),
+        ));
+    }
     lines.push(info_label_value(
         "Cursor",
         format!("{},{}", state.cursor().x, state.cursor().y),
@@ -109,6 +121,15 @@ fn artboard_info_lines(state: &State, interacting: bool) -> Vec<Line<'static>> {
         theme::AMBER(),
     ));
     lines.push(pan_indicator_line(state));
+    lines.push(info_label_value(
+        "Snapshots",
+        if state.is_archive_view_active() {
+            "g live".to_string()
+        } else {
+            "g open".to_string()
+        },
+        theme::TEXT_BRIGHT(),
+    ));
 
     let (brush, brush_color) = match state.brush_mode() {
         BrushMode::None => ("none".to_string(), theme::TEXT_FAINT()),
@@ -153,7 +174,7 @@ fn artboard_info_lines(state: &State, interacting: bool) -> Vec<Line<'static>> {
             .into_iter()
             .map(|peer| (peer.name, rgb(peer.color), false)),
     );
-    if !users.is_empty() {
+    if !state.is_archive_view_active() && !users.is_empty() {
         lines.push(Line::from(""));
         lines.push(section_label("Users"));
         for (name, color, is_you) in users {
@@ -384,6 +405,9 @@ fn render_swatch_strip(
     info_area: Option<Rect>,
     state: &State,
 ) -> [Option<Rect>; SWATCH_CAPACITY] {
+    if state.is_archive_view_active() {
+        return [None; SWATCH_CAPACITY];
+    }
     let rects = swatch_box_rects_in_game_area(game_area, info_area, state.private_notice.is_some());
     let active_idx = state.active_swatch_index();
     let is_transparent = state.floating_is_transparent();
@@ -734,6 +758,10 @@ fn help_popup_area(area: Rect) -> Rect {
     centered_rect(96, 34, area)
 }
 
+fn snapshot_browser_popup_area(area: Rect) -> Rect {
+    centered_rect(74, 24, area)
+}
+
 fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
     let vertical = Layout::vertical([Constraint::Length(height.min(area.height))])
         .flex(Flex::Center)
@@ -842,14 +870,147 @@ fn draw_help(frame: &mut Frame, area: Rect, state: &State) {
     );
 
     let footer = Line::from(vec![
-        Span::styled("  Tab/S+Tab", Style::default().fg(theme::AMBER_DIM())),
-        Span::styled(" switch tabs  ", Style::default().fg(theme::TEXT_DIM())),
-        Span::styled("↑↓ j/k", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled("  ↑↓ j/k", Style::default().fg(theme::AMBER_DIM())),
         Span::styled(" scroll  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("Tab/S+Tab", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" switch tabs  ", Style::default().fg(theme::TEXT_DIM())),
         Span::styled("Esc/q", Style::default().fg(theme::AMBER_DIM())),
         Span::styled(" close", Style::default().fg(theme::TEXT_DIM())),
     ]);
     frame.render_widget(Paragraph::new(footer), layout[4]);
+}
+
+fn draw_snapshot_browser(frame: &mut Frame, area: Rect, state: &State) {
+    let popup = snapshot_browser_popup_area(area);
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title(" Artboard Snapshots ")
+        .title_style(
+            Style::default()
+                .fg(theme::AMBER_GLOW())
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::BORDER_ACTIVE()));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    if inner.width < 12 || inner.height < 5 {
+        return;
+    }
+
+    let layout = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Min(3),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+
+    let active_label = state
+        .active_archive_snapshot()
+        .map(|snapshot| format!("{} {}", snapshot.kind.label(), snapshot.label))
+        .unwrap_or_else(|| "live".to_string());
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("  Viewing ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(active_label, Style::default().fg(theme::TEXT_BRIGHT())),
+        ])),
+        layout[0],
+    );
+
+    let list_area = layout[1].inner(Margin::new(2, 0));
+    let visible_height = list_area.height as usize;
+    state.set_snapshot_browser_visible_height(visible_height);
+    let lines = snapshot_browser_lines(state, visible_height, list_area.width as usize);
+    frame.render_widget(Paragraph::new(Text::from(lines)), list_area);
+
+    let footer = Line::from(vec![
+        Span::styled("  ↑↓ j/k", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" navigate  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("↵", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" view  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("Esc/q", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" close  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("top row", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" live", Style::default().fg(theme::TEXT_DIM())),
+    ]);
+    frame.render_widget(Paragraph::new(footer), layout[2]);
+}
+
+fn snapshot_browser_lines(
+    state: &State,
+    visible_height: usize,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let total = state.snapshot_browser_items().len() + 1;
+    let start = state.snapshot_browser_scroll_offset().min(total);
+    let end = (start + visible_height).min(total);
+    let mut lines = Vec::new();
+
+    for option_idx in start..end {
+        let selected = option_idx == state.snapshot_browser_selected_index();
+        if option_idx == 0 {
+            lines.push(snapshot_browser_row(
+                selected,
+                "live",
+                "Current artboard",
+                "editable after closing",
+                width,
+            ));
+            continue;
+        }
+        let snapshot = &state.snapshot_browser_items()[option_idx - 1];
+        lines.push(snapshot_browser_row(
+            selected,
+            snapshot.kind.label(),
+            &snapshot.label,
+            &snapshot.board_key,
+            width,
+        ));
+    }
+
+    if state.snapshot_browser_loading() {
+        lines.push(Line::from(Span::styled(
+            "  loading snapshots...",
+            Style::default().fg(theme::TEXT_DIM()),
+        )));
+    } else if let Some(error) = state.snapshot_browser_error() {
+        lines.push(Line::from(Span::styled(
+            format!("  {error}"),
+            Style::default().fg(theme::AMBER_DIM()),
+        )));
+    } else if total == 1 {
+        lines.push(Line::from(Span::styled(
+            "  no daily or monthly snapshots yet",
+            Style::default().fg(theme::TEXT_DIM()),
+        )));
+    }
+
+    lines
+}
+
+fn snapshot_browser_row(
+    selected: bool,
+    kind: &str,
+    label: &str,
+    detail: &str,
+    width: usize,
+) -> Line<'static> {
+    let marker = if selected { ">" } else { " " };
+    let mut text = format!(" {marker} {kind:<7} {label:<10} {detail}");
+    if text.chars().count() > width {
+        text = text.chars().take(width).collect();
+    }
+    let style = if selected {
+        Style::default()
+            .fg(theme::AMBER_GLOW())
+            .bg(theme::BG_HIGHLIGHT())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT())
+    };
+    Line::from(Span::styled(text, style))
 }
 
 fn draw_tabs(frame: &mut Frame, area: Rect, selected: HelpTab) {
@@ -879,7 +1040,7 @@ mod tests {
     use dartboard_editor::Clipboard;
     use ratatui::buffer::Buffer;
 
-    use super::super::svc::{DartboardService, DartboardSnapshot};
+    use super::super::svc::{ArtboardSnapshotService, DartboardService, DartboardSnapshot};
 
     #[test]
     fn canvas_area_matches_artboard_frame_layout() {
@@ -891,7 +1052,7 @@ mod tests {
         let state = test_state();
         assert_eq!(
             artboard_info_area_for_screen((80, 24), &state),
-            Some(Rect::new(27, 1, 28, 12))
+            Some(Rect::new(27, 1, 28, 13))
         );
     }
 
@@ -972,7 +1133,7 @@ mod tests {
     }
 
     #[test]
-    fn info_lines_include_mode_and_pan_rows_before_brush() {
+    fn info_lines_include_mode_pan_and_snapshot_rows_before_brush() {
         let state = test_state();
         let lines = artboard_info_lines(&state, false);
 
@@ -981,11 +1142,12 @@ mod tests {
         assert_eq!(lines[2].to_string(), "Owner      ?");
         assert_eq!(lines[3].to_string(), "Cell       0,0");
         assert_eq!(lines[4].to_string(), "Pan        ◀ ▲ ▼ ▶");
-        assert_eq!(lines[5].to_string(), "Brush      none");
-        assert_eq!(lines[6].to_string(), "Selection  none");
-        assert_eq!(lines[7].to_string(), "");
-        assert_eq!(lines[8].to_string(), "Users");
-        assert_eq!(lines[9].to_string(), "• painter (you)");
+        assert_eq!(lines[5].to_string(), "Snapshots  g open");
+        assert_eq!(lines[6].to_string(), "Brush      none");
+        assert_eq!(lines[7].to_string(), "Selection  none");
+        assert_eq!(lines[8].to_string(), "");
+        assert_eq!(lines[9].to_string(), "Users");
+        assert_eq!(lines[10].to_string(), "• painter (you)");
     }
 
     #[test]
@@ -999,7 +1161,7 @@ mod tests {
 
         let lines = artboard_info_lines(&state, true);
         assert_eq!(lines[0].to_string(), "Mode       active");
-        assert_eq!(lines[6].to_string(), "Selection  3x2");
+        assert_eq!(lines[7].to_string(), "Selection  3x2");
     }
 
     #[test]
@@ -1048,7 +1210,7 @@ mod tests {
         let mut state = test_state();
         state.private_notice = Some("Heads up".to_string());
         let rects = swatch_box_rects((80, 24), &state);
-        assert_eq!(rects[0], Some(Rect::new(9, 13, 16, 8)));
+        assert_eq!(rects[0], Some(Rect::new(11, 13, 16, 8)));
     }
 
     #[test]
@@ -1193,6 +1355,11 @@ mod tests {
             ..Default::default()
         };
         let svc = DartboardService::disconnected_for_tests(snapshot);
-        State::new(svc, "painter".to_string(), shared_provenance)
+        State::new(
+            svc,
+            ArtboardSnapshotService::disabled(),
+            "painter".to_string(),
+            shared_provenance,
+        )
     }
 }

--- a/late-ssh/src/app/chat/news/state.rs
+++ b/late-ssh/src/app/chat/news/state.rs
@@ -1,9 +1,8 @@
-use ratatui::style::{Modifier, Style};
 use ratatui_textarea::{TextArea, WrapMode};
 use tokio::sync::{broadcast, watch};
 use uuid::Uuid;
 
-use crate::app::common::primitives::Banner;
+use crate::app::common::{composer, primitives::Banner};
 use late_core::models::article::{ArticleEvent, ArticleFeedItem, ArticleSnapshot};
 
 use super::svc::ArticleService;
@@ -79,6 +78,10 @@ impl State {
         &self.composer
     }
 
+    pub fn refresh_composer_theme(&mut self) {
+        composer::apply_themed_textarea_style(&mut self.composer, self.composing);
+    }
+
     pub fn processing(&self) -> bool {
         self.processing
     }
@@ -86,7 +89,7 @@ impl State {
     pub fn start_composing(&mut self) {
         self.composing = true;
         self.processing = false;
-        set_news_cursor_visible(&mut self.composer, true);
+        composer::set_themed_textarea_cursor_visible(&mut self.composer, true);
     }
 
     pub fn stop_composing(&mut self) {
@@ -112,7 +115,7 @@ impl State {
     pub fn composer_clear(&mut self) {
         if !self.processing {
             self.composer = new_news_textarea();
-            set_news_cursor_visible(&mut self.composer, self.composing);
+            composer::set_themed_textarea_cursor_visible(&mut self.composer, self.composing);
         }
     }
     pub fn composer_pop(&mut self) {
@@ -196,7 +199,7 @@ impl State {
             return;
         }
         self.processing = true;
-        set_news_cursor_visible(&mut self.composer, false);
+        composer::set_themed_textarea_cursor_visible(&mut self.composer, false);
         self.current_task = Some(self.article_service.process_url(self.user_id, url.trim()));
     }
 
@@ -228,7 +231,10 @@ impl State {
                     ArticleEvent::Failed { user_id, error } if self.user_id == user_id => {
                         self.current_task = None;
                         self.processing = false;
-                        set_news_cursor_visible(&mut self.composer, self.composing);
+                        composer::set_themed_textarea_cursor_visible(
+                            &mut self.composer,
+                            self.composing,
+                        );
                         banner = Some(Banner::error(&format!("Failed: {}", error)));
                     }
                     ArticleEvent::Deleted { user_id } if self.user_id == user_id => {
@@ -283,20 +289,7 @@ fn move_index(current: usize, delta: isize, len: usize) -> usize {
 }
 
 fn new_news_textarea() -> TextArea<'static> {
-    let mut ta = TextArea::default();
-    ta.set_cursor_line_style(Style::default());
-    ta.set_cursor_style(Style::default());
-    ta.set_wrap_mode(WrapMode::Glyph);
-    ta
-}
-
-fn set_news_cursor_visible(ta: &mut TextArea<'static>, visible: bool) {
-    let style = if visible {
-        Style::default().add_modifier(Modifier::REVERSED)
-    } else {
-        Style::default()
-    };
-    ta.set_cursor_style(style);
+    composer::new_themed_textarea("", WrapMode::Glyph, false)
 }
 
 #[cfg(test)]

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -7,14 +7,13 @@ use late_core::{
         chat_message_reaction::ChatMessageReactionSummary, chat_room::ChatRoom,
     },
 };
-use ratatui::style::{Modifier, Style};
 use ratatui_textarea::{CursorMove, Input, TextArea, WrapMode};
 use tokio::sync::watch;
 use uuid::Uuid;
 
 use crate::app::common::overlay::Overlay;
 
-use crate::app::common::{primitives::Banner, theme};
+use crate::app::common::{composer, primitives::Banner};
 use crate::app::help_modal::data::HelpTopic;
 use crate::state::{ActiveUser, ActiveUsers};
 
@@ -185,6 +184,11 @@ impl ChatState {
         &self.composer
     }
 
+    pub(crate) fn refresh_composer_theme(&mut self) {
+        composer::apply_themed_textarea_style(&mut self.composer, self.composing);
+        self.news.refresh_composer_theme();
+    }
+
     pub fn is_composing(&self) -> bool {
         self.composing
     }
@@ -202,7 +206,7 @@ impl ChatState {
         self.selected_message_id = None;
         self.reply_target = None;
         self.edited_message_id = None;
-        set_composer_cursor_visible(&mut self.composer, true);
+        composer::set_themed_textarea_cursor_visible(&mut self.composer, true);
     }
 
     pub fn request_list(&self) {
@@ -360,7 +364,7 @@ impl ChatState {
         self.composing = true;
         self.composer_room_id = Some(room_id);
         self.edited_message_id = None;
-        set_composer_cursor_visible(&mut self.composer, true);
+        composer::set_themed_textarea_cursor_visible(&mut self.composer, true);
         None
     }
 
@@ -392,7 +396,7 @@ impl ChatState {
         self.composer.insert_str(body);
         self.composing = true;
         self.composer_room_id = Some(room_id);
-        set_composer_cursor_visible(&mut self.composer, true);
+        composer::set_themed_textarea_cursor_visible(&mut self.composer, true);
         None
     }
 
@@ -714,7 +718,7 @@ impl ChatState {
         self.composer_room_id = None;
         self.reaction_leader_active = false;
         self.reply_target = None;
-        set_composer_cursor_visible(&mut self.composer, false);
+        composer::set_themed_textarea_cursor_visible(&mut self.composer, false);
     }
 
     pub fn reset_composer(&mut self) {
@@ -740,7 +744,7 @@ impl ChatState {
 
     fn clear_composer_after_send(&mut self) {
         self.composer = new_chat_textarea();
-        set_composer_cursor_visible(&mut self.composer, self.composing);
+        composer::set_themed_textarea_cursor_visible(&mut self.composer, self.composing);
         self.room_jump_active = false;
         self.reaction_leader_active = false;
         self.reply_target = None;
@@ -987,7 +991,7 @@ impl ChatState {
     pub fn composer_clear(&mut self) {
         let composing = self.composing;
         self.composer = new_chat_textarea();
-        set_composer_cursor_visible(&mut self.composer, composing);
+        composer::set_themed_textarea_cursor_visible(&mut self.composer, composing);
     }
 
     pub fn composer_backspace(&mut self) {
@@ -1181,7 +1185,7 @@ impl ChatState {
         let composing = self.composing;
         self.composer = new_chat_textarea();
         self.composer.insert_str(next);
-        set_composer_cursor_visible(&mut self.composer, composing);
+        composer::set_themed_textarea_cursor_visible(&mut self.composer, composing);
         self.mention_ac = MentionAutocomplete::default();
     }
 
@@ -1928,34 +1932,7 @@ fn reply_preview_text(body: &str) -> String {
 }
 
 pub(crate) fn new_chat_textarea() -> TextArea<'static> {
-    let mut ta = TextArea::default();
-    ta.set_style(Style::default().fg(theme::TEXT()));
-    ta.set_placeholder_text("Type a message...");
-    ta.set_placeholder_style(Style::default().fg(theme::TEXT_DIM()));
-    ta.set_cursor_line_style(Style::default().fg(theme::TEXT()));
-    ta.set_cursor_style(hidden_composer_cursor_style());
-    ta.set_wrap_mode(WrapMode::Word);
-    ta
-}
-
-fn set_composer_cursor_visible(ta: &mut TextArea<'static>, visible: bool) {
-    let style = if visible {
-        visible_composer_cursor_style()
-    } else {
-        hidden_composer_cursor_style()
-    };
-    ta.set_cursor_style(style);
-}
-
-fn hidden_composer_cursor_style() -> Style {
-    Style::default().fg(theme::TEXT())
-}
-
-fn visible_composer_cursor_style() -> Style {
-    Style::default()
-        .fg(theme::BG_CANVAS())
-        .bg(theme::TEXT())
-        .add_modifier(Modifier::BOLD)
+    composer::new_themed_textarea("Type a message...", WrapMode::Word, false)
 }
 
 fn news_reply_preview_text(body: &str) -> Option<String> {
@@ -2045,6 +2022,7 @@ fn strip_markdown_preview_markers(text: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::common::theme;
 
     fn names(matches: &[MentionMatch]) -> Vec<&str> {
         matches.iter().map(|m| m.name.as_str()).collect()
@@ -2218,7 +2196,7 @@ mod tests {
     #[test]
     fn composer_cursor_visible_uses_explicit_theme_colors() {
         let mut textarea = new_chat_textarea();
-        set_composer_cursor_visible(&mut textarea, true);
+        composer::set_themed_textarea_cursor_visible(&mut textarea, true);
         assert_eq!(textarea.cursor_style().fg, Some(theme::BG_CANVAS()));
         assert_eq!(textarea.cursor_style().bg, Some(theme::TEXT()));
     }
@@ -2226,10 +2204,28 @@ mod tests {
     #[test]
     fn composer_cursor_hidden_restores_plain_text_color() {
         let mut textarea = new_chat_textarea();
-        set_composer_cursor_visible(&mut textarea, true);
-        set_composer_cursor_visible(&mut textarea, false);
+        composer::set_themed_textarea_cursor_visible(&mut textarea, true);
+        composer::set_themed_textarea_cursor_visible(&mut textarea, false);
         assert_eq!(textarea.cursor_style().fg, Some(theme::TEXT()));
         assert_eq!(textarea.cursor_style().bg, None);
+    }
+
+    #[test]
+    fn common_textarea_theme_refreshes_existing_chat_textarea_colors() {
+        theme::set_current_by_id("late");
+        let mut textarea = new_chat_textarea();
+        let late_text = textarea.style().fg;
+
+        theme::set_current_by_id("contrast");
+        composer::apply_themed_textarea_style(&mut textarea, true);
+
+        assert_ne!(textarea.style().fg, late_text);
+        assert_eq!(textarea.style().fg, Some(theme::TEXT()));
+        assert_eq!(textarea.cursor_line_style().fg, Some(theme::TEXT()));
+        assert_eq!(textarea.cursor_style().fg, Some(theme::BG_CANVAS()));
+        assert_eq!(textarea.cursor_style().bg, Some(theme::TEXT()));
+
+        theme::set_current_by_id("late");
     }
 
     #[test]

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -1263,6 +1263,14 @@ impl ChatState {
                     {
                         continue;
                     }
+                    if is_targeted
+                        && !self
+                            .rooms
+                            .iter()
+                            .any(|(room, _)| room.id == message.room_id)
+                    {
+                        self.request_list();
+                    }
                     // Desktop notification queueing. target_user_ids is Some for
                     // DM/private rooms, None for public rooms. Don't notify on
                     // messages we authored ourselves.

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -567,6 +567,19 @@ impl ChatService {
         if !is_member {
             anyhow::bail!("user is not a member of room");
         }
+        let room = ChatRoom::get(client, room_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("room not found"))?;
+        if room.kind == "dm" {
+            let user_a = room
+                .dm_user_a
+                .ok_or_else(|| anyhow::anyhow!("dm room is missing first participant"))?;
+            let user_b = room
+                .dm_user_b
+                .ok_or_else(|| anyhow::anyhow!("dm room is missing second participant"))?;
+            ChatRoomMember::join(client, room_id, user_a).await?;
+            ChatRoomMember::join(client, room_id, user_b).await?;
+        }
 
         let message = ChatMessageParams {
             room_id,

--- a/late-ssh/src/app/common/composer.rs
+++ b/late-ssh/src/app/common/composer.rs
@@ -1,6 +1,13 @@
 //! Legacy word-wrap helpers used for composer-height estimation and for
 //! rendering read-only wrapped text (e.g. the profile bio). The interactive
-//! composer/editor state lives in `ratatui_textarea::TextArea`.
+//! composer/editor state lives in `ratatui_textarea::TextArea`, but common
+//! theme styling for those text areas belongs here so every composer can
+//! refresh after the active theme changes.
+
+use ratatui::style::{Modifier, Style};
+use ratatui_textarea::{TextArea, WrapMode};
+
+use super::theme;
 
 #[derive(Clone, Debug)]
 pub struct ComposerRow {
@@ -83,6 +90,45 @@ pub fn composer_line_count(text: &str, width: usize) -> usize {
     }
 }
 
+pub fn new_themed_textarea(
+    placeholder: impl Into<String>,
+    wrap_mode: WrapMode,
+    cursor_visible: bool,
+) -> TextArea<'static> {
+    let mut ta = TextArea::default();
+    apply_themed_textarea_style(&mut ta, cursor_visible);
+    ta.set_placeholder_text(placeholder);
+    ta.set_wrap_mode(wrap_mode);
+    ta
+}
+
+pub fn apply_themed_textarea_style(ta: &mut TextArea<'static>, cursor_visible: bool) {
+    ta.set_style(Style::default().fg(theme::TEXT()));
+    ta.set_placeholder_style(Style::default().fg(theme::TEXT_DIM()));
+    ta.set_cursor_line_style(Style::default().fg(theme::TEXT()));
+    set_themed_textarea_cursor_visible(ta, cursor_visible);
+}
+
+pub fn set_themed_textarea_cursor_visible(ta: &mut TextArea<'static>, visible: bool) {
+    let style = if visible {
+        visible_textarea_cursor_style()
+    } else {
+        hidden_textarea_cursor_style()
+    };
+    ta.set_cursor_style(style);
+}
+
+fn hidden_textarea_cursor_style() -> Style {
+    Style::default().fg(theme::TEXT())
+}
+
+fn visible_textarea_cursor_style() -> Style {
+    Style::default()
+        .fg(theme::BG_CANVAS())
+        .bg(theme::TEXT())
+        .add_modifier(Modifier::BOLD)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -92,5 +138,39 @@ mod tests {
         let rows = build_composer_rows("hello wide world", 8);
         let texts: Vec<&str> = rows.iter().map(|row| row.text.as_str()).collect();
         assert_eq!(texts, vec!["hello", "wide", "world"]);
+    }
+
+    #[test]
+    fn themed_textarea_uses_theme_text_color() {
+        let textarea = new_themed_textarea("Type a message...", WrapMode::Word, false);
+        assert_eq!(textarea.style().fg, Some(theme::TEXT()));
+        assert_eq!(textarea.cursor_line_style().fg, Some(theme::TEXT()));
+        assert_eq!(textarea.cursor_style().fg, Some(theme::TEXT()));
+        assert_eq!(textarea.cursor_style().bg, None);
+    }
+
+    #[test]
+    fn themed_textarea_visible_cursor_uses_explicit_theme_colors() {
+        let textarea = new_themed_textarea("Type a message...", WrapMode::Word, true);
+        assert_eq!(textarea.cursor_style().fg, Some(theme::BG_CANVAS()));
+        assert_eq!(textarea.cursor_style().bg, Some(theme::TEXT()));
+    }
+
+    #[test]
+    fn apply_themed_textarea_style_refreshes_existing_textarea_colors() {
+        theme::set_current_by_id("late");
+        let mut textarea = new_themed_textarea("Type a message...", WrapMode::Word, false);
+        let late_text = textarea.style().fg;
+
+        theme::set_current_by_id("contrast");
+        apply_themed_textarea_style(&mut textarea, true);
+
+        assert_ne!(textarea.style().fg, late_text);
+        assert_eq!(textarea.style().fg, Some(theme::TEXT()));
+        assert_eq!(textarea.cursor_line_style().fg, Some(theme::TEXT()));
+        assert_eq!(textarea.cursor_style().fg, Some(theme::BG_CANVAS()));
+        assert_eq!(textarea.cursor_style().bg, Some(theme::TEXT()));
+
+        theme::set_current_by_id("late");
     }
 }

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -221,7 +221,7 @@ fn overview_lines() -> Vec<String> {
         "This modal",
         "  Tab / Shift+Tab   next / previous tab",
         "  j / k / ↑ / ↓     scroll current tab",
-        "  ? / q / Esc       close",
+        "  Esc / q / ?       close",
         "",
         "Use /help and /music in chat if you want to jump directly to those slides from the composer.",
     ]

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -898,6 +898,10 @@ fn dispatch_escape(app: &mut App) {
         let Some(state) = app.dartboard_state.as_ref() else {
             return;
         };
+        if state.is_snapshot_browser_open() {
+            dispatch_screen_key(app, ctx.screen, 0x1B);
+            return;
+        }
         if state.is_glyph_picker_open() || state.is_help_open() {
             dispatch_screen_key(app, ctx.screen, 0x1B);
             return;
@@ -1125,6 +1129,14 @@ fn handle_global_key(app: &mut App, ctx: InputContext, byte: u8) -> bool {
 
     match byte {
         b'q' | b'Q' => {
+            if ctx.screen == Screen::Artboard
+                && app
+                    .dartboard_state
+                    .as_ref()
+                    .is_some_and(|state| state.is_snapshot_browser_open())
+            {
+                return false;
+            }
             trigger_global_quit(app);
             true
         }

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -146,6 +146,7 @@ impl App {
             self.profile_state.theme_id().to_string()
         };
         theme::set_current_by_id(&active_theme_id);
+        self.chat.refresh_composer_theme();
 
         // Synchronize terminal background color with theme bg_canvas if enabled
         let enabled = if self.show_settings {
@@ -678,10 +679,9 @@ fn app_frame_title(screen: Screen, ctx: &DrawContext<'_>) -> Line<'static> {
         } else {
             &[
                 ("view", "pan"),
-                ("Alt+arrows", "pan"),
-                ("R-drag", "pan"),
+                ("Alt+arrows/R-drag", "pan"),
                 ("i", "edit"),
-                ("Ctrl+\\", "owners"),
+                ("g", "gallery"),
             ]
         };
         for (key, desc) in hints {

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -795,8 +795,7 @@ impl App {
     }
 
     /// Reset the terminal diff state so the next `render()` emits a full frame.
-    /// Used by integration test helpers.
-    #[allow(dead_code)]
+    /// Used after dropped SSH frames and by integration test helpers.
     pub fn reset_render(&mut self) {
         let _ = self.terminal.clear();
         self.shared.take();

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -127,6 +127,7 @@ pub struct SessionConfig {
     /// enters the dartboard game from the arcade.
     pub dartboard_server: dartboard_local::ServerHandle,
     pub dartboard_provenance: crate::app::artboard::provenance::SharedArtboardProvenance,
+    pub artboard_snapshot_service: crate::app::artboard::svc::ArtboardSnapshotService,
     pub username: String,
     pub bonsai_service: crate::app::bonsai::svc::BonsaiService,
     pub initial_bonsai_tree: Option<late_core::models::bonsai::Tree>,
@@ -263,6 +264,7 @@ pub struct App {
     pub(crate) artboard_interacting: bool,
     pub(crate) dartboard_server: dartboard_local::ServerHandle,
     pub(crate) dartboard_provenance: crate::app::artboard::provenance::SharedArtboardProvenance,
+    pub(crate) artboard_snapshot_service: crate::app::artboard::svc::ArtboardSnapshotService,
     pub(crate) username: String,
 
     /// Late Chips balance (loaded on login, updated via leaderboard refresh)
@@ -541,6 +543,7 @@ impl App {
         );
         let dartboard_server = config.dartboard_server.clone();
         let dartboard_provenance = config.dartboard_provenance.clone();
+        let artboard_snapshot_service = config.artboard_snapshot_service.clone();
         let username = config.username.clone();
 
         let bonsai_state = if let Some(tree) = config.initial_bonsai_tree {
@@ -656,6 +659,7 @@ impl App {
             artboard_interacting: false,
             dartboard_server,
             dartboard_provenance,
+            artboard_snapshot_service,
             username,
             chip_balance: config.initial_chip_balance,
             pending_clipboard: None,
@@ -690,6 +694,7 @@ impl App {
         );
         self.dartboard_state = Some(crate::app::artboard::state::State::new(
             svc,
+            self.artboard_snapshot_service.clone(),
             self.username.clone(),
             self.dartboard_provenance.clone(),
         ));
@@ -717,6 +722,7 @@ impl App {
             state.clear_local_state();
             state.close_help();
             state.close_glyph_picker();
+            state.close_snapshot_browser();
         }
     }
 

--- a/late-ssh/src/ssh.rs
+++ b/late-ssh/src/ssh.rs
@@ -712,6 +712,9 @@ impl russh::server::Handler for ClientHandler {
             blackjack_service: self.state.blackjack_service.clone(),
             dartboard_server: self.state.dartboard_server.clone(),
             dartboard_provenance: self.state.dartboard_provenance.clone(),
+            artboard_snapshot_service: crate::app::artboard::svc::ArtboardSnapshotService::new(
+                self.state.db.clone(),
+            ),
             username: user.username.clone(),
             bonsai_service: self.state.bonsai_service.clone(),
             initial_bonsai_tree,

--- a/late-ssh/src/ssh.rs
+++ b/late-ssh/src/ssh.rs
@@ -1093,8 +1093,9 @@ async fn render_once(
         (frame, terminal_commands)
     };
 
-    match timeout(Duration::from_millis(50), handle.data(channel_id, frame)).await {
-        Ok(Ok(())) => {}
+    let frame_sent = match timeout(Duration::from_millis(50), handle.data(channel_id, frame)).await
+    {
+        Ok(Ok(())) => true,
         Ok(Err(err)) => {
             return Err(anyhow::anyhow!(
                 "render_once: handle send failed: {:?}",
@@ -1107,6 +1108,18 @@ async fn render_once(
             if drops.is_multiple_of(frame_drop_log_every) {
                 tracing::debug!(drops, "frame drops (handle busy)");
             }
+            false
+        }
+    };
+
+    if !frame_sent {
+        // `app.render()` already advanced ratatui's diff buffers. If the SSH
+        // write is dropped, force the next successful frame to repaint from a
+        // blank previous buffer so old terminal cells cannot leak through.
+        let mut app = app.lock().await;
+        app.reset_render();
+        if !signal.dirty.swap(true, Ordering::AcqRel) {
+            signal.notify.notify_one();
         }
     }
 

--- a/late-ssh/tests/artboard/state.rs
+++ b/late-ssh/tests/artboard/state.rs
@@ -1,10 +1,13 @@
 //! State-level integration tests for artboard client behavior.
 
-use dartboard_core::Pos;
+use dartboard_core::{Canvas, CanvasOp, Pos};
+use late_core::models::artboard::Snapshot;
+use late_ssh::app::artboard::provenance::ArtboardProvenance;
 use late_ssh::app::artboard::state::State;
+use late_ssh::app::artboard::svc::ArtboardSnapshotService;
 use late_ssh::dartboard;
 
-use super::{connected_service, shared_provenance, wait_for};
+use super::{connected_service, helpers::new_test_db, shared_provenance, test_color, wait_for};
 
 #[test]
 fn paste_bytes_lays_out_multiline_text_with_wrap() {
@@ -16,7 +19,12 @@ fn paste_bytes_lays_out_multiline_text_with_wrap() {
     let rx = svc.subscribe_state();
     wait_for(|| rx.borrow().your_user_id.is_some().then_some(()));
 
-    let mut state = State::new(svc, "painter".to_string(), shared);
+    let mut state = State::new(
+        svc,
+        ArtboardSnapshotService::disabled(),
+        "painter".to_string(),
+        shared,
+    );
     state.tick(); // drain the initial snapshot into local state
 
     // Start paste from (2, 1) so the wrap column is x=2 on the second line.
@@ -33,4 +41,72 @@ fn paste_bytes_lays_out_multiline_text_with_wrap() {
     assert_eq!(canvas.get(Pos { x: 6, y: 1 }), 'o');
     assert_eq!(canvas.get(Pos { x: 2, y: 2 }), 'w');
     assert_eq!(canvas.get(Pos { x: 6, y: 2 }), 'd');
+}
+
+#[tokio::test]
+async fn snapshot_browser_activates_archive_readonly_and_returns_to_live() {
+    let test_db = new_test_db().await;
+    let server = dartboard::spawn_server();
+    let shared = shared_provenance();
+    let svc = connected_service(server, "painter", shared.clone());
+    let rx = svc.subscribe_state();
+    wait_for(|| rx.borrow().your_user_id.is_some().then_some(()));
+    svc.submit_op(CanvasOp::PaintCell {
+        pos: Pos { x: 0, y: 0 },
+        ch: 'L',
+        fg: test_color(),
+    });
+    wait_for(|| (rx.borrow().canvas.get(Pos { x: 0, y: 0 }) == 'L').then_some(()));
+
+    let mut archive_canvas = Canvas::with_size(dartboard::CANVAS_WIDTH, dartboard::CANVAS_HEIGHT);
+    archive_canvas.set(Pos { x: 0, y: 0 }, 'A');
+    let mut archive_provenance = ArtboardProvenance::default();
+    archive_provenance.set_username(Pos { x: 0, y: 0 }, "archivist");
+    let client = test_db.db.get().await.expect("db client");
+    Snapshot::upsert(
+        &client,
+        "daily:2026-04-23",
+        serde_json::to_value(&archive_canvas).expect("canvas json"),
+        serde_json::to_value(&archive_provenance).expect("provenance json"),
+    )
+    .await
+    .expect("insert archive snapshot");
+
+    let mut state = State::new(
+        svc,
+        ArtboardSnapshotService::new(test_db.db.clone()),
+        "painter".to_string(),
+        shared,
+    );
+    state.tick();
+    state.open_snapshot_browser();
+    wait_for_archive_load(&mut state).await;
+    assert_eq!(state.snapshot_browser_items().len(), 1);
+
+    state.move_snapshot_browser_selection(1);
+    state.activate_snapshot_browser_selection();
+    assert!(state.is_archive_view_active());
+    assert_eq!(state.snapshot.canvas.get(Pos { x: 0, y: 0 }), 'A');
+    state.type_char('X', (80, 24));
+    assert_eq!(
+        state.snapshot.canvas.get(Pos { x: 0, y: 0 }),
+        'A',
+        "historical archive view must stay read-only"
+    );
+
+    state.exit_archive_view();
+    assert!(!state.is_archive_view_active());
+    assert_eq!(state.snapshot.canvas.get(Pos { x: 0, y: 0 }), 'L');
+}
+
+async fn wait_for_archive_load(state: &mut State) {
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(2);
+    while std::time::Instant::now() < deadline {
+        state.tick();
+        if !state.snapshot_browser_loading() {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    panic!("timed out waiting for archive snapshot browser load");
 }

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -114,6 +114,94 @@ async fn emits_message_created_and_send_succeeded_when_sender_is_member() {
 }
 
 #[tokio::test]
+async fn dm_message_rejoins_recipient_who_left() {
+    let test_db = new_test_db().await;
+    let service = ChatService::new(
+        test_db.db.clone(),
+        NotificationService::new(test_db.db.clone()),
+    );
+    let mut events = service.subscribe_events();
+    let client = test_db.db.get().await.expect("db client");
+
+    let sender = create_test_user(&test_db.db, "dm_reopen_sender").await;
+    let recipient = create_test_user(&test_db.db, "dm_reopen_recipient").await;
+    let room = ChatRoom::get_or_create_dm(&client, sender.id, recipient.id)
+        .await
+        .expect("dm room");
+    ChatRoomMember::join(&client, room.id, sender.id)
+        .await
+        .expect("join sender");
+    ChatRoomMember::join(&client, room.id, recipient.id)
+        .await
+        .expect("join recipient");
+    ChatRoomMember::leave(&client, room.id, recipient.id)
+        .await
+        .expect("recipient leaves");
+
+    assert!(
+        !ChatRoomMember::is_member(&client, room.id, recipient.id)
+            .await
+            .expect("recipient membership check"),
+        "recipient should start outside the DM"
+    );
+
+    let request_id = Uuid::now_v7();
+    service.send_message_task(
+        sender.id,
+        room.id,
+        room.slug.clone(),
+        "ping after leave".to_string(),
+        request_id,
+        false,
+    );
+
+    let first = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("first event timeout")
+        .expect("first event");
+    let second = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("second event timeout")
+        .expect("second event");
+
+    let mut saw_created = false;
+    let mut saw_success = false;
+    for event in [first, second] {
+        match event {
+            ChatEvent::MessageCreated {
+                message,
+                target_user_ids,
+            } => {
+                saw_created = true;
+                assert_eq!(message.room_id, room.id);
+                assert_eq!(message.user_id, sender.id);
+                let targets = target_user_ids.expect("dm message should be targeted");
+                assert!(targets.contains(&sender.id));
+                assert!(targets.contains(&recipient.id));
+            }
+            ChatEvent::SendSucceeded {
+                user_id,
+                request_id: got_request,
+            } => {
+                saw_success = true;
+                assert_eq!(user_id, sender.id);
+                assert_eq!(got_request, request_id);
+            }
+            _ => {}
+        }
+    }
+
+    assert!(saw_created, "expected MessageCreated event");
+    assert!(saw_success, "expected SendSucceeded event");
+    assert!(
+        ChatRoomMember::is_member(&client, room.id, recipient.id)
+            .await
+            .expect("recipient membership check"),
+        "recipient should be rejoined when a DM arrives"
+    );
+}
+
+#[tokio::test]
 async fn emits_message_reactions_updated_when_member_reacts() {
     let test_db = new_test_db().await;
     let service = ChatService::new(

--- a/late-ssh/tests/helpers/mod.rs
+++ b/late-ssh/tests/helpers/mod.rs
@@ -220,6 +220,9 @@ pub fn make_app_with_chat_service(
         ),
         dartboard_server: test_dartboard_server(),
         dartboard_provenance: test_dartboard_provenance(),
+        artboard_snapshot_service: late_ssh::app::artboard::svc::ArtboardSnapshotService::new(
+            db.clone(),
+        ),
         username: "test-user".to_string(),
         bonsai_service: BonsaiService::new(db.clone(), broadcast::channel::<ActivityEvent>(64).0),
         initial_bonsai_tree: None,
@@ -314,6 +317,9 @@ pub fn make_app_with_paired_client(
         ),
         dartboard_server: test_dartboard_server(),
         dartboard_provenance: test_dartboard_provenance(),
+        artboard_snapshot_service: late_ssh::app::artboard::svc::ArtboardSnapshotService::new(
+            db.clone(),
+        ),
         username: "test-user".to_string(),
         bonsai_service: BonsaiService::new(db.clone(), broadcast::channel::<ActivityEvent>(64).0),
         initial_bonsai_tree: None,


### PR DESCRIPTION
## Summary
- Adds a read-only **snapshot gallery** to the Artboard so players can revisit the daily and monthly archives that the server now rolls over automatically. Press `g` in Artboard view mode to open the browser, pick an archive with `j/k` or arrows, and `Enter` loads that historical board alongside its provenance. The top row of the browser is always "live" — selecting it (or pressing `g` again while in an archive) returns to the current shared canvas.
- Along the way, unifies composer textarea theming so the chat and news composers refresh when the active theme changes, and bumps the Android CLI build to NDK API level 26.

## What changed
- **Snapshot browser (Artboard):** new popup rendered over the canvas listing all `daily:` and `monthly:` snapshots from `late_core::models::artboard::Snapshot`. Loads asynchronously through a new `ArtboardSnapshotService` wired in via `SessionConfig`.
- **Archive view mode:** selecting an archive swaps the local snapshot to the historical canvas/provenance, shows `Mode: snapshot` and an `Archive <kind> <label>` row in the sidebar, and suppresses peers/users + swatch strip (the board is not shared while viewing history).
- **Read-only enforcement:** while an archive view is active, edits, selection ops, glyph picker, help toggling, and left-click-to-enter-active are all blocked; the snapshot receiver stops overwriting the displayed canvas until the user exits the archive.
- **Hints + help:** the Artboard frame title now advertises `g -> gallery` (and consolidates the pan hint). The help modal close hint is normalized to `Esc / q / ?` order, and `CONTEXT.md` documents the snapshot view.
- **Composer theming refactor:** `app/common/composer.rs` now owns `new_themed_textarea`, `apply_themed_textarea_style`, and `set_themed_textarea_cursor_visible`. Chat + news composers delegate to these helpers, and `App::render` calls `chat.refresh_composer_theme()` after applying the active theme so cursor/text colors update live when the user switches themes.
- **Android build:** `deploy_cli.yml` links CLI Android targets with `android26-clang` instead of `android24-clang` for aarch64 and x86_64.

## Behavior notes
- Opening the gallery clears local selection/floating state and closes the help/glyph-picker overlays to preserve the "at most one overlay" invariant.
- While an archive is active, `toggle_snapshot_browser_or_live` interprets `g` as "return to live" rather than re-opening the list; `Esc`, `q`, and `g` all close the browser (global quit is suppressed when the browser is open so `q` cannot exit the SSH session by mistake).
- The browser falls back cleanly when the DB is unavailable: `ArtboardSnapshotService::disabled()` (used in tests) simply emits an empty result so the UI renders "no daily or monthly snapshots yet" instead of erroring.
- The snapshot watch channel is still drained in the background but `tick()` skips applying new live snapshots into the editor while an archive is active, so coming back to live re-syncs to the latest server state at that moment.

## Feature flags
None. The gallery is available to every user as soon as this merges; the archives it reads from are already being populated by the snapshot rollover job landed in #99.

## Screenshots / Video
UI assets still need to be attached before review — the new snapshot browser popup and the "Mode: snapshot / Archive daily ..." sidebar rows should be captured at a minimum.

## Testing
- **Automated**
  - New integration test `snapshot_browser_activates_archive_readonly_and_returns_to_live` seeds a `daily:2026-04-23` snapshot, opens the browser, activates the archive, verifies typing is a no-op on the read-only canvas, and confirms exiting returns to the live board.
  - Existing artboard UI tests updated for the new `Snapshots g open` info row and the shifted swatch/info rects.
  - New `common::composer` tests cover themed textarea creation, cursor visibility, and live theme refresh; equivalent assertion added for `new_chat_textarea` after a theme swap.
- **Manual**
  - In `view` mode, press `g` — browser opens, `j/k` and arrows navigate, the top row is highlighted as "live".
  - Select a daily snapshot with `Enter` — sidebar shows `Mode: snapshot` and `Archive daily <label>`; try to paint/type/open glyph picker and confirm nothing changes.
  - Press `g` again — returns to live and edits apply again; press `g`, pick the top "live" row — also returns to live.
  - Switch themes via settings while the chat composer is focused and confirm cursor + text colors update without needing to reopen the composer.