### PR TITLE
Add a dedicated Themes tab with grouped tree browser and live preview

### DIFF
--- a/late-ssh/src/app/common/theme.rs
+++ b/late-ssh/src/app/common/theme.rs
@@ -43,6 +43,20 @@ pub struct ThemeOption {
 }
 
 #[derive(Clone, Copy)]
+pub struct ThemePreview {
+    pub bg_canvas: Color,
+    pub bg_selection: Color,
+    pub border_active: Color,
+    pub text: Color,
+    pub text_bright: Color,
+    pub amber: Color,
+    pub chat_author: Color,
+    pub mention: Color,
+    pub success: Color,
+    pub error: Color,
+}
+
+#[derive(Clone, Copy)]
 struct Palette {
     bg_canvas: Color,
     bg_selection: Color,
@@ -1173,7 +1187,11 @@ fn option_by_id(id: &str) -> ThemeOption {
 }
 
 fn current_palette() -> &'static Palette {
-    CURRENT_THEME.with(|current| match current.get() {
+    CURRENT_THEME.with(|current| palette_for_kind(current.get()))
+}
+
+fn palette_for_kind(kind: ThemeKind) -> &'static Palette {
+    match kind {
         ThemeKind::Contrast => &PALETTE_CONTRAST,
         ThemeKind::Purple => &PALETTE_PURPLE,
         ThemeKind::Mocha => &PALETTE_MOCHA,
@@ -1204,7 +1222,27 @@ fn current_palette() -> &'static Palette {
         ThemeKind::ENADreamBbq => &PALETTE_ENA_DREAM_BBQ,
         ThemeKind::Kirii => &PALETTE_KIRII,
         ThemeKind::Late => &PALETTE_LATE,
-    })
+    }
+}
+
+pub fn preview_for_id(id: &str) -> ThemePreview {
+    preview_for_option(option_by_id(id))
+}
+
+pub fn preview_for_option(option: ThemeOption) -> ThemePreview {
+    let palette = palette_for_kind(option.kind);
+    ThemePreview {
+        bg_canvas: palette.bg_canvas,
+        bg_selection: palette.bg_selection,
+        border_active: palette.border_active,
+        text: palette.text,
+        text_bright: palette.text_bright,
+        amber: palette.amber,
+        chat_author: palette.chat_author,
+        mention: palette.mention,
+        success: palette.success,
+        error: palette.error,
+    }
 }
 
 #[allow(non_snake_case)]

--- a/late-ssh/src/app/common/theme.rs
+++ b/late-ssh/src/app/common/theme.rs
@@ -35,9 +35,46 @@ pub enum ThemeKind {
     Kirii = 29,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ThemeGroup {
+    Core,
+    Catppuccin,
+    Coffee,
+    Ports,
+    Copper,
+    Experimental,
+}
+
+impl ThemeGroup {
+    pub const ALL: [ThemeGroup; 6] = [
+        ThemeGroup::Core,
+        ThemeGroup::Catppuccin,
+        ThemeGroup::Coffee,
+        ThemeGroup::Ports,
+        ThemeGroup::Copper,
+        ThemeGroup::Experimental,
+    ];
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ThemeGroup::Core => "Core",
+            ThemeGroup::Catppuccin => "Catppuccin",
+            ThemeGroup::Coffee => "Coffee",
+            ThemeGroup::Ports => "Ports",
+            ThemeGroup::Copper => "Copper",
+            ThemeGroup::Experimental => "Experimental",
+        }
+    }
+
+    pub fn bit(self) -> u8 {
+        1 << (self as u8)
+    }
+}
+
 #[derive(Clone, Copy)]
 pub struct ThemeOption {
     pub kind: ThemeKind,
+    pub group: ThemeGroup,
     pub id: &'static str,
     pub label: &'static str,
 }
