### PR TITLE
User preference: show settings on connect (or not)

### DIFF
--- a/late-core/src/models/profile.rs
+++ b/late-core/src/models/profile.rs
@@ -6,7 +6,7 @@ use super::user::{
     User, extract_bio, extract_country, extract_enable_background_color, extract_favorite_room_ids,
     extract_notify_bell, extract_notify_cooldown_mins, extract_notify_format, extract_notify_kinds,
     extract_show_dashboard_header, extract_show_games_sidebar, extract_show_right_sidebar,
-    extract_theme_id, extract_timezone,
+    extract_show_settings_on_connect, extract_theme_id, extract_timezone,
 };
 
 #[derive(Clone, Debug)]
@@ -25,6 +25,8 @@ pub struct Profile {
     pub show_dashboard_header: bool,
     pub show_right_sidebar: bool,
     pub show_games_sidebar: bool,
+    /// When false, the settings modal is not auto-opened on connect.
+    pub show_settings_on_connect: bool,
     /// Ordered list of room ids pinned to the dashboard quick-switch strip.
     pub favorite_room_ids: Vec<Uuid>,
 }
@@ -45,6 +47,7 @@ impl Default for Profile {
             show_dashboard_header: true,
             show_right_sidebar: true,
             show_games_sidebar: true,
+            show_settings_on_connect: true,
             favorite_room_ids: Vec::new(),
         }
     }
@@ -65,6 +68,7 @@ pub struct ProfileParams {
     pub show_dashboard_header: bool,
     pub show_right_sidebar: bool,
     pub show_games_sidebar: bool,
+    pub show_settings_on_connect: bool,
     pub favorite_room_ids: Vec<Uuid>,
 }
 
