### PR TITLE
Add public Artboard gallery at `/gallery` and tidy global keyboard shortcuts

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: late.sh - Terminal Clubhouse for Developers
 - Primary audience: LLM agents working on this codebase, human contributors
-- Last updated: 2026-04-24 (Artboard paint color selector context)
+- Last updated: 2026-04-25 (keyboard shortcut cleanup + Artboard web gallery context)
 - Status: Active
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change often.
 
@@ -521,7 +521,7 @@ The artboard is keyboard-first, but it is not "just type into a grid". It layers
 - `view` mode: inspect the board, move the cursor/viewport, and keep global page switching (`1-4`, `Tab`, `Shift+Tab`) available.
 - `active` mode: edit the board. Single-key global shortcuts are suppressed so typing goes to the canvas/editor.
 - `snapshot` view: read-only historical daily/monthly archive view. `g` in Artboard view mode opens the snapshot browser; `j/k` or arrows move, `Enter` selects, the top row returns to the live board, and `g` exits an active historical snapshot back to live.
-- The public web gallery for Artboard snapshots is `https://late.sh/gallery`.
+- The public web gallery for Artboard snapshots is `https://late.sh/gallery`. It is read-only: `late-web` reads `artboard_snapshots` directly from Postgres, lists `main`, `daily:*`, and `monthly:*`, renders one selected saved snapshot, and shows hovered cell coordinates / author from persisted provenance. The `main` gallery entry is the latest saved DB snapshot, not a live in-memory `ServerHandle` stream, so it can lag active drawing by the persistence interval.
 
 ```text
 type chars -> draw directly
@@ -606,6 +606,7 @@ Mouse-specific extras:
 - `late-ssh/src/app/artboard/data.rs` — hand-authored help text for the 4 help tabs
 - `late-ssh/src/app/artboard/provenance.rs` — per-cell authorship map + ownership overlay source of truth
 - `late-ssh/tests/games/artboard.rs` — service + persistence integration tests
+- `late-web/src/pages/gallery/` — read-only public gallery for saved Artboard snapshots
 - `late-ssh/src/app/input.rs`, `late-ssh/src/app/tick.rs`, `late-ssh/src/app/render.rs` — SSH app integration points
 
 ---
@@ -1302,7 +1303,7 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `m` | Global | Toggle mute on paired client |
 | `+` / `=` | Global | Volume up on paired client |
 | `-` / `_` | Global | Volume down on paired client |
-| `w` | Global (not composing, games override) | Open the Bonsai care modal |
+| `w` | Global (not composing, active games override) | Open the Bonsai care modal |
 | `w` | Bonsai modal | Water bonsai / replant dead tree, with a short watering animation |
 | `p` | Bonsai modal | Hard-prune: -100 growth, reroll shape, reset today's wrong-branch cuts |
 | `h` / `j` / `k` / `l` / arrows | Bonsai modal prune mode | Move spatial branch cursor |
@@ -1310,7 +1311,6 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `s` | Bonsai modal | Copy bonsai ASCII snippet to clipboard |
 | `?` | Bonsai modal | Open help modal on the Bonsai section |
 | `L` / `C` / `A` / `Z` | Dashboard | Vote genre |
-| `s` | Global (not composing) | Copy bonsai ASCII snippet to clipboard |
 | `j` / `k` / arrows | Dashboard | Scroll chat |
 | `p` | Dashboard chat selection | Open selected user's read-only profile modal |
 | `r` | Dashboard chat selection | Reply to selected general chat message |
@@ -1364,7 +1364,7 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `/unignore [@user]` | Chat composer | Remove a user from your ignore list |
 | `j` / `k` / arrows | Chat overlay (`/help`, ignore list) | Scroll overlay |
 | `Esc` / `q` | Chat overlay (`/help`, ignore list) | Close overlay |
-| `Ctrl+O` | Global | Open the settings modal from anywhere |
+| `Ctrl+O` | Global | Open the settings modal from anywhere, including active games |
 | `↑` / `↓` / `j` / `k` | Settings modal | Move between rows (Username, Theme, Background, Right sidebar, Games sidebar, Country, Timezone, DMs, @mentions, Game events, Bell, Cooldown, Format) |
 | `←` / `→` | Settings modal | Cycle the current row's setting (theme, toggles, cooldown, notification format) |
 | `Space` / `Enter` / `e` | Settings modal | Activate row — edit username/bio, cycle a setting, or open the country/timezone picker |
@@ -1373,7 +1373,8 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `j` / `k` / `↑` / `↓` | Read-only profile modal | Scroll |
 | `Esc` / `q` | Read-only profile modal | Close |
 | `Esc` | Any modal | Close/cancel |
-| `c` | Chat (not composing) | Open web chat QR (copies URL + shows it as fallback) |
+| `c` | Dashboard / Chat message selection | Copy selected message |
+| `C` | Chat (not composing) | Open web chat QR (copies URL + shows it as fallback) |
 | `Ctrl+]` | Dashboard / Chat | Open icon picker (emoji + nerd font). Auto-starts the composer if not already composing. Inserts into the chat composer only. |
 | `↑` / `↓` / `j` / `k` | Icon picker | Move selection |
 | `Ctrl+U` / `Ctrl+D` | Icon picker | Half-page up / down |
@@ -1391,7 +1392,7 @@ When modifying any keybinding, update **all** of the following:
 2. **Help modal** — `app/help_modal/data.rs` (slide copy, e.g. Overview "This modal" section) and `app/help_modal/ui.rs` `draw_footer()` keybind line
 3. **Settings modal** — `app/settings_modal/ui.rs` `draw_footer()` keybind line and the bordered help callout in `draw_help_callout()`
 4. **Sidebar hints** — `app/common/sidebar.rs`, e.g. the volume/mute hint line in Now Playing
-5. **Game guard** — `app/input.rs` `handle_global_key()`, the `!matches!(byte, ...)` allowlist for keys that pass through during active games
+5. **Game guard** — `app/input.rs` `handle_global_key()`, where active games suppress global byte shortcuts before screen-specific game routing
 6. **This table** — the keyboard shortcuts table above in CONTEXT.md
 7. **Game info panels** — per-game UI panels that show controls (check each game's `ui.rs`)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,6 +2652,7 @@ dependencies = [
  "axum",
  "bytes",
  "chrono",
+ "dartboard-core",
  "futures-util",
  "late-core",
  "opentelemetry",

--- a/infra/service-web.tf
+++ b/infra/service-web.tf
@@ -94,6 +94,47 @@ resource "kubernetes_deployment_v1" "service_web" {
             name  = "LATE_AUDIO_URL"
             value = "https://audio.${var.DOMAIN}"
           }
+
+          # --- Database (CloudNativePG) ---
+          env {
+            name  = "LATE_DB_HOST"
+            value = "postgres-rw"
+          }
+          env {
+            name  = "LATE_DB_PORT"
+            value = "5432"
+          }
+          env {
+            name = "LATE_DB_NAME"
+            value_from {
+              secret_key_ref {
+                name = "postgres-app"
+                key  = "dbname"
+              }
+            }
+          }
+          env {
+            name = "LATE_DB_USER"
+            value_from {
+              secret_key_ref {
+                name = "postgres-app"
+                key  = "user"
+              }
+            }
+          }
+          env {
+            name = "LATE_DB_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = "postgres-app"
+                key  = "password"
+              }
+            }
+          }
+          env {
+            name  = "LATE_DB_POOL_SIZE"
+            value = var.DB_POOL_SIZE
+          }
         }
 
         image_pull_secrets {

--- a/late-ssh/src/app/artboard/input.rs
+++ b/late-ssh/src/app/artboard/input.rs
@@ -671,8 +671,8 @@ mod tests {
             &MouseEvent {
                 kind: MouseEventKind::Down,
                 button: Some(MouseButton::Left),
-                x: 11,
-                y: 17,
+                x: 21,
+                y: 20,
                 modifiers: Default::default(),
             },
         );
@@ -685,8 +685,8 @@ mod tests {
             &MouseEvent {
                 kind: MouseEventKind::Up,
                 button: Some(MouseButton::Left),
-                x: 11,
-                y: 17,
+                x: 21,
+                y: 20,
                 modifiers: Default::default(),
             },
         );
@@ -699,8 +699,8 @@ mod tests {
             &MouseEvent {
                 kind: MouseEventKind::Moved,
                 button: None,
-                x: 11,
-                y: 17,
+                x: 21,
+                y: 20,
                 modifiers: Default::default(),
             },
         );
@@ -766,8 +766,8 @@ mod tests {
             &MouseEvent {
                 kind: MouseEventKind::Down,
                 button: Some(MouseButton::Left),
-                x: 11,
-                y: 17,
+                x: 21,
+                y: 20,
                 modifiers: crate::app::input::MouseModifiers {
                     ctrl: true,
                     ..Default::default()
@@ -795,8 +795,8 @@ mod tests {
             &MouseEvent {
                 kind: MouseEventKind::Down,
                 button: Some(MouseButton::Left),
-                x: 11,
-                y: 17,
+                x: 21,
+                y: 20,
                 modifiers: crate::app::input::MouseModifiers {
                     ctrl: true,
                     ..Default::default()
@@ -1218,7 +1218,7 @@ mod tests {
             &MouseEvent {
                 kind: MouseEventKind::ScrollDown,
                 button: None,
-                x: 30,
+                x: 35,
                 y: 3,
                 modifiers: Default::default(),
             },

--- a/late-ssh/src/app/artboard/ui.rs
+++ b/late-ssh/src/app/artboard/ui.rs
@@ -88,7 +88,7 @@ fn artboard_info_lines(state: &State, interacting: bool) -> Vec<Line<'static>> {
         (true, _, _) => "snapshot".to_string(),
         (false, BrushMode::Glyph(ch), _) => format!("brush {ch}"),
         (false, BrushMode::Swatch, _) => "swatch".to_string(),
-        (false, BrushMode::None, true) => "interact".to_string(),
+        (false, BrushMode::None, true) => "active".to_string(),
         (false, BrushMode::None, false) => "view".to_string(),
     };
     let mode_color = if state.is_archive_view_active() {
@@ -1257,7 +1257,7 @@ mod tests {
         let mut state = test_state();
         state.begin_selection_from_cursor();
         let lines = artboard_info_lines(&state, true);
-        assert_eq!(lines[0].to_string(), "Mode       interact");
+        assert_eq!(lines[0].to_string(), "Mode       active");
         assert_eq!(lines[4].to_string(), "Cursor     1x1");
 
         state.move_right((80, 24));
@@ -1266,7 +1266,7 @@ mod tests {
         assert!(state.update_selection_to_cursor());
 
         let lines = artboard_info_lines(&state, true);
-        assert_eq!(lines[0].to_string(), "Mode       interact");
+        assert_eq!(lines[0].to_string(), "Mode       active");
         assert_eq!(lines[4].to_string(), "Cursor     3x2");
     }
 

--- a/late-ssh/src/app/bonsai/ui.rs
+++ b/late-ssh/src/app/bonsai/ui.rs
@@ -268,17 +268,19 @@ fn water_hint_title(can_water: bool, width: u16) -> Option<Line<'static>> {
     if !can_water || width < 12 {
         return None;
     }
-    Some(Line::from(vec![
-        Span::raw(" "),
-        Span::styled(
-            "w",
-            Style::default()
-                .fg(theme::AMBER())
-                .add_modifier(Modifier::BOLD),
-        ),
-        Span::styled(" care ", Style::default().fg(theme::TEXT_DIM())),
-    ])
-    .right_aligned())
+    Some(
+        Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                "w",
+                Style::default()
+                    .fg(theme::AMBER())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(" care ", Style::default().fg(theme::TEXT_DIM())),
+        ])
+        .right_aligned(),
+    )
 }
 
 fn leaf_color_for_stage(stage: Stage) -> ratatui::style::Color {

--- a/late-ssh/src/app/bonsai/ui.rs
+++ b/late-ssh/src/app/bonsai/ui.rs
@@ -32,7 +32,7 @@ pub fn draw_bonsai(frame: &mut Frame, area: Rect, state: &BonsaiState, beat: f32
         " Bonsai [RIP] ".to_string()
     };
 
-    let block = Block::default()
+    let mut block = Block::default()
         .title(title)
         .borders(Borders::ALL)
         .border_style(Style::default().fg(if state.is_alive {
@@ -40,9 +40,11 @@ pub fn draw_bonsai(frame: &mut Frame, area: Rect, state: &BonsaiState, beat: f32
         } else {
             theme::TEXT_FAINT()
         }));
+    if let Some(hint) = water_hint_title(state.can_water(), area.width) {
+        block = block.title_top(hint);
+    }
     let inner = block.inner(area);
     frame.render_widget(block, area);
-    draw_water_hint(frame, area, state.can_water());
 
     if inner.height < 2 || inner.width < 10 {
         return;
@@ -262,18 +264,11 @@ fn status_line_specs(is_alive: bool, _stage: Stage, can_water: bool) -> Vec<Stat
     lines
 }
 
-fn draw_water_hint(frame: &mut Frame, area: Rect, can_water: bool) {
-    if !can_water || area.width < 12 {
-        return;
+fn water_hint_title(can_water: bool, width: u16) -> Option<Line<'static>> {
+    if !can_water || width < 12 {
+        return None;
     }
-    let width = 9;
-    let hint_area = Rect {
-        x: area.x + area.width.saturating_sub(width + 2),
-        y: area.y,
-        width,
-        height: 1,
-    };
-    let line = Line::from(vec![
+    Some(Line::from(vec![
         Span::raw(" "),
         Span::styled(
             "w",
@@ -282,8 +277,8 @@ fn draw_water_hint(frame: &mut Frame, area: Rect, can_water: bool) {
                 .add_modifier(Modifier::BOLD),
         ),
         Span::styled(" care ", Style::default().fg(theme::TEXT_DIM())),
-    ]);
-    frame.render_widget(Paragraph::new(line), hint_area);
+    ])
+    .right_aligned())
 }
 
 fn leaf_color_for_stage(stage: Stage) -> ratatui::style::Color {

--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -397,7 +397,7 @@ pub fn handle_byte(app: &mut App, byte: u8) -> bool {
             app.chat.start_composing();
             true
         }
-        b'c' | b'C' => {
+        b'C' => {
             if let Some(ref registry) = app.web_chat_registry {
                 let username = app.profile_state.profile().username.clone();
                 let base_url = app

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -1033,7 +1033,7 @@ fn build_room_list_rows(view: &ChatRenderInput<'_>, rooms_area: Rect) -> RoomLis
     push_row(section_divider("Mobile"), None, false);
     push_row(
         Line::from(vec![
-            Span::styled(" c", Style::default().fg(theme::AMBER_DIM())),
+            Span::styled(" C", Style::default().fg(theme::AMBER_DIM())),
             Span::styled(" open web chat", Style::default().fg(theme::TEXT_DIM())),
         ]),
         None,

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -140,7 +140,7 @@ pub fn chat_help_lines() -> Vec<String> {
         "  h / l  or  ← / →   previous / next room",
         "  Space              room jump hints",
         "  Enter / i          start composing",
-        "  c                  copy a web-chat link to this session",
+        "  C                  copy a web-chat link to this session",
         "",
         "Compose",
         "  Enter              send and exit",

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -1269,10 +1269,7 @@ fn handle_global_key(app: &mut App, ctx: InputContext, byte: u8) -> bool {
         return false;
     }
 
-    if ctx.screen == Screen::Games
-        && app.is_playing_game
-        && !matches!(byte, b'm' | b'M' | b'+' | b'=' | b'-' | b'_')
-    {
+    if ctx.screen == Screen::Games && app.is_playing_game {
         return false;
     }
 
@@ -1356,14 +1353,6 @@ fn handle_global_key(app: &mut App, ctx: InputContext, byte: u8) -> bool {
             app.show_settings = false;
             app.show_quit_confirm = false;
             app.show_bonsai_modal = true;
-            true
-        }
-        b's' | b'S' if !ctx.chat_composing && !ctx.news_composing => {
-            let snippet = app.bonsai_state.share_snippet();
-            app.pending_clipboard = Some(snippet);
-            app.banner = Some(crate::app::common::primitives::Banner::success(
-                "Bonsai copied to clipboard!",
-            ));
             true
         }
         b'1' if !artboard_blocks_page_switch => {

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -227,8 +227,8 @@ async fn active_artboard_ctrl_c_copies_without_quitting() {
     tokio::time::sleep(Duration::from_millis(60)).await;
     let frame = render_plain(&mut app);
     assert!(
-        frame.contains("Mode       active"),
-        "expected Ctrl+C to stay inside active artboard; frame={frame:?}"
+        frame.contains("Mode       swatch"),
+        "expected Ctrl+C to copy into the primary swatch and stay inside active artboard; frame={frame:?}"
     );
     assert!(
         !frame.contains(" Quit? "),

--- a/late-web/Cargo.toml
+++ b/late-web/Cargo.toml
@@ -14,6 +14,7 @@ otel = [
 
 [dependencies]
 late-core.workspace = true
+dartboard-core.workspace = true
 
 # Core Utils
 anyhow = { workspace = true }

--- a/late-web/src/lib.rs
+++ b/late-web/src/lib.rs
@@ -12,9 +12,10 @@ use axum::{
 use late_core::telemetry::http_telemetry_middleware;
 use tower_http::services::ServeDir;
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AppState {
     pub config: config::Config,
+    pub db: late_core::db::Db,
     pub http_client: reqwest::Client,
 }
 

--- a/late-web/src/main.rs
+++ b/late-web/src/main.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use anyhow::Context;
+use late_core::db::Db;
 use late_web::{AppState, app, config::Config};
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -16,11 +17,13 @@ async fn main() -> anyhow::Result<()> {
         .no_proxy()
         .build()
         .context("failed to build HTTP client")?;
+    let db = Db::from_env().context("failed to initialize database pool")?;
 
     let port = config.port;
 
     let state = AppState {
         config,
+        db,
         http_client,
     };
 

--- a/late-web/src/pages/connect/page.html
+++ b/late-web/src/pages/connect/page.html
@@ -484,6 +484,11 @@
     <div class="stagger stagger-4 mb-14 text-sm leading-loose">
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> lofi radio &amp; genre voting</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> the arcade <span class="text-gray-700">(2048, sudoku, nonograms, solitaire)</span></div>
+        <div class="text-gray-500">
+            <span class="text-gray-700">&#9500;&#9472;</span>
+            collaborative artboard
+            <a href="/gallery" class="text-green-700 hover:text-green-500 transition-colors">(browse the gallery &rarr;)</a>
+        </div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> daily challenges &amp; streaks</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> live chat</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> share &amp; discuss news</div>

--- a/late-web/src/pages/connect/page.html
+++ b/late-web/src/pages/connect/page.html
@@ -484,15 +484,34 @@
     <div class="stagger stagger-4 mb-14 text-sm leading-loose">
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> lofi radio &amp; genre voting</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> the arcade <span class="text-gray-700">(2048, sudoku, nonograms, solitaire)</span></div>
-        <div class="text-gray-500">
-            <span class="text-gray-700">&#9500;&#9472;</span>
-            collaborative artboard
-            <a href="/gallery" class="text-green-700 hover:text-green-500 transition-colors">(browse the gallery &rarr;)</a>
-        </div>
+        <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> collaborative artboard</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> daily challenges &amp; streaks</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> live chat</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> share &amp; discuss news</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9492;&#9472;</span> multiplayer games <span class="text-gray-700">(coming soon)</span></div>
+    </div>
+
+    <div class="stagger stagger-5 mb-4 text-xs leading-relaxed">
+        <div class="text-gray-600 mb-3"><span class="text-gray-700">#</span> artboard</div>
+        <div class="text-gray-500">a shared <span class="text-green-600">ASCII canvas</span>. paint, erase, sign your work.</div>
+        <div class="text-gray-500">each cell remembers who placed it.</div>
+        <div class="text-gray-600 mt-3">snapshots are saved daily and monthly,</div>
+        <div class="text-gray-600">so the history sticks around as the board keeps changing.</div>
+    </div>
+
+    <div class="stagger stagger-5 mb-14">
+        <a href="/gallery"
+            class="group block w-full text-left border border-gray-700 hover:border-green-900 px-5 py-4 transition-colors duration-200 bg-gray-900/40">
+            <div class="flex items-center justify-between gap-4">
+                <span class="text-lg min-w-0 truncate">
+                    <span class="text-gray-100">/gallery</span>
+                </span>
+                <span class="shrink-0 text-xs text-gray-700 group-hover:text-green-600 transition-colors">browse &rarr;</span>
+            </div>
+            <div class="mt-2 text-xs text-gray-600">
+                full-screen viewer with pan, zoom, and per-cell author info
+            </div>
+        </a>
     </div>
 
     <div class="stagger stagger-5 mb-14 text-xs leading-relaxed">

--- a/late-web/src/pages/gallery/mod.rs
+++ b/late-web/src/pages/gallery/mod.rs
@@ -1,0 +1,302 @@
+use std::collections::{BTreeSet, HashMap};
+
+use anyhow::Context;
+use askama::Template;
+use axum::{
+    Router,
+    extract::{Query, State},
+    response::{Html, IntoResponse},
+    routing::get,
+};
+use dartboard_core::{Canvas, CellValue, Pos};
+use late_core::models::artboard::Snapshot;
+use serde::{Deserialize, Serialize};
+
+use crate::{AppState, error::AppError, metrics};
+
+const DAILY_PREFIX: &str = "daily:";
+const MONTHLY_PREFIX: &str = "monthly:";
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/gallery", get(handler))
+}
+
+#[derive(Deserialize)]
+struct GalleryQuery {
+    key: Option<String>,
+}
+
+#[derive(Template)]
+#[template(path = "pages/gallery/page.html")]
+struct Page {
+    live_items: Vec<SnapshotNavItem>,
+    daily_items: Vec<SnapshotNavItem>,
+    monthly_items: Vec<SnapshotNavItem>,
+    show_live_empty: bool,
+    show_daily_empty: bool,
+    show_monthly_empty: bool,
+    has_selected: bool,
+    selected_title: String,
+    selected_updated: String,
+    selected_cell_count: usize,
+    selected_author_count: usize,
+    snapshot_json: String,
+}
+
+#[derive(Debug)]
+struct SnapshotNavItem {
+    key: String,
+    label: String,
+    meta: String,
+    active: bool,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GalleryProvenance {
+    cells: Vec<(Pos, String)>,
+}
+
+#[derive(Serialize)]
+struct GallerySnapshotData {
+    key: String,
+    width: usize,
+    height: usize,
+    cells: Vec<GalleryCell>,
+    authors: Vec<GalleryAuthor>,
+}
+
+#[derive(Serialize)]
+struct GalleryCell {
+    x: usize,
+    y: usize,
+    ch: String,
+    width: usize,
+    fg: Option<String>,
+    author: Option<String>,
+}
+
+#[derive(Serialize)]
+struct GalleryAuthor {
+    x: usize,
+    y: usize,
+    username: String,
+}
+
+#[tracing::instrument(skip_all)]
+async fn handler(
+    State(state): State<AppState>,
+    Query(query): Query<GalleryQuery>,
+) -> Result<impl IntoResponse, AppError> {
+    metrics::record_page_view("gallery", false);
+
+    let client = state
+        .db
+        .get()
+        .await
+        .context("failed to get db client for gallery")?;
+    let live = Snapshot::find_by_board_key(&client, Snapshot::MAIN_BOARD_KEY)
+        .await
+        .context("failed to load live artboard snapshot")?;
+    let daily = Snapshot::list_by_board_key_prefix(&client, DAILY_PREFIX)
+        .await
+        .context("failed to load daily artboard snapshots")?;
+    let monthly = Snapshot::list_by_board_key_prefix(&client, MONTHLY_PREFIX)
+        .await
+        .context("failed to load monthly artboard snapshots")?;
+
+    let requested_key = query.key;
+    let default_key = live
+        .as_ref()
+        .map(|snapshot| snapshot.board_key.clone())
+        .or_else(|| daily.first().map(|snapshot| snapshot.board_key.clone()))
+        .or_else(|| monthly.first().map(|snapshot| snapshot.board_key.clone()));
+    let selected_key = requested_key.or(default_key);
+    let selected = match selected_key.as_deref() {
+        Some(key) => Snapshot::find_by_board_key(&client, key)
+            .await
+            .with_context(|| format!("failed to load artboard snapshot {key}"))?,
+        None => None,
+    };
+
+    let live_items: Vec<SnapshotNavItem> = live
+        .iter()
+        .map(|snapshot| nav_item(snapshot, selected_key.as_deref()))
+        .collect();
+    let daily_items: Vec<SnapshotNavItem> = daily
+        .iter()
+        .map(|snapshot| nav_item(snapshot, selected_key.as_deref()))
+        .collect();
+    let monthly_items: Vec<SnapshotNavItem> = monthly
+        .iter()
+        .map(|snapshot| nav_item(snapshot, selected_key.as_deref()))
+        .collect();
+
+    let show_live_empty = live_items.is_empty();
+    let show_daily_empty = daily_items.is_empty();
+    let show_monthly_empty = monthly_items.is_empty();
+    let mut page = Page {
+        live_items,
+        daily_items,
+        monthly_items,
+        show_live_empty,
+        show_daily_empty,
+        show_monthly_empty,
+        has_selected: false,
+        selected_title: "No snapshot selected".to_string(),
+        selected_updated: String::new(),
+        selected_cell_count: 0,
+        selected_author_count: 0,
+        snapshot_json: "null".to_string(),
+    };
+
+    if let Some(snapshot) = selected {
+        let selected = build_selected_snapshot(snapshot)?;
+        page.has_selected = true;
+        page.selected_title = selected.title;
+        page.selected_updated = selected.updated;
+        page.selected_cell_count = selected.cell_count;
+        page.selected_author_count = selected.author_count;
+        page.snapshot_json = selected.snapshot_json;
+    }
+
+    Ok(Html(page.render()?))
+}
+
+struct SelectedSnapshot {
+    title: String,
+    updated: String,
+    cell_count: usize,
+    author_count: usize,
+    snapshot_json: String,
+}
+
+fn build_selected_snapshot(snapshot: Snapshot) -> anyhow::Result<SelectedSnapshot> {
+    let canvas: Canvas =
+        serde_json::from_value(snapshot.canvas).context("failed to decode artboard canvas")?;
+    let provenance: GalleryProvenance = serde_json::from_value(snapshot.provenance)
+        .context("failed to decode artboard provenance")?;
+    let data = snapshot_data(&snapshot.board_key, &canvas, &provenance);
+    let cell_count = data.cells.len();
+    let author_count = data
+        .authors
+        .iter()
+        .map(|author| author.username.as_str())
+        .collect::<BTreeSet<_>>()
+        .len();
+    let snapshot_json = serde_json::to_string(&data)
+        .context("failed to serialize gallery snapshot data")?
+        .replace("</", "<\\/");
+
+    Ok(SelectedSnapshot {
+        title: snapshot_title(&snapshot.board_key),
+        updated: snapshot.updated.format("%Y-%m-%d %H:%M UTC").to_string(),
+        cell_count,
+        author_count,
+        snapshot_json,
+    })
+}
+
+fn snapshot_data(
+    board_key: &str,
+    canvas: &Canvas,
+    provenance: &GalleryProvenance,
+) -> GallerySnapshotData {
+    let authors = provenance.author_map();
+    let mut cells = Vec::new();
+    for (pos, cell) in canvas.iter() {
+        let ch = match cell {
+            CellValue::Narrow(ch) | CellValue::Wide(ch) => *ch,
+            CellValue::WideCont => continue,
+        };
+        let Some(glyph) = canvas.glyph_at(*pos) else {
+            continue;
+        };
+        cells.push(GalleryCell {
+            x: pos.x,
+            y: pos.y,
+            ch: ch.to_string(),
+            width: glyph.width,
+            fg: glyph.fg.map(rgb_hex),
+            author: authors.get(pos).cloned(),
+        });
+    }
+    cells.sort_by_key(|cell| (cell.y, cell.x));
+
+    let mut authors: Vec<_> = authors
+        .into_iter()
+        .map(|(pos, username)| GalleryAuthor {
+            x: pos.x,
+            y: pos.y,
+            username,
+        })
+        .collect();
+    authors.sort_by_key(|author| (author.y, author.x));
+
+    GallerySnapshotData {
+        key: board_key.to_string(),
+        width: canvas.width,
+        height: canvas.height,
+        cells,
+        authors,
+    }
+}
+
+impl GalleryProvenance {
+    fn author_map(&self) -> HashMap<Pos, String> {
+        self.cells.iter().cloned().collect()
+    }
+}
+
+fn nav_item(snapshot: &Snapshot, selected_key: Option<&str>) -> SnapshotNavItem {
+    SnapshotNavItem {
+        key: snapshot.board_key.clone(),
+        label: snapshot_label(&snapshot.board_key),
+        meta: snapshot.updated.format("%Y-%m-%d %H:%M UTC").to_string(),
+        active: Some(snapshot.board_key.as_str()) == selected_key,
+    }
+}
+
+fn snapshot_title(key: &str) -> String {
+    match key {
+        Snapshot::MAIN_BOARD_KEY => "Live / latest saved".to_string(),
+        _ if key.starts_with(DAILY_PREFIX) => {
+            format!("Daily {}", key.trim_start_matches(DAILY_PREFIX))
+        }
+        _ if key.starts_with(MONTHLY_PREFIX) => {
+            format!("Monthly {}", key.trim_start_matches(MONTHLY_PREFIX))
+        }
+        _ => key.to_string(),
+    }
+}
+
+fn snapshot_label(key: &str) -> String {
+    match key {
+        Snapshot::MAIN_BOARD_KEY => "Live".to_string(),
+        _ if key.starts_with(DAILY_PREFIX) => key.trim_start_matches(DAILY_PREFIX).to_string(),
+        _ if key.starts_with(MONTHLY_PREFIX) => key.trim_start_matches(MONTHLY_PREFIX).to_string(),
+        _ => key.to_string(),
+    }
+}
+
+fn rgb_hex(color: dartboard_core::RgbColor) -> String {
+    format!("#{:02X}{:02X}{:02X}", color.r, color.g, color.b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{snapshot_label, snapshot_title};
+
+    #[test]
+    fn snapshot_labels_are_human_readable() {
+        assert_eq!(snapshot_label("main"), "Live");
+        assert_eq!(snapshot_label("daily:2026-04-24"), "2026-04-24");
+        assert_eq!(snapshot_label("monthly:2026-04"), "2026-04");
+    }
+
+    #[test]
+    fn snapshot_titles_include_kind() {
+        assert_eq!(snapshot_title("main"), "Live / latest saved");
+        assert_eq!(snapshot_title("daily:2026-04-24"), "Daily 2026-04-24");
+        assert_eq!(snapshot_title("monthly:2026-04"), "Monthly 2026-04");
+    }
+}

--- a/late-web/src/pages/gallery/page.html
+++ b/late-web/src/pages/gallery/page.html
@@ -12,7 +12,7 @@
     .gal-root {
         position: fixed;
         inset: 0;
-        background: #020617;
+        background: #030712;
         color: #e5e7eb;
         display: flex;
         flex-direction: column;
@@ -25,14 +25,14 @@
         align-items: center;
         gap: 0.75rem;
         padding: 0.55rem 0.9rem;
-        border-bottom: 1px solid #0f172a;
-        background: #050b18;
+        border-bottom: 1px solid #1f2937;
+        background: #111827;
         flex-shrink: 0;
         font-size: 0.8rem;
     }
 
     .gal-topbar a { color: inherit; text-decoration: none; }
-    .gal-topbar .crumb-sep { color: #1f2937; }
+    .gal-topbar .crumb-sep { color: #374151; }
     .gal-topbar .meta { margin-left: auto; color: #4b5563; font-size: 0.7rem; }
 
     .gal-body {
@@ -40,14 +40,14 @@
         flex: 1;
         min-height: 0;
         display: flex;
-        background: #020617;
+        background: #030712;
     }
 
     .gal-side {
         width: 16rem;
         flex-shrink: 0;
-        border-right: 1px solid #0f172a;
-        background: #050b18;
+        border-right: 1px solid #1f2937;
+        background: #111827;
         overflow: hidden auto;
         transition: width 0.18s ease;
     }
@@ -84,10 +84,11 @@
         border-color: #1f2937;
     }
     .snap-link.active {
-        color: #f9fafb;
-        border-color: #065f46;
-        background: #052e26;
+        color: #22c55e;
+        border-color: #14532d;
+        background: rgba(20, 83, 45, 0.22);
     }
+    .snap-link.active .snap-meta { color: #15803d; }
     .snap-meta {
         display: block;
         margin-top: 0.15rem;
@@ -104,7 +105,7 @@
         flex: 1;
         position: relative;
         overflow: hidden;
-        background-color: #020617;
+        background-color: #030712;
         background-image:
             linear-gradient(rgba(31, 41, 55, 0.35) 1px, transparent 1px),
             linear-gradient(90deg, rgba(31, 41, 55, 0.35) 1px, transparent 1px);
@@ -127,11 +128,11 @@
     #gallery-canvas {
         display: block;
         image-rendering: pixelated;
-        background: #030712;
+        background: #111827;
         box-shadow:
             0 0 0 1px #1f2937,
             0 30px 80px -20px rgba(0, 0, 0, 0.85),
-            0 0 60px -10px rgba(16, 185, 129, 0.08);
+            0 0 60px -10px rgba(34, 197, 94, 0.06);
     }
 
     .gal-toolbar {
@@ -149,7 +150,7 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        background: rgba(11, 19, 34, 0.85);
+        background: rgba(17, 24, 39, 0.85);
         border: 1px solid #1f2937;
         color: #9ca3af;
         cursor: pointer;
@@ -159,8 +160,8 @@
         transition: color 0.15s ease, border-color 0.15s ease;
     }
     .gal-btn:hover {
-        color: #d1fae5;
-        border-color: #065f46;
+        color: #22c55e;
+        border-color: #14532d;
     }
     .gal-btn svg { width: 14px; height: 14px; }
 
@@ -170,10 +171,10 @@
         bottom: 0.85rem;
         font-size: 0.72rem;
         color: #6b7280;
-        background: rgba(2, 6, 23, 0.7);
+        background: rgba(17, 24, 39, 0.7);
         backdrop-filter: blur(4px);
         padding: 0.35rem 0.65rem;
-        border: 1px solid #0f172a;
+        border: 1px solid #1f2937;
         z-index: 4;
         pointer-events: none;
         max-width: calc(100% - 5rem);
@@ -184,10 +185,10 @@
         top: 0.85rem;
         font-size: 0.7rem;
         color: #6b7280;
-        background: rgba(2, 6, 23, 0.7);
+        background: rgba(17, 24, 39, 0.7);
         backdrop-filter: blur(4px);
         padding: 0.25rem 0.55rem;
-        border: 1px solid #0f172a;
+        border: 1px solid #1f2937;
         z-index: 4;
         pointer-events: none;
     }
@@ -394,7 +395,7 @@
                 c.style.height = c.height + 'px';
 
                 const ctx = this.ctx;
-                ctx.fillStyle = '#030712';
+                ctx.fillStyle = '#111827';
                 ctx.fillRect(0, 0, c.width, c.height);
                 ctx.font = this.fontSize + 'px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace';
                 ctx.textBaseline = 'top';

--- a/late-web/src/pages/gallery/page.html
+++ b/late-web/src/pages/gallery/page.html
@@ -1,0 +1,201 @@
+{% extends "pages/app.html" %}
+
+{% block title %}Artboard Gallery - late.sh{% endblock %}
+
+{% block content %}
+<style>
+    .gallery-shell {
+        max-width: 92rem;
+        margin: 0 auto;
+        display: grid;
+        grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr);
+        gap: 1rem;
+    }
+
+    .gallery-panel {
+        background: #111827;
+        border: 1px solid #1f2937;
+    }
+
+    .snapshot-link {
+        display: block;
+        padding: 0.55rem 0.7rem;
+        border: 1px solid transparent;
+        color: #9ca3af;
+        text-decoration: none;
+    }
+
+    .snapshot-link:hover,
+    .snapshot-link.active {
+        color: #f9fafb;
+        border-color: #065f46;
+        background: #052e26;
+    }
+
+    .snapshot-meta {
+        display: block;
+        margin-top: 0.15rem;
+        color: #6b7280;
+        font-size: 0.7rem;
+    }
+
+    .gallery-canvas-wrap {
+        overflow: auto;
+        background: #030712;
+        border: 1px solid #1f2937;
+        max-height: 72vh;
+    }
+
+    #gallery-canvas {
+        display: block;
+        image-rendering: pixelated;
+    }
+
+    @media (max-width: 900px) {
+        .gallery-shell {
+            grid-template-columns: 1fr;
+        }
+    }
+</style>
+
+<div class="gallery-shell">
+    <aside class="gallery-panel p-4">
+        <div class="mb-5">
+            <h1 class="text-xl text-white font-semibold">Artboard Gallery</h1>
+            <p class="mt-1 text-xs text-gray-500">saved snapshots only</p>
+        </div>
+
+        <section class="mb-5">
+            <h2 class="mb-2 text-xs uppercase tracking-wide text-gray-500">Live</h2>
+            {% if show_live_empty %}
+            <div class="text-sm text-gray-600">not saved yet</div>
+            {% endif %}
+            {% for item in live_items %}
+            <a class="snapshot-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
+                {{ item.label }}
+                <span class="snapshot-meta">{{ item.meta }}</span>
+            </a>
+            {% endfor %}
+        </section>
+
+        <section class="mb-5">
+            <h2 class="mb-2 text-xs uppercase tracking-wide text-gray-500">Daily</h2>
+            {% if show_daily_empty %}
+            <div class="text-sm text-gray-600">none yet</div>
+            {% endif %}
+            {% for item in daily_items %}
+            <a class="snapshot-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
+                {{ item.label }}
+                <span class="snapshot-meta">{{ item.meta }}</span>
+            </a>
+            {% endfor %}
+        </section>
+
+        <section>
+            <h2 class="mb-2 text-xs uppercase tracking-wide text-gray-500">Monthly</h2>
+            {% if show_monthly_empty %}
+            <div class="text-sm text-gray-600">none yet</div>
+            {% endif %}
+            {% for item in monthly_items %}
+            <a class="snapshot-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
+                {{ item.label }}
+                <span class="snapshot-meta">{{ item.meta }}</span>
+            </a>
+            {% endfor %}
+        </section>
+    </aside>
+
+    <section class="min-w-0">
+        {% if has_selected %}
+        <div class="mb-3 flex flex-wrap items-end justify-between gap-3">
+            <div>
+                <h2 class="text-2xl text-white font-semibold">{{ selected_title }}</h2>
+                <div class="mt-1 text-xs text-gray-500">
+                    saved {{ selected_updated }} · {{ selected_cell_count }} cells · {{ selected_author_count }} authors
+                </div>
+            </div>
+            <div id="gallery-cell-status" class="text-sm text-gray-400">move over the board</div>
+        </div>
+
+        <div class="gallery-canvas-wrap">
+            <canvas id="gallery-canvas" aria-label="{{ selected_title }}"></canvas>
+        </div>
+
+        <script id="snapshot-data" type="application/json">{{ snapshot_json|safe }}</script>
+        <script>
+            (() => {
+                const dataEl = document.getElementById('snapshot-data');
+                const canvas = document.getElementById('gallery-canvas');
+                const status = document.getElementById('gallery-cell-status');
+                if (!dataEl || !canvas || !status) return;
+
+                const snapshot = JSON.parse(dataEl.textContent);
+                const ctx = canvas.getContext('2d');
+                const cellW = 8;
+                const cellH = 16;
+                const fontSize = 14;
+                const keyFor = (x, y) => `${x},${y}`;
+                const glyphs = new Map();
+                const authors = new Map();
+
+                for (const author of snapshot.authors) {
+                    authors.set(keyFor(author.x, author.y), author.username);
+                }
+                for (const cell of snapshot.cells) {
+                    glyphs.set(keyFor(cell.x, cell.y), cell);
+                    if (cell.width === 2 && cell.x + 1 < snapshot.width) {
+                        glyphs.set(keyFor(cell.x + 1, cell.y), cell);
+                        if (cell.author) authors.set(keyFor(cell.x + 1, cell.y), cell.author);
+                    }
+                    if (cell.author) authors.set(keyFor(cell.x, cell.y), cell.author);
+                }
+
+                function renderSnapshot() {
+                    canvas.width = snapshot.width * cellW;
+                    canvas.height = snapshot.height * cellH;
+                    canvas.style.width = `${canvas.width}px`;
+                    canvas.style.height = `${canvas.height}px`;
+
+                    ctx.fillStyle = '#030712';
+                    ctx.fillRect(0, 0, canvas.width, canvas.height);
+                    ctx.font = `${fontSize}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace`;
+                    ctx.textBaseline = 'top';
+
+                    for (const cell of snapshot.cells) {
+                        ctx.fillStyle = cell.fg || '#d1d5db';
+                        ctx.fillText(cell.ch, cell.x * cellW, cell.y * cellH);
+                    }
+                }
+
+                function updateStatus(event) {
+                    const rect = canvas.getBoundingClientRect();
+                    const x = Math.floor((event.clientX - rect.left) * snapshot.width / rect.width);
+                    const y = Math.floor((event.clientY - rect.top) * snapshot.height / rect.height);
+                    if (x < 0 || y < 0 || x >= snapshot.width || y >= snapshot.height) {
+                        status.textContent = 'move over the board';
+                        return;
+                    }
+
+                    const key = keyFor(x, y);
+                    const glyph = glyphs.get(key);
+                    const author = (glyph && glyph.author) || authors.get(key);
+                    const cellText = glyph ? `cell "${glyph.ch}"` : 'empty cell';
+                    const authorText = author ? `by ${author}` : 'unknown author';
+                    status.textContent = `${x},${y} · ${cellText} · ${authorText}`;
+                }
+
+                renderSnapshot();
+                canvas.addEventListener('mousemove', updateStatus);
+                canvas.addEventListener('mouseleave', () => {
+                    status.textContent = 'move over the board';
+                });
+            })();
+        </script>
+        {% else %}
+        <div class="gallery-panel p-8 text-gray-500">
+            No saved artboard snapshots are available yet.
+        </div>
+        {% endif %}
+    </section>
+</div>
+{% endblock %}

--- a/late-web/src/pages/gallery/page.html
+++ b/late-web/src/pages/gallery/page.html
@@ -4,7 +4,8 @@
 
 {% block content %}
 <style>
-    html, body {
+    html,
+    body {
         overflow: hidden !important;
         overscroll-behavior: none;
     }
@@ -31,9 +32,20 @@
         font-size: 0.8rem;
     }
 
-    .gal-topbar a { color: inherit; text-decoration: none; }
-    .gal-topbar .crumb-sep { color: #374151; }
-    .gal-topbar .meta { margin-left: auto; color: #4b5563; font-size: 0.7rem; }
+    .gal-topbar a {
+        color: inherit;
+        text-decoration: none;
+    }
+
+    .gal-topbar .crumb-sep {
+        color: #374151;
+    }
+
+    .gal-topbar .meta {
+        margin-left: auto;
+        color: #4b5563;
+        font-size: 0.7rem;
+    }
 
     .gal-body {
         position: relative;
@@ -51,10 +63,12 @@
         overflow: hidden auto;
         transition: width 0.18s ease;
     }
+
     .gal-side.collapsed {
         width: 0;
         border-right-width: 0;
     }
+
     .gal-side-inner {
         width: 16rem;
         padding: 1rem 0.85rem;
@@ -67,7 +81,10 @@
         text-transform: uppercase;
         color: #4b5563;
     }
-    .gal-side section + section { margin-top: 1.1rem; }
+
+    .gal-side section+section {
+        margin-top: 1.1rem;
+    }
 
     .snap-link {
         display: block;
@@ -79,22 +96,29 @@
         font-size: 0.78rem;
         line-height: 1.2;
     }
+
     .snap-link:hover {
         color: #e5e7eb;
         border-color: #1f2937;
     }
+
     .snap-link.active {
         color: #22c55e;
         border-color: #14532d;
         background: rgba(20, 83, 45, 0.22);
     }
-    .snap-link.active .snap-meta { color: #15803d; }
+
+    .snap-link.active .snap-meta {
+        color: #15803d;
+    }
+
     .snap-meta {
         display: block;
         margin-top: 0.15rem;
         color: #4b5563;
         font-size: 0.65rem;
     }
+
     .snap-empty {
         font-size: 0.72rem;
         color: #4b5563;
@@ -114,8 +138,14 @@
         user-select: none;
         touch-action: none;
     }
-    .gal-stage.is-panning { cursor: grabbing; }
-    .gal-stage.is-empty { cursor: default; }
+
+    .gal-stage.is-panning {
+        cursor: grabbing;
+    }
+
+    .gal-stage.is-empty {
+        cursor: default;
+    }
 
     .gal-frame {
         position: absolute;
@@ -144,6 +174,7 @@
         gap: 0.25rem;
         z-index: 4;
     }
+
     .gal-btn {
         width: 2.1rem;
         height: 2.1rem;
@@ -159,11 +190,16 @@
         backdrop-filter: blur(4px);
         transition: color 0.15s ease, border-color 0.15s ease;
     }
+
     .gal-btn:hover {
         color: #22c55e;
         border-color: #14532d;
     }
-    .gal-btn svg { width: 14px; height: 14px; }
+
+    .gal-btn svg {
+        width: 14px;
+        height: 14px;
+    }
 
     .gal-status {
         position: absolute;
@@ -179,6 +215,7 @@
         pointer-events: none;
         max-width: calc(100% - 5rem);
     }
+
     .gal-zoom {
         position: absolute;
         right: 0.85rem;
@@ -210,24 +247,20 @@
             z-index: 6;
             box-shadow: 0 0 40px rgba(0, 0, 0, 0.6);
         }
-        .gal-status { font-size: 0.65rem; }
+
+        .gal-status {
+            font-size: 0.65rem;
+        }
     }
 </style>
 
-<div class="gal-root"
-     x-data="gallery()"
-     x-init="init()"
-     @keydown.window="onKey($event)">
+<div class="gal-root" x-data="gallery()" x-init="init()" @keydown.window="onKey($event)">
 
     <header class="gal-topbar">
-        <button type="button"
-                class="gal-btn"
-                style="width: 1.9rem; height: 1.9rem;"
-                @click="sidebarHidden = !sidebarHidden"
-                aria-label="toggle snapshots panel"
-                title="toggle list (s)">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                 stroke-linecap="round" stroke-linejoin="round">
+        <button type="button" class="gal-btn" style="width: 1.9rem; height: 1.9rem;"
+            @click="sidebarHidden = !sidebarHidden" aria-label="toggle snapshots panel" title="toggle list (s)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                stroke-linejoin="round">
                 <line x1="4" y1="6" x2="20" y2="6"></line>
                 <line x1="4" y1="12" x2="20" y2="12"></line>
                 <line x1="4" y1="18" x2="20" y2="18"></line>
@@ -291,14 +324,9 @@
             </div>
         </aside>
 
-        <div class="gal-stage"
-             :class="[panning && 'is-panning', !hasSelected && 'is-empty']"
-             x-ref="stage"
-             @mousedown="onMouseDown($event)"
-             @mousemove="onMouseMove($event)"
-             @mouseleave="onMouseLeave()"
-             @wheel.prevent="onWheel($event)"
-             @dblclick="fitToView()">
+        <div class="gal-stage" :class="[panning && 'is-panning', !hasSelected && 'is-empty']" x-ref="stage"
+            @mousedown="onMouseDown($event)" @mousemove="onMouseMove($event)" @mouseleave="onMouseLeave()"
+            @wheel.prevent="onWheel($event)" @dblclick="fitToView()">
 
             {% if has_selected %}
             <div class="gal-frame" x-ref="frame">
@@ -313,8 +341,8 @@
                 <button type="button" class="gal-btn" @click="zoomBy(0.8)" title="zoom out (-)">-</button>
                 <button type="button" class="gal-btn" @click="actualSize()" title="100% (1)">1:1</button>
                 <button type="button" class="gal-btn" @click="fitToView()" title="fit (f / dbl-click)">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
-                         stroke-linecap="round" stroke-linejoin="round">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                        stroke-linejoin="round">
                         <polyline points="4 9 4 4 9 4"></polyline>
                         <polyline points="20 9 20 4 15 4"></polyline>
                         <polyline points="20 15 20 20 15 20"></polyline>
@@ -385,7 +413,7 @@
                 window.addEventListener('resize', this._onResize);
             },
 
-            keyFor(x, y) { return x + ',' + y; },
+            keyFor(x, y) {return x + ',' + y;},
 
             renderSnapshot() {
                 const c = this.canvas;
@@ -481,7 +509,7 @@
                 this.statusText = this.defaultStatus;
             },
 
-            endPan() { this.panning = false; },
+            endPan() {this.panning = false;},
 
             onWheel(e) {
                 const rect = this.stageRect();

--- a/late-web/src/pages/gallery/page.html
+++ b/late-web/src/pages/gallery/page.html
@@ -4,198 +4,521 @@
 
 {% block content %}
 <style>
-    .gallery-shell {
-        max-width: 92rem;
-        margin: 0 auto;
-        display: grid;
-        grid-template-columns: minmax(14rem, 18rem) minmax(0, 1fr);
-        gap: 1rem;
+    html, body {
+        overflow: hidden !important;
+        overscroll-behavior: none;
     }
 
-    .gallery-panel {
-        background: #111827;
-        border: 1px solid #1f2937;
+    .gal-root {
+        position: fixed;
+        inset: 0;
+        background: #020617;
+        color: #e5e7eb;
+        display: flex;
+        flex-direction: column;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+        z-index: 1;
     }
 
-    .snapshot-link {
+    .gal-topbar {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        padding: 0.55rem 0.9rem;
+        border-bottom: 1px solid #0f172a;
+        background: #050b18;
+        flex-shrink: 0;
+        font-size: 0.8rem;
+    }
+
+    .gal-topbar a { color: inherit; text-decoration: none; }
+    .gal-topbar .crumb-sep { color: #1f2937; }
+    .gal-topbar .meta { margin-left: auto; color: #4b5563; font-size: 0.7rem; }
+
+    .gal-body {
+        position: relative;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        background: #020617;
+    }
+
+    .gal-side {
+        width: 16rem;
+        flex-shrink: 0;
+        border-right: 1px solid #0f172a;
+        background: #050b18;
+        overflow: hidden auto;
+        transition: width 0.18s ease;
+    }
+    .gal-side.collapsed {
+        width: 0;
+        border-right-width: 0;
+    }
+    .gal-side-inner {
+        width: 16rem;
+        padding: 1rem 0.85rem;
+    }
+
+    .gal-side h2 {
+        margin: 0 0 0.4rem;
+        font-size: 0.62rem;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #4b5563;
+    }
+    .gal-side section + section { margin-top: 1.1rem; }
+
+    .snap-link {
         display: block;
-        padding: 0.55rem 0.7rem;
+        padding: 0.4rem 0.55rem;
+        margin: 0.15rem 0;
         border: 1px solid transparent;
         color: #9ca3af;
         text-decoration: none;
+        font-size: 0.78rem;
+        line-height: 1.2;
     }
-
-    .snapshot-link:hover,
-    .snapshot-link.active {
+    .snap-link:hover {
+        color: #e5e7eb;
+        border-color: #1f2937;
+    }
+    .snap-link.active {
         color: #f9fafb;
         border-color: #065f46;
         background: #052e26;
     }
-
-    .snapshot-meta {
+    .snap-meta {
         display: block;
         margin-top: 0.15rem;
-        color: #6b7280;
-        font-size: 0.7rem;
+        color: #4b5563;
+        font-size: 0.65rem;
+    }
+    .snap-empty {
+        font-size: 0.72rem;
+        color: #4b5563;
+        padding: 0.25rem 0.55rem;
     }
 
-    .gallery-canvas-wrap {
-        overflow: auto;
-        background: #030712;
-        border: 1px solid #1f2937;
-        max-height: 72vh;
+    .gal-stage {
+        flex: 1;
+        position: relative;
+        overflow: hidden;
+        background-color: #020617;
+        background-image:
+            linear-gradient(rgba(31, 41, 55, 0.35) 1px, transparent 1px),
+            linear-gradient(90deg, rgba(31, 41, 55, 0.35) 1px, transparent 1px);
+        background-size: 32px 32px;
+        cursor: grab;
+        user-select: none;
+        touch-action: none;
+    }
+    .gal-stage.is-panning { cursor: grabbing; }
+    .gal-stage.is-empty { cursor: default; }
+
+    .gal-frame {
+        position: absolute;
+        top: 0;
+        left: 0;
+        transform-origin: 0 0;
+        will-change: transform;
     }
 
     #gallery-canvas {
         display: block;
         image-rendering: pixelated;
+        background: #030712;
+        box-shadow:
+            0 0 0 1px #1f2937,
+            0 30px 80px -20px rgba(0, 0, 0, 0.85),
+            0 0 60px -10px rgba(16, 185, 129, 0.08);
     }
 
-    @media (max-width: 900px) {
-        .gallery-shell {
-            grid-template-columns: 1fr;
+    .gal-toolbar {
+        position: absolute;
+        right: 0.85rem;
+        bottom: 0.85rem;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        z-index: 4;
+    }
+    .gal-btn {
+        width: 2.1rem;
+        height: 2.1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: rgba(11, 19, 34, 0.85);
+        border: 1px solid #1f2937;
+        color: #9ca3af;
+        cursor: pointer;
+        font-family: inherit;
+        font-size: 0.85rem;
+        backdrop-filter: blur(4px);
+        transition: color 0.15s ease, border-color 0.15s ease;
+    }
+    .gal-btn:hover {
+        color: #d1fae5;
+        border-color: #065f46;
+    }
+    .gal-btn svg { width: 14px; height: 14px; }
+
+    .gal-status {
+        position: absolute;
+        left: 0.85rem;
+        bottom: 0.85rem;
+        font-size: 0.72rem;
+        color: #6b7280;
+        background: rgba(2, 6, 23, 0.7);
+        backdrop-filter: blur(4px);
+        padding: 0.35rem 0.65rem;
+        border: 1px solid #0f172a;
+        z-index: 4;
+        pointer-events: none;
+        max-width: calc(100% - 5rem);
+    }
+    .gal-zoom {
+        position: absolute;
+        right: 0.85rem;
+        top: 0.85rem;
+        font-size: 0.7rem;
+        color: #6b7280;
+        background: rgba(2, 6, 23, 0.7);
+        backdrop-filter: blur(4px);
+        padding: 0.25rem 0.55rem;
+        border: 1px solid #0f172a;
+        z-index: 4;
+        pointer-events: none;
+    }
+
+    .gal-empty {
+        position: absolute;
+        inset: 0;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: #4b5563;
+        font-size: 0.85rem;
+    }
+
+    @media (max-width: 768px) {
+        .gal-side {
+            position: absolute;
+            inset: 0 auto 0 0;
+            z-index: 6;
+            box-shadow: 0 0 40px rgba(0, 0, 0, 0.6);
         }
+        .gal-status { font-size: 0.65rem; }
     }
 </style>
 
-<div class="gallery-shell">
-    <aside class="gallery-panel p-4">
-        <div class="mb-5">
-            <h1 class="text-xl text-white font-semibold">Artboard Gallery</h1>
-            <p class="mt-1 text-xs text-gray-500">saved snapshots only</p>
-        </div>
+<div class="gal-root"
+     x-data="gallery()"
+     x-init="init()"
+     @keydown.window="onKey($event)">
 
-        <section class="mb-5">
-            <h2 class="mb-2 text-xs uppercase tracking-wide text-gray-500">Live</h2>
-            {% if show_live_empty %}
-            <div class="text-sm text-gray-600">not saved yet</div>
-            {% endif %}
-            {% for item in live_items %}
-            <a class="snapshot-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
-                {{ item.label }}
-                <span class="snapshot-meta">{{ item.meta }}</span>
-            </a>
-            {% endfor %}
-        </section>
-
-        <section class="mb-5">
-            <h2 class="mb-2 text-xs uppercase tracking-wide text-gray-500">Daily</h2>
-            {% if show_daily_empty %}
-            <div class="text-sm text-gray-600">none yet</div>
-            {% endif %}
-            {% for item in daily_items %}
-            <a class="snapshot-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
-                {{ item.label }}
-                <span class="snapshot-meta">{{ item.meta }}</span>
-            </a>
-            {% endfor %}
-        </section>
-
-        <section>
-            <h2 class="mb-2 text-xs uppercase tracking-wide text-gray-500">Monthly</h2>
-            {% if show_monthly_empty %}
-            <div class="text-sm text-gray-600">none yet</div>
-            {% endif %}
-            {% for item in monthly_items %}
-            <a class="snapshot-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
-                {{ item.label }}
-                <span class="snapshot-meta">{{ item.meta }}</span>
-            </a>
-            {% endfor %}
-        </section>
-    </aside>
-
-    <section class="min-w-0">
+    <header class="gal-topbar">
+        <button type="button"
+                class="gal-btn"
+                style="width: 1.9rem; height: 1.9rem;"
+                @click="sidebarHidden = !sidebarHidden"
+                aria-label="toggle snapshots panel"
+                title="toggle list (s)">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                 stroke-linecap="round" stroke-linejoin="round">
+                <line x1="4" y1="6" x2="20" y2="6"></line>
+                <line x1="4" y1="12" x2="20" y2="12"></line>
+                <line x1="4" y1="18" x2="20" y2="18"></line>
+            </svg>
+        </button>
+        <a href="/" class="text-green-500 tracking-tight">late.sh</a>
+        <span class="crumb-sep">/</span>
+        <span class="text-gray-400">gallery</span>
         {% if has_selected %}
-        <div class="mb-3 flex flex-wrap items-end justify-between gap-3">
-            <div>
-                <h2 class="text-2xl text-white font-semibold">{{ selected_title }}</h2>
-                <div class="mt-1 text-xs text-gray-500">
-                    saved {{ selected_updated }} · {{ selected_cell_count }} cells · {{ selected_author_count }} authors
-                </div>
-            </div>
-            <div id="gallery-cell-status" class="text-sm text-gray-400">move over the board</div>
-        </div>
-
-        <div class="gallery-canvas-wrap">
-            <canvas id="gallery-canvas" aria-label="{{ selected_title }}"></canvas>
-        </div>
-
-        <script id="snapshot-data" type="application/json">{{ snapshot_json|safe }}</script>
-        <script>
-            (() => {
-                const dataEl = document.getElementById('snapshot-data');
-                const canvas = document.getElementById('gallery-canvas');
-                const status = document.getElementById('gallery-cell-status');
-                if (!dataEl || !canvas || !status) return;
-
-                const snapshot = JSON.parse(dataEl.textContent);
-                const ctx = canvas.getContext('2d');
-                const cellW = 8;
-                const cellH = 16;
-                const fontSize = 14;
-                const keyFor = (x, y) => `${x},${y}`;
-                const glyphs = new Map();
-                const authors = new Map();
-
-                for (const author of snapshot.authors) {
-                    authors.set(keyFor(author.x, author.y), author.username);
-                }
-                for (const cell of snapshot.cells) {
-                    glyphs.set(keyFor(cell.x, cell.y), cell);
-                    if (cell.width === 2 && cell.x + 1 < snapshot.width) {
-                        glyphs.set(keyFor(cell.x + 1, cell.y), cell);
-                        if (cell.author) authors.set(keyFor(cell.x + 1, cell.y), cell.author);
-                    }
-                    if (cell.author) authors.set(keyFor(cell.x, cell.y), cell.author);
-                }
-
-                function renderSnapshot() {
-                    canvas.width = snapshot.width * cellW;
-                    canvas.height = snapshot.height * cellH;
-                    canvas.style.width = `${canvas.width}px`;
-                    canvas.style.height = `${canvas.height}px`;
-
-                    ctx.fillStyle = '#030712';
-                    ctx.fillRect(0, 0, canvas.width, canvas.height);
-                    ctx.font = `${fontSize}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace`;
-                    ctx.textBaseline = 'top';
-
-                    for (const cell of snapshot.cells) {
-                        ctx.fillStyle = cell.fg || '#d1d5db';
-                        ctx.fillText(cell.ch, cell.x * cellW, cell.y * cellH);
-                    }
-                }
-
-                function updateStatus(event) {
-                    const rect = canvas.getBoundingClientRect();
-                    const x = Math.floor((event.clientX - rect.left) * snapshot.width / rect.width);
-                    const y = Math.floor((event.clientY - rect.top) * snapshot.height / rect.height);
-                    if (x < 0 || y < 0 || x >= snapshot.width || y >= snapshot.height) {
-                        status.textContent = 'move over the board';
-                        return;
-                    }
-
-                    const key = keyFor(x, y);
-                    const glyph = glyphs.get(key);
-                    const author = (glyph && glyph.author) || authors.get(key);
-                    const cellText = glyph ? `cell "${glyph.ch}"` : 'empty cell';
-                    const authorText = author ? `by ${author}` : 'unknown author';
-                    status.textContent = `${x},${y} · ${cellText} · ${authorText}`;
-                }
-
-                renderSnapshot();
-                canvas.addEventListener('mousemove', updateStatus);
-                canvas.addEventListener('mouseleave', () => {
-                    status.textContent = 'move over the board';
-                });
-            })();
-        </script>
+        <span class="crumb-sep">/</span>
+        <span class="text-white truncate">{{ selected_title }}</span>
+        <span class="meta">
+            saved {{ selected_updated }} · {{ selected_cell_count }} cells · {{ selected_author_count }} authors
+        </span>
         {% else %}
-        <div class="gallery-panel p-8 text-gray-500">
-            No saved artboard snapshots are available yet.
-        </div>
+        <span class="meta">no snapshots yet</span>
         {% endif %}
-    </section>
+    </header>
+
+    <div class="gal-body">
+        <aside class="gal-side" :class="sidebarHidden && 'collapsed'">
+            <div class="gal-side-inner">
+                <section>
+                    <h2>Live</h2>
+                    {% if show_live_empty %}
+                    <div class="snap-empty">not saved yet</div>
+                    {% endif %}
+                    {% for item in live_items %}
+                    <a class="snap-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
+                        {{ item.label }}
+                        <span class="snap-meta">{{ item.meta }}</span>
+                    </a>
+                    {% endfor %}
+                </section>
+
+                <section>
+                    <h2>Daily</h2>
+                    {% if show_daily_empty %}
+                    <div class="snap-empty">none yet</div>
+                    {% endif %}
+                    {% for item in daily_items %}
+                    <a class="snap-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
+                        {{ item.label }}
+                        <span class="snap-meta">{{ item.meta }}</span>
+                    </a>
+                    {% endfor %}
+                </section>
+
+                <section>
+                    <h2>Monthly</h2>
+                    {% if show_monthly_empty %}
+                    <div class="snap-empty">none yet</div>
+                    {% endif %}
+                    {% for item in monthly_items %}
+                    <a class="snap-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
+                        {{ item.label }}
+                        <span class="snap-meta">{{ item.meta }}</span>
+                    </a>
+                    {% endfor %}
+                </section>
+            </div>
+        </aside>
+
+        <div class="gal-stage"
+             :class="[panning && 'is-panning', !hasSelected && 'is-empty']"
+             x-ref="stage"
+             @mousedown="onMouseDown($event)"
+             @mousemove="onMouseMove($event)"
+             @mouseleave="onMouseLeave()"
+             @wheel.prevent="onWheel($event)"
+             @dblclick="fitToView()">
+
+            {% if has_selected %}
+            <div class="gal-frame" x-ref="frame">
+                <canvas id="gallery-canvas" aria-label="{{ selected_title }}"></canvas>
+            </div>
+
+            <div class="gal-zoom" x-text="zoomLabel"></div>
+            <div class="gal-status" x-text="statusText"></div>
+
+            <div class="gal-toolbar">
+                <button type="button" class="gal-btn" @click="zoomBy(1.25)" title="zoom in (+)">+</button>
+                <button type="button" class="gal-btn" @click="zoomBy(0.8)" title="zoom out (-)">-</button>
+                <button type="button" class="gal-btn" @click="actualSize()" title="100% (1)">1:1</button>
+                <button type="button" class="gal-btn" @click="fitToView()" title="fit (f / dbl-click)">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                         stroke-linecap="round" stroke-linejoin="round">
+                        <polyline points="4 9 4 4 9 4"></polyline>
+                        <polyline points="20 9 20 4 15 4"></polyline>
+                        <polyline points="20 15 20 20 15 20"></polyline>
+                        <polyline points="4 15 4 20 9 20"></polyline>
+                    </svg>
+                </button>
+            </div>
+            {% else %}
+            <div class="gal-empty">no saved artboard snapshots yet</div>
+            {% endif %}
+        </div>
+    </div>
 </div>
+
+{% if has_selected %}
+<script id="snapshot-data" type="application/json">{{ snapshot_json|safe }}</script>
+<script>
+    function gallery() {
+        return {
+            hasSelected: true,
+            sidebarHidden: false,
+            scale: 1,
+            tx: 0,
+            ty: 0,
+            panning: false,
+            panStartX: 0,
+            panStartY: 0,
+            panStartTx: 0,
+            panStartTy: 0,
+            zoomLabel: '100%',
+            statusText: 'drag to pan · scroll to zoom · double-click to fit',
+            defaultStatus: 'drag to pan · scroll to zoom · double-click to fit',
+            cellW: 8,
+            cellH: 16,
+            fontSize: 14,
+            minScale: 0.1,
+            maxScale: 12,
+
+            init() {
+                const dataEl = document.getElementById('snapshot-data');
+                this.snapshot = JSON.parse(dataEl.textContent);
+                this.canvas = document.getElementById('gallery-canvas');
+                this.ctx = this.canvas.getContext('2d');
+
+                this.glyphs = new Map();
+                this.authors = new Map();
+                for (const author of this.snapshot.authors) {
+                    this.authors.set(this.keyFor(author.x, author.y), author.username);
+                }
+                for (const cell of this.snapshot.cells) {
+                    this.glyphs.set(this.keyFor(cell.x, cell.y), cell);
+                    if (cell.width === 2 && cell.x + 1 < this.snapshot.width) {
+                        this.glyphs.set(this.keyFor(cell.x + 1, cell.y), cell);
+                        if (cell.author) this.authors.set(this.keyFor(cell.x + 1, cell.y), cell.author);
+                    }
+                    if (cell.author) this.authors.set(this.keyFor(cell.x, cell.y), cell.author);
+                }
+
+                this.renderSnapshot();
+
+                this.$nextTick(() => {
+                    this.fitToView();
+                });
+
+                this._onUp = () => this.endPan();
+                window.addEventListener('mouseup', this._onUp);
+                this._onResize = () => this.clampView();
+                window.addEventListener('resize', this._onResize);
+            },
+
+            keyFor(x, y) { return x + ',' + y; },
+
+            renderSnapshot() {
+                const c = this.canvas;
+                c.width = this.snapshot.width * this.cellW;
+                c.height = this.snapshot.height * this.cellH;
+                c.style.width = c.width + 'px';
+                c.style.height = c.height + 'px';
+
+                const ctx = this.ctx;
+                ctx.fillStyle = '#030712';
+                ctx.fillRect(0, 0, c.width, c.height);
+                ctx.font = this.fontSize + 'px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace';
+                ctx.textBaseline = 'top';
+
+                for (const cell of this.snapshot.cells) {
+                    ctx.fillStyle = cell.fg || '#d1d5db';
+                    ctx.fillText(cell.ch, cell.x * this.cellW, cell.y * this.cellH);
+                }
+            },
+
+            applyTransform() {
+                this.$refs.frame.style.transform =
+                    'translate(' + this.tx + 'px, ' + this.ty + 'px) scale(' + this.scale + ')';
+                this.zoomLabel = Math.round(this.scale * 100) + '%';
+            },
+
+            stageRect() {
+                return this.$refs.stage.getBoundingClientRect();
+            },
+
+            fitToView() {
+                const rect = this.stageRect();
+                const cw = this.canvas.width;
+                const ch = this.canvas.height;
+                const margin = 32;
+                const sx = Math.max(rect.width - margin * 2, 50) / cw;
+                const sy = Math.max(rect.height - margin * 2, 50) / ch;
+                this.scale = Math.min(sx, sy);
+                this.tx = (rect.width - cw * this.scale) / 2;
+                this.ty = (rect.height - ch * this.scale) / 2;
+                this.applyTransform();
+            },
+
+            actualSize() {
+                this.scale = 1;
+                this.tx = 0;
+                this.ty = 0;
+                this.applyTransform();
+            },
+
+            zoomBy(factor) {
+                const rect = this.stageRect();
+                this.zoomAt(factor, rect.width / 2, rect.height / 2);
+            },
+
+            zoomAt(factor, sx, sy) {
+                const next = Math.max(this.minScale, Math.min(this.maxScale, this.scale * factor));
+                if (next === this.scale) return;
+                const k = next / this.scale;
+                this.tx = sx - (sx - this.tx) * k;
+                this.ty = sy - (sy - this.ty) * k;
+                this.scale = next;
+                this.applyTransform();
+            },
+
+            clampView() {
+                this.applyTransform();
+            },
+
+            onMouseDown(e) {
+                if (e.button !== 0) return;
+                if (e.target.closest('.gal-toolbar')) return;
+                this.panning = true;
+                this.panStartX = e.clientX;
+                this.panStartY = e.clientY;
+                this.panStartTx = this.tx;
+                this.panStartTy = this.ty;
+                e.preventDefault();
+            },
+
+            onMouseMove(e) {
+                if (this.panning) {
+                    this.tx = this.panStartTx + (e.clientX - this.panStartX);
+                    this.ty = this.panStartTy + (e.clientY - this.panStartY);
+                    this.applyTransform();
+                    return;
+                }
+                this.updateStatus(e);
+            },
+
+            onMouseLeave() {
+                this.endPan();
+                this.statusText = this.defaultStatus;
+            },
+
+            endPan() { this.panning = false; },
+
+            onWheel(e) {
+                const rect = this.stageRect();
+                const sx = e.clientX - rect.left;
+                const sy = e.clientY - rect.top;
+                const factor = e.deltaY < 0 ? 1.12 : 1 / 1.12;
+                this.zoomAt(factor, sx, sy);
+            },
+
+            onKey(e) {
+                if (e.target && /^(INPUT|TEXTAREA)$/.test(e.target.tagName)) return;
+                switch (e.key) {
+                    case 'f': case 'F': this.fitToView(); break;
+                    case '1': this.actualSize(); break;
+                    case '+': case '=': this.zoomBy(1.25); break;
+                    case '-': case '_': this.zoomBy(0.8); break;
+                    case 's': case 'S': this.sidebarHidden = !this.sidebarHidden; break;
+                }
+            },
+
+            updateStatus(e) {
+                const rect = this.canvas.getBoundingClientRect();
+                if (rect.width === 0 || rect.height === 0) return;
+                const x = Math.floor((e.clientX - rect.left) * this.snapshot.width / rect.width);
+                const y = Math.floor((e.clientY - rect.top) * this.snapshot.height / rect.height);
+                if (x < 0 || y < 0 || x >= this.snapshot.width || y >= this.snapshot.height) {
+                    this.statusText = this.defaultStatus;
+                    return;
+                }
+                const key = this.keyFor(x, y);
+                const glyph = this.glyphs.get(key);
+                const author = (glyph && glyph.author) || this.authors.get(key);
+                const cellText = glyph ? 'cell "' + glyph.ch + '"' : 'empty';
+                const authorText = author ? 'by ' + author : 'no author';
+                this.statusText = x + ',' + y + ' · ' + cellText + ' · ' + authorText;
+            },
+        };
+    }
+</script>
+{% endif %}
 {% endblock %}

--- a/late-web/src/pages/mod.rs
+++ b/late-web/src/pages/mod.rs
@@ -4,6 +4,7 @@ use axum::Router;
 pub mod chat;
 pub mod connect;
 pub mod dashboard;
+pub mod gallery;
 pub mod shared;
 pub mod stream;
 
@@ -11,6 +12,7 @@ pub fn router() -> Router<AppState> {
     Router::new()
         .nest("/chat", chat::router())
         .merge(connect::router())
+        .merge(gallery::router())
         .merge(stream::router())
         .nest("/dashboard", dashboard::router())
 }

--- a/late-web/static/style.css
+++ b/late-web/static/style.css
@@ -58,6 +58,7 @@
     --font-weight-semibold: 600;
     --font-weight-bold: 700;
     --tracking-tight: -0.025em;
+    --tracking-wide: 0.025em;
     --tracking-wider: 0.05em;
     --leading-relaxed: 1.625;
     --leading-loose: 2;
@@ -284,6 +285,9 @@
   .mb-4 {
     margin-bottom: calc(var(--spacing) * 4);
   }
+  .mb-5 {
+    margin-bottom: calc(var(--spacing) * 5);
+  }
   .mb-6 {
     margin-bottom: calc(var(--spacing) * 6);
   }
@@ -397,6 +401,9 @@
   }
   .flex-col {
     flex-direction: column;
+  }
+  .flex-wrap {
+    flex-wrap: wrap;
   }
   .items-center {
     align-items: center;
@@ -568,6 +575,9 @@
   .p-6 {
     padding: calc(var(--spacing) * 6);
   }
+  .p-8 {
+    padding: calc(var(--spacing) * 8);
+  }
   .px-1 {
     padding-inline: calc(var(--spacing) * 1);
   }
@@ -678,6 +688,10 @@
   .tracking-tight {
     --tw-tracking: var(--tracking-tight);
     letter-spacing: var(--tracking-tight);
+  }
+  .tracking-wide {
+    --tw-tracking: var(--tracking-wide);
+    letter-spacing: var(--tracking-wide);
   }
   .tracking-wider {
     --tw-tracking: var(--tracking-wider);

--- a/late-web/static/style.css
+++ b/late-web/static/style.css
@@ -240,11 +240,17 @@
       max-width: 96rem;
     }
   }
+  .mx-0 {
+    margin-inline: calc(var(--spacing) * 0);
+  }
   .mx-0\.5 {
     margin-inline: calc(var(--spacing) * 0.5);
   }
   .mx-auto {
     margin-inline: auto;
+  }
+  .mt-0 {
+    margin-top: calc(var(--spacing) * 0);
   }
   .mt-0\.5 {
     margin-top: calc(var(--spacing) * 0.5);
@@ -327,8 +333,17 @@
   .inline-flex {
     display: inline-flex;
   }
+  .table {
+    display: table;
+  }
+  .h-1 {
+    height: calc(var(--spacing) * 1);
+  }
   .h-1\.5 {
     height: calc(var(--spacing) * 1.5);
+  }
+  .h-3 {
+    height: calc(var(--spacing) * 3);
   }
   .h-3\.5 {
     height: calc(var(--spacing) * 3.5);
@@ -345,8 +360,14 @@
   .min-h-screen {
     min-height: 100vh;
   }
+  .w-1 {
+    width: calc(var(--spacing) * 1);
+  }
   .w-1\.5 {
     width: calc(var(--spacing) * 1.5);
+  }
+  .w-3 {
+    width: calc(var(--spacing) * 3);
   }
   .w-3\.5 {
     width: calc(var(--spacing) * 3.5);
@@ -383,6 +404,9 @@
   }
   .flex-grow {
     flex-grow: 1;
+  }
+  .border-collapse {
+    border-collapse: collapse;
   }
   .transform {
     transform: var(--tw-rotate-x,) var(--tw-rotate-y,) var(--tw-rotate-z,) var(--tw-skew-x,) var(--tw-skew-y,);
@@ -521,6 +545,9 @@
   .border-green-800 {
     border-color: var(--color-green-800);
   }
+  .border-red-500 {
+    border-color: var(--color-red-500);
+  }
   .border-red-500\/50 {
     border-color: color-mix(in srgb, oklch(63.7% 0.237 25.331) 50%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -563,6 +590,9 @@
   .bg-purple-500 {
     background-color: var(--color-purple-500);
   }
+  .bg-red-500 {
+    background-color: var(--color-red-500);
+  }
   .bg-red-500\/20 {
     background-color: color-mix(in srgb, oklch(63.7% 0.237 25.331) 20%, transparent);
     @supports (color: color-mix(in lab, red, red)) {
@@ -592,6 +622,9 @@
   }
   .px-5 {
     padding-inline: calc(var(--spacing) * 5);
+  }
+  .py-0 {
+    padding-block: calc(var(--spacing) * 0);
   }
   .py-0\.5 {
     padding-block: calc(var(--spacing) * 0.5);
@@ -782,6 +815,10 @@
     --tw-shadow: 0 10px 15px -3px var(--tw-shadow-color, rgb(0 0 0 / 0.1)), 0 4px 6px -4px var(--tw-shadow-color, rgb(0 0 0 / 0.1));
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
+  .outline {
+    outline-style: var(--tw-outline-style);
+    outline-width: 1px;
+  }
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
@@ -820,6 +857,13 @@
     &:is(:where(.group):hover *) {
       @media (hover: hover) {
         color: var(--color-gray-500);
+      }
+    }
+  }
+  .group-hover\:text-green-600 {
+    &:is(:where(.group):hover *) {
+      @media (hover: hover) {
+        color: var(--color-green-600);
       }
     }
   }
@@ -1031,6 +1075,11 @@
   inherits: false;
   initial-value: 0 0 #0000;
 }
+@property --tw-outline-style {
+  syntax: "*";
+  inherits: false;
+  initial-value: solid;
+}
 @property --tw-blur {
   syntax: "*";
   inherits: false;
@@ -1156,6 +1205,7 @@
       --tw-ring-offset-width: 0px;
       --tw-ring-offset-color: #fff;
       --tw-ring-offset-shadow: 0 0 #0000;
+      --tw-outline-style: solid;
       --tw-blur: initial;
       --tw-brightness: initial;
       --tw-contrast: initial;

--- a/late-web/static/style.css
+++ b/late-web/static/style.css
@@ -375,6 +375,9 @@
   .flex-1 {
     flex: 1;
   }
+  .flex-shrink {
+    flex-shrink: 1;
+  }
   .shrink-0 {
     flex-shrink: 0;
   }
@@ -782,6 +785,15 @@
   .filter {
     filter: var(--tw-blur,) var(--tw-brightness,) var(--tw-contrast,) var(--tw-grayscale,) var(--tw-hue-rotate,) var(--tw-invert,) var(--tw-saturate,) var(--tw-sepia,) var(--tw-drop-shadow,);
   }
+  .backdrop-filter {
+    -webkit-backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+    backdrop-filter: var(--tw-backdrop-blur,) var(--tw-backdrop-brightness,) var(--tw-backdrop-contrast,) var(--tw-backdrop-grayscale,) var(--tw-backdrop-hue-rotate,) var(--tw-backdrop-invert,) var(--tw-backdrop-opacity,) var(--tw-backdrop-saturate,) var(--tw-backdrop-sepia,);
+  }
+  .transition {
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to, opacity, box-shadow, transform, translate, scale, rotate, filter, -webkit-backdrop-filter, backdrop-filter, display, content-visibility, overlay, pointer-events;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
   .transition-all {
     transition-property: all;
     transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
@@ -1072,6 +1084,42 @@
   syntax: "*";
   inherits: false;
 }
+@property --tw-backdrop-blur {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-brightness {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-contrast {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-grayscale {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-hue-rotate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-invert {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-opacity {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-saturate {
+  syntax: "*";
+  inherits: false;
+}
+@property --tw-backdrop-sepia {
+  syntax: "*";
+  inherits: false;
+}
 @property --tw-duration {
   syntax: "*";
   inherits: false;
@@ -1121,6 +1169,15 @@
       --tw-drop-shadow-color: initial;
       --tw-drop-shadow-alpha: 100%;
       --tw-drop-shadow-size: initial;
+      --tw-backdrop-blur: initial;
+      --tw-backdrop-brightness: initial;
+      --tw-backdrop-contrast: initial;
+      --tw-backdrop-grayscale: initial;
+      --tw-backdrop-hue-rotate: initial;
+      --tw-backdrop-invert: initial;
+      --tw-backdrop-opacity: initial;
+      --tw-backdrop-saturate: initial;
+      --tw-backdrop-sepia: initial;
       --tw-duration: initial;
     }
   }

--- a/late-web/tests/dashboard.rs
+++ b/late-web/tests/dashboard.rs
@@ -1,4 +1,5 @@
 use axum::{Json, routing::get};
+use late_core::db::{Db, DbConfig};
 use late_web::{AppState, app, config::Config};
 use serde_json::json;
 use std::sync::Once;
@@ -25,6 +26,7 @@ fn test_state(ssh_internal_url: String) -> AppState {
     };
     AppState {
         config,
+        db: Db::new(&DbConfig::default()).expect("lazy db"),
         http_client: reqwest::Client::new(),
     }
 }

--- a/late-web/tests/stream.rs
+++ b/late-web/tests/stream.rs
@@ -1,4 +1,5 @@
 use axum::{body::Body, http::StatusCode, response::IntoResponse, routing::get};
+use late_core::db::{Db, DbConfig};
 use late_web::{AppState, app, config::Config};
 use std::time::Duration;
 use tokio::sync::oneshot;
@@ -12,6 +13,7 @@ fn test_state(audio_base_url: String) -> AppState {
     };
     AppState {
         config,
+        db: Db::new(&DbConfig::default()).expect("lazy db"),
         http_client: reqwest::Client::new(),
     }
 }


### PR DESCRIPTION
## Summary
- Ships a read-only public web gallery for Artboard snapshots so anyone can browse what's been drawn — no SSH required. Adds a discovery card to `/connect` so first-time visitors can see the canvas before signing in.
- Tightens the global keyboard map in the SSH app: frees `c` for "copy selected chat message", retires the global `s` bonsai-snippet shortcut, and lets `Ctrl+O` open settings even mid-game.

## What changed

### Public Artboard gallery (`late-web`)
- New route `GET /gallery` rendering one of `main` / `daily:*` / `monthly:*` snapshots, with a sidebar grouping Live / Daily / Monthly entries.
- Renders the saved canvas to an HTML `<canvas>` with pan, scroll-zoom, fit-to-view, 1:1, and `+/-/f/1/s` keyboard controls.
- Hover surfaces per-cell coordinates, glyph, and the author from persisted provenance.
- `/connect` gains a new "collaborative artboard" feature line and a prominent `/gallery` card linking to the viewer.
- `late-web` now opens a Postgres pool on startup (`Db::from_env()`), reading snapshots directly from `artboard_snapshots`. Infra wires `LATE_DB_*` env vars from the CloudNativePG `postgres-app` secret in `infra/service-web.tf`.

### Keyboard shortcut cleanup (`late-ssh`)
- `c` in chat is freed up (was: open web-chat QR). The web-chat QR shortcut moves to capital `C`; the room-list hint, help modal, and CONTEXT.md table are updated to match. `c` is now reserved for "copy selected chat message" per the shortcuts table.
- The duplicate global `s` / `S` "copy bonsai snippet" shortcut is removed; the snippet remains copyable from inside the Bonsai modal.
- Active games now suppress *all* global byte shortcuts instead of an explicit `m/+/-` allowlist; volume/mute keys still reach their handlers via the earlier paired-client branch, and `Ctrl+O` (settings) intentionally bypasses the game guard so it works from anywhere.
- Bonsai's `w care` hint is rendered as a right-aligned block title rather than an overlaid paragraph, so it tracks the border instead of floating outside it.

## Behavior notes
- The gallery's `main` entry is the latest *saved* DB snapshot, not a live `ServerHandle` stream — it can lag active drawing by the persistence interval. This is documented in CONTEXT.md.
- `late-web` will fail to start if `LATE_DB_*` env is missing in environments that previously ran without a database. The deployment manifest update covers prod; local dev needs a Postgres reachable via env.
- Test fixtures use `Db::new(&DbConfig::default())` to construct a lazy pool that doesn't connect until used, so existing dashboard/stream tests run without a database.

## Feature flags
- None.

## Screenshots / Video
- Needed before review: a screenshot of `/gallery` with a snapshot loaded (sidebar + canvas + status line) and the updated `/connect` page showing the new artboard card.

## Testing
- Automated:
  - Unit tests in `late-web/src/pages/gallery/mod.rs` covering `snapshot_label` / `snapshot_title` formatting for `main`, `daily:*`, `monthly:*`.
  - Existing `late-web/tests/{dashboard,stream}.rs` updated to construct `AppState` with the new `db` field via the lazy default pool.
- Manual verification to perform:
  - Visit `/gallery` with no snapshots saved — empty state renders, no JS errors.
  - Save a snapshot via the SSH app, reload `/gallery` — Live entry appears, canvas paints, hover shows `x,y · cell "X" · by <user>`, pan/zoom/fit/`1:1` all work, `s` toggles the sidebar.
  - Switch between Live / Daily / Monthly entries via `?key=` links — selection highlight and breadcrumb update.
  - In SSH app, confirm `c` no longer opens the web-chat QR; capital `C` does. Confirm `s` no longer copies the bonsai snippet from the dashboard, but `s` inside the Bonsai modal still does. Confirm `Ctrl+O` opens settings while a game is active.