### PR TITLE
Collapse mention read state to a per-user cursor

### DIFF
--- a/MUSIC.md
+++ b/MUSIC.md
@@ -10,7 +10,7 @@ This file tracks the local music catalog used by `late.sh` radio.
 
 - `lofi`: done, 202-track manifest, mixed `CC0` and `CC-BY 4.0`
 - `ambient`: done, 204 tracks, mixed `CC0` and `CC-BY 4.0`
-- `classic`: done, 100-track calm-first manifest, public domain via Musopen / Internet Archive
+- `classic`: done, 201-track calm-first manifest, public domain via Musopen / Internet Archive (Musopen Chopin CC0 + Kimiko Ishizaka's "Open Well-Tempered Clavier" CC0/PD-mark + MusopenCollectionAsFlac PD)
 - `jazz`: pending
 
 ## Lofi
@@ -435,7 +435,7 @@ This section documents the current 204-track ambient manifest used by the regene
 
 ## Classic
 
-This section documents the current 100-track calm-first classical manifest used by the regenerated playlist files. The dev Liquidsoap stack mounts `tmp/music/classic` onto `/music/classic`, so the local runtime playlist resolves against the refreshed temp library.
+This section documents the current 201-track calm-first classical manifest used by the regenerated playlist files. The dev Liquidsoap stack mounts `tmp/music/classic` onto `/music/classic`, so the local runtime playlist resolves against the refreshed temp library. Tracks 1-100 are the original Musopen Public Domain pass; tracks 101-201 are the second-pass coding-session expansion (5 chill leftovers from MusopenCollectionAsFlac, 48 Bach Well-Tempered Clavier Book I prelude/fugue pairs by Kimiko Ishizaka under CC0/PD mark, and 48 Chopin pieces from Musopen's CC0 Complete Chopin Collection).
 
 | # | Artist | Title | License | Source URL |
 |---|--------|-------|---------|------------|
@@ -539,6 +539,107 @@ This section documents the current 100-track calm-first classical manifest used 
 | 98 | Bedrich Smetana | Ma Vlast - Vltava | Public Domain | https://archive.org/download/MusopenCollectionAsFlac/Smetana_Vltava/BedichSmetana-MVlast-Vltava.mp3 |
 | 99 | Wolfgang Amadeus Mozart | Symphony No. 40 in G Minor, K. 550 - II. Andante | Public Domain | https://archive.org/download/MusopenCollectionAsFlac/Mozart_SymphonyNo.40inGMinor/WolfgangAmadeusMozart-SymphonyNo.40InGMinorK.550-02-Andante.mp3 |
 | 100 | Wolfgang Amadeus Mozart | Symphony No. 40 in G Minor, K. 550 - III. Menuetto Allegretto | Public Domain | https://archive.org/download/MusopenCollectionAsFlac/Mozart_SymphonyNo.40inGMinor/WolfgangAmadeusMozart-SymphonyNo.40InGMinorK.550-03-MenuettoAllegretto.mp3 |
+| 101 | Felix Mendelssohn | String Quartet No. 6 in F Minor, Op. 80 - III. Adagio | Public Domain | https://archive.org/download/MusopenCollectionAsFlac/Mendelssohn_StringQuartetNo.6inFMinorOp.80/FelixMendelssohn-StringQuartetNo.6InFMinorOp.80-03-Adagio.mp3 |
+| 102 | Franz Schubert | Sonata in D Major, D. 850 - II. Con moto | Public Domain | https://archive.org/download/MusopenCollectionAsFlac/Schubert_SonataInDMajorD.850/FranzSchubert-SonataInDMajorD.850-02-ConMoto.mp3 |
+| 103 | Pyotr Ilyich Tchaikovsky | Symphony No. 6 in B Minor, Op. 74 'Pathetique' - IV. Finale Adagio lamentoso | Public Domain | https://archive.org/download/MusopenCollectionAsFlac/Tchaikovsky_SymphonyPathetique/PyotrIlyichTchaikovsky-SymphonyNo.6InBMinorOp.74pathtique-04-FinaleAdagioLamentoso.mp3 |
+| 104 | Johannes Brahms | Symphony No. 1 in C Minor, Op. 68 - IV. Adagio - Piu andante - Allegro non troppo | Public Domain | https://archive.org/download/MusopenCollectionAsFlac/Brahms_SymphonyNo.1inCMinor/JohannesBrahms-SymphonyNo.1InCMinorOp.68-04-Adagio-PiAndante-AllegroNonTroppoMaConBrio.mp3 |
+| 105 | Franz Schubert | Sonata in C Minor, D. 958 - III. Menuetto Allegro | Public Domain | https://archive.org/download/MusopenCollectionAsFlac/Schubert_SonataInCMinorD.958/FranzSchubert-SonataInCMinorD.958-03-MenuettoAllegro.mp3 |
+| 106 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 1 in C major, BWV 846 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 01 Prelude No. 1 in C major, BWV 846.mp3 |
+| 107 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 1 in C major, BWV 846 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 02 Fugue No. 1 in C major, BWV 846.mp3 |
+| 108 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 2 in C minor, BWV 847 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 03 Prelude No. 2 in C minor, BWV 847.mp3 |
+| 109 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 2 in C minor, BWV 847 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 04 Fugue No. 2 in C minor, BWV 847.mp3 |
+| 110 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 3 in C-sharp major, BWV 848 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 05 Prelude No. 3 in C-sharp major, BWV 848.mp3 |
+| 111 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 3 in C-sharp major, BWV 848 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 06 Fugue No. 3 in C-sharp major, BWV 848.mp3 |
+| 112 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 4 in C-sharp minor, BWV 849 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 07 Prelude No. 4 in C-sharp minor, BWV 849.mp3 |
+| 113 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 4 in C-sharp minor, BWV 849 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 08 Fugue No. 4 in C-sharp minor, BWV 849.mp3 |
+| 114 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 5 in D major, BWV 850 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 09 Prelude No. 5 in D major, BWV 850.mp3 |
+| 115 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 5 in D major, BWV 850 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 10 Fugue No. 5 in D major, BWV 850.mp3 |
+| 116 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 6 in D minor, BWV 851 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 11 Prelude No. 6 in D minor, BWV 851.mp3 |
+| 117 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 6 in D minor, BWV 851 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 12 Fugue No. 6 in D minor, BWV 851.mp3 |
+| 118 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 7 in E-flat major, BWV 852 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 13 Prelude No. 7 in E-flat major, BWV 852.mp3 |
+| 119 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 7 in E-flat major, BWV 852 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 14 Fugue No. 7 in E-flat major, BWV 852.mp3 |
+| 120 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 8 in E-flat minor, BWV 853 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 15 Prelude No. 8 in E-flat minor, BWV 853.mp3 |
+| 121 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 8 in D-sharp minor, BWV 853 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 16 Fugue No. 8 in D-sharp minor, BWV 853.mp3 |
+| 122 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 9 in E major, BWV 854 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 17 Prelude No. 9 in E major, BWV 854.mp3 |
+| 123 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 9 in E major, BWV 854 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 18 Fugue No. 9 in E major, BWV 854.mp3 |
+| 124 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 10 in E minor, BWV 855 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 19 Prelude No. 10 in E minor, BWV 855.mp3 |
+| 125 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 10 in E minor, BWV 855 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 20 Fugue No. 10 in E minor, BWV 855.mp3 |
+| 126 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 11 in F major, BWV 856 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 21 Prelude No. 11 in F major, BWV 856.mp3 |
+| 127 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 11 in F major, BWV 856 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 22 Fugue No. 11 in F major, BWV 856.mp3 |
+| 128 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 12 in F minor, BWV 857 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 23 Prelude No. 12 in F minor, BWV 857.mp3 |
+| 129 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 12 in F minor, BWV 857 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 24 Fugue No. 12 in F minor, BWV 857.mp3 |
+| 130 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 13 in F-sharp major, BWV 858 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 25 Prelude No. 13 in F-sharp major, BWV 858.mp3 |
+| 131 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 13 in F-sharp major, BWV 858 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 26 Fugue No. 13 in F-sharp major, BWV 858.mp3 |
+| 132 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 14 in F-sharp minor, BWV 859 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 27 Prelude No. 14 in F-sharp minor, BWV 859.mp3 |
+| 133 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 14 in F-sharp minor, BWV 859 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 28 Fugue No. 14 in F-sharp minor, BWV 859.mp3 |
+| 134 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 15 in G major, BWV 860 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 29 Prelude No. 15 in G major, BWV 860.mp3 |
+| 135 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 15 in G major, BWV 860 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 30 Fugue No. 15 in G major, BWV 860.mp3 |
+| 136 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 16 in G minor, BWV 861 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 31 Prelude No. 16 in G minor, BWV 861.mp3 |
+| 137 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 16 in G minor, BWV 861 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 32 Fugue No. 16 in G minor, BWV 861.mp3 |
+| 138 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 17 in A-flat major, BWV 862 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 33 Prelude No. 17 in A-flat major, BWV 862.mp3 |
+| 139 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 17 in A-flat major, BWV 862 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 34 Fugue No. 17 in A-flat major, BWV 862.mp3 |
+| 140 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 18 in G-sharp minor, BWV 863 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 35 Prelude No. 18 in G-sharp minor, BWV 863.mp3 |
+| 141 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 18 in G-sharp minor, BWV 863 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 36 Fugue No. 18 in G-sharp minor, BWV 863.mp3 |
+| 142 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 19 in A major, BWV 864 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 37 Prelude No. 19 in A major, BWV 864.mp3 |
+| 143 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 19 in A major, BWV 864 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 38 Fugue No. 19 in A major, BWV 864.mp3 |
+| 144 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 20 in A minor, BWV 865 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 39 Prelude No. 20 in A minor, BWV 865.mp3 |
+| 145 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 20 in A minor, BWV 865 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 40 Fugue No. 20 in A minor, BWV 865.mp3 |
+| 146 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 21 in B-flat major, BWV 866 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 41 Prelude No. 21 in B-flat major, BWV 866.mp3 |
+| 147 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 21 in B-flat major, BWV 866 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 42 Fugue No. 21 in B-flat major, BWV 866.mp3 |
+| 148 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 22 in B-flat minor, BWV 867 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 43 Prelude No. 22 in B-flat minor, BWV 867.mp3 |
+| 149 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 22 in B-flat minor, BWV 867 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 44 Fugue No. 22 in B-flat minor, BWV 867.mp3 |
+| 150 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 23 in B major, BWV 868 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 45 Prelude No. 23 in B major, BWV 868.mp3 |
+| 151 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 23 in B major, BWV 868 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 46 Fugue No. 23 in B major, BWV 868.mp3 |
+| 152 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Prelude No. 24 in B minor, BWV 869 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 47 Prelude No. 24 in B minor, BWV 869.mp3 |
+| 153 | J.S. Bach (Kimiko Ishizaka) | Well-Tempered Clavier Book I - Fugue No. 24 in B minor, BWV 869 | CC0 / PD Mark | https://archive.org/download/bach-well-tempered-clavier-book-1/Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 48 Fugue No. 24 in B minor, BWV 869.mp3 |
+| 154 | Frederic Chopin | Nocturne Op. 9 No. 1 in B-flat minor | CC0 | https://archive.org/download/musopen-chopin/NocturneOp.9No.1InBFlatMinor.mp3 |
+| 155 | Frederic Chopin | Nocturne Op. 9 No. 2 in E-flat major | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 9 no. 2 in E flat major.mp3 |
+| 156 | Frederic Chopin | Nocturne Op. 9 No. 3 in B major | CC0 | https://archive.org/download/musopen-chopin/NocturneOp.9No.3.mp3 |
+| 157 | Frederic Chopin | Nocturne Op. 15 No. 1 in F major | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 15 no. 1 In F major.mp3 |
+| 158 | Frederic Chopin | Nocturne Op. 27 No. 1 in C-sharp minor | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 27 no. 1 in C sharp minor.mp3 |
+| 159 | Frederic Chopin | Nocturne Op. 32 No. 1 in B major | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 32 no. 1 in B major.mp3 |
+| 160 | Frederic Chopin | Nocturne Op. 32 No. 2 in A-flat major | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 32 no. 2 in A flat major.mp3 |
+| 161 | Frederic Chopin | Nocturne Op. 48 No. 1 in C minor | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 48 no. 1 in C minor.mp3 |
+| 162 | Frederic Chopin | Nocturne Op. 48 No. 2 in F-sharp minor | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 48 no. 2 in F sharp minor.mp3 |
+| 163 | Frederic Chopin | Nocturne Op. 55 No. 1 in F minor | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 55 no. 1 in F minor.mp3 |
+| 164 | Frederic Chopin | Nocturne Op. 55 No. 2 in E-flat major | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 55 no. 2 in E flat major.mp3 |
+| 165 | Frederic Chopin | Nocturne Op. 62 No. 2 in E major | CC0 | https://archive.org/download/musopen-chopin/Nocturne Op. 62 no. 2 in E major.mp3 |
+| 166 | Frederic Chopin | Nocturne Op. 72 No. 1 in E minor | CC0 | https://archive.org/download/musopen-chopin/NocturneOp.72No.1InEMinor.mp3 |
+| 167 | Frederic Chopin | Nocturne B. 108 in C minor | CC0 | https://archive.org/download/musopen-chopin/Nocturne B. 108 in C minor.mp3 |
+| 168 | Frederic Chopin | Nocturne B. 49 in C-sharp minor 'Lento con gran espressione' | CC0 | https://archive.org/download/musopen-chopin/Nocturne B. 49 in C sharp minor 'Lento con gran espressione' (1).mp3 |
+| 169 | Frederic Chopin | Nocturne Op. 27 No. 2 in D-flat major | CC0 | https://archive.org/download/musopen-chopin/NocturneOp27No2.mp3 |
+| 170 | Frederic Chopin | Mazurka Op. 17 No. 3 in A-flat major | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 17 no. 3 in A flat major.mp3 |
+| 171 | Frederic Chopin | Mazurka Op. 17 No. 4 in A minor | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 17 no. 4 in A minor.mp3 |
+| 172 | Frederic Chopin | Mazurka Op. 24 No. 4 in B-flat minor | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 24 no. 4 in B flat minor.mp3 |
+| 173 | Frederic Chopin | Mazurka Op. 50 No. 3 in C-sharp minor | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 50 no. 3 in C sharp minor.mp3 |
+| 174 | Frederic Chopin | Mazurka Op. 56 No. 1 in B major | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 56 no. 1 in B major.mp3 |
+| 175 | Frederic Chopin | Mazurka Op. 56 No. 3 in C minor | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 56 no. 3 in C minor.mp3 |
+| 176 | Frederic Chopin | Mazurka Op. 59 No. 1 in A minor | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 59 no. 1 in A minor.mp3 |
+| 177 | Frederic Chopin | Mazurka Op. 59 No. 3 in F-sharp minor | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 59 no. 3 in F sharp minor.mp3 |
+| 178 | Frederic Chopin | Mazurka Op. 50 No. 1 in G major | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 50 no. 1 in G major.mp3 |
+| 179 | Frederic Chopin | Mazurka Op. 50 No. 2 in A-flat major | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 50 no. 2 in A flat major.mp3 |
+| 180 | Frederic Chopin | Mazurka Op. 7 No. 3 in F minor | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 7 no. 3 in F minor.mp3 |
+| 181 | Frederic Chopin | Mazurka Op. 24 No. 3 in A-flat major | CC0 | https://archive.org/download/musopen-chopin/Mazurka Op. 24 no. 3 in A flat major.mp3 |
+| 182 | Frederic Chopin | Waltz Op. 64 No. 2 in C-sharp minor | CC0 | https://archive.org/download/musopen-chopin/Waltz Op. 64 no. 2 in C sharp minor.mp3 |
+| 183 | Frederic Chopin | Waltz Op. 69 No. 1 in A-flat major | CC0 | https://archive.org/download/musopen-chopin/Waltz Op. 69 no. 1 in A flat major.mp3 |
+| 184 | Frederic Chopin | Waltz Op. 69 No. 2 in B minor | CC0 | https://archive.org/download/musopen-chopin/Waltz Op. 69 no. 2 in B minor.mp3 |
+| 185 | Frederic Chopin | Waltz Op. 70 No. 2 in F minor | CC0 | https://archive.org/download/musopen-chopin/Waltz Op. 70 no. 2 in F minor.mp3 |
+| 186 | Frederic Chopin | Waltz Op. 70 No. 3 in D-flat major | CC0 | https://archive.org/download/musopen-chopin/Waltz Op. 70 no. 3 in D flat major.mp3 |
+| 187 | Frederic Chopin | Waltz Op. 34 No. 2 in A minor | CC0 | https://archive.org/download/musopen-chopin/WaltzOp.34No.2InAMinor.mp3 |
+| 188 | Frederic Chopin | Waltz B. 46 in E-flat major | CC0 | https://archive.org/download/musopen-chopin/WaltzB.46InEFlatMajor.mp3 |
+| 189 | Frederic Chopin | Waltz B. 56 in E minor | CC0 | https://archive.org/download/musopen-chopin/WaltzB.56InEMinor.mp3 |
+| 190 | Frederic Chopin | Waltz Op. 34 No. 3 in F major | CC0 | https://archive.org/download/musopen-chopin/WaltzOp.34No.3InFMajor.mp3 |
+| 191 | Frederic Chopin | Waltz B. 21 in A-flat major | CC0 | https://archive.org/download/musopen-chopin/WaltzB.21InAFlatMajor.mp3 |
+| 192 | Frederic Chopin | Fantaisie-Impromptu Op. 66 in C-sharp minor | CC0 | https://archive.org/download/musopen-chopin/Fantasie Impromptu Op. 66.mp3 |
+| 193 | Frederic Chopin | Impromptu No. 1 Op. 29 in A-flat major | CC0 | https://archive.org/download/musopen-chopin/Impromptu no. 1 - Op. 29.mp3 |
+| 194 | Frederic Chopin | Impromptu No. 2 Op. 36 in F-sharp major | CC0 | https://archive.org/download/musopen-chopin/Impromptu no. 2 - Op. 36.mp3 |
+| 195 | Frederic Chopin | Impromptu No. 3 Op. 51 in G-flat major | CC0 | https://archive.org/download/musopen-chopin/Impromptu no. 3 - Op. 51.mp3 |
+| 196 | Frederic Chopin | Prelude Op. 28 No. 6 in B minor | CC0 | https://archive.org/download/musopen-chopin/Prelude Op. 28 no. 6.mp3 |
+| 197 | Frederic Chopin | Prelude Op. 28 No. 7 in A major | CC0 | https://archive.org/download/musopen-chopin/Prelude Op. 28 no. 7.mp3 |
+| 198 | Frederic Chopin | Prelude Op. 28 No. 13 in F-sharp major | CC0 | https://archive.org/download/musopen-chopin/Prelude Op. 28 no. 13.mp3 |
+| 199 | Frederic Chopin | Prelude Op. 28 No. 15 in D-flat major 'Raindrop' | CC0 | https://archive.org/download/musopen-chopin/Prelude Op. 28 no. 15.mp3 |
+| 200 | Frederic Chopin | Prelude Op. 28 No. 17 in A-flat major | CC0 | https://archive.org/download/musopen-chopin/Prelude Op. 28 no. 17.mp3 |
+| 201 | Frederic Chopin | Sonata for Piano and Cello, Op. 65 - III. Largo | CC0 | https://archive.org/download/musopen-chopin/Sonata for Piano and Cello in G Minor, Op. 65 - III. Largo.mp3 |
 
 ## Planned Sources
 

--- a/infra/liquidsoap/classic.m3u
+++ b/infra/liquidsoap/classic.m3u
@@ -98,3 +98,104 @@ annotate:artist="Felix Mendelssohn",title="Hebrides Overture 'Fingal's Cave'",du
 annotate:artist="Bedrich Smetana",title="Ma Vlast - Vltava",duration="770":/music/classic/bedrich-smetana-ma-vlast-vltava.mp3
 annotate:artist="Wolfgang Amadeus Mozart",title="Symphony No. 40 in G Minor, K. 550 - II. Andante",duration="456":/music/classic/wolfgang-amadeus-mozart-symphony-no-40-in-g-minor-k-550-ii-andante.mp3
 annotate:artist="Wolfgang Amadeus Mozart",title="Symphony No. 40 in G Minor, K. 550 - III. Menuetto Allegretto",duration="272":/music/classic/wolfgang-amadeus-mozart-symphony-no-40-in-g-minor-k-550-iii-menuetto-allegretto.mp3
+annotate:artist="Felix Mendelssohn",title="String Quartet No. 6 in F Minor, Op. 80 - III. Adagio",duration="486":/music/classic/felix-mendelssohn-string-quartet-no-6-in-f-minor-op-80-iii-adagio.mp3
+annotate:artist="Franz Schubert",title="Sonata in D Major, D. 850 - II. Con moto",duration="726":/music/classic/franz-schubert-sonata-in-d-major-d-850-ii-con-moto.mp3
+annotate:artist="Pyotr Ilyich Tchaikovsky",title="Symphony No. 6 in B Minor, Op. 74 'Pathetique' - IV. Finale Adagio lamentoso",duration="618":/music/classic/pyotr-ilyich-tchaikovsky-symphony-no-6-in-b-minor-op-74-pathetique-iv-finale-ada.mp3
+annotate:artist="Johannes Brahms",title="Symphony No. 1 in C Minor, Op. 68 - IV. Adagio - Piu andante - Allegro non troppo",duration="1016":/music/classic/johannes-brahms-symphony-no-1-in-c-minor-op-68-iv-adagio-piu-andante-allegro-non.mp3
+annotate:artist="Franz Schubert",title="Sonata in C Minor, D. 958 - III. Menuetto Allegro",duration="194":/music/classic/franz-schubert-sonata-in-c-minor-d-958-iii-menuetto-allegro.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 1 in C major, BWV 846",duration="162":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-1-in-c-major-bwv.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 1 in C major, BWV 846",duration="116":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-1-in-c-major-bwv-8.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 2 in C minor, BWV 847",duration="107":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-2-in-c-minor-bwv.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 2 in C minor, BWV 847",duration="115":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-2-in-c-minor-bwv-8.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 3 in C-sharp major, BWV 848",duration="75":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-3-in-c-sharp-maj.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 3 in C-sharp major, BWV 848",duration="155":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-3-in-c-sharp-major.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 4 in C-sharp minor, BWV 849",duration="178":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-4-in-c-sharp-min.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 4 in C-sharp minor, BWV 849",duration="160":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-4-in-c-sharp-minor.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 5 in D major, BWV 850",duration="92":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-5-in-d-major-bwv.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 5 in D major, BWV 850",duration="108":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-5-in-d-major-bwv-8.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 6 in D minor, BWV 851",duration="98":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-6-in-d-minor-bwv.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 6 in D minor, BWV 851",duration="129":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-6-in-d-minor-bwv-8.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 7 in E-flat major, BWV 852",duration="213":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-7-in-e-flat-majo.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 7 in E-flat major, BWV 852",duration="108":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-7-in-e-flat-major-.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 8 in E-flat minor, BWV 853",duration="238":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-8-in-e-flat-mino.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 8 in D-sharp minor, BWV 853",duration="234":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-8-in-d-sharp-minor.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 9 in E major, BWV 854",duration="104":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-9-in-e-major-bwv.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 9 in E major, BWV 854",duration="81":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-9-in-e-major-bwv-8.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 10 in E minor, BWV 855",duration="120":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-10-in-e-minor-bw.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 10 in E minor, BWV 855",duration="89":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-10-in-e-minor-bwv-.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 11 in F major, BWV 856",duration="64":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-11-in-f-major-bw.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 11 in F major, BWV 856",duration="87":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-11-in-f-major-bwv-.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 12 in F minor, BWV 857",duration="173":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-12-in-f-minor-bw.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 12 in F minor, BWV 857",duration="237":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-12-in-f-minor-bwv-.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 13 in F-sharp major, BWV 858",duration="100":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-13-in-f-sharp-ma.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 13 in F-sharp major, BWV 858",duration="126":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-13-in-f-sharp-majo.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 14 in F-sharp minor, BWV 859",duration="65":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-14-in-f-sharp-mi.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 14 in F-sharp minor, BWV 859",duration="196":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-14-in-f-sharp-mino.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 15 in G major, BWV 860",duration="55":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-15-in-g-major-bw.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 15 in G major, BWV 860",duration="156":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-15-in-g-major-bwv-.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 16 in G minor, BWV 861",duration="134":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-16-in-g-minor-bw.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 16 in G minor, BWV 861",duration="113":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-16-in-g-minor-bwv-.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 17 in A-flat major, BWV 862",duration="92":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-17-in-a-flat-maj.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 17 in A-flat major, BWV 862",duration="119":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-17-in-a-flat-major.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 18 in G-sharp minor, BWV 863",duration="121":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-18-in-g-sharp-mi.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 18 in G-sharp minor, BWV 863",duration="137":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-18-in-g-sharp-mino.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 19 in A major, BWV 864",duration="91":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-19-in-a-major-bw.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 19 in A major, BWV 864",duration="116":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-19-in-a-major-bwv-.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 20 in A minor, BWV 865",duration="84":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-20-in-a-minor-bw.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 20 in A minor, BWV 865",duration="244":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-20-in-a-minor-bwv-.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 21 in B-flat major, BWV 866",duration="78":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-21-in-b-flat-maj.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 21 in B-flat major, BWV 866",duration="115":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-21-in-b-flat-major.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 22 in B-flat minor, BWV 867",duration="147":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-22-in-b-flat-min.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 22 in B-flat minor, BWV 867",duration="197":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-22-in-b-flat-minor.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 23 in B major, BWV 868",duration="59":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-23-in-b-major-bw.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 23 in B major, BWV 868",duration="109":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-23-in-b-major-bwv-.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Prelude No. 24 in B minor, BWV 869",duration="148":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-prelude-no-24-in-b-minor-bw.mp3
+annotate:artist="J.S. Bach (Kimiko Ishizaka)",title="Well-Tempered Clavier Book I - Fugue No. 24 in B minor, BWV 869",duration="482":/music/classic/js-bach-kimiko-ishizaka-well-tempered-clavier-book-i-fugue-no-24-in-b-minor-bwv-.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 9 No. 1 in B-flat minor",duration="337":/music/classic/frederic-chopin-nocturne-op-9-no-1-in-b-flat-minor.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 9 No. 2 in E-flat major",duration="276":/music/classic/frederic-chopin-nocturne-op-9-no-2-in-e-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 9 No. 3 in B major",duration="417":/music/classic/frederic-chopin-nocturne-op-9-no-3-in-b-major.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 15 No. 1 in F major",duration="305":/music/classic/frederic-chopin-nocturne-op-15-no-1-in-f-major.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 27 No. 1 in C-sharp minor",duration="351":/music/classic/frederic-chopin-nocturne-op-27-no-1-in-c-sharp-minor.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 32 No. 1 in B major",duration="301":/music/classic/frederic-chopin-nocturne-op-32-no-1-in-b-major.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 32 No. 2 in A-flat major",duration="343":/music/classic/frederic-chopin-nocturne-op-32-no-2-in-a-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 48 No. 1 in C minor",duration="379":/music/classic/frederic-chopin-nocturne-op-48-no-1-in-c-minor.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 48 No. 2 in F-sharp minor",duration="496":/music/classic/frederic-chopin-nocturne-op-48-no-2-in-f-sharp-minor.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 55 No. 1 in F minor",duration="316":/music/classic/frederic-chopin-nocturne-op-55-no-1-in-f-minor.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 55 No. 2 in E-flat major",duration="309":/music/classic/frederic-chopin-nocturne-op-55-no-2-in-e-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 62 No. 2 in E major",duration="339":/music/classic/frederic-chopin-nocturne-op-62-no-2-in-e-major.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 72 No. 1 in E minor",duration="272":/music/classic/frederic-chopin-nocturne-op-72-no-1-in-e-minor.mp3
+annotate:artist="Frederic Chopin",title="Nocturne B. 108 in C minor",duration="193":/music/classic/frederic-chopin-nocturne-b-108-in-c-minor.mp3
+annotate:artist="Frederic Chopin",title="Nocturne B. 49 in C-sharp minor 'Lento con gran espressione'",duration="238":/music/classic/frederic-chopin-nocturne-b-49-in-c-sharp-minor-lento-con-gran-espressione.mp3
+annotate:artist="Frederic Chopin",title="Nocturne Op. 27 No. 2 in D-flat major",duration="377":/music/classic/frederic-chopin-nocturne-op-27-no-2-in-d-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 17 No. 3 in A-flat major",duration="246":/music/classic/frederic-chopin-mazurka-op-17-no-3-in-a-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 17 No. 4 in A minor",duration="299":/music/classic/frederic-chopin-mazurka-op-17-no-4-in-a-minor.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 24 No. 4 in B-flat minor",duration="287":/music/classic/frederic-chopin-mazurka-op-24-no-4-in-b-flat-minor.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 50 No. 3 in C-sharp minor",duration="360":/music/classic/frederic-chopin-mazurka-op-50-no-3-in-c-sharp-minor.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 56 No. 1 in B major",duration="317":/music/classic/frederic-chopin-mazurka-op-56-no-1-in-b-major.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 56 No. 3 in C minor",duration="374":/music/classic/frederic-chopin-mazurka-op-56-no-3-in-c-minor.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 59 No. 1 in A minor",duration="262":/music/classic/frederic-chopin-mazurka-op-59-no-1-in-a-minor.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 59 No. 3 in F-sharp minor",duration="219":/music/classic/frederic-chopin-mazurka-op-59-no-3-in-f-sharp-minor.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 50 No. 1 in G major",duration="171":/music/classic/frederic-chopin-mazurka-op-50-no-1-in-g-major.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 50 No. 2 in A-flat major",duration="198":/music/classic/frederic-chopin-mazurka-op-50-no-2-in-a-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 7 No. 3 in F minor",duration="148":/music/classic/frederic-chopin-mazurka-op-7-no-3-in-f-minor.mp3
+annotate:artist="Frederic Chopin",title="Mazurka Op. 24 No. 3 in A-flat major",duration="155":/music/classic/frederic-chopin-mazurka-op-24-no-3-in-a-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Waltz Op. 64 No. 2 in C-sharp minor",duration="230":/music/classic/frederic-chopin-waltz-op-64-no-2-in-c-sharp-minor.mp3
+annotate:artist="Frederic Chopin",title="Waltz Op. 69 No. 1 in A-flat major",duration="248":/music/classic/frederic-chopin-waltz-op-69-no-1-in-a-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Waltz Op. 69 No. 2 in B minor",duration="215":/music/classic/frederic-chopin-waltz-op-69-no-2-in-b-minor.mp3
+annotate:artist="Frederic Chopin",title="Waltz Op. 70 No. 2 in F minor",duration="185":/music/classic/frederic-chopin-waltz-op-70-no-2-in-f-minor.mp3
+annotate:artist="Frederic Chopin",title="Waltz Op. 70 No. 3 in D-flat major",duration="170":/music/classic/frederic-chopin-waltz-op-70-no-3-in-d-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Waltz Op. 34 No. 2 in A minor",duration="303":/music/classic/frederic-chopin-waltz-op-34-no-2-in-a-minor.mp3
+annotate:artist="Frederic Chopin",title="Waltz B. 46 in E-flat major",duration="143":/music/classic/frederic-chopin-waltz-b-46-in-e-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Waltz B. 56 in E minor",duration="175":/music/classic/frederic-chopin-waltz-b-56-in-e-minor.mp3
+annotate:artist="Frederic Chopin",title="Waltz Op. 34 No. 3 in F major",duration="126":/music/classic/frederic-chopin-waltz-op-34-no-3-in-f-major.mp3
+annotate:artist="Frederic Chopin",title="Waltz B. 21 in A-flat major",duration="118":/music/classic/frederic-chopin-waltz-b-21-in-a-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Fantaisie-Impromptu Op. 66 in C-sharp minor",duration="326":/music/classic/frederic-chopin-fantaisie-impromptu-op-66-in-c-sharp-minor.mp3
+annotate:artist="Frederic Chopin",title="Impromptu No. 1 Op. 29 in A-flat major",duration="280":/music/classic/frederic-chopin-impromptu-no-1-op-29-in-a-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Impromptu No. 2 Op. 36 in F-sharp major",duration="367":/music/classic/frederic-chopin-impromptu-no-2-op-36-in-f-sharp-major.mp3
+annotate:artist="Frederic Chopin",title="Impromptu No. 3 Op. 51 in G-flat major",duration="388":/music/classic/frederic-chopin-impromptu-no-3-op-51-in-g-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Prelude Op. 28 No. 6 in B minor",duration="108":/music/classic/frederic-chopin-prelude-op-28-no-6-in-b-minor.mp3
+annotate:artist="Frederic Chopin",title="Prelude Op. 28 No. 7 in A major",duration="155":/music/classic/frederic-chopin-prelude-op-28-no-7-in-a-major.mp3
+annotate:artist="Frederic Chopin",title="Prelude Op. 28 No. 13 in F-sharp major",duration="166":/music/classic/frederic-chopin-prelude-op-28-no-13-in-f-sharp-major.mp3
+annotate:artist="Frederic Chopin",title="Prelude Op. 28 No. 15 in D-flat major 'Raindrop'",duration="295":/music/classic/frederic-chopin-prelude-op-28-no-15-in-d-flat-major-raindrop.mp3
+annotate:artist="Frederic Chopin",title="Prelude Op. 28 No. 17 in A-flat major",duration="179":/music/classic/frederic-chopin-prelude-op-28-no-17-in-a-flat-major.mp3
+annotate:artist="Frederic Chopin",title="Sonata for Piano and Cello, Op. 65 - III. Largo",duration="218":/music/classic/frederic-chopin-sonata-for-piano-and-cello-op-65-iii-largo.mp3

--- a/late-core/migrations/036_collapse_mention_reads_to_cursor.sql
+++ b/late-core/migrations/036_collapse_mention_reads_to_cursor.sql
@@ -1,0 +1,16 @@
+CREATE TABLE mention_feed_reads (
+    user_id UUID PRIMARY KEY REFERENCES users(id) ON DELETE CASCADE,
+    last_read_at TIMESTAMPTZ,
+    updated TIMESTAMPTZ NOT NULL DEFAULT current_timestamp
+);
+
+INSERT INTO mention_feed_reads (user_id, last_read_at, updated)
+SELECT user_id, MAX(read_at), current_timestamp
+FROM notifications
+WHERE read_at IS NOT NULL
+GROUP BY user_id;
+
+DROP INDEX IF EXISTS idx_notifications_user_unread;
+
+ALTER TABLE notifications
+DROP COLUMN read_at;

--- a/late-core/src/models/mention_feed_read.rs
+++ b/late-core/src/models/mention_feed_read.rs
@@ -1,0 +1,52 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use tokio_postgres::Client;
+use uuid::Uuid;
+
+#[derive(Debug, Clone)]
+pub struct MentionFeedRead {
+    pub user_id: Uuid,
+    pub last_read_at: Option<DateTime<Utc>>,
+}
+
+impl MentionFeedRead {
+    pub async fn mark_read_now(client: &Client, user_id: Uuid) -> Result<()> {
+        client
+            .execute(
+                "INSERT INTO mention_feed_reads (user_id, last_read_at, updated)
+                 VALUES ($1, current_timestamp, current_timestamp)
+                 ON CONFLICT (user_id)
+                 DO UPDATE SET
+                   last_read_at = EXCLUDED.last_read_at,
+                   updated = current_timestamp",
+                &[&user_id],
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    pub async fn last_read_at(client: &Client, user_id: Uuid) -> Result<Option<DateTime<Utc>>> {
+        let row = client
+            .query_opt(
+                "SELECT last_read_at FROM mention_feed_reads WHERE user_id = $1",
+                &[&user_id],
+            )
+            .await?;
+        Ok(row.map(|row| row.get("last_read_at")).unwrap_or(None))
+    }
+
+    pub async fn unread_count_for_user(client: &Client, user_id: Uuid) -> Result<i64> {
+        let row = client
+            .query_one(
+                "SELECT COUNT(n.id)::bigint AS unread_count
+                 FROM notifications n
+                 LEFT JOIN mention_feed_reads mfr ON mfr.user_id = $1
+                 WHERE n.user_id = $1
+                   AND n.created > COALESCE(mfr.last_read_at, '-infinity'::timestamptz)",
+                &[&user_id],
+            )
+            .await?;
+        Ok(row.get("unread_count"))
+    }
+}

--- a/late-core/src/models/mod.rs
+++ b/late-core/src/models/mod.rs
@@ -9,6 +9,7 @@ pub mod chat_room_member;
 pub mod chips;
 pub mod game_room;
 pub mod leaderboard;
+pub mod mention_feed_read;
 pub mod minesweeper;
 pub mod nonogram;
 pub mod notification;

--- a/late-core/src/models/notification.rs
+++ b/late-core/src/models/notification.rs
@@ -3,6 +3,8 @@ use chrono::{DateTime, Utc};
 use tokio_postgres::Client;
 use uuid::Uuid;
 
+use super::mention_feed_read::MentionFeedRead;
+
 crate::user_scoped_model! {
     table = "notifications";
     user_field = user_id;
@@ -12,8 +14,7 @@ crate::user_scoped_model! {
         pub user_id: Uuid,
         pub actor_id: Uuid,
         pub message_id: Uuid,
-        pub room_id: Uuid,
-        pub read_at: Option<DateTime<Utc>>
+        pub room_id: Uuid
     }
 }
 
@@ -26,7 +27,6 @@ pub struct NotificationView {
     pub actor_id: Uuid,
     pub message_id: Uuid,
     pub room_id: Uuid,
-    pub read_at: Option<DateTime<Utc>>,
     pub actor_username: String,
     pub room_slug: Option<String>,
     pub message_preview: String,
@@ -76,7 +76,7 @@ impl Notification {
     ) -> Result<Vec<NotificationView>> {
         let rows = client
             .query(
-                "SELECT n.id, n.created, n.user_id, n.actor_id, n.message_id, n.room_id, n.read_at,
+                "SELECT n.id, n.created, n.user_id, n.actor_id, n.message_id, n.room_id,
                         COALESCE(u.username, '') AS actor_username,
                         r.slug AS room_slug,
                         LEFT(m.body, 120) AS message_preview
@@ -100,7 +100,6 @@ impl Notification {
                 actor_id: row.get("actor_id"),
                 message_id: row.get("message_id"),
                 room_id: row.get("room_id"),
-                read_at: row.get("read_at"),
                 actor_username: row.get("actor_username"),
                 room_slug: row.get("room_slug"),
                 message_preview: row.get("message_preview"),
@@ -110,24 +109,16 @@ impl Notification {
 
     /// Count unread notifications for a user.
     pub async fn unread_count(client: &Client, user_id: Uuid) -> Result<i64> {
-        let row = client
-            .query_one(
-                "SELECT COUNT(*)::bigint AS cnt FROM notifications WHERE user_id = $1 AND read_at IS NULL",
-                &[&user_id],
-            )
-            .await?;
-        Ok(row.get("cnt"))
+        MentionFeedRead::unread_count_for_user(client, user_id).await
     }
 
     /// Mark all unread notifications as read for a user.
-    pub async fn mark_all_read(client: &Client, user_id: Uuid) -> Result<u64> {
-        let count = client
-            .execute(
-                "UPDATE notifications SET read_at = current_timestamp WHERE user_id = $1 AND read_at IS NULL",
-                &[&user_id],
-            )
-            .await?;
-        Ok(count)
+    pub async fn mark_all_read(client: &Client, user_id: Uuid) -> Result<()> {
+        MentionFeedRead::mark_read_now(client, user_id).await
+    }
+
+    pub async fn last_read_at(client: &Client, user_id: Uuid) -> Result<Option<DateTime<Utc>>> {
+        MentionFeedRead::last_read_at(client, user_id).await
     }
 
     /// Resolve @usernames to user IDs, excluding the actor.

--- a/late-core/tests/mention_feed_read.rs
+++ b/late-core/tests/mention_feed_read.rs
@@ -1,0 +1,88 @@
+use late_core::{
+    models::{
+        chat_message::{ChatMessage, ChatMessageParams},
+        chat_room::ChatRoom,
+        mention_feed_read::MentionFeedRead,
+        notification::Notification,
+    },
+    test_utils::{create_test_user, test_db},
+};
+use tokio::time::{Duration, sleep};
+
+#[tokio::test]
+async fn mention_feed_unread_uses_timestamp_cursor() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let room = ChatRoom::ensure_general(&client)
+        .await
+        .expect("ensure general");
+    let actor = create_test_user(&test_db.db, "mention-actor").await;
+    let reader = create_test_user(&test_db.db, "mention-reader").await;
+
+    let first = ChatMessage::create(
+        &client,
+        ChatMessageParams {
+            room_id: room.id,
+            user_id: actor.id,
+            body: "@mention-reader one".to_string(),
+        },
+    )
+    .await
+    .expect("create first message");
+    Notification::create_mentions_batch(&client, &[reader.id], actor.id, first.id, room.id)
+        .await
+        .expect("create first mention");
+
+    let second = ChatMessage::create(
+        &client,
+        ChatMessageParams {
+            room_id: room.id,
+            user_id: actor.id,
+            body: "@mention-reader two".to_string(),
+        },
+    )
+    .await
+    .expect("create second message");
+    Notification::create_mentions_batch(&client, &[reader.id], actor.id, second.id, room.id)
+        .await
+        .expect("create second mention");
+
+    let unread_before = MentionFeedRead::unread_count_for_user(&client, reader.id)
+        .await
+        .expect("count unread before");
+    assert_eq!(unread_before, 2);
+
+    MentionFeedRead::mark_read_now(&client, reader.id)
+        .await
+        .expect("mark read");
+    let read_cursor = MentionFeedRead::last_read_at(&client, reader.id)
+        .await
+        .expect("read cursor");
+    assert!(read_cursor.is_some());
+
+    let unread_after = MentionFeedRead::unread_count_for_user(&client, reader.id)
+        .await
+        .expect("count unread after mark read");
+    assert_eq!(unread_after, 0);
+
+    sleep(Duration::from_millis(5)).await;
+
+    let third = ChatMessage::create(
+        &client,
+        ChatMessageParams {
+            room_id: room.id,
+            user_id: actor.id,
+            body: "@mention-reader three".to_string(),
+        },
+    )
+    .await
+    .expect("create third message");
+    Notification::create_mentions_batch(&client, &[reader.id], actor.id, third.id, room.id)
+        .await
+        .expect("create third mention");
+
+    let unread_after_new = MentionFeedRead::unread_count_for_user(&client, reader.id)
+        .await
+        .expect("count unread after new mention");
+    assert_eq!(unread_after_new, 1);
+}

--- a/late-ssh/src/app/chat/notifications/state.rs
+++ b/late-ssh/src/app/chat/notifications/state.rs
@@ -1,3 +1,4 @@
+use chrono::{DateTime, Utc};
 use tokio::sync::{broadcast, watch};
 use uuid::Uuid;
 
@@ -14,6 +15,8 @@ pub struct State {
     snapshot_rx: watch::Receiver<NotificationSnapshot>,
     event_rx: broadcast::Receiver<NotificationEvent>,
     unread_count: i64,
+    last_read_at: Option<DateTime<Utc>>,
+    marker_read_at: Option<DateTime<Utc>>,
 }
 
 impl State {
@@ -29,6 +32,8 @@ impl State {
             snapshot_rx,
             event_rx,
             unread_count: 0,
+            last_read_at: None,
+            marker_read_at: None,
         }
     }
 
@@ -57,7 +62,12 @@ impl State {
         self.unread_count
     }
 
+    pub fn marker_read_at(&self) -> Option<DateTime<Utc>> {
+        self.marker_read_at
+    }
+
     pub fn mark_read(&mut self) {
+        self.marker_read_at = self.last_read_at;
         self.unread_count = 0;
         self.service.mark_all_read_task(self.user_id);
     }
@@ -85,8 +95,10 @@ impl State {
                     NotificationEvent::UnreadCountUpdated {
                         user_id,
                         unread_count,
+                        last_read_at,
                     } if user_id == self.user_id => {
                         self.unread_count = unread_count;
+                        self.last_read_at = last_read_at;
                     }
                     NotificationEvent::NewMention {
                         user_id,

--- a/late-ssh/src/app/chat/notifications/svc.rs
+++ b/late-ssh/src/app/chat/notifications/svc.rs
@@ -16,8 +16,15 @@ pub struct NotificationSnapshot {
 
 #[derive(Clone, Debug)]
 pub enum NotificationEvent {
-    UnreadCountUpdated { user_id: Uuid, unread_count: i64 },
-    NewMention { user_id: Uuid, unread_count: i64 },
+    UnreadCountUpdated {
+        user_id: Uuid,
+        unread_count: i64,
+        last_read_at: Option<chrono::DateTime<chrono::Utc>>,
+    },
+    NewMention {
+        user_id: Uuid,
+        unread_count: i64,
+    },
 }
 
 #[derive(Clone)]
@@ -93,9 +100,11 @@ impl NotificationService {
     async fn publish_unread_count(&self, user_id: Uuid) -> anyhow::Result<()> {
         let client = self.db.get().await?;
         let unread_count = Notification::unread_count(&client, user_id).await?;
+        let last_read_at = Notification::last_read_at(&client, user_id).await?;
         let _ = self.evt_tx.send(NotificationEvent::UnreadCountUpdated {
             user_id,
             unread_count,
+            last_read_at,
         });
         Ok(())
     }
@@ -123,9 +132,11 @@ impl NotificationService {
     async fn do_mark_all_read(&self, user_id: Uuid) -> anyhow::Result<()> {
         let client = self.db.get().await?;
         Notification::mark_all_read(&client, user_id).await?;
+        let last_read_at = Notification::last_read_at(&client, user_id).await?;
         let _ = self.evt_tx.send(NotificationEvent::UnreadCountUpdated {
             user_id,
             unread_count: 0,
+            last_read_at,
         });
         Ok(())
     }

--- a/late-ssh/src/app/chat/notifications/ui.rs
+++ b/late-ssh/src/app/chat/notifications/ui.rs
@@ -1,4 +1,5 @@
 use crate::app::common::{primitives::format_relative_time, theme};
+use chrono::{DateTime, Utc};
 use late_core::models::notification::NotificationView;
 use ratatui::{
     Frame,
@@ -11,6 +12,7 @@ use ratatui::{
 pub struct NotificationListView<'a> {
     pub items: &'a [NotificationView],
     pub selected_index: usize,
+    pub marker_read_at: Option<DateTime<Utc>>,
 }
 
 const ITEM_HEIGHT: u16 = 4;
@@ -76,10 +78,14 @@ pub fn draw_notification_list(frame: &mut Frame, area: Rect, view: &Notification
             .map(|s| format!("#{s}"))
             .unwrap_or_else(|| "DM".to_string());
 
-        let read_indicator = if item.read_at.is_some() {
-            Span::styled(" ", Style::default())
-        } else {
+        let is_unread = view
+            .marker_read_at
+            .map(|last_read_at| item.created > last_read_at)
+            .unwrap_or(true);
+        let read_indicator = if is_unread {
             Span::styled("● ", Style::default().fg(theme::MENTION()))
+        } else {
+            Span::styled(" ", Style::default())
         };
 
         let mut lines = vec![Line::from(vec![

--- a/late-ssh/src/app/chat/showcase/ui.rs
+++ b/late-ssh/src/app/chat/showcase/ui.rs
@@ -113,11 +113,6 @@ pub fn draw_showcase_list(frame: &mut Frame, area: Rect, view: &ShowcaseListView
                 "  (yours)",
                 Style::default().fg(theme::AMBER_DIM()),
             ));
-        } else if view.is_admin {
-            title_spans.push(Span::styled(
-                "  (admin)",
-                Style::default().fg(theme::AMBER_DIM()),
-            ));
         }
         lines.push(Line::from(title_spans));
 

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -1432,6 +1432,7 @@ mod tests {
             notifications_view: crate::app::chat::notifications::ui::NotificationListView {
                 items: &[],
                 selected_index: 0,
+                marker_read_at: None,
             },
             showcase_selected: false,
             showcase_unread_count: 0,

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -1126,6 +1126,7 @@ fn handle_mouse_click(app: &mut App, screen: Screen, mouse: MouseEvent) -> bool 
                     crate::app::chat::notifications::ui::NotificationListView {
                         items: app.chat.notifications.all_items(),
                         selected_index: app.chat.notifications.selected_index(),
+                        marker_read_at: app.chat.notifications.marker_read_at(),
                     };
                 let mut rows_cache = crate::app::chat::ui::ChatRowsCache::default();
                 let view = crate::app::chat::ui::ChatRenderInput {

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -261,6 +261,7 @@ impl App {
         let notifications_view = chat::notifications::ui::NotificationListView {
             items: self.chat.notifications.all_items(),
             selected_index: self.chat.notifications.selected_index(),
+            marker_read_at: self.chat.notifications.marker_read_at(),
         };
         let showcase_view = chat::showcase::ui::ShowcaseListView {
             items: self.chat.showcase.all_items(),

--- a/scripts/fetch_cc_music.py
+++ b/scripts/fetch_cc_music.py
@@ -234,6 +234,136 @@ IA_ITEMS = [
     ("Jazz_Sampler-9619", "jazz", 20),
 ]
 
+# Second-pass classical expansion: ~100 chill picks for coding sessions, drawn
+# from explicitly CC0 / Public-Domain-marked archive.org items. These are
+# downloaded into tmp/classic/ and APPENDED to infra/liquidsoap/classic.m3u
+# (the existing 100-track manifest in R2 is left untouched). Triggered by
+# --classic-expand on the CLI.
+#
+# Sources:
+#   - musopen-chopin (CC0): Musopen's Complete Chopin Collection
+#   - bach-well-tempered-clavier-book-1 (PD mark): Kimiko Ishizaka's "Open
+#     Well-Tempered Clavier" Book I, the canonical PD recording
+#   - MusopenCollectionAsFlac (PD): chill movements not yet in the manifest
+IA_CLASSIC_EXPANSION = [
+    # ---- MusopenCollectionAsFlac: chill movements left over from pass 1 ----
+    ("MusopenCollectionAsFlac", "Mendelssohn_StringQuartetNo.6inFMinorOp.80/FelixMendelssohn-StringQuartetNo.6InFMinorOp.80-03-Adagio.mp3", "Felix Mendelssohn", "String Quartet No. 6 in F Minor, Op. 80 - III. Adagio"),
+    ("MusopenCollectionAsFlac", "Schubert_SonataInDMajorD.850/FranzSchubert-SonataInDMajorD.850-02-ConMoto.mp3", "Franz Schubert", "Sonata in D Major, D. 850 - II. Con moto"),
+    ("MusopenCollectionAsFlac", "Tchaikovsky_SymphonyPathetique/PyotrIlyichTchaikovsky-SymphonyNo.6InBMinorOp.74pathtique-04-FinaleAdagioLamentoso.mp3", "Pyotr Ilyich Tchaikovsky", "Symphony No. 6 in B Minor, Op. 74 'Pathetique' - IV. Finale Adagio lamentoso"),
+    ("MusopenCollectionAsFlac", "Brahms_SymphonyNo.1inCMinor/JohannesBrahms-SymphonyNo.1InCMinorOp.68-04-Adagio-PiAndante-AllegroNonTroppoMaConBrio.mp3", "Johannes Brahms", "Symphony No. 1 in C Minor, Op. 68 - IV. Adagio - Piu andante - Allegro non troppo"),
+    ("MusopenCollectionAsFlac", "Schubert_SonataInCMinorD.958/FranzSchubert-SonataInCMinorD.958-03-MenuettoAllegro.mp3", "Franz Schubert", "Sonata in C Minor, D. 958 - III. Menuetto Allegro"),
+
+    # ---- Kimiko Ishizaka, Open Well-Tempered Clavier Book I (CC0/PD mark) ----
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 01 Prelude No. 1 in C major, BWV 846.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 1 in C major, BWV 846"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 02 Fugue No. 1 in C major, BWV 846.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 1 in C major, BWV 846"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 03 Prelude No. 2 in C minor, BWV 847.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 2 in C minor, BWV 847"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 04 Fugue No. 2 in C minor, BWV 847.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 2 in C minor, BWV 847"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 05 Prelude No. 3 in C-sharp major, BWV 848.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 3 in C-sharp major, BWV 848"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 06 Fugue No. 3 in C-sharp major, BWV 848.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 3 in C-sharp major, BWV 848"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 07 Prelude No. 4 in C-sharp minor, BWV 849.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 4 in C-sharp minor, BWV 849"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 08 Fugue No. 4 in C-sharp minor, BWV 849.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 4 in C-sharp minor, BWV 849"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 09 Prelude No. 5 in D major, BWV 850.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 5 in D major, BWV 850"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 10 Fugue No. 5 in D major, BWV 850.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 5 in D major, BWV 850"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 11 Prelude No. 6 in D minor, BWV 851.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 6 in D minor, BWV 851"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 12 Fugue No. 6 in D minor, BWV 851.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 6 in D minor, BWV 851"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 13 Prelude No. 7 in E-flat major, BWV 852.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 7 in E-flat major, BWV 852"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 14 Fugue No. 7 in E-flat major, BWV 852.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 7 in E-flat major, BWV 852"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 15 Prelude No. 8 in E-flat minor, BWV 853.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 8 in E-flat minor, BWV 853"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 16 Fugue No. 8 in D-sharp minor, BWV 853.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 8 in D-sharp minor, BWV 853"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 17 Prelude No. 9 in E major, BWV 854.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 9 in E major, BWV 854"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 18 Fugue No. 9 in E major, BWV 854.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 9 in E major, BWV 854"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 19 Prelude No. 10 in E minor, BWV 855.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 10 in E minor, BWV 855"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 20 Fugue No. 10 in E minor, BWV 855.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 10 in E minor, BWV 855"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 21 Prelude No. 11 in F major, BWV 856.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 11 in F major, BWV 856"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 22 Fugue No. 11 in F major, BWV 856.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 11 in F major, BWV 856"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 23 Prelude No. 12 in F minor, BWV 857.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 12 in F minor, BWV 857"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 24 Fugue No. 12 in F minor, BWV 857.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 12 in F minor, BWV 857"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 25 Prelude No. 13 in F-sharp major, BWV 858.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 13 in F-sharp major, BWV 858"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 26 Fugue No. 13 in F-sharp major, BWV 858.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 13 in F-sharp major, BWV 858"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 27 Prelude No. 14 in F-sharp minor, BWV 859.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 14 in F-sharp minor, BWV 859"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 28 Fugue No. 14 in F-sharp minor, BWV 859.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 14 in F-sharp minor, BWV 859"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 29 Prelude No. 15 in G major, BWV 860.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 15 in G major, BWV 860"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 30 Fugue No. 15 in G major, BWV 860.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 15 in G major, BWV 860"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 31 Prelude No. 16 in G minor, BWV 861.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 16 in G minor, BWV 861"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 32 Fugue No. 16 in G minor, BWV 861.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 16 in G minor, BWV 861"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 33 Prelude No. 17 in A-flat major, BWV 862.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 17 in A-flat major, BWV 862"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 34 Fugue No. 17 in A-flat major, BWV 862.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 17 in A-flat major, BWV 862"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 35 Prelude No. 18 in G-sharp minor, BWV 863.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 18 in G-sharp minor, BWV 863"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 36 Fugue No. 18 in G-sharp minor, BWV 863.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 18 in G-sharp minor, BWV 863"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 37 Prelude No. 19 in A major, BWV 864.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 19 in A major, BWV 864"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 38 Fugue No. 19 in A major, BWV 864.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 19 in A major, BWV 864"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 39 Prelude No. 20 in A minor, BWV 865.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 20 in A minor, BWV 865"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 40 Fugue No. 20 in A minor, BWV 865.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 20 in A minor, BWV 865"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 41 Prelude No. 21 in B-flat major, BWV 866.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 21 in B-flat major, BWV 866"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 42 Fugue No. 21 in B-flat major, BWV 866.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 21 in B-flat major, BWV 866"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 43 Prelude No. 22 in B-flat minor, BWV 867.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 22 in B-flat minor, BWV 867"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 44 Fugue No. 22 in B-flat minor, BWV 867.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 22 in B-flat minor, BWV 867"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 45 Prelude No. 23 in B major, BWV 868.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 23 in B major, BWV 868"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 46 Fugue No. 23 in B major, BWV 868.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 23 in B major, BWV 868"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 47 Prelude No. 24 in B minor, BWV 869.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Prelude No. 24 in B minor, BWV 869"),
+    ("bach-well-tempered-clavier-book-1", "Kimiko Ishizaka - Bach- Well-Tempered Clavier, Book 1 - 48 Fugue No. 24 in B minor, BWV 869.mp3", "J.S. Bach (Kimiko Ishizaka)", "Well-Tempered Clavier Book I - Fugue No. 24 in B minor, BWV 869"),
+
+    # ---- Musopen Complete Chopin Collection (CC0) - Nocturnes ----
+    ("musopen-chopin", "NocturneOp.9No.1InBFlatMinor.mp3", "Frederic Chopin", "Nocturne Op. 9 No. 1 in B-flat minor"),
+    ("musopen-chopin", "Nocturne Op. 9 no. 2 in E flat major.mp3", "Frederic Chopin", "Nocturne Op. 9 No. 2 in E-flat major"),
+    ("musopen-chopin", "NocturneOp.9No.3.mp3", "Frederic Chopin", "Nocturne Op. 9 No. 3 in B major"),
+    ("musopen-chopin", "Nocturne Op. 15 no. 1 In F major.mp3", "Frederic Chopin", "Nocturne Op. 15 No. 1 in F major"),
+    ("musopen-chopin", "Nocturne Op. 27 no. 1 in C sharp minor.mp3", "Frederic Chopin", "Nocturne Op. 27 No. 1 in C-sharp minor"),
+    ("musopen-chopin", "Nocturne Op. 32 no. 1 in B major.mp3", "Frederic Chopin", "Nocturne Op. 32 No. 1 in B major"),
+    ("musopen-chopin", "Nocturne Op. 32 no. 2 in A flat major.mp3", "Frederic Chopin", "Nocturne Op. 32 No. 2 in A-flat major"),
+    ("musopen-chopin", "Nocturne Op. 48 no. 1 in C minor.mp3", "Frederic Chopin", "Nocturne Op. 48 No. 1 in C minor"),
+    ("musopen-chopin", "Nocturne Op. 48 no. 2 in F sharp minor.mp3", "Frederic Chopin", "Nocturne Op. 48 No. 2 in F-sharp minor"),
+    ("musopen-chopin", "Nocturne Op. 55 no. 1 in F minor.mp3", "Frederic Chopin", "Nocturne Op. 55 No. 1 in F minor"),
+    ("musopen-chopin", "Nocturne Op. 55 no. 2 in E flat major.mp3", "Frederic Chopin", "Nocturne Op. 55 No. 2 in E-flat major"),
+    ("musopen-chopin", "Nocturne Op. 62 no. 2 in E major.mp3", "Frederic Chopin", "Nocturne Op. 62 No. 2 in E major"),
+    ("musopen-chopin", "NocturneOp.72No.1InEMinor.mp3", "Frederic Chopin", "Nocturne Op. 72 No. 1 in E minor"),
+    ("musopen-chopin", "Nocturne B. 108 in C minor.mp3", "Frederic Chopin", "Nocturne B. 108 in C minor"),
+    ("musopen-chopin", "Nocturne B. 49 in C sharp minor 'Lento con gran espressione' (1).mp3", "Frederic Chopin", "Nocturne B. 49 in C-sharp minor 'Lento con gran espressione'"),
+    ("musopen-chopin", "NocturneOp27No2.mp3", "Frederic Chopin", "Nocturne Op. 27 No. 2 in D-flat major"),
+
+    # ---- Chopin: Mazurkas ----
+    ("musopen-chopin", "Mazurka Op. 17 no. 3 in A flat major.mp3", "Frederic Chopin", "Mazurka Op. 17 No. 3 in A-flat major"),
+    ("musopen-chopin", "Mazurka Op. 17 no. 4 in A minor.mp3", "Frederic Chopin", "Mazurka Op. 17 No. 4 in A minor"),
+    ("musopen-chopin", "Mazurka Op. 24 no. 4 in B flat minor.mp3", "Frederic Chopin", "Mazurka Op. 24 No. 4 in B-flat minor"),
+    ("musopen-chopin", "Mazurka Op. 50 no. 3 in C sharp minor.mp3", "Frederic Chopin", "Mazurka Op. 50 No. 3 in C-sharp minor"),
+    ("musopen-chopin", "Mazurka Op. 56 no. 1 in B major.mp3", "Frederic Chopin", "Mazurka Op. 56 No. 1 in B major"),
+    ("musopen-chopin", "Mazurka Op. 56 no. 3 in C minor.mp3", "Frederic Chopin", "Mazurka Op. 56 No. 3 in C minor"),
+    ("musopen-chopin", "Mazurka Op. 59 no. 1 in A minor.mp3", "Frederic Chopin", "Mazurka Op. 59 No. 1 in A minor"),
+    ("musopen-chopin", "Mazurka Op. 59 no. 3 in F sharp minor.mp3", "Frederic Chopin", "Mazurka Op. 59 No. 3 in F-sharp minor"),
+    ("musopen-chopin", "Mazurka Op. 50 no. 1 in G major.mp3", "Frederic Chopin", "Mazurka Op. 50 No. 1 in G major"),
+    ("musopen-chopin", "Mazurka Op. 50 no. 2 in A flat major.mp3", "Frederic Chopin", "Mazurka Op. 50 No. 2 in A-flat major"),
+    ("musopen-chopin", "Mazurka Op. 7 no. 3 in F minor.mp3", "Frederic Chopin", "Mazurka Op. 7 No. 3 in F minor"),
+    ("musopen-chopin", "Mazurka Op. 24 no. 3 in A flat major.mp3", "Frederic Chopin", "Mazurka Op. 24 No. 3 in A-flat major"),
+
+    # ---- Chopin: Waltzes (calmer, melodic ones) ----
+    ("musopen-chopin", "Waltz Op. 64 no. 2 in C sharp minor.mp3", "Frederic Chopin", "Waltz Op. 64 No. 2 in C-sharp minor"),
+    ("musopen-chopin", "Waltz Op. 69 no. 1 in A flat major.mp3", "Frederic Chopin", "Waltz Op. 69 No. 1 in A-flat major"),
+    ("musopen-chopin", "Waltz Op. 69 no. 2 in B minor.mp3", "Frederic Chopin", "Waltz Op. 69 No. 2 in B minor"),
+    ("musopen-chopin", "Waltz Op. 70 no. 2 in F minor.mp3", "Frederic Chopin", "Waltz Op. 70 No. 2 in F minor"),
+    ("musopen-chopin", "Waltz Op. 70 no. 3 in D flat major.mp3", "Frederic Chopin", "Waltz Op. 70 No. 3 in D-flat major"),
+    ("musopen-chopin", "WaltzOp.34No.2InAMinor.mp3", "Frederic Chopin", "Waltz Op. 34 No. 2 in A minor"),
+    ("musopen-chopin", "WaltzB.46InEFlatMajor.mp3", "Frederic Chopin", "Waltz B. 46 in E-flat major"),
+    ("musopen-chopin", "WaltzB.56InEMinor.mp3", "Frederic Chopin", "Waltz B. 56 in E minor"),
+    ("musopen-chopin", "WaltzOp.34No.3InFMajor.mp3", "Frederic Chopin", "Waltz Op. 34 No. 3 in F major"),
+    ("musopen-chopin", "WaltzB.21InAFlatMajor.mp3", "Frederic Chopin", "Waltz B. 21 in A-flat major"),
+
+    # ---- Chopin: Impromptus ----
+    ("musopen-chopin", "Fantasie Impromptu Op. 66.mp3", "Frederic Chopin", "Fantaisie-Impromptu Op. 66 in C-sharp minor"),
+    ("musopen-chopin", "Impromptu no. 1 - Op. 29.mp3", "Frederic Chopin", "Impromptu No. 1 Op. 29 in A-flat major"),
+    ("musopen-chopin", "Impromptu no. 2 - Op. 36.mp3", "Frederic Chopin", "Impromptu No. 2 Op. 36 in F-sharp major"),
+    ("musopen-chopin", "Impromptu no. 3 - Op. 51.mp3", "Frederic Chopin", "Impromptu No. 3 Op. 51 in G-flat major"),
+
+    # ---- Chopin: Preludes Op. 28 (calmer ones) ----
+    ("musopen-chopin", "Prelude Op. 28 no. 6.mp3", "Frederic Chopin", "Prelude Op. 28 No. 6 in B minor"),
+    ("musopen-chopin", "Prelude Op. 28 no. 7.mp3", "Frederic Chopin", "Prelude Op. 28 No. 7 in A major"),
+    ("musopen-chopin", "Prelude Op. 28 no. 13.mp3", "Frederic Chopin", "Prelude Op. 28 No. 13 in F-sharp major"),
+    ("musopen-chopin", "Prelude Op. 28 no. 15.mp3", "Frederic Chopin", "Prelude Op. 28 No. 15 in D-flat major 'Raindrop'"),
+    ("musopen-chopin", "Prelude Op. 28 no. 17.mp3", "Frederic Chopin", "Prelude Op. 28 No. 17 in A-flat major"),
+
+    # ---- Chopin: Cello Sonata Largo ----
+    ("musopen-chopin", "Sonata for Piano and Cello in G Minor, Op. 65 - III. Largo.mp3", "Frederic Chopin", "Sonata for Piano and Cello, Op. 65 - III. Largo"),
+]
+
 
 def slugify(text: str) -> str:
     """Convert text to a safe filename slug."""
@@ -444,6 +574,115 @@ def download_ia(identifier: str, genre: str, max_tracks: int):
     print(f"  Downloaded {count} tracks for {genre}")
 
 
+def download_classic_expansion():
+    """Download the IA_CLASSIC_EXPANSION batch into tmp/classic/ (skipping any
+    files already present locally or already represented in classic.m3u)."""
+    out_dir = MUSIC_DIR / "classic"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    existing_in_m3u = m3u_existing_container_paths("classic")
+
+    print(f"\n{'='*60}")
+    print(f"  Downloading classical expansion ({len(IA_CLASSIC_EXPANSION)} tracks)")
+    print(f"{'='*60}")
+
+    downloaded = 0
+    for i, (identifier, relative_path, artist, title) in enumerate(IA_CLASSIC_EXPANSION, start=1):
+        out_path = manifest_output_path("classic", artist, title)
+        container_path = f"/music/classic/{out_path.name}"
+        if container_path in existing_in_m3u:
+            print(f"  [skip-m3u] {artist} - {title}")
+            continue
+        if out_path.exists():
+            print(f"  [skip-file] {artist} - {title}")
+            continue
+
+        print(f"  [{i}/{len(IA_CLASSIC_EXPANSION)}] {artist} - {title}")
+        try:
+            dl_url = f"https://archive.org/download/{identifier}/{urllib.request.quote(relative_path)}"
+            urllib.request.urlretrieve(dl_url, str(out_path))
+            downloaded += 1
+        except Exception as e:
+            print(f"  [error] {e}")
+            if out_path.exists():
+                out_path.unlink()
+
+    print(f"  Downloaded {downloaded} new tracks to {out_dir}")
+
+
+def m3u_existing_container_paths(genre: str) -> set:
+    """Parse an existing .m3u and return the set of container paths already
+    represented (the part after the final ':' on annotate lines)."""
+    m3u_path = LIQUIDSOAP_DIR / f"{genre}.m3u"
+    if not m3u_path.exists():
+        return set()
+    paths = set()
+    for line in m3u_path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        # annotate:...:/music/<genre>/<file>
+        marker = f":/music/{genre}/"
+        idx = line.find(marker)
+        if idx >= 0:
+            paths.add(line[idx + 1:])
+        elif line.startswith(f"/music/{genre}/"):
+            paths.add(line)
+    return paths
+
+
+def append_classic_expansion_to_m3u():
+    """Append annotate lines for any IA_CLASSIC_EXPANSION tracks present in
+    tmp/classic/ but not yet in classic.m3u. Existing entries are untouched."""
+    m3u_path = LIQUIDSOAP_DIR / "classic.m3u"
+    existing_paths = m3u_existing_container_paths("classic")
+
+    new_lines = []
+    skipped_missing = 0
+    for identifier, relative_path, artist, title in IA_CLASSIC_EXPANSION:
+        mp3 = manifest_output_path("classic", artist, title)
+        container_path = f"/music/classic/{mp3.name}"
+        if container_path in existing_paths:
+            continue
+        if not mp3.exists():
+            skipped_missing += 1
+            continue
+
+        duration = ""
+        try:
+            result = subprocess.run(
+                ["ffprobe", "-v", "quiet", "-print_format", "json",
+                 "-show_format", str(mp3)],
+                capture_output=True, text=True, timeout=5,
+            )
+            if result.returncode == 0:
+                fmt = json.loads(result.stdout).get("format", {})
+                dur_secs = float(fmt.get("duration", 0))
+                if dur_secs > 0:
+                    duration = str(int(dur_secs))
+        except Exception:
+            pass
+
+        # liquidsoap annotate format expects double-quoted values; embed any
+        # apostrophes literally and replace any double quotes in source with
+        # single quotes (matches the existing manifest convention)
+        a = artist.replace('"', "'")
+        t = title.replace('"', "'")
+        dur_part = f',duration="{duration}"' if duration else ""
+        new_lines.append(f'annotate:artist="{a}",title="{t}"{dur_part}:{container_path}')
+
+    if not new_lines:
+        print(f"  No new tracks to append to {m3u_path.name} ({skipped_missing} missing locally)")
+        return
+
+    # Append, ensuring the existing file ends with a newline
+    existing_content = m3u_path.read_text() if m3u_path.exists() else ""
+    if existing_content and not existing_content.endswith("\n"):
+        existing_content += "\n"
+    m3u_path.write_text(existing_content + "\n".join(new_lines) + "\n")
+    print(f"  Appended {len(new_lines)} tracks to {m3u_path.name} (skipped {skipped_missing} missing locally)")
+
+
 def generate_m3u(genre: str):
     """Generate .m3u playlist from downloaded MP3 files."""
     music_path = MUSIC_DIR / genre
@@ -541,10 +780,26 @@ def main():
                         help="Only regenerate .m3u files from existing downloads")
     parser.add_argument("--skip-m3u", action="store_true",
                         help="Skip generating .m3u files")
+    parser.add_argument("--classic-expand", action="store_true",
+                        help="Download the IA_CLASSIC_EXPANSION batch into tmp/classic/ "
+                             "and append the new tracks to classic.m3u (existing entries "
+                             "are preserved). Skips all other genres and download paths.")
     args = parser.parse_args()
 
     MUSIC_DIR = args.music_dir.resolve()
     LIQUIDSOAP_DIR = args.liquidsoap_dir.resolve()
+
+    if args.classic_expand:
+        download_classic_expansion()
+        if not args.skip_m3u:
+            print(f"\n{'='*60}")
+            print("  Appending new classical tracks to classic.m3u")
+            print(f"{'='*60}")
+            append_classic_expansion_to_m3u()
+        print("\nDone! Next steps:")
+        print(f"  1. Review {LIQUIDSOAP_DIR}/classic.m3u (new entries appended at the end)")
+        print(f"  2. Upload tmp/classic/*.mp3 to R2, then clear tmp/classic/")
+        return
 
     genres = ["lofi", "ambient", "classic", "jazz"] if args.genre == "all" else [args.genre]
 


### PR DESCRIPTION
## Summary

The mention feed previously tracked read state by stamping `read_at` on every individual notification row, which meant a hot-path "mark all read" had to UPDATE potentially thousands of rows per user and the unread count had to scan the same. This PR replaces that scheme with a single per-user `last_read_at` cursor: marking the feed read becomes one upsert, unread count becomes "rows newer than your cursor", and the `notifications.read_at` column goes away.

The branch also includes a second-pass expansion of the classical music catalog (100 → 201 tracks) used by the local-music release, sourced entirely from CC0 / Public Domain archive.org material.

## What changed

### Notifications
- New `mention_feed_reads` table holding `(user_id, last_read_at)`. New `MentionFeedRead` model wraps `mark_read_now`, `last_read_at`, and `unread_count_for_user`.
- `Notification::unread_count` and `Notification::mark_all_read` now delegate to the cursor; `read_at` is dropped from `notifications` and from `NotificationView`.
- `NotificationEvent::UnreadCountUpdated` now carries `last_read_at` so the SSH client can keep its own copy of the cursor.
- The notifications panel now decides "unread dot" by comparing each item's `created` against a snapshot of the previous `last_read_at` (`marker_read_at`), captured at the moment the user opens the panel. This preserves the existing UX where dots stay visible while you're still looking at the list, then disappear on the next refresh — without needing per-row state.
- Showcase UI: dropped the `(admin)` suffix that was rendered next to admin-owned posts; only `(yours)` remains.

### Classical music (`classic` genre, pass 2)
- `MUSIC.md` and `infra/liquidsoap/classic.m3u` extended from 100 to 201 tracks. New material: 5 leftover chill movements from MusopenCollectionAsFlac (PD), all 48 Bach Well-Tempered Clavier Book I prelude/fugue pairs by Kimiko Ishizaka (CC0/PD mark), and 48 Chopin pieces from Musopen's Complete Chopin Collection (CC0).
- `scripts/fetch_cc_music.py` gains a `--classic-expand` flag that downloads only the new batch into `tmp/classic/` and **appends** to the existing m3u (leaving the 100 already-uploaded tracks and their R2 paths untouched).

## Behavior notes

- The migration is destructive: `ALTER TABLE notifications DROP COLUMN read_at`. The data backfill is `MAX(read_at) GROUP BY user_id` into the new `mention_feed_reads` table, so any unread mentions that were *older* than a user's most-recent read will appear read after deploy. This matches the new semantics (one cursor per user) and matters only for users who had previously read newer mentions while leaving older ones unread.
- `idx_notifications_user_unread` is dropped along with the column.
- The classical expansion is additive: the existing R2-hosted 100-track manifest is not regenerated, and `--classic-expand` is gated behind its own flag so the lofi/ambient/jazz paths are unaffected.

## Feature flags

None.

## Screenshots / Video

UI-visible change: the unread dot in the notifications panel is now driven by a server-published cursor instead of per-row `read_at`. **Screenshot of the notifications panel before/after marking all read still needs to be attached before review** to confirm the dot timing matches prior behavior.

## Testing

Automated:
- New `late-core/tests/mention_feed_read.rs` integration test (`mention_feed_unread_uses_timestamp_cursor`) covers: unread counts before mark-read, count → 0 after `mark_read_now`, cursor present, and a fresh mention created after the cursor is correctly counted as unread.

Manual verification to perform:
- Run migration `036_collapse_mention_reads_to_cursor.sql` against a copy of prod data, confirm the `mention_feed_reads` row count and `MAX(last_read_at)` values match the pre-migration `MAX(read_at) GROUP BY user_id` aggregate.
- In the SSH client: receive a new mention, confirm the unread badge increments; open the notifications panel, confirm the dot is shown; press mark-all-read, confirm the badge clears and (per the marker behavior) the dots remain on currently-visible items until the panel is reopened.
- Receive a new mention while the panel is already open, confirm it appears with a dot.
- For the music expansion: run `python scripts/fetch_cc_music.py --classic-expand` against a clean `tmp/`, confirm 101 new files land in `tmp/classic/` and that `infra/liquidsoap/classic.m3u` gains 101 appended `annotate:` lines without disturbing the first 100. Spot-check a couple of tracks in Liquidsoap.