@@ -79,7 +83,7 @@ impl Profile {
     /// Atomic partial update — merges
     /// bio/country/timezone/theme_id/notify_kinds/notify_bell/notify_cooldown_mins/
     /// enable_background_color/show_dashboard_header/show_right_sidebar/
-    /// show_games_sidebar into settings via
+    /// show_games_sidebar/show_settings_on_connect into settings via
     /// `settings || jsonb_build_object(...)`, so concurrent writes to unrelated keys
     /// (ignored_user_ids) are preserved.
     pub async fn update(client: &Client, user_id: Uuid, params: ProfileParams) -> Result<Self> {
@@ -142,10 +146,11 @@ impl Profile {
                          'show_dashboard_header', $11::bool,
                          'show_right_sidebar', $12::bool,
                          'show_games_sidebar', $13::bool,
-                         'favorite_room_ids', $14::jsonb
+                         'show_settings_on_connect', $14::bool,
+                         'favorite_room_ids', $15::jsonb
                      ),
                      updated = current_timestamp
-                 WHERE id = $15
+                 WHERE id = $16
                  RETURNING *",
                 &[
                     &params.username,
@@ -161,6 +166,7 @@ impl Profile {
                     &params.show_dashboard_header,
                     &params.show_right_sidebar,
                     &params.show_games_sidebar,
+                    &params.show_settings_on_connect,
                     &favorite_room_ids_json,
                     &user_id,
                 ],
@@ -185,6 +191,7 @@ impl Profile {
             show_dashboard_header: extract_show_dashboard_header(&user.settings),
             show_right_sidebar: extract_show_right_sidebar(&user.settings),
             show_games_sidebar: extract_show_games_sidebar(&user.settings),
+            show_settings_on_connect: extract_show_settings_on_connect(&user.settings),
             favorite_room_ids: extract_favorite_room_ids(&user.settings),
         }
     }

--- a/late-core/src/models/user.rs
+++ b/late-core/src/models/user.rs
@@ -33,6 +33,7 @@ const ENABLE_BACKGROUND_COLOR_KEY: &str = "enable_background_color";
 const SHOW_DASHBOARD_HEADER_KEY: &str = "show_dashboard_header";
 const SHOW_RIGHT_SIDEBAR_KEY: &str = "show_right_sidebar";
 const SHOW_GAMES_SIDEBAR_KEY: &str = "show_games_sidebar";
+const SHOW_SETTINGS_ON_CONNECT_KEY: &str = "show_settings_on_connect";
 const FAVORITE_ROOM_IDS_KEY: &str = "favorite_room_ids";
 const BIO_KEY: &str = "bio";
 const COUNTRY_KEY: &str = "country";
@@ -362,6 +363,13 @@ pub fn extract_show_right_sidebar(settings: &Value) -> bool {
 pub fn extract_show_games_sidebar(settings: &Value) -> bool {
     settings
         .get(SHOW_GAMES_SIDEBAR_KEY)
+        .and_then(Value::as_bool)
+        .unwrap_or(true)
+}
+
+pub fn extract_show_settings_on_connect(settings: &Value) -> bool {
+    settings
+        .get(SHOW_SETTINGS_ON_CONNECT_KEY)
         .and_then(Value::as_bool)
         .unwrap_or(true)
 }

--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -789,6 +789,7 @@ impl GhostService {
                 show_dashboard_header: profile.show_dashboard_header,
                 show_right_sidebar: profile.show_right_sidebar,
                 show_games_sidebar: profile.show_games_sidebar,
+                show_settings_on_connect: profile.show_settings_on_connect,
                 favorite_room_ids: profile.favorite_room_ids,
             },
         )

--- a/late-ssh/src/app/settings_modal/gem.rs
+++ b/late-ssh/src/app/settings_modal/gem.rs
@@ -1,0 +1,229 @@
+//! In-memory easter-egg "gem" rendered at the bottom of the Special tab.
+//!
+//! Per-session only — no persistence. Color rolls happen on every interaction;
+//! teleports (33%) brand the small gem with a count; the 10th teleport evolves
+//! it into the grand gem. Grand gem clicks roll a 10% shine in a separate
+//! random color.
+
+use std::cell::Cell;
+
+use rand_core::{OsRng, RngCore};
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+
+const PALETTE: &[Color] = &[
+    Color::Red,
+    Color::Yellow,
+    Color::Green,
+    Color::Cyan,
+    Color::Blue,
+    Color::Magenta,
+    Color::LightRed,
+    Color::LightYellow,
+    Color::LightGreen,
+    Color::LightCyan,
+    Color::LightBlue,
+    Color::LightMagenta,
+    Color::White,
+];
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GemPosition {
+    Left,
+    Right,
+}
+
+/// Direction the gem just moved during a teleport. Used to render a
+/// transient speed trail on the next render. Cleared on the next
+/// non-teleporting interaction so the gem only "smokes" right after a jump.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum MoveDirection {
+    Leftward,
+    Rightward,
+}
+
+/// Keys that interact with the gem. Used to dedupe consecutive presses of
+/// the same key — `<space><space>` is one interaction, `<space><j><space>`
+/// is three.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GemKey {
+    H,
+    J,
+    K,
+    L,
+    Space,
+    Up,
+    Down,
+}
+
+pub struct GemState {
+    color: Color,
+    position: GemPosition,
+    /// Brand displayed inside the small gem. `0` = unbranded; otherwise 1..=9.
+    brand: u8,
+    evolved: bool,
+    shining: bool,
+    shine_color: Color,
+    last_key: Option<GemKey>,
+    /// `Some(dir)` right after a teleport, cleared by any interaction that
+    /// doesn't itself teleport.
+    last_move: Option<MoveDirection>,
+    /// Last rendered terminal-coordinate rect of the gem, for mouse hit tests.
+    /// `None` until the Special tab has been drawn at least once.
+    pub hit_area: Cell<Option<Rect>>,
+}
+
+impl GemState {
+    pub fn new() -> Self {
+        Self {
+            color: PALETTE[0],
+            position: GemPosition::Left,
+            brand: 0,
+            evolved: false,
+            shining: false,
+            shine_color: PALETTE[0],
+            last_key: None,
+            last_move: None,
+            hit_area: Cell::new(None),
+        }
+    }
+
+    pub fn color(&self) -> Color {
+        self.color
+    }
+
+    pub fn position(&self) -> GemPosition {
+        self.position
+    }
+
+    pub fn brand(&self) -> u8 {
+        self.brand
+    }
+
+    pub fn evolved(&self) -> bool {
+        self.evolved
+    }
+
+    pub fn shining(&self) -> bool {
+        self.shining
+    }
+
+    pub fn shine_color(&self) -> Color {
+        self.shine_color
+    }
+
+    pub fn last_move(&self) -> Option<MoveDirection> {
+        self.last_move
+    }
+
+    /// Process a key press. Consecutive presses of the same key are ignored.
+    pub fn handle_key(&mut self, key: GemKey) {
+        if self.last_key == Some(key) {
+            return;
+        }
+        self.last_key = Some(key);
+        self.interact();
+    }
+
+    /// Process a mouse click. Mouse clicks aren't subject to the key dedupe
+    /// rule, but they do reset it so a subsequent same-as-before key press
+    /// counts again.
+    pub fn handle_click(&mut self) {
+        self.last_key = None;
+        self.interact();
+    }
+
+    fn interact(&mut self) {
+        // Color always changes.
+        self.color = random_color_excluding(self.color);
+
+        if self.evolved {
+            // Roll a fresh shine on every click.
+            self.shining = roll_percent(10);
+            if self.shining {
+                self.shine_color = random_color_excluding(self.color);
+            }
+            self.last_move = None;
+        } else if roll_percent(33) {
+            // Teleport.
+            if self.brand >= 9 {
+                self.evolved = true;
+                self.shining = false;
+                self.last_move = None;
+            } else {
+                self.brand += 1;
+                self.position = match self.position {
+                    GemPosition::Left => GemPosition::Right,
+                    GemPosition::Right => GemPosition::Left,
+                };
+                self.last_move = Some(match self.position {
+                    GemPosition::Left => MoveDirection::Leftward,
+                    GemPosition::Right => MoveDirection::Rightward,
+                });
+            }
+        } else {
+            // Interaction without a teleport — the gem is sitting still, so
+            // the previous trail blows away.
+            self.last_move = None;
+        }
+    }
+}
+
+impl Default for GemState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+fn roll_percent(threshold: u64) -> bool {
+    OsRng.next_u64() % 100 < threshold
+}
+
+fn random_color_excluding(current: Color) -> Color {
+    loop {
+        let idx = (OsRng.next_u64() as usize) % PALETTE.len();
+        let candidate = PALETTE[idx];
+        if candidate != current {
+            return candidate;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn duplicate_consecutive_keys_are_deduped() {
+        let mut gem = GemState::new();
+        let initial = gem.color();
+
+        gem.handle_key(GemKey::Space);
+        let after_first = gem.color();
+        assert_ne!(initial, after_first, "first press must change color");
+
+        // Second identical press is dropped — color stays put.
+        gem.handle_key(GemKey::Space);
+        assert_eq!(gem.color(), after_first);
+
+        // A different key counts again.
+        gem.handle_key(GemKey::J);
+        assert_ne!(gem.color(), after_first);
+    }
+
+    #[test]
+    fn mouse_click_resets_key_dedupe() {
+        let mut gem = GemState::new();
+        gem.handle_key(GemKey::Space);
+        let after_key = gem.color();
+
+        gem.handle_click();
+        let after_click = gem.color();
+        assert_ne!(after_key, after_click);
+
+        // Same key as before the click now counts because the click reset
+        // the dedupe state.
+        gem.handle_key(GemKey::Space);
+        assert_ne!(gem.color(), after_click);
+    }
+}

--- a/late-ssh/src/app/settings_modal/input.rs
+++ b/late-ssh/src/app/settings_modal/input.rs
@@ -1,6 +1,7 @@
-use crate::app::input::{MouseEventKind, ParsedInput, sanitize_paste_markers};
+use crate::app::input::{MouseButton, MouseEventKind, ParsedInput, sanitize_paste_markers};
 use crate::app::state::App;
 
+use super::gem::GemKey;
 use super::state::{PickerKind, Row, Tab};
 use crate::app::settings_modal::state::SettingsModalState;
 
@@ -51,6 +52,11 @@ pub fn handle_input(app: &mut App, event: ParsedInput) {
 
     if app.settings_modal_state.selected_tab() == Tab::Favorites {
         handle_favorites_tab_input(app, event);
+        return;
+    }
+
+    if app.settings_modal_state.selected_tab() == Tab::Special {
+        handle_special_tab_input(app, event);
         return;
     }
 
@@ -118,6 +124,66 @@ fn handle_favorites_tab_input(app: &mut App, event: ParsedInput) {
             state.open_picker(PickerKind::Room);
         }
         _ => {}
+    }
+}
+
+/// Special tab: holds the "show settings on connect" toggle and the gem
+/// easter egg.
+///
+/// Key routing:
+/// - `Enter`, `←`, `→` flip the toggle (matching the cycle convention from
+///   the other tabs).
+/// - `h`, `j`, `k`, `l`, `Space`, `↑`, `↓` interact with the gem
+///   (consecutive duplicates of the same key are ignored).
+/// - Left-click on the gem's rendered footprint also interacts.
+fn handle_special_tab_input(app: &mut App, event: ParsedInput) {
+    match event {
+        ParsedInput::Byte(b'?') | ParsedInput::Char('?') => open_help(app),
+        ParsedInput::Byte(b'\r') | ParsedInput::Arrow(b'C') | ParsedInput::Arrow(b'D') => {
+            app.settings_modal_state.toggle_show_settings_on_connect();
+        }
+        ParsedInput::Mouse(mouse) => {
+            if mouse.kind == MouseEventKind::Down && mouse.button == Some(MouseButton::Left) {
+                let Some(x) = mouse.x.checked_sub(1) else {
+                    return;
+                };
+                let Some(y) = mouse.y.checked_sub(1) else {
+                    return;
+                };
+                let hit = app
+                    .settings_modal_state
+                    .gem()
+                    .hit_area
+                    .get()
+                    .filter(|rect| {
+                        x >= rect.x
+                            && x < rect.x + rect.width
+                            && y >= rect.y
+                            && y < rect.y + rect.height
+                    });
+                if hit.is_some() {
+                    app.settings_modal_state.gem_mut().handle_click();
+                }
+            }
+        }
+        _ => {
+            if let Some(key) = gem_key_for_event(&event) {
+                app.settings_modal_state.gem_mut().handle_key(key);
+            }
+        }
+    }
+}
+
+fn gem_key_for_event(event: &ParsedInput) -> Option<GemKey> {
+    match event {
+        ParsedInput::Byte(b' ') | ParsedInput::Char(' ') => Some(GemKey::Space),
+        ParsedInput::Byte(b'h') | ParsedInput::Char('h') => Some(GemKey::H),
+        ParsedInput::Byte(b'j') | ParsedInput::Char('j') => Some(GemKey::J),
+        ParsedInput::Byte(b'k') | ParsedInput::Char('k') => Some(GemKey::K),
+        ParsedInput::Byte(b'l') | ParsedInput::Char('l') => Some(GemKey::L),
+        ParsedInput::Arrow(b'A') => Some(GemKey::Up),
+        ParsedInput::Arrow(b'B') => Some(GemKey::Down),
+        _ => None,
     }
 }
 

--- a/late-ssh/src/app/settings_modal/mod.rs
+++ b/late-ssh/src/app/settings_modal/mod.rs
@@ -1,4 +1,5 @@
 pub mod data;
+pub mod gem;
 pub mod input;
 pub mod state;
 pub mod ui;

--- a/late-ssh/src/app/settings_modal/state.rs
+++ b/late-ssh/src/app/settings_modal/state.rs
@@ -10,6 +10,7 @@ use crate::app::common::theme;
 use crate::app::profile::svc::ProfileService;
 
 use super::data::{CountryOption, filter_countries, filter_timezones};
+use super::gem::GemState;
 
 const USERNAME_MAX_LEN: usize = 12;
 pub const BIO_MAX_LEN: usize = 500;
@@ -80,10 +81,19 @@ pub enum Tab {
     Bio,
     Themes,
     Favorites,
+    /// Hidden until the user has filled out at least one of bio, country,
+    /// or timezone. Currently houses the "Show settings on connect" toggle.
+    Special,
 }
 
 impl Tab {
-    pub const ALL: [Tab; 4] = [Tab::Settings, Tab::Bio, Tab::Themes, Tab::Favorites];
+    pub const ALL: [Tab; 5] = [
+        Tab::Settings,
+        Tab::Bio,
+        Tab::Themes,
+        Tab::Favorites,
+        Tab::Special,
+    ];
 
     pub fn label(self) -> &'static str {
         match self {
@@ -91,6 +101,7 @@ impl Tab {
             Tab::Bio => "Bio",
             Tab::Themes => "Themes",
             Tab::Favorites => "Favorites",
+            Tab::Special => "Special",
         }
     }
 }
@@ -138,6 +149,9 @@ pub struct SettingsModalState {
     /// Cursor in the Favorites tab: 0..favorites.len() selects a favorite,
     /// the final slot (favorites.len()) selects the "Add favorite…" row.
     favorites_index: usize,
+    /// Per-session gem easter egg on the Special tab. Persists across modal
+    /// open/close cycles for the lifetime of the SSH session.
+    gem: GemState,
 }
 
 impl SettingsModalState {
@@ -160,7 +174,16 @@ impl SettingsModalState {
             picker: PickerState::default(),
             available_rooms: Vec::new(),
             favorites_index: 0,
+            gem: GemState::new(),
         }
+    }
+
+    pub fn gem(&self) -> &GemState {
+        &self.gem
+    }
+
+    pub fn gem_mut(&mut self) -> &mut GemState {
+        &mut self.gem
     }
 
     pub fn open_from_profile(
@@ -195,17 +218,19 @@ impl SettingsModalState {
 
     /// Switch to the neighboring tab. Auto-saves + ends any in-flight bio
     /// edit when leaving the Bio tab so the preview reflects the draft.
+    /// Skips the Special tab while it's hidden (no bio/country/timezone).
     pub fn cycle_tab(&mut self, forward: bool) {
-        let idx = Tab::ALL
+        let visible = self.visible_tabs();
+        let idx = visible
             .iter()
             .position(|t| *t == self.selected_tab)
             .unwrap_or(0);
         let next_idx = if forward {
-            (idx + 1) % Tab::ALL.len()
+            (idx + 1) % visible.len()
         } else {
-            (idx + Tab::ALL.len() - 1) % Tab::ALL.len()
+            (idx + visible.len() - 1) % visible.len()
         };
-        let next = Tab::ALL[next_idx];
+        let next = visible[next_idx];
         if self.selected_tab == Tab::Bio && next != Tab::Bio && self.editing_bio {
             self.stop_bio_edit();
             self.save();
@@ -219,6 +244,41 @@ impl SettingsModalState {
             self.sync_theme_index_to_draft();
         }
         self.selected_tab = next;
+    }
+
+    /// Tabs to show in the tab strip in display order. The Special tab is
+    /// hidden until the user has filled out at least one of bio, country,
+    /// or timezone.
+    pub fn visible_tabs(&self) -> Vec<Tab> {
+        Tab::ALL
+            .iter()
+            .copied()
+            .filter(|tab| *tab != Tab::Special || self.special_tab_unlocked())
+            .collect()
+    }
+
+    pub fn special_tab_unlocked(&self) -> bool {
+        let bio_filled = !self.draft.bio.trim().is_empty();
+        let country_filled = self
+            .draft
+            .country
+            .as_deref()
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false);
+        let timezone_filled = self
+            .draft
+            .timezone
+            .as_deref()
+            .map(|value| !value.trim().is_empty())
+            .unwrap_or(false);
+        bio_filled || country_filled || timezone_filled
+    }
+
+    /// Flip the "show settings on connect" toggle (the sole control on the
+    /// Special tab) and persist.
+    pub fn toggle_show_settings_on_connect(&mut self) {
+        self.draft.show_settings_on_connect ^= true;
+        self.save();
     }
 
     pub fn set_modal_width(&mut self, _modal_width: u16) {
@@ -907,6 +967,7 @@ impl SettingsModalState {
                 show_dashboard_header: self.draft.show_dashboard_header,
                 show_right_sidebar: self.draft.show_right_sidebar,
                 show_games_sidebar: self.draft.show_games_sidebar,
+                show_settings_on_connect: self.draft.show_settings_on_connect,
                 favorite_room_ids: self.draft.favorite_room_ids.clone(),
             },
         );

--- a/late-ssh/src/app/settings_modal/ui.rs
+++ b/late-ssh/src/app/settings_modal/ui.rs
@@ -10,6 +10,7 @@ use crate::app::common::{markdown::render_body_to_lines, theme};
 
 use super::{
     data::country_label,
+    gem::{GemPosition, GemState, MoveDirection},
     state::{BIO_MAX_LEN, PickerKind, Row, SettingsModalState, Tab, ThemeTreeRow},
 };
 
@@ -41,13 +42,14 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
     ])
     .split(inner);
 
-    draw_tabs(frame, layout[1], state.selected_tab());
+    draw_tabs(frame, layout[1], state);
 
     match state.selected_tab() {
         Tab::Settings => draw_settings_tab(frame, layout[3], state),
         Tab::Themes => draw_themes_tab(frame, layout[3], state),
         Tab::Bio => draw_bio_tab(frame, layout[3], state),
         Tab::Favorites => draw_favorites_tab(frame, layout[3], state),
+        Tab::Special => draw_special_tab(frame, layout[3], state),
     }
 
     draw_footer(frame, layout[4], state.selected_tab(), state.editing_bio());
@@ -57,9 +59,10 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
     }
 }
 