@@ -90,151 +127,181 @@ struct Palette {
 pub const OPTIONS: &[ThemeOption] = &[
     ThemeOption {
         kind: ThemeKind::Late,
+        group: ThemeGroup::Core,
         id: "late",
         label: "Late",
     },
     ThemeOption {
         kind: ThemeKind::Contrast,
+        group: ThemeGroup::Core,
         id: "contrast",
         label: "High Contrast",
     },
     ThemeOption {
         kind: ThemeKind::Purple,
+        group: ThemeGroup::Core,
         id: "purple",
         label: "Purple Haze",
     },
     ThemeOption {
         kind: ThemeKind::Mocha,
+        group: ThemeGroup::Catppuccin,
         id: "mocha",
         label: "Catppuccin Mocha",
     },
     ThemeOption {
         kind: ThemeKind::Macchiato,
+        group: ThemeGroup::Catppuccin,
         id: "macchiato",
         label: "Catppuccin Macchiato",
     },
     ThemeOption {
         kind: ThemeKind::Frappe,
+        group: ThemeGroup::Catppuccin,
         id: "frappe",
         label: "Catppuccin Frappé",
     },
     ThemeOption {
         kind: ThemeKind::Latte,
+        group: ThemeGroup::Catppuccin,
         id: "latte",
         label: "Catppuccin Latte",
     },
     ThemeOption {
         kind: ThemeKind::EggCoffee,
+        group: ThemeGroup::Coffee,
         id: "egg_coffee",
         label: "Egg Coffee",
     },
     ThemeOption {
         kind: ThemeKind::Americano,
+        group: ThemeGroup::Coffee,
         id: "americano",
         label: "Americano",
     },
     ThemeOption {
         kind: ThemeKind::Espresso,
+        group: ThemeGroup::Coffee,
         id: "espresso",
         label: "Espresso",
     },
     ThemeOption {
         kind: ThemeKind::GruvboxDark,
+        group: ThemeGroup::Ports,
         id: "gruvboxdark",
         label: "Gruvbox Dark",
     },
     ThemeOption {
         kind: ThemeKind::OneDarkPro,
+        group: ThemeGroup::Ports,
         id: "onedarkpro",
         label: "One Dark Pro",
     },
     ThemeOption {
         kind: ThemeKind::RosePine,
+        group: ThemeGroup::Ports,
         id: "rosepine",
         label: "Rose Pine",
     },
     ThemeOption {
         kind: ThemeKind::TokyoNight,
+        group: ThemeGroup::Ports,
         id: "tokyonight",
         label: "Tokyo Night",
     },
     ThemeOption {
         kind: ThemeKind::Kanagawa,
+        group: ThemeGroup::Ports,
         id: "kanagawa",
         label: "Kanagawa",
     },
     ThemeOption {
         kind: ThemeKind::Dracula,
+        group: ThemeGroup::Ports,
         id: "dracula",
         label: "Dracula",
     },
     ThemeOption {
         kind: ThemeKind::Oxocarbon,
+        group: ThemeGroup::Ports,
         id: "oxocarbon",
         label: "Oxocarbon",
     },
     ThemeOption {
         kind: ThemeKind::CopperFresh,
+        group: ThemeGroup::Copper,
         id: "copperfresh",
         label: "Copper Fresh",
     },
     ThemeOption {
         kind: ThemeKind::ExposedCopper,
+        group: ThemeGroup::Copper,
         id: "exposedcopper",
         label: "Exposed Copper",
     },
     ThemeOption {
         kind: ThemeKind::WeatheredCopper,
+        group: ThemeGroup::Copper,
         id: "weatheredcopper",
         label: "Weathered Copper",
     },
     ThemeOption {
         kind: ThemeKind::OxidizedCopper,
+        group: ThemeGroup::Copper,
         id: "oxidizedcopper",
         label: "Oxidized Copper",
     },
     ThemeOption {
         kind: ThemeKind::Arachne,
+        group: ThemeGroup::Experimental,
         id: "arachne",
         label: "Arachne",
     },
     ThemeOption {
         kind: ThemeKind::CyberAcme,
+        group: ThemeGroup::Experimental,
         id: "cyberacme",
         label: "CyberAcme",
     },
     ThemeOption {
         kind: ThemeKind::NuCaloric,
+        group: ThemeGroup::Experimental,
         id: "nucaloric",
         label: "NuCaloric",
     },
     ThemeOption {
         kind: ThemeKind::Sekiguchi,
+        group: ThemeGroup::Experimental,
         id: "sekiguchi",
         label: "Sekiguchi",
     },
     ThemeOption {
         kind: ThemeKind::Traxus,
+        group: ThemeGroup::Experimental,
         id: "traxus",
         label: "Traxus",
     },
     ThemeOption {
         kind: ThemeKind::Mida,
+        group: ThemeGroup::Experimental,
         id: "mida",
         label: "Mida",
     },
     ThemeOption {
         kind: ThemeKind::ENA,
+        group: ThemeGroup::Experimental,
         id: "ena",
         label: "ENA",
     },
     ThemeOption {
         kind: ThemeKind::ENADreamBbq,
+        group: ThemeGroup::Experimental,
         id: "enadreambbq",
         label: "ENA Dream BBQ",
     },
     ThemeOption {
         kind: ThemeKind::Kirii,
+        group: ThemeGroup::Experimental,
         id: "kirii",
         label: "Kirii",
     },

--- a/late-ssh/src/app/settings_modal/input.rs
+++ b/late-ssh/src/app/settings_modal/input.rs
@@ -44,6 +44,11 @@ pub fn handle_input(app: &mut App, event: ParsedInput) {
         return;
     }
 
+    if app.settings_modal_state.selected_tab() == Tab::Themes {
+        handle_themes_tab_input(app, event);
+        return;
+    }
+
     if app.settings_modal_state.selected_tab() == Tab::Favorites {
         handle_favorites_tab_input(app, event);
         return;
@@ -61,6 +66,29 @@ pub fn handle_input(app: &mut App, event: ParsedInput) {
         ParsedInput::Arrow(b'D') => app.settings_modal_state.cycle_setting(false),
         ParsedInput::Byte(b' ') | ParsedInput::Byte(b'\r') => activate_selected_row(app),
         ParsedInput::Char('e') | ParsedInput::Char('E') => activate_selected_row(app),
+        _ => {}
+    }
+}
+
+fn handle_themes_tab_input(app: &mut App, event: ParsedInput) {
+    let state: &mut SettingsModalState = &mut app.settings_modal_state;
+    match event {
+        ParsedInput::Byte(b'?') | ParsedInput::Char('?') => open_help(app),
+        ParsedInput::Byte(b'j' | b'J')
+        | ParsedInput::Char('j' | 'J')
+        | ParsedInput::Arrow(b'B')
+        | ParsedInput::Arrow(b'C') => state.move_theme_cursor(1),
+        ParsedInput::Byte(b'k' | b'K')
+        | ParsedInput::Char('k' | 'K')
+        | ParsedInput::Arrow(b'A')
+        | ParsedInput::Arrow(b'D') => state.move_theme_cursor(-1),
+        ParsedInput::PageDown => state.page_theme_cursor(1),
+        ParsedInput::PageUp => state.page_theme_cursor(-1),
+        ParsedInput::Home => state.first_theme(),
+        ParsedInput::End => state.last_theme(),
+        ParsedInput::Byte(b'\r') | ParsedInput::Byte(b' ') => {
+            state.select_theme_index(state.theme_index())
+        }
         _ => {}
     }
 }

--- a/late-ssh/src/app/settings_modal/input.rs
+++ b/late-ssh/src/app/settings_modal/input.rs
@@ -76,19 +76,13 @@ fn handle_themes_tab_input(app: &mut App, event: ParsedInput) {
         ParsedInput::Byte(b'?') | ParsedInput::Char('?') => open_help(app),
         ParsedInput::Byte(b'j' | b'J')
         | ParsedInput::Char('j' | 'J')
-        | ParsedInput::Arrow(b'B')
-        | ParsedInput::Arrow(b'C') => state.move_theme_cursor(1),
+        | ParsedInput::Arrow(b'B') => state.move_theme_cursor(1),
         ParsedInput::Byte(b'k' | b'K')
         | ParsedInput::Char('k' | 'K')
-        | ParsedInput::Arrow(b'A')
-        | ParsedInput::Arrow(b'D') => state.move_theme_cursor(-1),
-        ParsedInput::PageDown => state.page_theme_cursor(1),
-        ParsedInput::PageUp => state.page_theme_cursor(-1),
-        ParsedInput::Home => state.first_theme(),
-        ParsedInput::End => state.last_theme(),
-        ParsedInput::Byte(b'\r') | ParsedInput::Byte(b' ') => {
-            state.select_theme_index(state.theme_index())
-        }
+        | ParsedInput::Arrow(b'A') => state.move_theme_cursor(-1),
+        ParsedInput::Arrow(b'D') => state.theme_cursor_left(),
+        ParsedInput::Arrow(b'C') => state.theme_cursor_right(),
+        ParsedInput::Byte(b'\r') | ParsedInput::Byte(b' ') => state.toggle_theme_tree_row(),
         _ => {}
     }
 }

--- a/late-ssh/src/app/settings_modal/state.rs
+++ b/late-ssh/src/app/settings_modal/state.rs
@@ -77,22 +77,34 @@ impl Row {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Tab {
     Settings,
-    Themes,
     Bio,
+    Themes,
     Favorites,
 }
 
 impl Tab {
-    pub const ALL: [Tab; 4] = [Tab::Settings, Tab::Themes, Tab::Bio, Tab::Favorites];
+    pub const ALL: [Tab; 4] = [Tab::Settings, Tab::Bio, Tab::Themes, Tab::Favorites];
 
     pub fn label(self) -> &'static str {
         match self {
             Tab::Settings => "Settings",
-            Tab::Themes => "Themes",
             Tab::Bio => "Bio",
+            Tab::Themes => "Themes",
             Tab::Favorites => "Favorites",
         }
     }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ThemeTreeRow {
+    Group {
+        group: theme::ThemeGroup,
+        collapsed: bool,
+    },
+    Theme {
+        option_index: usize,
+        last_in_group: bool,
+    },
 }
 
 #[derive(Default)]
@@ -111,8 +123,10 @@ pub struct SettingsModalState {
     selected_tab: Tab,
     row_index: usize,
     theme_index: usize,
+    theme_selected_row: usize,
     theme_scroll_offset: usize,
     theme_visible_height: Cell<usize>,
+    theme_collapsed_groups: u8,
     editing_username: bool,
     username_input: TextArea<'static>,
     editing_bio: bool,
@@ -135,8 +149,10 @@ impl SettingsModalState {
             selected_tab: Tab::Settings,
             row_index: 0,
             theme_index: 0,
+            theme_selected_row: 0,
             theme_scroll_offset: 0,
             theme_visible_height: Cell::new(1),
+            theme_collapsed_groups: 0,
             editing_username: false,
             username_input: new_username_textarea(false),
             editing_bio: false,
@@ -222,8 +238,8 @@ impl SettingsModalState {
         self.row_index = (self.row_index as isize + delta).clamp(0, last) as usize;
     }
 
-    pub fn theme_index(&self) -> usize {
-        self.theme_index
+    pub fn theme_selected_row(&self) -> usize {
+        self.theme_selected_row
     }
 
     pub fn theme_scroll_offset(&self) -> usize {
@@ -235,28 +251,87 @@ impl SettingsModalState {
     }
 
     pub fn move_theme_cursor(&mut self, delta: isize) {
-        let last = theme::OPTIONS.len().saturating_sub(1) as isize;
-        let next = (self.theme_index as isize + delta).clamp(0, last) as usize;
-        self.select_theme_index(next);
+        let rows = self.theme_tree_rows();
+        let last = rows.len().saturating_sub(1) as isize;
+        self.theme_selected_row =
+            (self.theme_selected_row as isize + delta).clamp(0, last) as usize;
+        if let Some(ThemeTreeRow::Theme { option_index, .. }) =
+            rows.get(self.theme_selected_row).copied()
+        {
+            self.apply_theme_index(option_index);
+        }
+        self.keep_theme_cursor_visible();
     }
 
-    pub fn page_theme_cursor(&mut self, delta_pages: isize) {
-        let page = self.theme_visible_height.get().max(1) as isize;
-        self.move_theme_cursor(delta_pages * page);
+    pub fn theme_cursor_left(&mut self) {
+        let rows = self.theme_tree_rows();
+        match rows.get(self.theme_selected_row).copied() {
+            Some(ThemeTreeRow::Group {
+                group,
+                collapsed: false,
+            }) => self.collapse_theme_group(group),
+            Some(ThemeTreeRow::Theme { option_index, .. }) => {
+                self.collapse_theme_group(theme::OPTIONS[option_index].group);
+            }
+            _ => {}
+        }
     }
 
-    pub fn first_theme(&mut self) {
-        self.select_theme_index(0);
+    pub fn theme_cursor_right(&mut self) {
+        let rows = self.theme_tree_rows();
+        match rows.get(self.theme_selected_row).copied() {
+            Some(ThemeTreeRow::Group {
+                group,
+                collapsed: true,
+            }) => self.expand_theme_group(group),
+            Some(ThemeTreeRow::Group {
+                group,
+                collapsed: false,
+            }) => {
+                if let Some(row) = self.first_theme_row_for_group(group) {
+                    self.theme_selected_row = row;
+                    if let Some(ThemeTreeRow::Theme { option_index, .. }) =
+                        self.theme_tree_rows().get(row).copied()
+                    {
+                        self.apply_theme_index(option_index);
+                    }
+                    self.keep_theme_cursor_visible();
+                }
+            }
+            _ => {}
+        }
     }
 
-    pub fn last_theme(&mut self) {
-        self.select_theme_index(theme::OPTIONS.len().saturating_sub(1));
+    pub fn toggle_theme_tree_row(&mut self) {
+        let rows = self.theme_tree_rows();
+        if let Some(row) = rows.get(self.theme_selected_row).copied() {
+            match row {
+                ThemeTreeRow::Group { group, collapsed } => {
+                    if collapsed {
+                        self.expand_theme_group(group);
+                    } else {
+                        self.collapse_theme_group(group);
+                    }
+                }
+                ThemeTreeRow::Theme { option_index, .. } => self.select_theme_index(option_index),
+            }
+        }
     }
 
     pub fn select_theme_index(&mut self, index: usize) {
         let clamped = index.min(theme::OPTIONS.len().saturating_sub(1));
+        self.expand_theme_group(theme::OPTIONS[clamped].group);
         self.theme_index = clamped;
-        if let Some(option) = theme::OPTIONS.get(clamped) {
+        self.theme_selected_row = self
+            .theme_row_for_option(clamped)
+            .unwrap_or(self.theme_selected_row);
+        self.apply_theme_index(clamped);
+        self.keep_theme_cursor_visible();
+    }
+
+    fn apply_theme_index(&mut self, index: usize) {
+        if let Some(option) = theme::OPTIONS.get(index) {
+            self.theme_index = index;
             let current = self
                 .draft
                 .theme_id
@@ -272,6 +347,31 @@ impl SettingsModalState {
         }
     }
 
+    pub fn theme_tree_rows(&self) -> Vec<ThemeTreeRow> {
+        let mut rows = Vec::new();
+        for group in theme::ThemeGroup::ALL {
+            let collapsed = self.theme_group_collapsed(group);
+            rows.push(ThemeTreeRow::Group { group, collapsed });
+            if collapsed {
+                continue;
+            }
+
+            let option_indices: Vec<usize> = theme::OPTIONS
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, option)| (option.group == group).then_some(idx))
+                .collect();
+            let last_option_idx = option_indices.len().saturating_sub(1);
+            for (idx, option_index) in option_indices.into_iter().enumerate() {
+                rows.push(ThemeTreeRow::Theme {
+                    option_index,
+                    last_in_group: idx == last_option_idx,
+                });
+            }
+        }
+        rows
+    }
+
     fn sync_theme_index_to_draft(&mut self) {
         let current = self
             .draft
@@ -283,16 +383,60 @@ impl SettingsModalState {
             .iter()
             .position(|option| option.id == normalized)
             .unwrap_or(0);
+        self.expand_theme_group(theme::OPTIONS[self.theme_index].group);
+        self.theme_selected_row = self.theme_row_for_option(self.theme_index).unwrap_or(0);
         self.keep_theme_cursor_visible();
     }
 
     fn keep_theme_cursor_visible(&mut self) {
         let visible = self.theme_visible_height.get().max(1);
-        if self.theme_index < self.theme_scroll_offset {
-            self.theme_scroll_offset = self.theme_index;
-        } else if self.theme_index >= self.theme_scroll_offset + visible {
-            self.theme_scroll_offset = self.theme_index.saturating_sub(visible - 1);
+        let max_scroll = self.theme_tree_rows().len().saturating_sub(visible);
+        if self.theme_selected_row < self.theme_scroll_offset {
+            self.theme_scroll_offset = self.theme_selected_row;
+        } else if self.theme_selected_row >= self.theme_scroll_offset + visible {
+            self.theme_scroll_offset = self.theme_selected_row.saturating_sub(visible - 1);
         }
+        self.theme_scroll_offset = self.theme_scroll_offset.min(max_scroll);
+    }
+
+    fn theme_group_collapsed(&self, group: theme::ThemeGroup) -> bool {
+        self.theme_collapsed_groups & group.bit() != 0
+    }
+
+    fn expand_theme_group(&mut self, group: theme::ThemeGroup) {
+        self.theme_collapsed_groups &= !group.bit();
+        self.keep_theme_cursor_visible();
+    }
+
+    fn collapse_theme_group(&mut self, group: theme::ThemeGroup) {
+        self.theme_collapsed_groups |= group.bit();
+        self.theme_selected_row = self.theme_group_row(group).unwrap_or_else(|| {
+            self.theme_selected_row
+                .min(self.theme_tree_rows().len().saturating_sub(1))
+        });
+        self.keep_theme_cursor_visible();
+    }
+
+    fn theme_group_row(&self, group: theme::ThemeGroup) -> Option<usize> {
+        self.theme_tree_rows()
+            .iter()
+            .position(|row| matches!(row, ThemeTreeRow::Group { group: row_group, .. } if *row_group == group))
+    }
+
+    fn theme_row_for_option(&self, option_index: usize) -> Option<usize> {
+        self.theme_tree_rows().iter().position(
+            |row| matches!(row, ThemeTreeRow::Theme { option_index: row_index, .. } if *row_index == option_index),
+        )
+    }
+
+    fn first_theme_row_for_group(&self, group: theme::ThemeGroup) -> Option<usize> {
+        self.theme_tree_rows().iter().position(|row| {
+            matches!(
+                row,
+                ThemeTreeRow::Theme { option_index, .. }
+                    if theme::OPTIONS[*option_index].group == group
+            )
+        })
     }
 
     pub fn editing_username(&self) -> bool {

--- a/late-ssh/src/app/settings_modal/state.rs
+++ b/late-ssh/src/app/settings_modal/state.rs
@@ -69,23 +69,26 @@ impl Row {
     ];
 }
 
-/// Top-level tab in the settings modal. `Settings` holds every compact
-/// row (identity/appearance/location/notifications); `Bio` is a separate
-/// full-width pane with the markdown editor + preview; `Favorites` manages
-/// the dashboard quick-switch room list.
+/// Top-level tab in the settings modal. `Settings` holds every compact row
+/// (identity/appearance/location/notifications); `Themes` is a fast browser
+/// for the expanded theme catalog; `Bio` is a separate full-width pane with
+/// the markdown editor + preview; `Favorites` manages the dashboard
+/// quick-switch room list.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Tab {
     Settings,
+    Themes,
     Bio,
     Favorites,
 }
 
 impl Tab {
-    pub const ALL: [Tab; 3] = [Tab::Settings, Tab::Bio, Tab::Favorites];
+    pub const ALL: [Tab; 4] = [Tab::Settings, Tab::Themes, Tab::Bio, Tab::Favorites];
 
     pub fn label(self) -> &'static str {
         match self {
             Tab::Settings => "Settings",
+            Tab::Themes => "Themes",
             Tab::Bio => "Bio",
             Tab::Favorites => "Favorites",
         }
@@ -107,6 +110,9 @@ pub struct SettingsModalState {
     draft: Profile,
     selected_tab: Tab,
     row_index: usize,
+    theme_index: usize,
+    theme_scroll_offset: usize,
+    theme_visible_height: Cell<usize>,
     editing_username: bool,
     username_input: TextArea<'static>,
     editing_bio: bool,
@@ -128,6 +134,9 @@ impl SettingsModalState {
             draft: Profile::default(),
             selected_tab: Tab::Settings,
             row_index: 0,
+            theme_index: 0,
+            theme_scroll_offset: 0,
+            theme_visible_height: Cell::new(1),
             editing_username: false,
             username_input: new_username_textarea(false),
             editing_bio: false,
@@ -155,6 +164,7 @@ impl SettingsModalState {
         self.available_rooms = available_rooms;
         self.selected_tab = Tab::Settings;
         self.row_index = 0;
+        self.sync_theme_index_to_draft();
         self.editing_username = false;
         self.username_input = new_username_textarea(false);
         self.editing_bio = false;
@@ -189,6 +199,9 @@ impl SettingsModalState {
             self.submit_username();
             self.save();
         }
+        if next == Tab::Themes {
+            self.sync_theme_index_to_draft();
+        }
         self.selected_tab = next;
     }
 
@@ -207,6 +220,79 @@ impl SettingsModalState {
     pub fn move_row(&mut self, delta: isize) {
         let last = Row::ALL.len().saturating_sub(1) as isize;
         self.row_index = (self.row_index as isize + delta).clamp(0, last) as usize;
+    }
+
+    pub fn theme_index(&self) -> usize {
+        self.theme_index
+    }
+
+    pub fn theme_scroll_offset(&self) -> usize {
+        self.theme_scroll_offset
+    }
+
+    pub fn set_theme_visible_height(&self, height: usize) {
+        self.theme_visible_height.set(height.max(1));
+    }
+
+    pub fn move_theme_cursor(&mut self, delta: isize) {
+        let last = theme::OPTIONS.len().saturating_sub(1) as isize;
+        let next = (self.theme_index as isize + delta).clamp(0, last) as usize;
+        self.select_theme_index(next);
+    }
+
+    pub fn page_theme_cursor(&mut self, delta_pages: isize) {
+        let page = self.theme_visible_height.get().max(1) as isize;
+        self.move_theme_cursor(delta_pages * page);
+    }
+
+    pub fn first_theme(&mut self) {
+        self.select_theme_index(0);
+    }
+
+    pub fn last_theme(&mut self) {
+        self.select_theme_index(theme::OPTIONS.len().saturating_sub(1));
+    }
+
+    pub fn select_theme_index(&mut self, index: usize) {
+        let clamped = index.min(theme::OPTIONS.len().saturating_sub(1));
+        self.theme_index = clamped;
+        if let Some(option) = theme::OPTIONS.get(clamped) {
+            let current = self
+                .draft
+                .theme_id
+                .as_deref()
+                .map(theme::normalize_id)
+                .unwrap_or("late");
+            let changed = current != option.id;
+            self.draft.theme_id = Some(option.id.to_string());
+            self.keep_theme_cursor_visible();
+            if changed {
+                self.save();
+            }
+        }
+    }
+
+    fn sync_theme_index_to_draft(&mut self) {
+        let current = self
+            .draft
+            .theme_id
+            .as_deref()
+            .unwrap_or_else(|| theme::normalize_id(""));
+        let normalized = theme::normalize_id(current);
+        self.theme_index = theme::OPTIONS
+            .iter()
+            .position(|option| option.id == normalized)
+            .unwrap_or(0);
+        self.keep_theme_cursor_visible();
+    }
+
+    fn keep_theme_cursor_visible(&mut self) {
+        let visible = self.theme_visible_height.get().max(1);
+        if self.theme_index < self.theme_scroll_offset {
+            self.theme_scroll_offset = self.theme_index;
+        } else if self.theme_index >= self.theme_scroll_offset + visible {
+            self.theme_scroll_offset = self.theme_index.saturating_sub(visible - 1);
+        }
     }
 
     pub fn editing_username(&self) -> bool {
@@ -602,6 +688,7 @@ impl SettingsModalState {
                     .as_deref()
                     .unwrap_or_else(|| theme::normalize_id(""));
                 self.draft.theme_id = Some(theme::cycle_id(current, forward).to_string());
+                self.sync_theme_index_to_draft();
                 true
             }
             Row::BackgroundColor => {

--- a/late-ssh/src/app/settings_modal/ui.rs
+++ b/late-ssh/src/app/settings_modal/ui.rs
@@ -45,6 +45,7 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
 
     match state.selected_tab() {
         Tab::Settings => draw_settings_tab(frame, layout[3], state),
+        Tab::Themes => draw_themes_tab(frame, layout[3], state),
         Tab::Bio => draw_bio_tab(frame, layout[3], state),
         Tab::Favorites => draw_favorites_tab(frame, layout[3], state),
     }
@@ -114,6 +115,18 @@ fn draw_footer(frame: &mut Frame, area: Rect, tab: Tab, editing_bio: bool) {
                 Span::styled(" close", Style::default().fg(theme::TEXT_DIM())),
             ]);
         }
+        (Tab::Themes, _) => {
+            spans.extend([
+                Span::styled("↑↓ j/k", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled(" preview  ", Style::default().fg(theme::TEXT_DIM())),
+                Span::styled("PgUp/PgDn", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled(" page  ", Style::default().fg(theme::TEXT_DIM())),
+                Span::styled("Tab/S+Tab", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled(" switch tabs  ", Style::default().fg(theme::TEXT_DIM())),
+                Span::styled("Esc/q", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled(" close", Style::default().fg(theme::TEXT_DIM())),
+            ]);
+        }
         (Tab::Favorites, _) => {
             spans.extend([
                 Span::styled("↑↓ j/k", Style::default().fg(theme::AMBER_DIM())),
@@ -132,6 +145,198 @@ fn draw_footer(frame: &mut Frame, area: Rect, tab: Tab, editing_bio: bool) {
         }
     }
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_themes_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
+    let sections = Layout::vertical([
+        Constraint::Length(1), // heading
+        Constraint::Length(1), // summary
+        Constraint::Length(1), // breathing
+        Constraint::Min(4),    // tree
+    ])
+    .split(area);
+
+    frame.render_widget(
+        Paragraph::new(section_heading("Theme browser")),
+        sections[0],
+    );
+
+    let active_id = state.draft().theme_id.as_deref().unwrap_or("late");
+    let active_preview = theme::preview_for_id(active_id);
+    let summary = Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            theme::label_for_id(active_id).to_string(),
+            Style::default()
+                .fg(theme::TEXT_BRIGHT())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled("   ", Style::default().fg(theme::TEXT_DIM())),
+        swatch(active_preview.bg_canvas),
+        swatch(active_preview.bg_selection),
+        swatch(active_preview.border_active),
+        swatch(active_preview.amber),
+        swatch(active_preview.chat_author),
+        swatch(active_preview.mention),
+        swatch(active_preview.success),
+        swatch(active_preview.error),
+        Span::styled(
+            format!("   {}", theme::color_to_hex(active_preview.border_active)),
+            Style::default().fg(theme::TEXT_DIM()),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(summary), sections[1]);
+
+    let tree_area = sections[3];
+    let width = tree_area.width as usize;
+    let visible_height = tree_area.height as usize;
+    state.set_theme_visible_height(visible_height.saturating_sub(2).max(1));
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    let mut last_group: Option<&'static str> = None;
+    for (idx, option) in theme::OPTIONS
+        .iter()
+        .enumerate()
+        .skip(state.theme_scroll_offset())
+    {
+        if lines.len() >= visible_height {
+            break;
+        }
+
+        let group = theme_group(option.kind);
+        if last_group != Some(group) && lines.len() + 1 < visible_height {
+            lines.push(theme_group_line(group));
+            last_group = Some(group);
+        }
+
+        if lines.len() >= visible_height {
+            break;
+        }
+        lines.push(theme_option_line(
+            *option,
+            idx == state.theme_index(),
+            idx + 1 == theme::OPTIONS.len() || theme_group(theme::OPTIONS[idx + 1].kind) != group,
+            width,
+        ));
+    }
+
+    frame.render_widget(Paragraph::new(lines), tree_area);
+}
+
+fn theme_group_line(group: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled("  ▾ ", Style::default().fg(theme::BORDER())),
+        Span::styled(
+            group.to_string(),
+            Style::default()
+                .fg(theme::AMBER())
+                .add_modifier(Modifier::BOLD),
+        ),
+    ])
+}
+
+fn theme_option_line(
+    option: theme::ThemeOption,
+    selected: bool,
+    last_in_group: bool,
+    width: usize,
+) -> Line<'static> {
+    let preview = theme::preview_for_option(option);
+    let marker = if selected { "›" } else { " " };
+    let branch = if last_in_group { "└─" } else { "├─" };
+    let prefix = format!(" {marker} {branch} ");
+    let prefix_style = if selected {
+        Style::default()
+            .fg(theme::AMBER_GLOW())
+            .bg(theme::BG_SELECTION())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT_FAINT())
+    };
+    let label_style = if selected {
+        Style::default()
+            .fg(theme::TEXT_BRIGHT())
+            .bg(theme::BG_SELECTION())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT_BRIGHT())
+    };
+    let id_style = if selected {
+        Style::default()
+            .fg(theme::TEXT_DIM())
+            .bg(theme::BG_SELECTION())
+    } else {
+        Style::default().fg(theme::TEXT_FAINT())
+    };
+    let trailing_style = if selected {
+        Style::default().bg(theme::BG_SELECTION())
+    } else {
+        Style::default()
+    };
+    let swatches = [
+        preview.bg_canvas,
+        preview.bg_selection,
+        preview.border_active,
+        preview.text,
+        preview.text_bright,
+        preview.amber,
+        preview.chat_author,
+        preview.mention,
+    ];
+    let id_text = format!("  {}", option.id);
+    let used = prefix.chars().count()
+        + option.label.chars().count()
+        + id_text.chars().count()
+        + 2
+        + (swatches.len() * 2);
+    let padding = width.saturating_sub(used);
+    let mut spans = vec![
+        Span::styled(prefix, prefix_style),
+        Span::styled(option.label.to_string(), label_style),
+        Span::styled(id_text, id_style),
+        Span::styled(" ".repeat(padding + 2), trailing_style),
+    ];
+    for color in swatches {
+        spans.push(swatch(color));
+    }
+    Line::from(spans)
+}
+
+fn swatch(color: ratatui::style::Color) -> Span<'static> {
+    Span::styled("  ", Style::default().bg(color))
+}
+
+fn theme_group(kind: theme::ThemeKind) -> &'static str {
+    match kind {
+        theme::ThemeKind::Late | theme::ThemeKind::Contrast | theme::ThemeKind::Purple => "Core",
+        theme::ThemeKind::Mocha
+        | theme::ThemeKind::Macchiato
+        | theme::ThemeKind::Frappe
+        | theme::ThemeKind::Latte => "Catppuccin",
+        theme::ThemeKind::EggCoffee | theme::ThemeKind::Americano | theme::ThemeKind::Espresso => {
+            "Coffee"
+        }
+        theme::ThemeKind::GruvboxDark
+        | theme::ThemeKind::OneDarkPro
+        | theme::ThemeKind::RosePine
+        | theme::ThemeKind::TokyoNight
+        | theme::ThemeKind::Kanagawa
+        | theme::ThemeKind::Dracula
+        | theme::ThemeKind::Oxocarbon => "Ports",
+        theme::ThemeKind::CopperFresh
+        | theme::ThemeKind::ExposedCopper
+        | theme::ThemeKind::WeatheredCopper
+        | theme::ThemeKind::OxidizedCopper => "Copper",
+        theme::ThemeKind::Arachne
+        | theme::ThemeKind::CyberAcme
+        | theme::ThemeKind::NuCaloric
+        | theme::ThemeKind::Sekiguchi
+        | theme::ThemeKind::Traxus
+        | theme::ThemeKind::Mida
+        | theme::ThemeKind::ENA
+        | theme::ThemeKind::ENADreamBbq
+        | theme::ThemeKind::Kirii => "Experimental",
+    }
 }
 
 fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {

--- a/late-ssh/src/app/settings_modal/ui.rs
+++ b/late-ssh/src/app/settings_modal/ui.rs
@@ -10,7 +10,7 @@ use crate::app::common::{markdown::render_body_to_lines, theme};
 
 use super::{
     data::country_label,
-    state::{BIO_MAX_LEN, PickerKind, Row, SettingsModalState, Tab},
+    state::{BIO_MAX_LEN, PickerKind, Row, SettingsModalState, Tab, ThemeTreeRow},
 };
 
 pub const MODAL_WIDTH: u16 = 96;
@@ -119,8 +119,8 @@ fn draw_footer(frame: &mut Frame, area: Rect, tab: Tab, editing_bio: bool) {
             spans.extend([
                 Span::styled("↑↓ j/k", Style::default().fg(theme::AMBER_DIM())),
                 Span::styled(" preview  ", Style::default().fg(theme::TEXT_DIM())),
-                Span::styled("PgUp/PgDn", Style::default().fg(theme::AMBER_DIM())),
-                Span::styled(" page  ", Style::default().fg(theme::TEXT_DIM())),
+                Span::styled("←→", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled(" close/open  ", Style::default().fg(theme::TEXT_DIM())),
                 Span::styled("Tab/S+Tab", Style::default().fg(theme::AMBER_DIM())),
                 Span::styled(" switch tabs  ", Style::default().fg(theme::TEXT_DIM())),
                 Span::styled("Esc/q", Style::default().fg(theme::AMBER_DIM())),
@@ -190,12 +190,12 @@ fn draw_themes_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
     let tree_area = sections[3];
     let width = tree_area.width as usize;
     let visible_height = tree_area.height as usize;
-    state.set_theme_visible_height(visible_height.saturating_sub(2).max(1));
+    state.set_theme_visible_height(visible_height.max(1));
 
     let mut lines: Vec<Line<'static>> = Vec::new();
-    let mut last_group: Option<&'static str> = None;
-    for (idx, option) in theme::OPTIONS
-        .iter()
+    for (row_idx, row) in state
+        .theme_tree_rows()
+        .into_iter()
         .enumerate()
         .skip(state.theme_scroll_offset())
     {
@@ -203,35 +203,56 @@ fn draw_themes_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
             break;
         }
 
-        let group = theme_group(option.kind);
-        if last_group != Some(group) && lines.len() + 1 < visible_height {
-            lines.push(theme_group_line(group));
-            last_group = Some(group);
+        let selected = row_idx == state.theme_selected_row();
+        match row {
+            ThemeTreeRow::Group { group, collapsed } => {
+                lines.push(theme_group_line(group, collapsed, selected, width));
+            }
+            ThemeTreeRow::Theme {
+                option_index,
+                last_in_group,
+            } => {
+                lines.push(theme_option_line(
+                    theme::OPTIONS[option_index],
+                    selected,
+                    last_in_group,
+                    width,
+                ));
+            }
         }
-
-        if lines.len() >= visible_height {
-            break;
-        }
-        lines.push(theme_option_line(
-            *option,
-            idx == state.theme_index(),
-            idx + 1 == theme::OPTIONS.len() || theme_group(theme::OPTIONS[idx + 1].kind) != group,
-            width,
-        ));
     }
 
     frame.render_widget(Paragraph::new(lines), tree_area);
 }
 
-fn theme_group_line(group: &str) -> Line<'static> {
+fn theme_group_line(
+    group: theme::ThemeGroup,
+    collapsed: bool,
+    selected: bool,
+    width: usize,
+) -> Line<'static> {
+    let marker = if selected { "›" } else { " " };
+    let symbol = if collapsed { "▸" } else { "▾" };
+    let text = format!(" {marker} {symbol} {}", group.label());
+    let padding = width.saturating_sub(text.chars().count());
+    let style = if selected {
+        Style::default()
+            .fg(theme::AMBER_GLOW())
+            .bg(theme::BG_SELECTION())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(theme::AMBER())
+            .add_modifier(Modifier::BOLD)
+    };
+    let trailing_style = if selected {
+        Style::default().bg(theme::BG_SELECTION())
+    } else {
+        Style::default()
+    };
     Line::from(vec![
-        Span::styled("  ▾ ", Style::default().fg(theme::BORDER())),
-        Span::styled(
-            group.to_string(),
-            Style::default()
-                .fg(theme::AMBER())
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(text, style),
+        Span::styled(" ".repeat(padding), trailing_style),
     ])
 }
 
@@ -304,39 +325,6 @@ fn theme_option_line(
 
 fn swatch(color: ratatui::style::Color) -> Span<'static> {
     Span::styled("  ", Style::default().bg(color))
-}
-
-fn theme_group(kind: theme::ThemeKind) -> &'static str {
-    match kind {
-        theme::ThemeKind::Late | theme::ThemeKind::Contrast | theme::ThemeKind::Purple => "Core",
-        theme::ThemeKind::Mocha
-        | theme::ThemeKind::Macchiato
-        | theme::ThemeKind::Frappe
-        | theme::ThemeKind::Latte => "Catppuccin",
-        theme::ThemeKind::EggCoffee | theme::ThemeKind::Americano | theme::ThemeKind::Espresso => {
-            "Coffee"
-        }
-        theme::ThemeKind::GruvboxDark
-        | theme::ThemeKind::OneDarkPro
-        | theme::ThemeKind::RosePine
-        | theme::ThemeKind::TokyoNight
-        | theme::ThemeKind::Kanagawa
-        | theme::ThemeKind::Dracula
-        | theme::ThemeKind::Oxocarbon => "Ports",
-        theme::ThemeKind::CopperFresh
-        | theme::ThemeKind::ExposedCopper
-        | theme::ThemeKind::WeatheredCopper
-        | theme::ThemeKind::OxidizedCopper => "Copper",
-        theme::ThemeKind::Arachne
-        | theme::ThemeKind::CyberAcme
-        | theme::ThemeKind::NuCaloric
-        | theme::ThemeKind::Sekiguchi
-        | theme::ThemeKind::Traxus
-        | theme::ThemeKind::Mida
-        | theme::ThemeKind::ENA
-        | theme::ThemeKind::ENADreamBbq
-        | theme::ThemeKind::Kirii => "Experimental",
-    }
 }
 
 fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {


### PR DESCRIPTION
## Summary
The theme list has grown to 30 entries, and cycling through them from the single `Appearance` row in Settings is slow and gives no sense of what each theme looks like before committing. This PR adds a dedicated `Themes` tab to the settings modal with a collapsible tree, color swatches, and live preview as the cursor moves, so users can browse the catalog and pick a theme by sight rather than by repeatedly tapping `Next`.

## What changed
- New `Themes` tab in the settings modal, sitting between `Bio` and `Favorites`.
- Themes are organized into six groups — Core, Catppuccin, Coffee, Ports, Copper, Experimental — rendered as a tree with expand/collapse per group.
- Each theme row shows its label, id, and a row of swatches drawn from its actual palette (canvas, selection, active border, text, bright text, amber, chat author, mention).
- A summary line above the tree previews the currently active theme with its swatches and the active border hex.
- Moving the cursor over a theme applies it immediately so the rest of the modal repaints in that theme; collapsing a group keeps the cursor on the group header.
- Cycling the existing `Appearance` row still works and now also keeps the Themes tab cursor in sync.
- Keybindings on the Themes tab: `j`/`k` or `↑`/`↓` to move and preview, `←`/`→` to collapse/expand a group (or jump into the first child), `Enter`/`Space` to toggle a group or re-select the highlighted theme, `?` for help, `Esc`/`q` to close.

## Behavior notes
- Selecting a theme via preview (cursor movement) writes through to the profile draft and saves only when the id actually changes, so scrolling within the same theme does not generate redundant saves.
- Opening the Themes tab re-syncs the cursor and scroll offset to whatever theme is currently set, and auto-expands the group that contains it.
- Group collapse state is held in a `u8` bitmask on the modal state (one bit per group); it is per-session and not persisted.
- The existing `Appearance` row in the Settings tab is unchanged for users who prefer cycling.

## Feature flags
None.

## Screenshots / Video
UI-visible change — screenshots/video of the new Themes tab (collapsed groups, expanded group with swatches, live preview while moving the cursor) still need to be attached before review.

## Testing
- Automated: no new tests; the change is UI-only and exercises existing theme palette data through a new presentation surface.
- Manual:
  - Open the settings modal, `Tab` to `Themes`, confirm the tree renders with all six groups and the active theme's group is expanded with the cursor on the active row.
  - Move with `j`/`k` and `↑`/`↓`; verify the modal repaints in the previewed theme on every step and the summary line updates.
  - Use `←` on a theme row to collapse its group and land the cursor on the group header; use `→` on a collapsed group to expand it, and on an expanded group to jump to its first theme.
  - Press `Enter`/`Space` on a group header to toggle, and on a theme row to re-select it; confirm the theme persists after closing and reopening the modal.
  - Cycle the `Appearance` row in the Settings tab, switch to Themes, and verify the cursor is on the newly-selected theme.
  - Resize the terminal and confirm the tree scrolls to keep the selected row visible without clipping.