### PR TITLE
fix(ci): prevent shell injection via GitHub context interpolation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,13 @@ jobs:
 
       - name: resolve_image_tag
         id: vars
+        env:
+          REGISTRY: ${{ inputs.registry }}
+          REPOSITORY: ${{ github.repository }}
+          IMAGE_NAME: ${{ inputs.image_name }}
+          IMAGE_TAG: ${{ inputs.image_tag }}
         run: |
-          echo "image_tag=${{ inputs.registry }}/${{ github.repository }}/${{ inputs.image_name }}:${{ inputs.image_tag }}" >> "$GITHUB_OUTPUT"
+          echo "image_tag=$REGISTRY/$REPOSITORY/$IMAGE_NAME:$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: setup_qemu
         uses: docker/setup-qemu-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,12 +57,24 @@ jobs:
         run: rustup component add clippy
       - name: cargo_clippy
         env:
-          CARGO_PACKAGE: ${{ inputs.package && format('-p {0}', inputs.package) || '--workspace' }}
-        run: cargo clippy $CARGO_PACKAGE --all-targets --features otel -- -D warnings
+          CARGO_PACKAGE: ${{ inputs.package }}
+        run: |
+          package_args=(--workspace)
+          if [ -n "$CARGO_PACKAGE" ]; then
+            package_args=(-p "$CARGO_PACKAGE")
+          fi
+
+          cargo clippy "${package_args[@]}" --all-targets --features otel -- -D warnings
       - name: install_nextest
         uses: taiki-e/install-action@nextest
       - name: cargo_test
         env:
           TEST_DATABASE_URL: "host=127.0.0.1 port=5432 user=test password=test dbname=postgres"
-          CARGO_PACKAGE: ${{ inputs.package && format('-p {0}', inputs.package) || '--workspace' }}
-        run: cargo nextest run $CARGO_PACKAGE --all-targets
+          CARGO_PACKAGE: ${{ inputs.package }}
+        run: |
+          package_args=(--workspace)
+          if [ -n "$CARGO_PACKAGE" ]; then
+            package_args=(-p "$CARGO_PACKAGE")
+          fi
+
+          cargo nextest run "${package_args[@]}" --all-targets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,13 @@ jobs:
       - name: install_clippy
         run: rustup component add clippy
       - name: cargo_clippy
-        run: cargo clippy ${{ inputs.package && format('-p {0}', inputs.package) || '--workspace' }} --all-targets --features otel -- -D warnings
+        env:
+          CARGO_PACKAGE: ${{ inputs.package && format('-p {0}', inputs.package) || '--workspace' }}
+        run: cargo clippy $CARGO_PACKAGE --all-targets --features otel -- -D warnings
       - name: install_nextest
         uses: taiki-e/install-action@nextest
       - name: cargo_test
         env:
           TEST_DATABASE_URL: "host=127.0.0.1 port=5432 user=test password=test dbname=postgres"
-        run: cargo nextest run ${{ inputs.package && format('-p {0}', inputs.package) || '--workspace' }} --all-targets
+          CARGO_PACKAGE: ${{ inputs.package && format('-p {0}', inputs.package) || '--workspace' }}
+        run: cargo nextest run $CARGO_PACKAGE --all-targets


### PR DESCRIPTION
`${{ github.repository }}` and `${{ inputs.package }}` were interpolated directly into `run:` shell commands in `build.yml` and `ci.yml`. This is flagged by Semgrep rule `yaml.github-actions.security.run-shell-injection`.

If either value contains shell metacharacters, an attacker who controls the input (for example via a fork PR or a crafted workflow dispatch payload) could inject arbitrary commands into the runner and exfiltrate secrets.

The fix moves all context values into `env:` variables and references them as `$ENV_VAR` in the shell. GitHub's runner binds `env:` values as environment variables, so the shell receives them as data rather than code — no quoting bypass possible.

**build.yml** — `resolve_image_tag` step: `inputs.registry`, `github.repository`, `inputs.image_name`, `inputs.image_tag`
**ci.yml** — `cargo_clippy` and `cargo_test` steps: `inputs.package`