-fn draw_tabs(frame: &mut Frame, area: Rect, selected: Tab) {
+fn draw_tabs(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
+    let selected = state.selected_tab();
     let mut spans = vec![Span::raw("  ")];
-    for tab in Tab::ALL {
+    for tab in state.visible_tabs() {
         let active = tab == selected;
         let style = if active {
             Style::default()
@@ -121,6 +124,16 @@ fn draw_footer(frame: &mut Frame, area: Rect, tab: Tab, editing_bio: bool) {
                 Span::styled(" preview  ", Style::default().fg(theme::TEXT_DIM())),
                 Span::styled("←→", Style::default().fg(theme::AMBER_DIM())),
                 Span::styled(" close/open  ", Style::default().fg(theme::TEXT_DIM())),
+                Span::styled("Tab/S+Tab", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled(" switch tabs  ", Style::default().fg(theme::TEXT_DIM())),
+                Span::styled("Esc/q", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled(" close", Style::default().fg(theme::TEXT_DIM())),
+            ]);
+        }
+        (Tab::Special, _) => {
+            spans.extend([
+                Span::styled("←→ ↵", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled(" toggle  ", Style::default().fg(theme::TEXT_DIM())),
                 Span::styled("Tab/S+Tab", Style::default().fg(theme::AMBER_DIM())),
                 Span::styled(" switch tabs  ", Style::default().fg(theme::TEXT_DIM())),
                 Span::styled("Esc/q", Style::default().fg(theme::AMBER_DIM())),
@@ -536,6 +549,295 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
         )),
         sections[20],
     );
+}
+
+fn draw_special_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
+    // Reserve a 7-line strip at the bottom: 6 for the shining grand gem
+    // (5-line body + 1 row of sparkles above) and 1 row of padding off the
+    // dialog's bottom border.
+    const GEM_STRIP_HEIGHT: u16 = 7;
+    let gem_strip_height = GEM_STRIP_HEIGHT.min(area.height.saturating_sub(4));
+
+    let sections = Layout::vertical([
+        Constraint::Length(1),                // heading
+        Constraint::Length(1),                // hint
+        Constraint::Length(1),                // breathing
+        Constraint::Length(1),                // toggle row
+        Constraint::Min(0),                   // flex spacer
+        Constraint::Length(gem_strip_height), // gem
+    ])
+    .split(area);
+
+    frame.render_widget(Paragraph::new(section_heading("Special")), sections[0]);
+
+    let hint = Line::from(vec![
+        Span::raw("  "),
+        Span::styled(
+            "Power-user toggles unlocked by completing your profile.",
+            Style::default().fg(theme::TEXT_DIM()),
+        ),
+    ]);
+    frame.render_widget(Paragraph::new(hint), sections[1]);
+
+    let width = area.width as usize;
+    let label = "Show settings on connect";
+    let value = toggle_span(state.draft().show_settings_on_connect);
+
+    let prefix_style = Style::default()
+        .fg(theme::AMBER_GLOW())
+        .bg(theme::BG_SELECTION())
+        .add_modifier(Modifier::BOLD);
+    let label_style = Style::default()
+        .fg(theme::TEXT_BRIGHT())
+        .bg(theme::BG_SELECTION())
+        .add_modifier(Modifier::BOLD);
+    let value_style = value.style.bg(theme::BG_SELECTION());
+    let trailing_style = Style::default().bg(theme::BG_SELECTION());
+
+    let prefix = " › ".to_string();
+    let label_text = format!("{label:<26}");
+    let mut used = prefix.chars().count() + label_text.chars().count() + value.text.chars().count();
+    if used > width {
+        used = width;
+    }
+    let trailing = " ".repeat(width.saturating_sub(used));
+
+    let line = Line::from(vec![
+        Span::styled(prefix, prefix_style),
+        Span::styled(label_text, label_style),
+        Span::styled(value.text, value_style),
+        Span::styled(trailing, trailing_style),
+    ]);
+    frame.render_widget(Paragraph::new(line), sections[3]);
+
+    if gem_strip_height > 0 {
+        // Pad 2 cols off each side and lift the gem 1 row off the bottom
+        // border so it doesn't crowd the dialog frame.
+        const PAD_X: u16 = 2;
+        const PAD_BOTTOM: u16 = 1;
+        let strip = sections[5];
+        let pad_x = PAD_X.min(strip.width / 2);
+        let pad_bottom = PAD_BOTTOM.min(strip.height);
+        let gem_area = Rect::new(
+            strip.x + pad_x,
+            strip.y,
+            strip.width.saturating_sub(pad_x * 2),
+            strip.height.saturating_sub(pad_bottom),
+        );
+        if gem_area.width > 0 && gem_area.height > 0 {
+            draw_gem(frame, gem_area, state.gem());
+        } else {
+            state.gem().hit_area.set(None);
+        }
+    } else {
+        state.gem().hit_area.set(None);
+    }
+}
+
+/// Layout note: `area` is the 6-line strip reserved at the bottom of the
+/// Special tab. The small gem hugs a corner; the grand gem is centered.
+/// The gem's screen-coordinate rect is stashed back on `gem.hit_area` so the
+/// input handler can do mouse hit testing.
+fn draw_gem(frame: &mut Frame, area: Rect, gem: &GemState) {
+    if gem.evolved() {
+        draw_grand_gem(frame, area, gem);
+    } else {
+        draw_small_gem(frame, area, gem);
+    }
+}
+
+fn draw_small_gem(frame: &mut Frame, area: Rect, gem: &GemState) {
+    const SMALL_W: u16 = 3;
+    const SMALL_H: u16 = 3;
+    if area.width < SMALL_W || area.height < SMALL_H {
+        gem.hit_area.set(None);
+        return;
+    }
+    let style = Style::default().fg(gem.color());
+    let mid = match gem.brand() {
+        0 => "\\ /".to_string(),
+        n => format!("\\{}/", n),
+    };
+    let rows = ["___", mid.as_str(), " ' "];
+
+    let x = match gem.position() {
+        GemPosition::Left => area.x,
+        GemPosition::Right => area.x + area.width.saturating_sub(SMALL_W),
+    };
+    let y_start = area.y + area.height.saturating_sub(SMALL_H);
+
+    for (i, row) in rows.iter().enumerate() {
+        let row_rect = Rect::new(x, y_start + i as u16, SMALL_W, 1);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(row.to_string(), style))),
+            row_rect,
+        );
+    }
+
+    if let Some(direction) = gem.last_move() {
+        draw_speed_trail(frame, area, x, y_start, direction, style);
+    }
+
+    gem.hit_area
+        .set(Some(Rect::new(x, y_start, SMALL_W, SMALL_H)));
+}
+
+/// Speed-trail wisps. Rendered on the gem's middle and bottom rows,
+/// extending away from the gem in the direction it just came from.
+fn draw_speed_trail(
+    frame: &mut Frame,
+    area: Rect,
+    gem_x: u16,
+    gem_y_start: u16,
+    direction: MoveDirection,
+    style: Style,
+) {
+    // The two rows of trail ASCII, side-aligned with the gem so position
+    // math stays in one place. Each pair is `(mid_row, bottom_row)`.
+    let (mid, bottom) = match direction {
+        MoveDirection::Leftward => ("  .:`  .:    .", "   ':.. ':..  ':..  ':..  :..  ..  .   ."),
+        MoveDirection::Rightward => (
+            ".    :.  `:.  ",
+            "   .   .  ..  ..:  ..:'  ..:'  ..:' ..:'    ",
+        ),
+    };
+
+    let mid_y = gem_y_start + 1;
+    let bottom_y = gem_y_start + 2;
+
+    let area_left = area.x;
+    let area_right = area.x + area.width;
+
+    for (text, y) in [(mid, mid_y), (bottom, bottom_y)] {
+        let len = text.chars().count() as u16;
+        let (x, render_text): (u16, String) = match direction {
+            MoveDirection::Leftward => {
+                // Trail starts immediately to the right of the gem; clip
+                // anything that would spill past the area's right edge.
+                let start = gem_x + 3;
+                let available = area_right.saturating_sub(start);
+                let clipped: String = text.chars().take(available as usize).collect();
+                (start, clipped)
+            }
+            MoveDirection::Rightward => {
+                // Trail ends immediately before the gem; clip from the
+                // front if the area can't fit the full length.
+                let want_start = gem_x.saturating_sub(len);
+                let start = want_start.max(area_left);
+                let drop = (start - want_start) as usize;
+                let clipped: String = text.chars().skip(drop).collect();
+                (start, clipped)
+            }
+        };
+        if render_text.is_empty() {
+            continue;
+        }
+        let width = render_text.chars().count() as u16;
+        let rect = Rect::new(x, y, width, 1);
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(render_text, style))),
+            rect,
+        );
+    }
+}
+
+fn draw_grand_gem(frame: &mut Frame, area: Rect, gem: &GemState) {
+    // Each row is a list of (text, kind). `Kind::Gem` styles with the gem
+    // color; `Kind::Shine` styles with the shine color. Splitting by kind
+    // lets the two colors live on the same cell row.
+    #[derive(Clone, Copy)]
+    enum Kind {
+        Gem,
+        Shine,
+    }
+
+    let body: [&[(&str, Kind)]; 5] = [
+        &[("    _________", Kind::Gem)],
+        &[("   /_|_____|_\\", Kind::Gem)],
+        &[("   '. \\   / .'", Kind::Gem)],
+        &[("     '.\\ /.'", Kind::Gem)],
+        &[("       '.'", Kind::Gem)],
+    ];
+    // Sparkle decorations layered on top when shining. Indices align with
+    // the body rows; the extra row ABOVE the body is `shine_top`. Each
+    // shining row carries 3 leading spaces so the shine's footprint is
+    // symmetric around the body (the natural layout adds 3 chars on the
+    // right but only replaces a leading space on the left); that way plain
+    // `max_width` centering keeps the body columns stable across shining
+    // and non-shining renders.
+    let shine_top: &[(&str, Kind)] = &[("     .  `  '  `  .", Kind::Shine)];
+    let shine_overlay: [&[(&str, Kind)]; 5] = [
+        &[
+            ("    `  ", Kind::Shine),
+            ("_________", Kind::Gem),
+            ("  `", Kind::Shine),
+        ],
+        &[
+            ("   _  ", Kind::Shine),
+            ("/_|_____|_\\", Kind::Gem),
+            ("  _", Kind::Shine),
+        ],
+        // Body row 2 — unchanged content, just shifted right with the rest.
+        &[("      '. \\   / .'", Kind::Gem)],
+        &[
+            ("     `  ", Kind::Shine),
+            ("'.\\ /.'", Kind::Gem),
+            ("  `", Kind::Shine),
+        ],
+        // Body row 4 — unchanged content, shifted with the rest.
+        &[("          '.'", Kind::Gem)],
+    ];
+
+    let shining = gem.shining();
+    let (rows, total_height): (Vec<&[(&str, Kind)]>, u16) = if shining {
+        let mut v: Vec<&[(&str, Kind)]> = Vec::with_capacity(6);
+        v.push(shine_top);
+        for row in &shine_overlay {
+            v.push(*row);
+        }
+        (v, 6)
+    } else {
+        (body.to_vec(), 5)
+    };
+
+    if area.height < total_height {
+        gem.hit_area.set(None);
+        return;
+    }
+
+    let row_widths: Vec<u16> = rows
+        .iter()
+        .map(|row| row.iter().map(|(s, _)| s.chars().count() as u16).sum())
+        .collect();
+    let max_width = row_widths.iter().copied().max().unwrap_or(0);
+    if area.width < max_width {
+        gem.hit_area.set(None);
+        return;
+    }
+
+    let x_origin = area.x + (area.width.saturating_sub(max_width)) / 2;
+    let y_origin = area.y + area.height.saturating_sub(total_height);
+    let gem_style = Style::default().fg(gem.color());
+    let shine_style = Style::default().fg(gem.shine_color());
+
+    for (i, row) in rows.iter().enumerate() {
+        let row_width: u16 = row.iter().map(|(s, _)| s.chars().count() as u16).sum();
+        let row_rect = Rect::new(x_origin, y_origin + i as u16, row_width, 1);
+        let spans: Vec<Span<'_>> = row
+            .iter()
+            .map(|(text, kind)| {
+                let style = match kind {
+                    Kind::Gem => gem_style,
+                    Kind::Shine => shine_style,
+                };
+                Span::styled((*text).to_string(), style)
+            })
+            .collect();
+        frame.render_widget(Paragraph::new(Line::from(spans)), row_rect);
+    }
+
+    gem.hit_area
+        .set(Some(Rect::new(x_origin, y_origin, max_width, total_height)));
 }
 
 fn notify_format_label(format: Option<&str>) -> &'static str {

