### PR TITLE
Artboard: local paint color picker with Ctrl+U / Ctrl+Y

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: late.sh - Terminal Clubhouse for Developers
 - Primary audience: LLM agents working on this codebase, human contributors
-- Last updated: 2026-04-24 (Artboard global help/gallery context)
+- Last updated: 2026-04-24 (Artboard paint color selector context)
 - Status: Active
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change often.
 
@@ -475,6 +475,7 @@ Only canvas mutations are shared. Editor affordances stay local to the current S
 - Active selection anchor
 - Floating brush / floating selection preview
 - Swatch strip contents + pin state
+- Selected paint color from the 16-color local palette (`Ctrl+U` / `Ctrl+Y`)
 - Temporary sampled glyph brush
 - Help overlay tab + scroll
 - Glyph picker search state
@@ -545,11 +546,12 @@ Key behaviors:
 - Activating the currently active swatch again toggles floating-brush transparency.
 - `Enter` or `Ctrl+V` stamps the active floating brush without dismissing it.
 - `Ctrl+Shift+arrows` strokes a floating brush from the keyboard.
+- `Ctrl+U` / `Ctrl+Y` cycle previous/next paint color in a local 16-color palette. This affects subsequent typed glyphs, paste, glyph picker insertion, swatch stamping, and floating previews, but does not change the peer-list assigned color.
 - `Ctrl+]` opens the glyph picker for emoji / Unicode glyph insertion.
 - Double-clicking an existing non-space cell samples it into a temporary one-glyph brush.
 - `Ctrl+P` toggles the help overlay.
 - `Ctrl+\` toggles the ownership overlay. When on, cells render as per-author initials tinted by a deterministic username color derived from the provenance map.
-- Selection-local shape ops now stop at `Ctrl+T` (flip selection corner), `Ctrl+B` (draw border), and `Ctrl+Space` (smart-fill). The older `Ctrl+H/J/K/L` and `Ctrl+Y/U/I/O` push/pull chords are intentionally unbound.
+- Selection-local shape ops now stop at `Ctrl+T` (flip selection corner), `Ctrl+B` (draw border), and `Ctrl+Space` (smart-fill). The older `Ctrl+H/J/K/L` and `Ctrl+I/O` push/pull chords are intentionally unbound; `Ctrl+U/Y` now cycle paint color.
 - The Info sidebar always shows `Owner` and `Cell` for the current cursor/hover subject. The overlay only changes canvas rendering.
 - `Esc` closes transient Artboard overlays first, then clears floating brush / sampled brush / selection in `active` mode, and only falls back to `view` mode once there is no local editor state left to dismiss.
 
@@ -568,6 +570,7 @@ Mouse-specific extras:
 | Enter active mode | `i`, `Enter` | Switches the screen from inspect to edit |
 | Snapshot browser | `g` | View daily/monthly archives read-only; `j/k` or arrows navigate, `Enter` selects, top row returns live |
 | Draw / erase in active mode | `<type>`, `Space`, `Backspace`, `Delete` | Plain typing edits the shared canvas |
+| Paint color | `Ctrl+U`, `Ctrl+Y` | Previous/next local paint color; printable glyphs remain drawable |
 | Select | `Shift+arrows`, mouse drag | Local selection only |
 | Selection shape ops | `Ctrl+T`, `Ctrl+B`, `Ctrl+Space` | Flip corner, draw border, or smart-fill the current selection |
 | Copy / cut to swatch | `Ctrl+C`, `Ctrl+X` | Fills swatch strip; does not sync to peers |
@@ -586,7 +589,7 @@ Mouse-specific extras:
 - Artboard now lives under `late-ssh/src/app/artboard/`, not `app/games/artboard/`.
 - The Artboard screen has its own renderer and does **not** use the generic game frame/sidebar layout used by the arcade games.
 - The screen chrome exposes `view` vs `active` mode explicitly in both the frame title and the Artboard info sidebar.
-- The artboard info sidebar shows cursor position, `Owner`, `Cell`, pan availability, brush status, current selection size, and connected peers.
+- The artboard info sidebar shows cursor position, `Owner`, `Cell`, pan availability, selected paint color + palette row, brush status, current selection size, and connected peers.
 - The Artboard help overlay mirrors the global help modal style: single-row tabs, TitleCase labels, Amber active chip, `Tab` / `Shift+Tab` switches tabs, `j` / `k` / arrows scroll. Copy lives in `artboard/data.rs` (not pulled from upstream keymap).
 - The global help modal also has an `Artboard` tab. Its copy lives in `late-ssh/src/app/help_modal/data.rs` and is included in `bot_app_context()`, so `@bot` can answer common Artboard questions including daily/monthly snapshots and the web gallery URL.
 - Tab-switching keybindings were unified across modals: both the global help modal and the settings modal use `Tab` / `Shift+Tab` as the canonical tab switcher; arrow/hl routing was dropped from the help modals.

--- a/late-ssh/src/app/artboard/data.rs
+++ b/late-ssh/src/app/artboard/data.rs
@@ -62,6 +62,7 @@ fn drawing_lines() -> Vec<String> {
         "  Space              erase at the cursor",
         "  Backspace          erase left and move back",
         "  Delete             erase at the cursor",
+        "  Ctrl+U / Ctrl+Y    previous / next paint color",
         "",
         "Selection",
         "  Shift+arrows       start or extend selection",

--- a/late-ssh/src/app/artboard/input.rs
+++ b/late-ssh/src/app/artboard/input.rs
@@ -33,6 +33,15 @@ pub fn handle_byte(state: &mut State, screen_size: (u16, u16), byte: u8) -> Inpu
         return handle_help_byte(state, byte);
     }
     match byte {
+        // Ctrl+U / Ctrl+Y cycle paint color without claiming printable glyphs.
+        0x15 => {
+            state.cycle_paint_color(-1);
+            InputAction::Handled
+        }
+        0x19 => {
+            state.cycle_paint_color(1);
+            InputAction::Handled
+        }
         // Ctrl+] / Ctrl+5 / raw GS — open the glyph picker.
         0x1D => {
             state.open_glyph_picker();
@@ -549,8 +558,9 @@ fn map_button(button: MouseButton) -> Option<AppPointerButton> {
 mod tests {
     use super::*;
     use crate::app::artboard::provenance::ArtboardProvenance;
+    use crate::app::artboard::state::PAINT_PALETTE;
     use crate::app::artboard::svc::{ArtboardSnapshotService, DartboardService, DartboardSnapshot};
-    use dartboard_core::{Canvas, CellValue, RgbColor};
+    use dartboard_core::{Canvas, CellValue};
     use dartboard_editor::Clipboard;
 
     #[test]
@@ -1088,6 +1098,19 @@ mod tests {
     }
 
     #[test]
+    fn ctrl_u_and_ctrl_y_cycle_paint_color() {
+        let mut state = test_state();
+
+        let prev = handle_byte(&mut state, (80, 24), 0x15);
+        assert!(matches!(prev, InputAction::Handled));
+        assert_eq!(state.active_paint_color_index(), 0);
+
+        let next = handle_byte(&mut state, (80, 24), 0x19);
+        assert!(matches!(next, InputAction::Handled));
+        assert_eq!(state.active_paint_color_index(), 1);
+    }
+
+    #[test]
     fn help_overlay_routes_navigation_keys() {
         let mut state = test_state();
         assert!(matches!(
@@ -1210,7 +1233,7 @@ mod tests {
         let snapshot = DartboardSnapshot {
             provenance: ArtboardProvenance::default(),
             your_user_id: Some(1),
-            your_color: Some(RgbColor::new(255, 196, 64)),
+            your_color: Some(PAINT_PALETTE[1]),
             ..Default::default()
         };
         let svc = DartboardService::disconnected_for_tests(snapshot);

--- a/late-ssh/src/app/artboard/page.rs
+++ b/late-ssh/src/app/artboard/page.rs
@@ -53,6 +53,10 @@ pub(crate) fn handle_key(app: &mut App, byte: u8) -> bool {
             let action = super::input::handle_byte(state, size, byte);
             handle_action(app, action)
         }
+        0x15 | 0x19 => {
+            let action = super::input::handle_byte(state, size, byte);
+            handle_action(app, action)
+        }
         _ => false,
     }
 }
@@ -249,12 +253,12 @@ fn handle_action(app: &mut App, action: super::input::InputAction) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use dartboard_core::{Canvas, Pos, RgbColor};
+    use dartboard_core::{Canvas, Pos};
 
     use super::*;
     use crate::app::artboard::{
         provenance::ArtboardProvenance,
-        state::State,
+        state::{PAINT_PALETTE, State},
         svc::{ArtboardSnapshotService, DartboardService, DartboardSnapshot},
     };
 
@@ -355,7 +359,7 @@ mod tests {
         let snapshot = DartboardSnapshot {
             provenance: ArtboardProvenance::default(),
             your_user_id: Some(1),
-            your_color: Some(RgbColor::new(255, 196, 64)),
+            your_color: Some(PAINT_PALETTE[1]),
             ..Default::default()
         };
         let svc = DartboardService::disconnected_for_tests(snapshot);

--- a/late-ssh/src/app/artboard/state.rs
+++ b/late-ssh/src/app/artboard/state.rs
@@ -27,6 +27,24 @@ use crate::app::icon_picker::{self, catalog::IconCatalogData};
 
 const DOUBLE_CLICK_WINDOW_MS: u128 = 400;
 pub(crate) const PRIMARY_SWATCH_IDX: usize = 0;
+pub(crate) const PAINT_PALETTE: [RgbColor; 16] = [
+    RgbColor::new(255, 110, 64),
+    RgbColor::new(255, 236, 96),
+    RgbColor::new(255, 214, 102),
+    RgbColor::new(145, 226, 88),
+    RgbColor::new(188, 255, 128),
+    RgbColor::new(72, 220, 170),
+    RgbColor::new(86, 245, 214),
+    RgbColor::new(84, 196, 255),
+    RgbColor::new(96, 225, 255),
+    RgbColor::new(128, 163, 255),
+    RgbColor::new(164, 146, 255),
+    RgbColor::new(192, 132, 255),
+    RgbColor::new(224, 116, 255),
+    RgbColor::new(255, 124, 196),
+    RgbColor::new(255, 142, 158),
+    RgbColor::new(238, 242, 255),
+];
 
 pub struct State {
     pub snapshot: DartboardSnapshot,
@@ -36,6 +54,7 @@ pub struct State {
     pub(crate) editor: EditorSession,
     active_brush: Option<Brush>,
     drag_brush: Option<Brush>,
+    paint_color_index: Option<usize>,
     floating_source_selection: Option<EditorSelection>,
     suppress_swatch_preview: bool,
     last_canvas_click: Option<(Instant, Pos)>,
@@ -73,6 +92,7 @@ impl State {
             editor: EditorSession::default(),
             active_brush: None,
             drag_brush: None,
+            paint_color_index: None,
             floating_source_selection: None,
             suppress_swatch_preview: false,
             last_canvas_click: None,
@@ -612,6 +632,24 @@ impl State {
         }
     }
 
+    pub fn active_paint_color(&self) -> RgbColor {
+        self.active_user_color()
+    }
+
+    pub fn active_paint_color_index(&self) -> usize {
+        self.paint_color_index
+            .or_else(|| palette_index(self.active_user_color()))
+            .unwrap_or(1)
+    }
+
+    pub fn cycle_paint_color(&mut self, delta: isize) {
+        let len = PAINT_PALETTE.len() as isize;
+        let current = self.active_paint_color_index() as isize;
+        let next = (current + delta).rem_euclid(len) as usize;
+        self.paint_color_index = Some(next);
+        self.suppress_swatch_preview = false;
+    }
+
     pub fn swatches(&self) -> &[Option<Swatch>; SWATCH_CAPACITY] {
         &self.editor.swatches
     }
@@ -1026,9 +1064,10 @@ impl State {
     }
 
     fn active_user_color(&self) -> RgbColor {
-        self.snapshot
-            .your_color
-            .unwrap_or_else(|| RgbColor::new(255, 196, 64))
+        self.paint_color_index
+            .and_then(|idx| PAINT_PALETTE.get(idx).copied())
+            .or(self.snapshot.your_color)
+            .unwrap_or(PAINT_PALETTE[1])
     }
 
     fn swatch_preview_suppressed(&self) -> bool {
@@ -1211,7 +1250,7 @@ fn owner_initial(username: &str) -> char {
 }
 
 fn owner_color(username: &str) -> RgbColor {
-    const PALETTE: [RgbColor; 8] = [
+    const OWNER_PALETTE: [RgbColor; 8] = [
         RgbColor::new(255, 110, 64),
         RgbColor::new(255, 196, 64),
         RgbColor::new(145, 226, 88),
@@ -1225,8 +1264,14 @@ fn owner_color(username: &str) -> RgbColor {
     let idx = username
         .bytes()
         .fold(0usize, |acc, byte| acc.wrapping_add(byte as usize))
-        % PALETTE.len();
-    PALETTE[idx]
+        % OWNER_PALETTE.len();
+    OWNER_PALETTE[idx]
+}
+
+fn palette_index(color: RgbColor) -> Option<usize> {
+    PAINT_PALETTE
+        .iter()
+        .position(|candidate| *candidate == color)
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1411,7 +1456,7 @@ mod tests {
             provenance: ArtboardProvenance::default(),
             your_name: "painter".to_string(),
             your_user_id: Some(1),
-            your_color: Some(RgbColor::new(255, 196, 64)),
+            your_color: Some(PAINT_PALETTE[1]),
             ..Default::default()
         };
         let svc = DartboardService::disconnected_for_tests(snapshot);
@@ -1472,6 +1517,33 @@ mod tests {
         state.type_char('A', (80, 24));
         assert_eq!(state.snapshot.canvas.get(Pos { x: 0, y: 0 }), 'A');
         assert_eq!(state.cursor(), Pos { x: 1, y: 0 });
+    }
+
+    #[test]
+    fn paint_color_cycles_and_typed_glyphs_use_selection() {
+        let mut state = test_state();
+        assert_eq!(state.active_paint_color_index(), 1);
+
+        state.cycle_paint_color(1);
+        assert_eq!(state.active_paint_color_index(), 2);
+        assert_eq!(state.active_paint_color(), PAINT_PALETTE[2]);
+
+        state.type_char('C', (80, 24));
+        assert_eq!(
+            state.snapshot.canvas.fg(Pos { x: 0, y: 0 }),
+            Some(PAINT_PALETTE[2])
+        );
+    }
+
+    #[test]
+    fn paint_color_cycle_wraps() {
+        let mut state = test_state();
+        state.cycle_paint_color(-2);
+        assert_eq!(state.active_paint_color_index(), PAINT_PALETTE.len() - 1);
+        assert_eq!(
+            state.active_paint_color(),
+            PAINT_PALETTE[PAINT_PALETTE.len() - 1]
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/artboard/ui.rs
+++ b/late-ssh/src/app/artboard/ui.rs
@@ -1202,7 +1202,7 @@ mod tests {
         let state = test_state();
         assert_eq!(
             artboard_info_area_for_screen((80, 24), &state),
-            Some(Rect::new(27, 1, 28, 13))
+            Some(Rect::new(27, 1, 28, 15))
         );
     }
 

--- a/late-ssh/src/app/artboard/ui.rs
+++ b/late-ssh/src/app/artboard/ui.rs
@@ -13,7 +13,7 @@ use ratatui::{
 use crate::app::{common::theme, games::ui::info_label_value};
 
 use super::data::lines_for;
-use super::state::{BrushMode, HelpTab, PRIMARY_SWATCH_IDX, State};
+use super::state::{BrushMode, HelpTab, PAINT_PALETTE, PRIMARY_SWATCH_IDX, State};
 
 const INFO_WIDTH: u16 = 28;
 const SWATCH_BOX_WIDTH: u16 = 16;
@@ -130,6 +130,17 @@ fn artboard_info_lines(state: &State, interacting: bool) -> Vec<Line<'static>> {
         },
         theme::TEXT_BRIGHT(),
     ));
+    lines.push(info_label_value(
+        "Color",
+        format!(
+            "{}/{} {}",
+            state.active_paint_color_index() + 1,
+            PAINT_PALETTE.len(),
+            rgb_hex(state.active_paint_color())
+        ),
+        rgb(state.active_paint_color()),
+    ));
+    lines.push(color_palette_line(state));
 
     let (brush, brush_color) = match state.brush_mode() {
         BrushMode::None => ("none".to_string(), theme::TEXT_FAINT()),
@@ -259,8 +270,25 @@ fn section_label(text: &str) -> Line<'static> {
     ))
 }
 
+fn color_palette_line(state: &State) -> Line<'static> {
+    let mut spans = vec![Span::styled(
+        format!("{:<11}", "Palette"),
+        Style::default().fg(theme::TEXT_DIM()),
+    )];
+    let active_idx = state.active_paint_color_index();
+    for (idx, color) in PAINT_PALETTE.iter().copied().enumerate() {
+        let marker = if idx == active_idx { "●" } else { "■" };
+        spans.push(Span::styled(marker, Style::default().fg(rgb(color))));
+    }
+    Line::from(spans)
+}
+
 fn rgb(color: dartboard_core::RgbColor) -> ratatui::style::Color {
     ratatui::style::Color::Rgb(color.r, color.g, color.b)
+}
+
+fn rgb_hex(color: dartboard_core::RgbColor) -> String {
+    format!("#{:02X}{:02X}{:02X}", color.r, color.g, color.b)
 }
 
 fn artboard_layout(area: Rect) -> ArtboardLayout {
@@ -1265,11 +1293,12 @@ mod tests {
         assert_eq!(lines[3].to_string(), "Cell       0,0");
         assert_eq!(lines[4].to_string(), "Pan        ◀ ▲ ▼ ▶");
         assert_eq!(lines[5].to_string(), "Snapshots  g open");
-        assert_eq!(lines[6].to_string(), "Brush      none");
-        assert_eq!(lines[7].to_string(), "Selection  none");
-        assert_eq!(lines[8].to_string(), "");
-        assert_eq!(lines[9].to_string(), "Users");
-        assert_eq!(lines[10].to_string(), "• painter (you)");
+        assert_eq!(lines[6].to_string(), "Color      2/16 #FFEC60");
+        assert_eq!(lines[8].to_string(), "Brush      none");
+        assert_eq!(lines[9].to_string(), "Selection  none");
+        assert_eq!(lines[10].to_string(), "");
+        assert_eq!(lines[11].to_string(), "Users");
+        assert_eq!(lines[12].to_string(), "• painter (you)");
     }
 
     #[test]
@@ -1283,7 +1312,7 @@ mod tests {
 
         let lines = artboard_info_lines(&state, true);
         assert_eq!(lines[0].to_string(), "Mode       active");
-        assert_eq!(lines[7].to_string(), "Selection  3x2");
+        assert_eq!(lines[9].to_string(), "Selection  3x2");
     }
 
     #[test]
@@ -1473,7 +1502,7 @@ mod tests {
             provenance: ArtboardProvenance::default(),
             your_name: "painter".to_string(),
             your_user_id: Some(1),
-            your_color: Some(RgbColor::new(255, 196, 64)),
+            your_color: Some(PAINT_PALETTE[1]),
             ..Default::default()
         };
         let svc = DartboardService::disconnected_for_tests(snapshot);

--- a/late-ssh/src/app/artboard/ui.rs
+++ b/late-ssh/src/app/artboard/ui.rs
@@ -1334,10 +1334,10 @@ mod tests {
     #[test]
     fn swatch_boxes_use_full_artboard_width_below_short_info_block() {
         let state = test_state();
-        let rects = swatch_box_rects((80, 24), &state);
-        assert_eq!(rects[0], Some(Rect::new(9, 14, 16, 8)));
-        assert_eq!(rects[1], Some(Rect::new(24, 14, 16, 8)));
-        assert_eq!(rects[2], Some(Rect::new(39, 14, 16, 8)));
+        let rects = swatch_box_rects((80, 26), &state);
+        assert_eq!(rects[0], Some(Rect::new(9, 16, 16, 8)));
+        assert_eq!(rects[1], Some(Rect::new(24, 16, 16, 8)));
+        assert_eq!(rects[2], Some(Rect::new(39, 16, 16, 8)));
         assert!(rects[3].is_none());
     }
 
@@ -1389,20 +1389,28 @@ mod tests {
             clipboard: Clipboard::new(1, 1, vec![Some(CellValue::Narrow('B'))]),
             pinned: false,
         });
-        let rects = swatch_box_rects((80, 24), &state);
+        let screen_size = (80, 26);
+        let rects = swatch_box_rects(screen_size, &state);
+        let first = rects[0].expect("first swatch visible");
         let second = rects[1].expect("second swatch visible");
+        let first_body = swatch_body_rect(first);
         let second_pin = swatch_pin_rect(second);
 
         assert_eq!(
-            swatch_hit((80, 24), &state, 11, 16),
+            swatch_hit(screen_size, &state, first_body.x + 1, first_body.y + 1),
             Some(SwatchHit::Body(0))
         );
         assert_eq!(
-            swatch_hit((80, 24), &state, 23, 21),
+            swatch_hit(
+                screen_size,
+                &state,
+                first_body.right(),
+                first_body.bottom().saturating_sub(1),
+            ),
             Some(SwatchHit::Body(0))
         );
         assert_eq!(
-            swatch_hit((80, 24), &state, second_pin.x + 1, second_pin.y + 1),
+            swatch_hit(screen_size, &state, second_pin.x + 1, second_pin.y + 1),
             Some(SwatchHit::Pin(1))
         );
     }

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -366,6 +366,7 @@ fn artboard_help_lines() -> Vec<String> {
         "  g                 open daily/monthly snapshot browser",
         "  Ctrl+\\           toggle owner overlay",
         "  Ctrl+]            open emoji / Unicode glyph picker",
+        "  Ctrl+U / Ctrl+Y   previous / next paint color",
         "",
         "Drawing basics",
         "  arrows            move cursor / focus",
@@ -391,7 +392,7 @@ fn artboard_help_lines() -> Vec<String> {
         "  canvas cells, connected peers, your assigned color, and cell ownership provenance",
         "",
         "What stays local",
-        "  cursor, viewport, selections, swatches, brush previews, glyph search, and help scroll",
+        "  cursor, viewport, selections, swatches, selected paint color, brush previews, glyph search, and help scroll",
     ]
     .into_iter()
     .map(str::to_string)


### PR DESCRIPTION
## Summary
Artboard painters were stuck with the single color assigned to them by the peer list, so they could not vary stroke color within a session. This PR adds a local 16-color palette that each painter can cycle through with `Ctrl+U` / `Ctrl+Y`, affecting their own typing, pastes, glyph-picker insertions, and floating previews without changing what peers see for them in the ownership overlay.

## What changed
- New `Ctrl+U` / `Ctrl+Y` keybindings cycle previous / next through a 16-entry paint palette defined in `artboard/state.rs`.
- The selected color drives subsequent typed glyphs, paste, glyph-picker insertion, swatch stamping, and the floating brush preview.
- The Artboard info sidebar now shows the active color (`Color  N/16  #RRGGBB`) plus a per-entry palette row with the active swatch marked.
- Palette state is per-user and local: it does not change the peer-assigned color used by the ownership overlay or peer list.
- Help overlay, Artboard help tab, and `CONTEXT.md` updated to document the new shortcut and what stays local.
- `Ctrl+U` / `Ctrl+Y` were previously listed as intentionally unbound push/pull chords; they are now explicitly reassigned to paint-color cycling.

