### PR TITLE
Support for parallel dev instances (dev infra)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 # --- General (Docker/dev containers) ---
 RUST_LOG ?= info,late_web=debug,late_ssh=debug,late_core=debug
 CARGO_TARGET_DIR ?= /app/target
+INSTANCE ?= late                                            # Prefix for container names; bump (e.g. late2) for a parallel clone
 
 # --- SSH ---
 LATE_FORCE_ADMIN ?= 1
@@ -22,7 +23,7 @@ LATE_SSH_PROXY_PROTOCOL ?= 0                                # Parse PROXY protoc
 LATE_SSH_PROXY_TRUSTED_CIDRS ?=                             # Comma-separated trusted proxy CIDRs (e.g. 10.42.0.0/16)
 LATE_WS_PAIR_MAX_ATTEMPTS_PER_IP ?= 30                      # Max WebSocket pair requests per IP before rate-limited
 LATE_WS_PAIR_RATE_LIMIT_WINDOW_SECS ?= 60                   # Rolling window for WS pair rate limiting
-LATE_ALLOWED_ORIGINS ?= http://localhost:3000               # Comma-separated list of allowed CORS origins
+LATE_ALLOWED_ORIGINS ?= http://localhost:$(LATE_WEB_PORT)   # Comma-separated list of allowed CORS origins
 
 # --- Database ---
 LATE_DB_HOST ?= postgres                                    # PostgreSQL hostname (docker service name)
@@ -31,16 +32,19 @@ LATE_DB_USER ?= postgres                                    # PostgreSQL user
 LATE_DB_PASSWORD ?= postgres                                # PostgreSQL password
 LATE_DB_NAME ?= postgres                                    # PostgreSQL database name
 LATE_DB_POOL_SIZE ?= 16                                     # PostgreSQL connection pool size
+LATE_PG_HOST_PORT ?= 5433                                   # Host-side port mapped to postgres 5432
 
 # --- Audio ---
 LATE_ICECAST_URL ?= http://icecast:8000                     # Icecast streaming server URL
 LATE_LIQUIDSOAP_ADDR ?= liquidsoap:1234                     # Liquidsoap telnet address for vibe switching
+LATE_ICECAST_HOST_PORT ?= 8000                              # Host-side port mapped to icecast 8000
+LATE_LIQUIDSOAP_HOST_PORT ?= 1234                           # Host-side port mapped to liquidsoap 1234
 
 # --- Web ---
 LATE_WEB_PORT ?= 3000                                       # Web server listen port
-LATE_WEB_URL ?= http://localhost:3000                       # Public web URL (used by SSH server)
-LATE_SSH_INTERNAL_URL ?= http://service-ssh:4000            # Internal SSH API URL (used by web server)
-LATE_SSH_PUBLIC_URL ?= localhost:4000                       # Public SSH API URL (used by browser for WS)
+LATE_WEB_URL ?= http://localhost:$(LATE_WEB_PORT)           # Public web URL (used by SSH server)
+LATE_SSH_INTERNAL_URL ?= http://service-ssh:$(LATE_API_PORT) # Internal SSH API URL (used by web server)
+LATE_SSH_PUBLIC_URL ?= localhost:$(LATE_API_PORT)           # Public SSH API URL (used by browser for WS)
 LATE_AUDIO_URL ?= http://icecast:8000                       # Upstream audio URL used by late-web /stream proxy
 
 # --- Vote ---
@@ -60,6 +64,7 @@ LATE_AI_MODEL ?= gemini-3.1-pro-preview                     # Gemini model to us
 .env:
 	@echo "RUST_LOG=$(RUST_LOG)" > .env
 	@echo "CARGO_TARGET_DIR=$(CARGO_TARGET_DIR)" >> .env
+	@echo "INSTANCE=$(INSTANCE)" >> .env
 	@echo "LATE_FORCE_ADMIN=$(LATE_FORCE_ADMIN)" >> .env
 	@echo "LATE_SSH_PORT=$(LATE_SSH_PORT)" >> .env
 	@echo "LATE_API_PORT=$(LATE_API_PORT)" >> .env
@@ -82,8 +87,11 @@ LATE_AI_MODEL ?= gemini-3.1-pro-preview                     # Gemini model to us
 	@echo "LATE_DB_PASSWORD=$(LATE_DB_PASSWORD)" >> .env
 	@echo "LATE_DB_NAME=$(LATE_DB_NAME)" >> .env
 	@echo "LATE_DB_POOL_SIZE=$(LATE_DB_POOL_SIZE)" >> .env
+	@echo "LATE_PG_HOST_PORT=$(LATE_PG_HOST_PORT)" >> .env
 	@echo "LATE_ICECAST_URL=$(LATE_ICECAST_URL)" >> .env
 	@echo "LATE_LIQUIDSOAP_ADDR=$(LATE_LIQUIDSOAP_ADDR)" >> .env