--- a/late-ssh/src/app/tick.rs
+++ b/late-ssh/src/app/tick.rs
@@ -49,11 +49,15 @@ impl App {
             && self.settings_modal_state.draft().username.is_empty()
             && !self.profile_state.profile().username.is_empty()
         {
-            self.settings_modal_state.open_from_profile(
-                self.profile_state.profile(),
-                self.chat.favorite_room_options(),
-                crate::app::settings_modal::ui::MODAL_WIDTH,
-            );
+            if self.profile_state.profile().show_settings_on_connect {
+                self.settings_modal_state.open_from_profile(
+                    self.profile_state.profile(),
+                    self.chat.favorite_room_options(),
+                    crate::app::settings_modal::ui::MODAL_WIDTH,
+                );
+            } else {
+                self.show_settings = false;
+            }
         }
 
         let mut updated = false;

--- a/late-ssh/tests/app_dashboard_flow.rs
+++ b/late-ssh/tests/app_dashboard_flow.rs
@@ -222,6 +222,7 @@ async fn dashboard_lazy_primes_favorite_histories_without_opening_chat() {
             show_dashboard_header: true,
             show_right_sidebar: true,
             show_games_sidebar: true,
+            show_settings_on_connect: true,
             favorite_room_ids: vec![alpha.id, beta.id],
         },
     )