## Behavior notes
- Cycling wraps at both ends (`rem_euclid` over 16 entries).
- Before the user cycles, the reported active index falls back to the palette slot matching the peer-assigned color, defaulting to index 1 when no match exists.
- Input handling routes `0x15` / `0x19` even when the help overlay is closed; the bytes are consumed so printable-glyph drawing is unaffected.

## Feature flags
- None.

## Screenshots / Video
- UI-visible change (new `Color` + `Palette` rows in the Artboard info sidebar). Screenshots / short capture of cycling should be attached before review.

## Testing
- Automated:
  - `ctrl_u_and_ctrl_y_cycle_paint_color` in `artboard/input.rs` verifies both keybindings are handled and advance the active index.
  - `paint_color_cycles_and_typed_glyphs_use_selection` in `artboard/state.rs` verifies a typed glyph picks up the cycled color on the canvas.
  - `paint_color_cycle_wraps` covers negative-delta wrap-around.
  - Existing sidebar snapshot tests updated to reflect the new `Color` and `Palette` lines.
- Manual:
  - Open Artboard, press `Ctrl+Y` / `Ctrl+U` and confirm the sidebar `Color` row and active palette marker update.
  - Type, paste, and insert from the glyph picker to confirm each uses the newly selected color.
  - Toggle the ownership overlay (`Ctrl+\`) and confirm peer colors / initials are unchanged by local cycling.