+	@echo "LATE_ICECAST_HOST_PORT=$(LATE_ICECAST_HOST_PORT)" >> .env
+	@echo "LATE_LIQUIDSOAP_HOST_PORT=$(LATE_LIQUIDSOAP_HOST_PORT)" >> .env
 	@echo "LATE_WEB_PORT=$(LATE_WEB_PORT)" >> .env
 	@echo "LATE_WEB_URL=$(LATE_WEB_URL)" >> .env
 	@echo "LATE_SSH_INTERNAL_URL=$(LATE_SSH_INTERNAL_URL)" >> .env
@@ -93,6 +101,27 @@ LATE_AI_MODEL ?= gemini-3.1-pro-preview                     # Gemini model to us
 	@echo "LATE_AI_ENABLED=$(LATE_AI_ENABLED)" >> .env
 	@echo "LATE_AI_API_KEY=$(LATE_AI_API_KEY)" >> .env
 	@echo "LATE_AI_MODEL=$(LATE_AI_MODEL)" >> .env
+
+# Recipe for a parallel "instance 2" clone. Run from the second clone:
+#   make start-instance2          # bring up the stack (foreground)
+#   make .env-instance2           # just (re)generate .env without starting
+# Only ports are overridden; URL/origin vars track the port defaults above.
+INSTANCE2_OVERRIDES = \
+  INSTANCE=late2 \
+  LATE_SSH_PORT=2223 \
+  LATE_API_PORT=4001 \
+  LATE_WEB_PORT=3001 \
+  LATE_PG_HOST_PORT=5434 \
+  LATE_ICECAST_HOST_PORT=8001 \
+  LATE_LIQUIDSOAP_HOST_PORT=1235
+
+.PHONY: .env-instance2
+.env-instance2:
+	@$(MAKE) .env $(INSTANCE2_OVERRIDES)
+
+.PHONY: start-instance2
+start-instance2:
+	@$(MAKE) start $(INSTANCE2_OVERRIDES)
 
 .PHONY: keys
 keys:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       target: dev-ssh
-    container_name: late-ssh
+    container_name: ${INSTANCE}-ssh
     ports:
       - "${LATE_SSH_PORT}:${LATE_SSH_PORT}"
       - "${LATE_API_PORT}:${LATE_API_PORT}"
@@ -27,7 +27,7 @@ services:
     build:
       context: .
       target: dev-web
-    container_name: late-web
+    container_name: ${INSTANCE}-web
     ports:
       - "${LATE_WEB_PORT}:${LATE_WEB_PORT}"
     env_file: .env
@@ -46,10 +46,10 @@ services:
       retries: 3
 
   postgres:
-    container_name: late-postgres
+    container_name: ${INSTANCE}-postgres
     image: postgres:18
     ports:
-      - 5433:5432
+      - "${LATE_PG_HOST_PORT}:5432"
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
@@ -62,19 +62,19 @@ services:
 
   icecast:
     image: libretime/icecast:2.4.4
-    container_name: late-icecast
+    container_name: ${INSTANCE}-icecast
     networks:
       default:
         aliases:
           - icecast-sv
     ports:
-      - "8000:8000"
+      - "${LATE_ICECAST_HOST_PORT}:8000"
     volumes:
       - ./infra/icecast/icecast.xml:/etc/icecast2/icecast.xml:ro
 
   liquidsoap:
     image: savonet/liquidsoap:v2.4.0
-    container_name: late-liquidsoap
+    container_name: ${INSTANCE}-liquidsoap
     depends_on:
       - icecast
     volumes:
@@ -86,7 +86,7 @@ services:
       - ./music:/music:ro
     command: ["liquidsoap", "/etc/liquidsoap/radio.liq"]
     ports:
-      - "1234:1234"
+      - "${LATE_LIQUIDSOAP_HOST_PORT}:1234"
 
 volumes:
   cargo-registry-ssh:


### PR DESCRIPTION
## Summary

Enable running a second local late-sh stack alongside the first by making previously-hardcoded values configurable.

- Container names now use an `INSTANCE` prefix (default `late`) so a second clone can use `late2` without colliding with the first
- Host-side ports for postgres, icecast, and liquidsoap are now overridable via `LATE_*_HOST_PORT` vars instead of being hardcoded
- `LATE_WEB_URL` / `LATE_SSH_*_URL` / `LATE_ALLOWED_ORIGINS` now derive from `LATE_WEB_PORT` and `LATE_API_PORT`, so overriding a port is enough -- no need to override the URLs separately
- Adds `make start-instance2` / `make .env-instance2` recipes that bundle the port + `INSTANCE` overrides for the second clone

The default single-instance workflow is unchanged: with no overrides, container names and ports match what was there before.

## Test plan

- [ ] `make start` from a fresh clone -- containers come up with `late-*` names on the original ports (3000/4000/2222/5433/8000/1234)
- [ ] From a second clone, `make start-instance2` brings up `late2-*` containers on 3001/4001/2223/5434/8001/1235 alongside the first instance
- [ ] Web UI on the second instance loads at http://localhost:3001 and the SSH WS endpoint resolves to localhost:4001 (no CORS errors)
- [ ] `ssh -p 2223 localhost` reaches the second instance's SSH service