### PR TITLE
Make chat refreshes cheaper and more consistent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,6 +2726,7 @@ dependencies = [
  "russh",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tokio-postgres",
  "tower-http",
@@ -5809,6 +5810,26 @@ dependencies = [
  "quick-error",
  "weezl",
  "zune-jpeg",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/late-ssh/Cargo.toml
+++ b/late-ssh/Cargo.toml
@@ -24,6 +24,9 @@ ipnet.workspace = true
 # Async Runtime
 tokio = { workspace = true }
 
+# Memory allocator
+tikv-jemallocator = "0.6"
+
 # Database
 tokio-postgres = { workspace = true }
 crossterm.workspace = true

--- a/late-ssh/src/app/artboard/svc.rs
+++ b/late-ssh/src/app/artboard/svc.rs
@@ -449,7 +449,11 @@ fn log_op(op: &CanvasOp, username: &str) {
             );
         }
         CanvasOp::PaintRegion { cells } if cells.len() > PAINT_REGION_LOG_THRESHOLD => {
-            info!(user = username, cells = cells.len(), "artboard paint region");
+            info!(
+                user = username,
+                cells = cells.len(),
+                "artboard paint region"
+            );
         }
         _ => {}
     }

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -137,8 +137,7 @@ impl ChatState {
     ) -> Self {
         let event_rx = service.subscribe_events();
         let (room_tx, room_rx) = watch::channel(None);
-        let (snapshot_rx, refresh_tx, bg_task) =
-            service.start_user_refresh_task(user_id, room_rx);
+        let (snapshot_rx, refresh_tx, bg_task) = service.start_user_refresh_task(user_id, room_rx);
 
         Self {
             service,
@@ -221,8 +220,16 @@ impl ChatState {
         composer::set_themed_textarea_cursor_visible(&mut self.composer, true);
     }
 
-    pub fn request_list(&self) {
+    pub fn request_list(&mut self) {
+        self.sync_refresh_room_id();
         let _ = self.refresh_tx.send(());
+    }
+
+    fn sync_refresh_room_id(&mut self) {
+        if self.refresh_room_id != self.selected_room_id {
+            self.refresh_room_id = self.selected_room_id;
+            let _ = self.room_tx.send(self.selected_room_id);
+        }
     }
 
     pub fn sync_selection(&mut self) {
@@ -1023,10 +1030,7 @@ impl ChatState {
     }
 
     pub fn tick(&mut self) -> Option<Banner> {
-        if self.refresh_room_id != self.selected_room_id {
-            self.refresh_room_id = self.selected_room_id;
-            let _ = self.room_tx.send(self.selected_room_id);
-        }
+        self.sync_refresh_room_id();
         self.drain_snapshot();
         let banner = self.drain_events();
         let news_banner = self.news.tick();

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -8,7 +8,7 @@ use late_core::{
     },
 };
 use ratatui_textarea::{CursorMove, Input, TextArea, WrapMode};
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 use uuid::Uuid;
 
 use crate::app::common::overlay::Overlay;
@@ -73,6 +73,8 @@ pub struct ChatState {
     pending_read_rooms: HashSet<Uuid>,
     visible_room_id: Option<Uuid>,
     room_tx: watch::Sender<Option<Uuid>>,
+    refresh_tx: mpsc::UnboundedSender<()>,
+    refresh_room_id: Option<Uuid>,
     pub(crate) selected_room_id: Option<Uuid>,
     pub(crate) room_jump_active: bool,
     composer: TextArea<'static>,
@@ -135,7 +137,8 @@ impl ChatState {
     ) -> Self {
         let event_rx = service.subscribe_events();
         let (room_tx, room_rx) = watch::channel(None);
-        let (snapshot_rx, bg_task) = service.start_user_refresh_task(user_id, room_rx);
+        let (snapshot_rx, refresh_tx, bg_task) =
+            service.start_user_refresh_task(user_id, room_rx);
 
         Self {
             service,
@@ -154,6 +157,8 @@ impl ChatState {
             pending_read_rooms: HashSet::new(),
             visible_room_id: None,
             room_tx,
+            refresh_tx,
+            refresh_room_id: None,
             selected_room_id: None,
             room_jump_active: false,
             composer: new_chat_textarea(),
@@ -217,8 +222,7 @@ impl ChatState {
     }
 
     pub fn request_list(&self) {
-        self.service
-            .list_chats_task(self.user_id, self.selected_room_id);
+        let _ = self.refresh_tx.send(());
     }
 
     pub fn sync_selection(&mut self) {
@@ -1019,7 +1023,10 @@ impl ChatState {
     }
 
     pub fn tick(&mut self) -> Option<Banner> {
-        let _ = self.room_tx.send(self.selected_room_id);
+        if self.refresh_room_id != self.selected_room_id {
+            self.refresh_room_id = self.selected_room_id;
+            let _ = self.room_tx.send(self.selected_room_id);
+        }
         self.drain_snapshot();
         let banner = self.drain_events();
         let news_banner = self.news.tick();

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -133,10 +133,9 @@ impl ChatState {
         article_service: news::svc::ArticleService,
         showcase_service: showcase::svc::ShowcaseService,
     ) -> Self {
-        let snapshot_rx = service.subscribe_state();
         let event_rx = service.subscribe_events();
         let (room_tx, room_rx) = watch::channel(None);
-        let bg_task = service.start_user_refresh_task(user_id, room_rx);
+        let (snapshot_rx, bg_task) = service.start_user_refresh_task(user_id, room_rx);
 
         Self {
             service,

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -22,7 +22,7 @@ use late_core::{
         user::User,
     },
 };
-use tokio::sync::{Mutex as AsyncMutex, Notify, broadcast, watch};
+use tokio::sync::{Mutex as AsyncMutex, broadcast, mpsc, watch};
 use tracing::{Instrument, info_span};
 
 use crate::app::bonsai::state::stage_for;
@@ -44,7 +44,8 @@ pub struct ChatService {
     globals_refresh_started: Arc<AtomicBool>,
     refresh_sessions: Arc<Mutex<HashMap<Uuid, ChatRefreshSession>>>,
     refresh_scheduler_started: Arc<AtomicBool>,
-    refresh_notify: Arc<Notify>,
+    refresh_signal_tx: mpsc::UnboundedSender<Uuid>,
+    refresh_signal_rx: Arc<Mutex<Option<mpsc::UnboundedReceiver<Uuid>>>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -79,10 +80,11 @@ impl Default for ChatGlobalsCache {
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone)]
 struct ChatRefreshSession {
     user_id: Uuid,
     selected_room_id: Option<Uuid>,
+    snapshot_tx: watch::Sender<ChatSnapshot>,
 }
 
 struct ChatRefreshSessionGuard {
@@ -253,6 +255,7 @@ impl ChatService {
     pub fn new(db: Db, notification_svc: super::notifications::svc::NotificationService) -> Self {
         let (snapshot_tx, snapshot_rx) = watch::channel(ChatSnapshot::default());
         let (evt_tx, _) = broadcast::channel(512);
+        let (refresh_signal_tx, refresh_signal_rx) = mpsc::unbounded_channel();
 
         Self {
             db,
@@ -264,7 +267,8 @@ impl ChatService {
             globals_refresh_started: Arc::new(AtomicBool::new(false)),
             refresh_sessions: Arc::new(Mutex::new(HashMap::new())),
             refresh_scheduler_started: Arc::new(AtomicBool::new(false)),
-            refresh_notify: Arc::new(Notify::new()),
+            refresh_signal_tx,
+            refresh_signal_rx: Arc::new(Mutex::new(Some(refresh_signal_rx))),
         }
     }
     pub fn subscribe_state(&self) -> watch::Receiver<ChatSnapshot> {
@@ -360,6 +364,16 @@ impl ChatService {
 
     #[tracing::instrument(skip(self), fields(user_id = %user_id, selected_room_id = ?selected_room_id))]
     async fn list_chat_rooms(&self, user_id: Uuid, selected_room_id: Option<Uuid>) -> Result<()> {
+        let snapshot = self.build_chat_snapshot(user_id, selected_room_id).await?;
+        self.publish_snapshot(snapshot)
+    }
+
+    #[tracing::instrument(skip(self), fields(user_id = %user_id, selected_room_id = ?selected_room_id))]
+    async fn build_chat_snapshot(
+        &self,
+        user_id: Uuid,
+        selected_room_id: Option<Uuid>,
+    ) -> Result<ChatSnapshot> {
         let globals = self.chat_globals().await?;
         self.ensure_globals_refresh_task();
 
@@ -420,7 +434,7 @@ impl ChatService {
             })
             .collect();
 
-        self.publish_snapshot(ChatSnapshot {
+        Ok(ChatSnapshot {
             user_id: Some(user_id),
             chat_rooms: rooms,
             discover_rooms,
@@ -486,6 +500,11 @@ impl ChatService {
         }
 
         let service = self.clone();
+        let mut refresh_signal_rx = self
+            .refresh_signal_rx
+            .lock_recover()
+            .take()
+            .expect("chat refresh scheduler receiver missing");
         tokio::spawn(
             async move {
                 service.refresh_registered_sessions().await;
@@ -499,8 +518,8 @@ impl ChatService {
                         _ = interval.tick() => {
                             service.refresh_registered_sessions().await;
                         }
-                        _ = service.refresh_notify.notified() => {
-                            service.refresh_registered_sessions().await;
+                        Some(session_id) = refresh_signal_rx.recv() => {
+                            service.refresh_registered_session(session_id).await;
                         }
                     }
                 }
@@ -514,14 +533,34 @@ impl ChatService {
             .refresh_sessions
             .lock_recover()
             .values()
-            .copied()
+            .cloned()
             .collect();
 
         for session in sessions {
-            if let Err(e) = self
-                .list_chat_rooms(session.user_id, session.selected_room_id)
-                .await
-            {
+            self.refresh_session(session).await;
+        }
+    }
+
+    async fn refresh_registered_session(&self, session_id: Uuid) {
+        let session = self
+            .refresh_sessions
+            .lock_recover()
+            .get(&session_id)
+            .cloned();
+        if let Some(session) = session {
+            self.refresh_session(session).await;
+        }
+    }
+
+    async fn refresh_session(&self, session: ChatRefreshSession) {
+        match self
+            .build_chat_snapshot(session.user_id, session.selected_room_id)
+            .await
+        {
+            Ok(snapshot) => {
+                let _ = session.snapshot_tx.send(snapshot);
+            }
+            Err(e) => {
                 late_core::error_span!(
                     "chat_refresh_failed",
                     user_id = %session.user_id,
@@ -536,21 +575,23 @@ impl ChatService {
         &self,
         user_id: Uuid,
         room_rx: watch::Receiver<Option<Uuid>>,
-    ) -> tokio::task::AbortHandle {
+    ) -> (watch::Receiver<ChatSnapshot>, tokio::task::AbortHandle) {
         self.ensure_refresh_scheduler();
 
         let session_id = Uuid::now_v7();
+        let (snapshot_tx, snapshot_rx) = watch::channel(ChatSnapshot::default());
         self.refresh_sessions.lock_recover().insert(
             session_id,
             ChatRefreshSession {
                 user_id,
                 selected_room_id: *room_rx.borrow(),
+                snapshot_tx,
             },
         );
-        self.refresh_notify.notify_one();
+        let _ = self.refresh_signal_tx.send(session_id);
 
         let sessions = self.refresh_sessions.clone();
-        let notify = self.refresh_notify.clone();
+        let refresh_signal_tx = self.refresh_signal_tx.clone();
         let mut room_rx = room_rx;
         let handle = tokio::spawn(
             async move {
@@ -568,12 +609,12 @@ impl ChatService {
                     if let Some(session) = sessions.lock_recover().get_mut(&session_id) {
                         session.selected_room_id = selected_room_id;
                     }
-                    notify.notify_one();
+                    let _ = refresh_signal_tx.send(session_id);
                 }
             }
             .instrument(info_span!("chat.refresh_registration", user_id = %user_id, session_id = %session_id)),
         );
-        handle.abort_handle()
+        (snapshot_rx, handle.abort_handle())
     }
 
     pub fn list_chats_task(&self, user_id: Uuid, selected_room_id: Option<Uuid>) {

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -575,16 +575,22 @@ impl ChatService {
         &self,
         user_id: Uuid,
         room_rx: watch::Receiver<Option<Uuid>>,
-    ) -> (watch::Receiver<ChatSnapshot>, tokio::task::AbortHandle) {
+    ) -> (
+        watch::Receiver<ChatSnapshot>,
+        mpsc::UnboundedSender<()>,
+        tokio::task::AbortHandle,
+    ) {
         self.ensure_refresh_scheduler();
 
         let session_id = Uuid::now_v7();
         let (snapshot_tx, snapshot_rx) = watch::channel(ChatSnapshot::default());
+        let (force_refresh_tx, mut force_refresh_rx) = mpsc::unbounded_channel();
+        let initial_room_id = *room_rx.borrow();
         self.refresh_sessions.lock_recover().insert(
             session_id,
             ChatRefreshSession {
                 user_id,
-                selected_room_id: *room_rx.borrow(),
+                selected_room_id: initial_room_id,
                 snapshot_tx,
             },
         );
@@ -599,22 +605,34 @@ impl ChatService {
                     sessions: sessions.clone(),
                     session_id,
                 };
+                let mut last_selected_room_id = initial_room_id;
 
                 loop {
-                    if room_rx.changed().await.is_err() {
-                        break;
-                    }
+                    tokio::select! {
+                        changed = room_rx.changed() => {
+                            if changed.is_err() {
+                                break;
+                            }
 
-                    let selected_room_id = *room_rx.borrow_and_update();
-                    if let Some(session) = sessions.lock_recover().get_mut(&session_id) {
-                        session.selected_room_id = selected_room_id;
+                            let selected_room_id = *room_rx.borrow_and_update();
+                            if selected_room_id == last_selected_room_id {
+                                continue;
+                            }
+                            last_selected_room_id = selected_room_id;
+                            if let Some(session) = sessions.lock_recover().get_mut(&session_id) {
+                                session.selected_room_id = selected_room_id;
+                            }
+                            let _ = refresh_signal_tx.send(session_id);
+                        }
+                        Some(()) = force_refresh_rx.recv() => {
+                            let _ = refresh_signal_tx.send(session_id);
+                        }
                     }
-                    let _ = refresh_signal_tx.send(session_id);
                 }
             }
             .instrument(info_span!("chat.refresh_registration", user_id = %user_id, session_id = %session_id)),
         );
-        (snapshot_rx, handle.abort_handle())
+        (snapshot_rx, force_refresh_tx, handle.abort_handle())
     }
 
     pub fn list_chats_task(&self, user_id: Uuid, selected_room_id: Option<Uuid>) {

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -1,9 +1,17 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::{Duration, Instant},
+};
 use uuid::Uuid;
 
 use late_core::{
+    MutexRecover,
     db::Db,
     models::{
         bonsai::Tree,
@@ -14,7 +22,7 @@ use late_core::{
         user::User,
     },
 };
-use tokio::sync::{broadcast, watch};
+use tokio::sync::{Mutex as AsyncMutex, Notify, broadcast, watch};
 use tracing::{Instrument, info_span};
 
 use crate::app::bonsai::state::stage_for;
@@ -22,6 +30,8 @@ use crate::metrics;
 
 const HISTORY_LIMIT: i64 = 1000;
 const DELTA_LIMIT: i64 = 256;
+const CHAT_REFRESH_INTERVAL: Duration = Duration::from_secs(10);
+const CHAT_GLOBALS_TTL: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
 pub struct ChatService {
@@ -30,6 +40,11 @@ pub struct ChatService {
     snapshot_rx: watch::Receiver<ChatSnapshot>,
     evt_tx: broadcast::Sender<ChatEvent>,
     notification_svc: super::notifications::svc::NotificationService,
+    globals_cache: Arc<AsyncMutex<ChatGlobalsCache>>,
+    globals_refresh_started: Arc<AtomicBool>,
+    refresh_sessions: Arc<Mutex<HashMap<Uuid, ChatRefreshSession>>>,
+    refresh_scheduler_started: Arc<AtomicBool>,
+    refresh_notify: Arc<Notify>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -39,6 +54,46 @@ pub struct DiscoverRoomItem {
     pub member_count: i64,
     pub message_count: i64,
     pub last_message_at: Option<DateTime<Utc>>,
+}
+
+#[derive(Clone, Default)]
+struct ChatGlobals {
+    discover_rooms: Vec<DiscoverRoomItem>,
+    usernames: HashMap<Uuid, String>,
+    countries: HashMap<Uuid, String>,
+    all_usernames: Vec<String>,
+    bonsai_glyphs: HashMap<Uuid, String>,
+}
+
+struct ChatGlobalsCache {
+    snapshot: Arc<ChatGlobals>,
+    refreshed_at: Option<Instant>,
+}
+
+impl Default for ChatGlobalsCache {
+    fn default() -> Self {
+        Self {
+            snapshot: Arc::new(ChatGlobals::default()),
+            refreshed_at: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ChatRefreshSession {
+    user_id: Uuid,
+    selected_room_id: Option<Uuid>,
+}
+
+struct ChatRefreshSessionGuard {
+    sessions: Arc<Mutex<HashMap<Uuid, ChatRefreshSession>>>,
+    session_id: Uuid,
+}
+
+impl Drop for ChatRefreshSessionGuard {
+    fn drop(&mut self) {
+        self.sessions.lock_recover().remove(&self.session_id);
+    }
 }
 
 #[derive(Clone, Default)]
@@ -205,6 +260,11 @@ impl ChatService {
             snapshot_rx,
             evt_tx,
             notification_svc,
+            globals_cache: Arc::new(AsyncMutex::new(ChatGlobalsCache::default())),
+            globals_refresh_started: Arc::new(AtomicBool::new(false)),
+            refresh_sessions: Arc::new(Mutex::new(HashMap::new())),
+            refresh_scheduler_started: Arc::new(AtomicBool::new(false)),
+            refresh_notify: Arc::new(Notify::new()),
         }
     }
     pub fn subscribe_state(&self) -> watch::Receiver<ChatSnapshot> {
@@ -219,11 +279,92 @@ impl ChatService {
         Ok(())
     }
 
+    async fn chat_globals(&self) -> Result<Arc<ChatGlobals>> {
+        self.refresh_chat_globals(false).await
+    }
+
+    async fn refresh_chat_globals(&self, force: bool) -> Result<Arc<ChatGlobals>> {
+        let mut cache = self.globals_cache.lock().await;
+        if !force
+            && let Some(refreshed_at) = cache.refreshed_at
+            && refreshed_at.elapsed() < CHAT_GLOBALS_TTL
+        {
+            return Ok(cache.snapshot.clone());
+        }
+
+        let client = self.db.get().await?;
+        let globals = Arc::new(Self::load_chat_globals(&client).await?);
+        cache.snapshot = globals.clone();
+        cache.refreshed_at = Some(Instant::now());
+        Ok(globals)
+    }
+
+    async fn load_chat_globals(client: &tokio_postgres::Client) -> Result<ChatGlobals> {
+        let discover_rooms = Self::list_all_discover_rooms(client).await?;
+        let usernames = User::list_all_username_map(client).await?;
+        let countries = User::list_all_country_map(client).await?;
+        let mut all_usernames: Vec<String> = usernames.values().cloned().collect();
+        all_usernames.sort();
+        let bonsai_glyphs: HashMap<Uuid, String> = Tree::list_all(client)
+            .await?
+            .into_iter()
+            .filter_map(|t| {
+                let glyph = stage_for(t.is_alive, t.growth_points).glyph();
+                if glyph.is_empty() {
+                    None
+                } else {
+                    Some((t.user_id, glyph.to_string()))
+                }
+            })
+            .collect();
+
+        Ok(ChatGlobals {
+            discover_rooms,
+            usernames,
+            countries,
+            all_usernames,
+            bonsai_glyphs,
+        })
+    }
+
+    fn ensure_globals_refresh_task(&self) {
+        if self
+            .globals_refresh_started
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        let service = self.clone();
+        tokio::spawn(
+            async move {
+                let mut interval = tokio::time::interval(CHAT_GLOBALS_TTL);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                interval.tick().await;
+
+                loop {
+                    interval.tick().await;
+                    if let Err(e) = service.refresh_chat_globals(true).await {
+                        late_core::error_span!(
+                            "chat_globals_refresh_failed",
+                            error = ?e,
+                            "chat globals refresh failed"
+                        );
+                    }
+                }
+            }
+            .instrument(info_span!("chat.globals_refresh_loop")),
+        );
+    }
+
     #[tracing::instrument(skip(self), fields(user_id = %user_id, selected_room_id = ?selected_room_id))]
     async fn list_chat_rooms(&self, user_id: Uuid, selected_room_id: Option<Uuid>) -> Result<()> {
+        let globals = self.chat_globals().await?;
+        self.ensure_globals_refresh_task();
+
         let client = self.db.get().await?;
         let rooms = ChatRoom::list_for_user(&client, user_id).await?;
-        let discover_rooms = self.list_discover_rooms(&client, user_id).await?;
         let unread_counts = ChatRoomMember::unread_counts_for_user(&client, user_id).await?;
         let favorite_room_ids = User::favorite_room_ids(&client, user_id).await?;
         let general_room_id = rooms
@@ -255,6 +396,12 @@ impl ChatService {
             push_preload(room_id);
         }
 
+        let discover_rooms = globals
+            .discover_rooms
+            .iter()
+            .filter(|room| !joined_ids.contains(&room.room_id))
+            .cloned()
+            .collect();
         let recent_messages =
             ChatMessage::list_recent_for_rooms(&client, &preload_room_ids, HISTORY_LIMIT).await?;
         let message_ids: Vec<Uuid> = recent_messages
@@ -263,26 +410,7 @@ impl ChatService {
             .collect();
         let message_reactions =
             ChatMessageReaction::list_summaries_for_messages(&client, &message_ids).await?;
-        // General stays warm for the dashboard even when another room is
-        // selected. Favorites ride in the same preload set so the dashboard
-        // quick-switch never depends on a prior manual visit or lucky delta.
-        let usernames = User::list_all_username_map(&client).await?;
-        let countries = User::list_all_country_map(&client).await?;
-        let mut all_usernames: Vec<String> = usernames.values().cloned().collect();
-        all_usernames.sort();
         let ignored_user_ids = User::ignored_user_ids(&client, user_id).await?;
-        let bonsai_glyphs: HashMap<Uuid, String> = Tree::list_all(&client)
-            .await?
-            .into_iter()
-            .filter_map(|t| {
-                let glyph = stage_for(t.is_alive, t.growth_points).glyph();
-                if glyph.is_empty() {
-                    None
-                } else {
-                    Some((t.user_id, glyph.to_string()))
-                }
-            })
-            .collect();
 
         let rooms = rooms
             .into_iter()
@@ -298,19 +426,17 @@ impl ChatService {
             discover_rooms,
             message_reactions,
             general_room_id,
-            usernames,
-            countries,
+            usernames: globals.usernames.clone(),
+            countries: globals.countries.clone(),
             unread_counts,
-            all_usernames,
-            bonsai_glyphs,
+            all_usernames: globals.all_usernames.clone(),
+            bonsai_glyphs: globals.bonsai_glyphs.clone(),
             ignored_user_ids,
         })
     }
 
-    async fn list_discover_rooms(
-        &self,
+    async fn list_all_discover_rooms(
         client: &tokio_postgres::Client,
-        user_id: Uuid,
     ) -> Result<Vec<DiscoverRoomItem>> {
         let rows = client
             .query(
@@ -325,19 +451,13 @@ impl ChatService {
                  WHERE r.kind = 'topic'
                    AND r.visibility = 'public'
                    AND r.permanent = false
-                   AND NOT EXISTS (
-                       SELECT 1
-                       FROM chat_room_members self_member
-                       WHERE self_member.room_id = r.id
-                         AND self_member.user_id = $1
-                   )
                  GROUP BY r.id, r.slug
                  ORDER BY
                     COALESCE(MAX(msg.created), r.created) DESC,
                     message_count DESC,
                     member_count DESC,
                     r.slug ASC",
-                &[&user_id],
+                &[],
             )
             .await?;
 
@@ -356,27 +476,102 @@ impl ChatService {
             .collect())
     }
 
+    fn ensure_refresh_scheduler(&self) {
+        if self
+            .refresh_scheduler_started
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        let service = self.clone();
+        tokio::spawn(
+            async move {
+                service.refresh_registered_sessions().await;
+
+                let mut interval = tokio::time::interval(CHAT_REFRESH_INTERVAL);
+                interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                interval.tick().await;
+
+                loop {
+                    tokio::select! {
+                        _ = interval.tick() => {
+                            service.refresh_registered_sessions().await;
+                        }
+                        _ = service.refresh_notify.notified() => {
+                            service.refresh_registered_sessions().await;
+                        }
+                    }
+                }
+            }
+            .instrument(info_span!("chat.refresh_scheduler")),
+        );
+    }
+
+    async fn refresh_registered_sessions(&self) {
+        let sessions: Vec<ChatRefreshSession> = self
+            .refresh_sessions
+            .lock_recover()
+            .values()
+            .copied()
+            .collect();
+
+        for session in sessions {
+            if let Err(e) = self
+                .list_chat_rooms(session.user_id, session.selected_room_id)
+                .await
+            {
+                late_core::error_span!(
+                    "chat_refresh_failed",
+                    user_id = %session.user_id,
+                    error = ?e,
+                    "chat service refresh failed"
+                );
+            }
+        }
+    }
+
     pub fn start_user_refresh_task(
         &self,
         user_id: Uuid,
         room_rx: watch::Receiver<Option<Uuid>>,
     ) -> tokio::task::AbortHandle {
-        let service = self.clone();
+        self.ensure_refresh_scheduler();
+
+        let session_id = Uuid::now_v7();
+        self.refresh_sessions.lock_recover().insert(
+            session_id,
+            ChatRefreshSession {
+                user_id,
+                selected_room_id: *room_rx.borrow(),
+            },
+        );
+        self.refresh_notify.notify_one();
+
+        let sessions = self.refresh_sessions.clone();
+        let notify = self.refresh_notify.clone();
+        let mut room_rx = room_rx;
         let handle = tokio::spawn(
             async move {
+                let _guard = ChatRefreshSessionGuard {
+                    sessions: sessions.clone(),
+                    session_id,
+                };
+
                 loop {
-                    let room_id = *room_rx.borrow();
-                    if let Err(e) = service.list_chat_rooms(user_id, room_id).await {
-                        late_core::error_span!(
-                            "chat_refresh_failed",
-                            error = ?e,
-                            "chat service refresh failed"
-                        );
+                    if room_rx.changed().await.is_err() {
+                        break;
                     }
-                    tokio::time::sleep(std::time::Duration::from_secs(10)).await;
+
+                    let selected_room_id = *room_rx.borrow_and_update();
+                    if let Some(session) = sessions.lock_recover().get_mut(&session_id) {
+                        session.selected_room_id = selected_room_id;
+                    }
+                    notify.notify_one();
                 }
             }
-            .instrument(info_span!("chat.refresh_loop", user_id = %user_id)),
+            .instrument(info_span!("chat.refresh_registration", user_id = %user_id, session_id = %session_id)),
         );
         handle.abort_handle()
     }

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -507,8 +507,6 @@ impl ChatService {
             .expect("chat refresh scheduler receiver missing");
         tokio::spawn(
             async move {
-                service.refresh_registered_sessions().await;
-
                 let mut interval = tokio::time::interval(CHAT_REFRESH_INTERVAL);
                 interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 interval.tick().await;

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -4,6 +4,9 @@ use std::{
     time::Duration,
 };
 
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 use anyhow::Context;
 use late_core::{
     api_types::NowPlaying, db::Db, icecast, models::chat_room::ChatRoom, rate_limit::IpRateLimiter,

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -745,10 +745,12 @@ async fn shared_service_refresh_tasks_publish_per_session_snapshots() {
     .await
     .expect("message b");
 
-    let (_room_a_tx, room_a_rx) = tokio::sync::watch::channel(Some(room_a.id));
+    let (room_a_tx, room_a_rx) = tokio::sync::watch::channel(Some(room_a.id));
     let (_room_b_tx, room_b_rx) = tokio::sync::watch::channel(Some(room_b.id));
-    let (mut snapshot_a_rx, task_a) = service.start_user_refresh_task(user_a.id, room_a_rx);
-    let (mut snapshot_b_rx, task_b) = service.start_user_refresh_task(user_b.id, room_b_rx);
+    let (mut snapshot_a_rx, refresh_a, task_a) =
+        service.start_user_refresh_task(user_a.id, room_a_rx);
+    let (mut snapshot_b_rx, _refresh_b, task_b) =
+        service.start_user_refresh_task(user_b.id, room_b_rx);
 
     timeout(Duration::from_secs(2), snapshot_a_rx.changed())
         .await
@@ -776,6 +778,22 @@ async fn shared_service_refresh_tasks_publish_per_session_snapshots() {
                 .iter()
                 .any(|message| message.body == "only user b sees this")
     }));
+
+    room_a_tx
+        .send(Some(room_a.id))
+        .expect("same selected room send");
+    assert!(
+        timeout(Duration::from_millis(200), snapshot_a_rx.changed())
+            .await
+            .is_err(),
+        "unchanged selected room sends should not refresh the session"
+    );
+
+    refresh_a.send(()).expect("force refresh");
+    timeout(Duration::from_secs(2), snapshot_a_rx.changed())
+        .await
+        .expect("forced snapshot timeout")
+        .expect("forced snapshot changed");
 
     task_a.abort();
     task_b.abort();

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -692,6 +692,96 @@ async fn publishes_snapshot_with_discover_rooms_for_public_rooms_user_has_not_jo
 }
 
 #[tokio::test]
+async fn shared_service_refresh_tasks_publish_per_session_snapshots() {
+    let test_db = new_test_db().await;
+    let service = ChatService::new(
+        test_db.db.clone(),
+        NotificationService::new(test_db.db.clone()),
+    );
+    let client = test_db.db.get().await.expect("db client");
+
+    let user_a = create_test_user(&test_db.db, "shared_refresh_a").await;
+    let user_b = create_test_user(&test_db.db, "shared_refresh_b").await;
+    let author = create_test_user(&test_db.db, "shared_refresh_author").await;
+
+    let room_a = ChatRoom::get_or_create_public_room(&client, "shared-a")
+        .await
+        .expect("room a");
+    let room_b = ChatRoom::get_or_create_public_room(&client, "shared-b")
+        .await
+        .expect("room b");
+
+    ChatRoomMember::join(&client, room_a.id, user_a.id)
+        .await
+        .expect("join user a");
+    ChatRoomMember::join(&client, room_a.id, author.id)
+        .await
+        .expect("join author a");
+    ChatRoomMember::join(&client, room_b.id, user_b.id)
+        .await
+        .expect("join user b");
+    ChatRoomMember::join(&client, room_b.id, author.id)
+        .await
+        .expect("join author b");
+
+    ChatMessage::create(
+        &client,
+        ChatMessageParams {
+            room_id: room_a.id,
+            user_id: author.id,
+            body: "only user a sees this".to_string(),
+        },
+    )
+    .await
+    .expect("message a");
+    ChatMessage::create(
+        &client,
+        ChatMessageParams {
+            room_id: room_b.id,
+            user_id: author.id,
+            body: "only user b sees this".to_string(),
+        },
+    )
+    .await
+    .expect("message b");
+
+    let (_room_a_tx, room_a_rx) = tokio::sync::watch::channel(Some(room_a.id));
+    let (_room_b_tx, room_b_rx) = tokio::sync::watch::channel(Some(room_b.id));
+    let (mut snapshot_a_rx, task_a) = service.start_user_refresh_task(user_a.id, room_a_rx);
+    let (mut snapshot_b_rx, task_b) = service.start_user_refresh_task(user_b.id, room_b_rx);
+
+    timeout(Duration::from_secs(2), snapshot_a_rx.changed())
+        .await
+        .expect("snapshot a timeout")
+        .expect("snapshot a changed");
+    timeout(Duration::from_secs(2), snapshot_b_rx.changed())
+        .await
+        .expect("snapshot b timeout")
+        .expect("snapshot b changed");
+
+    let snapshot_a = snapshot_a_rx.borrow_and_update().clone();
+    let snapshot_b = snapshot_b_rx.borrow_and_update().clone();
+
+    assert_eq!(snapshot_a.user_id, Some(user_a.id));
+    assert_eq!(snapshot_b.user_id, Some(user_b.id));
+    assert!(snapshot_a.chat_rooms.iter().any(|(room, messages)| {
+        room.id == room_a.id
+            && messages
+                .iter()
+                .any(|message| message.body == "only user a sees this")
+    }));
+    assert!(snapshot_b.chat_rooms.iter().any(|(room, messages)| {
+        room.id == room_b.id
+            && messages
+                .iter()
+                .any(|message| message.body == "only user b sees this")
+    }));
+
+    task_a.abort();
+    task_b.abort();
+}
+
+#[tokio::test]
 async fn join_public_room_task_only_adds_requesting_user() {
     let test_db = new_test_db().await;
     let service = ChatService::new(


### PR DESCRIPTION
## Summary
- Keeps chat room state current for active SSH sessions while reducing repeated global lookups across users.
- Shares cached chat-wide data such as discoverable rooms, usernames, countries, and bonsai glyphs instead of reloading it for every session refresh.

## What changed
- Adds a shared chat refresh scheduler that refreshes registered user sessions every 10 seconds.
- Triggers an immediate refresh when the selected room changes.
- Caches chat-wide global data for 30 seconds and refreshes it in the background.
- Uses jemalloc as the global allocator for `late-ssh`.

## Behavior notes
- Discoverable rooms are loaded globally, then filtered per user to exclude rooms they have already joined.
- Active refresh registrations are removed automatically when the session task exits.
- Chat-wide metadata may be up to 30 seconds stale between cache refreshes.

## Feature flags
None.

## Screenshots / Video
Not applicable: no visual UI changes.

## Testing
- Automated: Not included in this diff.
- Manual: Not specified in the diff context.