@@ -289,6 +290,7 @@ async fn dashboard_switching_to_favorite_clears_strip_unread_count() {
             show_dashboard_header: true,
             show_right_sidebar: true,
             show_games_sidebar: true,
+            show_settings_on_connect: true,
             favorite_room_ids: vec![alpha.id, beta.id],
         },
     )
@@ -389,6 +391,7 @@ async fn dashboard_favorites_strip_is_mouse_clickable() {
             show_dashboard_header: true,
             show_right_sidebar: true,
             show_games_sidebar: true,
+            show_settings_on_connect: true,
             favorite_room_ids: vec![alpha.id, beta.id],
         },
     )

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -550,6 +550,7 @@ async fn publishes_snapshot_with_favorite_room_history() {
             show_dashboard_header: true,
             show_right_sidebar: true,
             show_games_sidebar: true,
+            show_settings_on_connect: true,
             favorite_room_ids: vec![favorite_room.id],
         },
     )

--- a/late-ssh/tests/profile/svc.rs
+++ b/late-ssh/tests/profile/svc.rs
@@ -68,6 +68,7 @@ async fn edit_profile_emits_saved_event_and_refreshes_snapshot() {
             show_dashboard_header: false,
             show_right_sidebar: true,
             show_games_sidebar: true,
+            show_settings_on_connect: true,
             favorite_room_ids: Vec::new(),
         },
     );
@@ -129,6 +130,7 @@ async fn edit_profile_normalizes_username_before_persisting() {
             show_dashboard_header: true,
             show_right_sidebar: true,
             show_games_sidebar: true,
+            show_settings_on_connect: true,
             favorite_room_ids: Vec::new(),
         },
     );
@@ -184,6 +186,7 @@ async fn edit_profile_preserves_unrelated_settings_keys() {
             show_dashboard_header: true,
             show_right_sidebar: true,
             show_games_sidebar: true,
+            show_settings_on_connect: true,
             favorite_room_ids: Vec::new(),
         },
     );


### PR DESCRIPTION
- New `show_settings_on_connect` profile setting (default on); when off, the settings modal no longer auto-opens on connect.

Users who fill out a bit of profile info get access to a settings section called "Special".  The new `show_settings_on_connect` setting lives there, along with a mysterious gem that no one seems to know the purpose of. 🤔