### PR TITLE
Improve blackjack table pacing and idle seat handling

### DIFF
--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -745,7 +745,11 @@ impl GhostService {
             return Ok(());
         }
 
-        let (history_str, usernames) = self.build_chat_history(&messages).await?;
+        let (history_str, mut usernames) = self.build_chat_history(&messages).await?;
+        if !usernames.contains_key(&trigger.user_id) {
+            let client = self.db.get().await?;
+            usernames.extend(User::list_usernames_by_ids(&client, &[trigger.user_id]).await?);
+        }
         let player = mention_target_for_user(
             usernames.get(&trigger.user_id).map(String::as_str),
             trigger.user_id,
@@ -1089,13 +1093,17 @@ fn sanitize_generated_reply(reply: &str, username: Option<&str>) -> Option<Strin
 }
 
 fn mention_target_for_user(username: Option<&str>, user_id: Uuid) -> String {
-    let handle = username
+    let handle = mention_handle_for_user(username, user_id);
+    format!("@{handle}")
+}
+
+fn mention_handle_for_user(username: Option<&str>, user_id: Uuid) -> String {
+    username
         .map(str::trim)
         .filter(|name| !name.is_empty())
         .map(sanitize_mention_handle)
         .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| short_user_id(user_id));
-    format!("@{handle}")
+        .unwrap_or_else(|| short_user_id(user_id))
 }
 
 fn sanitize_mention_handle(input: &str) -> String {
@@ -1403,5 +1411,14 @@ mod tests {
         let user_id = Uuid::from_u128(0x0123_4567_89ab_cdef_1111_2222_3333_4444);
         assert_eq!(mention_target_for_user(Some(""), user_id), "@01234567");
         assert_eq!(mention_target_for_user(Some("!!!"), user_id), "@01234567");
+    }
+
+    #[test]
+    fn mention_target_for_user_prefers_sanitized_current_username() {
+        let user_id = Uuid::from_u128(0x0123_4567_89ab_cdef_1111_2222_3333_4444);
+        assert_eq!(
+            mention_target_for_user(Some(" current-user "), user_id),
+            "@current-user"
+        );
     }
 }

--- a/late-ssh/src/app/bonsai/ui.rs
+++ b/late-ssh/src/app/bonsai/ui.rs
@@ -1,11 +1,11 @@
 use std::{collections::BTreeSet, time::SystemTime};
 
 use ratatui::{
+    Frame,
     layout::Rect,
     style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Paragraph},
-    Frame,
 };
 
 use super::{

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -36,6 +36,13 @@ fn custom_badge_for_username(username: &str) -> Option<&'static str> {
     }
 }
 
+fn is_bot_author(username: &str) -> bool {
+    matches!(
+        username.trim().to_ascii_lowercase().as_str(),
+        "bot" | "graybeard" | "dealer"
+    )
+}
+
 // ── Dashboard chat card ─────────────────────────────────────
 
 pub struct DashboardChatView<'a> {
@@ -494,7 +501,7 @@ fn ensure_chat_rows_cache(
             format_username_with_country(msg.user_id, raw_author, ctx.countries)
         };
         let contributor_badge = custom_badge_for_username(raw_author).unwrap_or_default();
-        let is_bot = raw_author == "bot" || raw_author == "graybeard";
+        let is_bot = is_bot_author(raw_author);
         let badge = if !is_bot {
             ctx.badges.get(&msg.user_id).copied()
         } else {
@@ -1532,6 +1539,15 @@ mod tests {
     #[test]
     fn short_user_id_handles_nil() {
         assert_eq!(short_user_id(Uuid::nil()), "00000000");
+    }
+
+    #[test]
+    fn is_bot_author_matches_all_ghost_users() {
+        assert!(is_bot_author("bot"));
+        assert!(is_bot_author("graybeard"));
+        assert!(is_bot_author("dealer"));
+        assert!(is_bot_author(" Dealer "));
+        assert!(!is_bot_author("mat"));
     }
 
     #[test]

--- a/late-ssh/src/app/dashboard/ui.rs
+++ b/late-ssh/src/app/dashboard/ui.rs
@@ -188,36 +188,113 @@ fn draw_blackjack_grid(
     ])
     .split(area);
 
+    // 7-track horizontal layout: vert | col1 | vert | col2 | vert | col3 | vert
     let cols = Layout::horizontal([
-        Constraint::Ratio(1, 3),
-        Constraint::Ratio(1, 3),
-        Constraint::Ratio(1, 3),
+        Constraint::Length(1),
+        Constraint::Fill(1),
+        Constraint::Length(1),
+        Constraint::Fill(1),
+        Constraint::Length(1),
+        Constraint::Fill(1),
+        Constraint::Length(1),
     ])
     .split(chunks[0]);
 
-    let loading = rooms.is_empty();
-    for slot in 0..BLACKJACK_GRID_COLUMNS {
-        let room = rooms.get(slot).copied();
-        draw_blackjack_slot(
-            frame,
-            cols[slot],
-            slot,
-            room,
-            snapshots,
-            prefix_armed,
-            loading,
-        );
+    let border_style = Style::default().fg(theme::BORDER_DIM());
+    for &vert_idx in &[0usize, 2, 4, 6] {
+        let lines = vec![Line::from("│"), Line::from("│"), Line::from("│")];
+        frame.render_widget(Paragraph::new(lines).style(border_style), cols[vert_idx]);
     }
 
-    // Single dim rule across the whole strip, separating it from chat below.
-    let rule_width = chunks[1].width as usize;
-    let rule = "─".repeat(rule_width);
+    let slot_areas = [cols[1], cols[3], cols[5]];
+    let loading = rooms.is_empty();
+    for (slot, area) in slot_areas
+        .iter()
+        .copied()
+        .enumerate()
+        .take(BLACKJACK_GRID_COLUMNS)
+    {
+        let room = rooms.get(slot).copied();
+        // 1-char left/right padding inside each column.
+        let padded = if area.width >= 4 {
+            Rect {
+                x: area.x + 1,
+                width: area.width - 2,
+                ..area
+            }
+        } else {
+            area
+        };
+        draw_blackjack_slot(frame, padded, slot, room, snapshots, prefix_armed, loading);
+    }
+
+    let rule_area = chunks[1];
+    let junctions = [
+        (cols[0].x.saturating_sub(rule_area.x) as usize, '└'),
+        (cols[2].x.saturating_sub(rule_area.x) as usize, '┴'),
+        (cols[4].x.saturating_sub(rule_area.x) as usize, '┴'),
+        (cols[6].x.saturating_sub(rule_area.x) as usize, '┘'),
+    ];
+    draw_blackjack_bottom_rule(frame, rule_area, &junctions, prefix_armed);
+}
+
+fn draw_blackjack_bottom_rule(
+    frame: &mut Frame,
+    area: Rect,
+    junctions: &[(usize, char)],
+    prefix_armed: bool,
+) {
+    let total_w = area.width as usize;
+    if total_w == 0 {
+        return;
+    }
+
+    let hint_text = if prefix_armed {
+        " press 1/2/3 "
+    } else {
+        " b + 1/2/3 to join "
+    };
+    let hint_chars: Vec<char> = hint_text.chars().collect();
+    let hint_w = hint_chars.len();
+
+    let make_rule_char = |i: usize| -> char {
+        junctions
+            .iter()
+            .find_map(|(off, ch)| if *off == i { Some(*ch) } else { None })
+            .unwrap_or('─')
+    };
+
+    let border_style = Style::default().fg(theme::BORDER_DIM());
+
+    if hint_w + 4 > total_w {
+        let rule: String = (0..total_w).map(make_rule_char).collect();
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(rule, border_style))),
+            area,
+        );
+        return;
+    }
+
+    let hint_start = (total_w - hint_w) / 2;
+    let hint_end = hint_start + hint_w;
+    let left: String = (0..hint_start).map(make_rule_char).collect();
+    let right: String = (hint_end..total_w).map(make_rule_char).collect();
+
+    let hint_style = if prefix_armed {
+        Style::default()
+            .fg(theme::AMBER_GLOW())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT_DIM())
+    };
+
     frame.render_widget(
-        Paragraph::new(Line::from(Span::styled(
-            rule,
-            Style::default().fg(theme::BORDER_DIM()),
-        ))),
-        chunks[1],
+        Paragraph::new(Line::from(vec![
+            Span::styled(left, border_style),
+            Span::styled(hint_text.to_string(), hint_style),
+            Span::styled(right, border_style),
+        ])),
+        area,
     );
 }
 

--- a/late-ssh/src/app/rooms/CONTEXT.md
+++ b/late-ssh/src/app/rooms/CONTEXT.md
@@ -76,22 +76,22 @@
 - `BlackjackPlayerDirectory` reads `late_core::models::blackjack::BlackjackPlayer` so seats can carry `BlackjackPlayerInfo { user_id, username, balance }`.
 - Player info is loaded from DB on sit. Accepted bets and settlements update the seated player's balance in-place; if no player info was hydrated, the service may synthesize a fallback username of `player`. Rendering should read `BlackjackSeat.player`; do not add per-render DB/chip lookups.
 - There are four seats. Entering a room starts as a viewer. `s` or `Enter` sits in the first open seat.
-- A hardcoded username block rejects seating for `imred`.
 - `l` leaves a seat when safe. Locked/pending bets block leaving during active phases, but settled players may leave during `Phase::Settling`.
 - Seated players build a shared visible stake through service-owned `SeatState.stake_chips`.
 - Chip selection is client-local (`selected_chip_index`). Thrown stake chips are service-owned and appear in every subscriber's `BlackjackSeat.stake_chips`.
 - Betting keys: `[`/`a` selects previous chip, `]`/`d` selects next chip, Space throws the selected chip, Backspace pulls one chip, `c`/Ctrl+W clears, `Enter`/`s` submits.
 - Table stake settings are `10`, `50`, `100`, or `500` chips. `min_bet` is the stake and `max_bet` is `stake * 10`.
 - Table pace settings (`Quick`, `Standard`, `Chill`) control the player action timeout only: 2m, 5m, or 10m.
-- The first confirmed bet starts a fixed 60s betting cap (`BETTING_LOCK_CAP_SECS`). It does not restart on later bets. If all seated players have locked bets, the round deals immediately.
+- The first confirmed bet starts a fixed 30s betting cap (`BETTING_LOCK_CAP_SECS`). It does not restart on later bets. If all seated players have locked bets, the round deals immediately.
 - Pending async chip debits can delay auto-deal; the service waits until no pending bets remain.
 - During `PlayerTurn`, all betting seats can hit/stand their own hands in parallel. Dealer resolution runs after every unresolved hand has stood, busted, or naturally settled.
-- Action timeout auto-stands remaining hands when the pace-specific deadline expires.
+- Action timeout auto-stands remaining hands when the pace-specific deadline expires, then removes those non-acting seats after settlement.
 - A seated player who misses 3 deals without a locked bet is removed from the table.
+- A seated player who sends no active-room input for 5 minutes is removed from the table; active-room keys, arrows, and scrolls refresh this room timer while seated.
 - Settlements use `ChipService`: zero-credit losses call `restore_floor`, payouts call `credit_payout`, and `BlackjackEvent::HandSettled` updates client balances.
 - House rules: 6-deck shoe, reshuffle at 52-card penetration, dealer stands on soft 17, natural blackjack requires exactly two cards, and blackjack pays 3:2.
 - `Phase::BetPending` exists in the shared enum and input/UI paths, but current pending debit state is expressed per seat as `SeatPhase::BetPending`; the service does not currently transition the whole table into `Phase::BetPending`.
-- `BlackjackService::deal_task` exists as a manual deal API, but active room input does not currently route a key to it. Normal play deals by all seated players locking bets or by the 60s betting cap.
+- `BlackjackService::deal_task` exists as a manual deal API, but active room input does not currently route a key to it. Normal play deals by all seated players locking bets or by the 30s betting cap.
 
 ## Blackjack UI Invariants
 - `blackjack/ui.rs` chooses render tier from area dimensions:

--- a/late-ssh/src/app/rooms/blackjack/state.rs
+++ b/late-ssh/src/app/rooms/blackjack/state.rs
@@ -1,3 +1,5 @@
+use std::time::{Duration, Instant};
+
 use rand_core::{OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use tokio::sync::{
@@ -21,6 +23,7 @@ pub const BLACKJACK_TARGET: u8 = 21;
 pub const DEALER_STAND_ON: u8 = 17;
 pub const SHOE_DECKS: usize = 6;
 pub const SHOE_PENETRATION: usize = 52;
+const SETTLEMENT_MIN_VIEW_MS: u64 = 1500;
 
 pub const DEALER_STANDS_ON_SOFT_17: bool = true;
 
@@ -297,6 +300,7 @@ pub struct State {
     pub(crate) snapshot: BlackjackSnapshot,
     pub(crate) private_notice: Option<String>,
     pending_request_id: Option<Uuid>,
+    settling_seen_at: Option<Instant>,
     svc: BlackjackService,
     snapshot_rx: watch::Receiver<BlackjackSnapshot>,
     event_rx: broadcast::Receiver<BlackjackEvent>,
@@ -306,6 +310,11 @@ impl State {
     pub fn new(svc: BlackjackService, user_id: Uuid, balance: i64) -> Self {
         let snapshot_rx = svc.subscribe_state();
         let snapshot = snapshot_rx.borrow().clone();
+        let settling_seen_at = if snapshot.phase == Phase::Settling {
+            Some(Instant::now())
+        } else {
+            None
+        };
         let event_rx = svc.subscribe_events();
         Self {
             user_id,
@@ -314,6 +323,7 @@ impl State {
             snapshot,
             private_notice: None,
             pending_request_id: None,
+            settling_seen_at,
             svc,
             snapshot_rx,
             event_rx,
@@ -322,7 +332,13 @@ impl State {
 
     pub fn tick(&mut self) {
         if self.snapshot_rx.has_changed().unwrap_or(false) {
+            let previous_phase = self.snapshot.phase;
             self.snapshot = self.snapshot_rx.borrow_and_update().clone();
+            if self.snapshot.phase == Phase::Settling && previous_phase != Phase::Settling {
+                self.settling_seen_at = Some(Instant::now());
+            } else if self.snapshot.phase != Phase::Settling {
+                self.settling_seen_at = None;
+            }
         }
 
         loop {
@@ -444,7 +460,16 @@ impl State {
     }
 
     pub fn next_hand(&mut self) {
+        if !self.settlement_min_view_elapsed() {
+            return;
+        }
         self.svc.next_hand_task(self.user_id);
+    }
+
+    pub fn settlement_min_view_elapsed(&self) -> bool {
+        self.settling_seen_at.is_none_or(|settling_seen_at| {
+            settling_seen_at.elapsed() >= Duration::from_millis(SETTLEMENT_MIN_VIEW_MS)
+        })
     }
 
     pub fn current_bet_amount(&self) -> Option<i64> {

--- a/late-ssh/src/app/rooms/blackjack/state.rs
+++ b/late-ssh/src/app/rooms/blackjack/state.rs
@@ -127,6 +127,7 @@ pub enum SeatAction {
     Hit,
     Stand,
     MissedDeal,
+    MissedAction,
 }
 
 pub fn settle(player: &[PlayingCard], dealer: &[PlayingCard]) -> Outcome {
@@ -345,6 +346,12 @@ impl State {
         }
         let current = self.selected_chip_index as isize;
         self.selected_chip_index = (current + delta).rem_euclid(len) as usize;
+    }
+
+    pub fn touch_activity(&self) {
+        if self.is_seated() {
+            self.svc.touch_activity_task(self.user_id);
+        }
     }
 
     pub fn selected_chip_value(&self) -> i64 {

--- a/late-ssh/src/app/rooms/blackjack/svc.rs
+++ b/late-ssh/src/app/rooms/blackjack/svc.rs
@@ -23,6 +23,7 @@ const BETTING_LOCK_CAP_SECS: u64 = 30;
 const MAX_MISSED_DEALS: u8 = 3;
 const SEAT_IDLE_TIMEOUT_SECS: u64 = 5 * 60;
 const DEALER_CARD_DELAY_MS: u64 = 1100;
+const SETTLEMENT_MIN_VIEW_MS: u64 = 1500;
 
 #[derive(Clone)]
 pub struct BlackjackService {
@@ -748,6 +749,9 @@ impl BlackjackService {
         if table.phase != Phase::Settling {
             return Err(ActionFailure::InvalidPhase("hand is still in progress"));
         }
+        if !table.settlement_min_view_elapsed() {
+            return Err(ActionFailure::InvalidPhase("round result is still showing"));
+        }
         let status = table.betting_prompt_with_timer();
         table.reset_to_betting(&status);
         let activity_generation = table.record_activity(user_id);
@@ -950,6 +954,7 @@ struct SharedTableState {
     action_countdown_id: u64,
     dealer_turn_id: u64,
     dealer_turn_scheduled: bool,
+    settled_at: Option<Instant>,
     status_message: String,
 }
 
@@ -1123,6 +1128,7 @@ impl SharedTableState {
             action_countdown_id: 0,
             dealer_turn_id: 0,
             dealer_turn_scheduled: false,
+            settled_at: None,
             status_message: "Sit to join, or watch the table.".to_string(),
         }
     }
@@ -1218,6 +1224,7 @@ impl SharedTableState {
             self.clear_action_countdown();
             return None;
         }
+        self.settled_at = None;
         self.action_countdown_id = self.action_countdown_id.wrapping_add(1);
         self.action_deadline =
             Some(Instant::now() + Duration::from_secs(self.settings.action_timeout_secs()));
@@ -1253,6 +1260,7 @@ impl SharedTableState {
     fn begin_dealer_turn(&mut self) {
         self.clear_action_countdown();
         self.phase = Phase::DealerTurn;
+        self.settled_at = None;
         self.dealer_turn_id = self.dealer_turn_id.wrapping_add(1);
         self.dealer_turn_scheduled = false;
         self.status_message = "Dealer reveals the hole card.".to_string();
@@ -1297,6 +1305,7 @@ impl SharedTableState {
             }
         }
         self.phase = Phase::Settling;
+        self.settled_at = Some(Instant::now());
         self.dealer_turn_scheduled = false;
         self.status_message = "Round settled. Press Space or Enter for next hand.".to_string();
         let left_seats = self.remove_deferred_leave_seats();
@@ -1305,6 +1314,12 @@ impl SharedTableState {
             settlements,
             left_seats,
         }
+    }
+
+    fn settlement_min_view_elapsed(&self) -> bool {
+        self.settled_at.is_none_or(|settled_at| {
+            settled_at.elapsed() >= Duration::from_millis(SETTLEMENT_MIN_VIEW_MS)
+        })
     }
 
     fn betting_prompt(&self) -> String {
@@ -1591,13 +1606,26 @@ impl SharedTableState {
         }
 
         let dealer_blackjack = is_natural_blackjack(&self.dealer_hand);
+        if dealer_blackjack {
+            self.begin_dealer_turn();
+            self.status_message = "Dealer reveals blackjack.".to_string();
+            if !auto_left_seats.is_empty() {
+                self.status_message = format!(
+                    "{} {}",
+                    self.status_message,
+                    format_auto_left_notice(&auto_left_seats)
+                );
+            }
+            return Ok(Vec::new());
+        }
+
         let mut settlements = Vec::new();
         for index in 0..self.seats.len() {
             if self.seats[index].bet.is_none() {
                 continue;
             }
             let player_blackjack = is_natural_blackjack(&self.seats[index].hand);
-            if player_blackjack || dealer_blackjack {
+            if player_blackjack {
                 let outcome = settle(&self.seats[index].hand, &self.dealer_hand);
                 if let Some(settlement) = self.finish_seat(index, outcome) {
                     settlements.push(settlement);
@@ -1607,9 +1635,11 @@ impl SharedTableState {
 
         if self.has_playable_seats() {
             self.phase = Phase::PlayerTurn;
+            self.settled_at = None;
             self.status_message = "Players hit or stand.".to_string();
         } else {
             self.phase = Phase::Settling;
+            self.settled_at = Some(Instant::now());
             self.clear_action_countdown();
             self.status_message = "Round settled. Press Space or Enter for next hand.".to_string();
         }
@@ -1659,6 +1689,7 @@ impl SharedTableState {
     fn advance_or_finish_round(&mut self) -> Vec<Settlement> {
         if self.has_playable_seats() {
             self.phase = Phase::PlayerTurn;
+            self.settled_at = None;
             self.status_message = "Waiting for remaining seats.".to_string();
             return Vec::new();
         }
@@ -1709,6 +1740,7 @@ impl SharedTableState {
     fn reset_to_betting(&mut self, status: &str) {
         self.dealer_hand.clear();
         self.phase = Phase::Betting;
+        self.settled_at = None;
         self.clear_betting_countdown();
         self.clear_action_countdown();
         for seat in &mut self.seats {
@@ -1851,7 +1883,10 @@ mod tests {
         assert_eq!(table.dealer_hand.len(), 2);
         assert_eq!(table.seats[seat_a].hand.len(), 2);
         assert_eq!(table.seats[seat_b].hand.len(), 2);
-        assert!(matches!(table.phase, Phase::PlayerTurn | Phase::Settling));
+        assert!(matches!(
+            table.phase,
+            Phase::PlayerTurn | Phase::DealerTurn | Phase::Settling
+        ));
     }
 
     #[test]

--- a/late-ssh/src/app/rooms/blackjack/svc.rs
+++ b/late-ssh/src/app/rooms/blackjack/svc.rs
@@ -19,8 +19,10 @@ use crate::app::{
     },
 };
 
-const BETTING_LOCK_CAP_SECS: u64 = 60;
+const BETTING_LOCK_CAP_SECS: u64 = 30;
 const MAX_MISSED_DEALS: u8 = 3;
+const SEAT_IDLE_TIMEOUT_SECS: u64 = 5 * 60;
+const DEALER_CARD_DELAY_MS: u64 = 1100;
 
 #[derive(Clone)]
 pub struct BlackjackService {
@@ -133,7 +135,6 @@ enum SeatFailure {
     TableFull,
     NotSeated,
     CannotLeaveWithBet,
-    BlockedUsername,
 }
 
 impl SeatFailure {
@@ -145,7 +146,6 @@ impl SeatFailure {
             SeatFailure::CannotLeaveWithBet => {
                 "finish the round before leaving your seat".to_string()
             }
-            SeatFailure::BlockedUsername => "imred cannot sit at this table".to_string(),
         }
     }
 }
@@ -155,6 +155,19 @@ struct BetSuccess {
     settlements: Vec<Settlement>,
     betting_countdown_id: Option<u64>,
     action_countdown_id: Option<u64>,
+    dealer_turn_id: Option<u64>,
+}
+
+struct InactivityKick {
+    left_seats: Vec<(Uuid, usize)>,
+    settlements: Vec<Settlement>,
+    dealer_turn_id: Option<u64>,
+}
+
+struct DealerStep {
+    done: bool,
+    settlements: Vec<Settlement>,
+    left_seats: Vec<(Uuid, usize)>,
 }
 
 impl BlackjackService {
@@ -232,22 +245,19 @@ impl BlackjackService {
 
     async fn sit(&self, user_id: Uuid) -> Result<usize, SeatFailure> {
         let player = self.player_directory.player_info(user_id).await.ok();
-        if player
-            .as_ref()
-            .is_some_and(|player| blocked_seat_username(&player.username))
-        {
-            return Err(SeatFailure::BlockedUsername);
-        }
-
         let seat_index = {
             let mut table = self.table.lock().await;
             let seat_index = table.sit(user_id)?;
+            let activity_generation = table.record_activity(user_id);
             if let Some(player) = player {
                 table.set_player_info(user_id, player);
             }
             table.status_message =
                 format!("Seat {} joined. {}", seat_index + 1, table.betting_prompt());
             self.publish_snapshot_locked(&table);
+            if let Some(activity_generation) = activity_generation {
+                self.schedule_inactivity_kick(user_id, activity_generation);
+            }
             seat_index
         };
 
@@ -281,6 +291,19 @@ impl BlackjackService {
         Ok(seat_index)
     }
 
+    pub fn touch_activity_task(&self, user_id: Uuid) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let activity_generation = {
+                let mut table = svc.table.lock().await;
+                table.record_activity(user_id)
+            };
+            if let Some(activity_generation) = activity_generation {
+                svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+        });
+    }
+
     pub fn throw_chip_task(&self, user_id: Uuid, chip: i64) {
         let svc = self.clone();
         tokio::spawn(async move {
@@ -294,9 +317,16 @@ impl BlackjackService {
     }
 
     async fn throw_chip(&self, user_id: Uuid, chip: i64) -> Result<(), StakeFailure> {
-        let mut table = self.table.lock().await;
-        table.throw_chip(user_id, chip)?;
-        self.publish_snapshot_locked(&table);
+        let activity_generation = {
+            let mut table = self.table.lock().await;
+            table.throw_chip(user_id, chip)?;
+            let activity_generation = table.record_activity(user_id);
+            self.publish_snapshot_locked(&table);
+            activity_generation
+        };
+        if let Some(activity_generation) = activity_generation {
+            self.schedule_inactivity_kick(user_id, activity_generation);
+        }
         Ok(())
     }
 
@@ -313,9 +343,16 @@ impl BlackjackService {
     }
 
     async fn pull_stake_chip(&self, user_id: Uuid) -> Result<(), StakeFailure> {
-        let mut table = self.table.lock().await;
-        table.pull_stake_chip(user_id)?;
-        self.publish_snapshot_locked(&table);
+        let activity_generation = {
+            let mut table = self.table.lock().await;
+            table.pull_stake_chip(user_id)?;
+            let activity_generation = table.record_activity(user_id);
+            self.publish_snapshot_locked(&table);
+            activity_generation
+        };
+        if let Some(activity_generation) = activity_generation {
+            self.schedule_inactivity_kick(user_id, activity_generation);
+        }
         Ok(())
     }
 
@@ -332,9 +369,16 @@ impl BlackjackService {
     }
 
     async fn clear_stake(&self, user_id: Uuid) -> Result<(), StakeFailure> {
-        let mut table = self.table.lock().await;
-        table.clear_stake(user_id)?;
-        self.publish_snapshot_locked(&table);
+        let activity_generation = {
+            let mut table = self.table.lock().await;
+            table.clear_stake(user_id)?;
+            let activity_generation = table.record_activity(user_id);
+            self.publish_snapshot_locked(&table);
+            activity_generation
+        };
+        if let Some(activity_generation) = activity_generation {
+            self.schedule_inactivity_kick(user_id, activity_generation);
+        }
         Ok(())
     }
 
@@ -348,6 +392,9 @@ impl BlackjackService {
                     }
                     if let Some(countdown_id) = success.action_countdown_id {
                         svc.schedule_action_timeout(countdown_id);
+                    }
+                    if let Some(dealer_turn_id) = success.dealer_turn_id {
+                        svc.schedule_dealer_turn(dealer_turn_id);
                     }
                     if let Err(e) = svc.persist_settlements(success.settlements).await {
                         tracing::error!(error = ?e, %user_id, "blackjack submit_stake settlement failed");
@@ -405,6 +452,9 @@ impl BlackjackService {
                     if let Some(countdown_id) = success.action_countdown_id {
                         svc.schedule_action_timeout(countdown_id);
                     }
+                    if let Some(dealer_turn_id) = success.dealer_turn_id {
+                        svc.schedule_dealer_turn(dealer_turn_id);
+                    }
                     if let Err(e) = svc.persist_settlements(success.settlements).await {
                         tracing::error!(error = ?e, %user_id, amount, "blackjack place_bet settlement failed");
                         Err("internal error".to_string())
@@ -428,7 +478,7 @@ impl BlackjackService {
     }
 
     async fn place_bet(&self, user_id: Uuid, amount: i64) -> Result<BetSuccess, BetFailure> {
-        {
+        let activity_generation = {
             let mut table = self.table.lock().await;
             let Some(seat_index) = table.user_seat_index(user_id) else {
                 return Err(BetFailure::NotSeated);
@@ -445,7 +495,12 @@ impl BlackjackService {
             table.seats[seat_index].pending_bet = Some(bet);
             table.seats[seat_index].stake_chips.clear();
             table.status_message = format!("Seat {} is placing {amount} chips...", seat_index + 1);
+            let activity_generation = table.record_activity(user_id);
             self.publish_snapshot_locked(&table);
+            activity_generation
+        };
+        if let Some(activity_generation) = activity_generation {
+            self.schedule_inactivity_kick(user_id, activity_generation);
         }
 
         let new_balance = match self.chip_svc.debit_bet(user_id, amount).await {
@@ -482,25 +537,32 @@ impl BlackjackService {
                 table.seats[seat_index].last_action = Some(SeatAction::Bet);
                 table.seats[seat_index].missed_deals = 0;
                 table.update_player_balance(user_id, new_balance);
+                let activity_generation = table.record_activity(user_id);
 
                 let mut settlements = Vec::new();
                 let mut action_countdown_id = None;
+                let mut dealer_turn_id = None;
                 let betting_countdown_id = if table.all_seated_bets_ready() {
                     settlements = table
                         .start_round()
                         .map_err(|e| BetFailure::Internal(anyhow::anyhow!("{e:?}")))?;
                     action_countdown_id = table.start_action_countdown_if_needed();
+                    dealer_turn_id = table.schedule_dealer_turn_if_needed();
                     None
                 } else {
                     Some(table.ensure_betting_countdown())
                 };
                 table.status_message = table.countdown_status();
                 self.publish_snapshot_locked(&table);
+                if let Some(activity_generation) = activity_generation {
+                    self.schedule_inactivity_kick(user_id, activity_generation);
+                }
                 return Ok(BetSuccess {
                     new_balance,
                     settlements,
                     betting_countdown_id,
                     action_countdown_id,
+                    dealer_turn_id,
                 });
             }
             self.publish_snapshot_locked(&table);
@@ -511,6 +573,7 @@ impl BlackjackService {
             settlements: Vec::new(),
             betting_countdown_id: None,
             action_countdown_id: None,
+            dealer_turn_id: None,
         })
     }
 
@@ -530,7 +593,7 @@ impl BlackjackService {
     }
 
     async fn hit(&self, user_id: Uuid) -> Result<(), ActionFailure> {
-        let settlements = {
+        let (settlements, activity_generation, dealer_turn_id) = {
             let mut table = self.table.lock().await;
             let Some(seat_index) = table.user_seat_index(user_id) else {
                 return Err(ActionFailure::NotSeated);
@@ -539,9 +602,17 @@ impl BlackjackService {
                 return Err(ActionFailure::InvalidPhase("you cannot hit right now"));
             }
             let settlements = table.hit_seat(seat_index)?;
+            let activity_generation = table.record_activity(user_id);
+            let dealer_turn_id = table.schedule_dealer_turn_if_needed();
             self.publish_snapshot_locked(&table);
-            settlements
+            (settlements, activity_generation, dealer_turn_id)
         };
+        if let Some(activity_generation) = activity_generation {
+            self.schedule_inactivity_kick(user_id, activity_generation);
+        }
+        if let Some(dealer_turn_id) = dealer_turn_id {
+            self.schedule_dealer_turn(dealer_turn_id);
+        }
 
         if !settlements.is_empty() {
             self.persist_settlements(settlements)
@@ -568,7 +639,7 @@ impl BlackjackService {
     }
 
     async fn stand(&self, user_id: Uuid) -> Result<(), ActionFailure> {
-        let settlements = {
+        let (settlements, activity_generation, dealer_turn_id) = {
             let mut table = self.table.lock().await;
             let Some(seat_index) = table.user_seat_index(user_id) else {
                 return Err(ActionFailure::NotSeated);
@@ -577,9 +648,17 @@ impl BlackjackService {
                 return Err(ActionFailure::InvalidPhase("you cannot stand right now"));
             }
             let settlements = table.stand_seat(seat_index)?;
+            let activity_generation = table.record_activity(user_id);
+            let dealer_turn_id = table.schedule_dealer_turn_if_needed();
             self.publish_snapshot_locked(&table);
-            settlements
+            (settlements, activity_generation, dealer_turn_id)
         };
+        if let Some(activity_generation) = activity_generation {
+            self.schedule_inactivity_kick(user_id, activity_generation);
+        }
+        if let Some(dealer_turn_id) = dealer_turn_id {
+            self.schedule_dealer_turn(dealer_turn_id);
+        }
 
         if !settlements.is_empty() {
             self.persist_settlements(settlements)
@@ -595,14 +674,18 @@ impl BlackjackService {
         tokio::spawn(async move {
             match svc.deal(user_id).await {
                 Ok(settlements) => {
-                    let action_countdown_id = {
+                    let (action_countdown_id, dealer_turn_id) = {
                         let mut table = svc.table.lock().await;
                         let action_countdown_id = table.start_action_countdown_if_needed();
+                        let dealer_turn_id = table.schedule_dealer_turn_if_needed();
                         svc.publish_snapshot_locked(&table);
-                        action_countdown_id
+                        (action_countdown_id, dealer_turn_id)
                     };
                     if let Some(countdown_id) = action_countdown_id {
                         svc.schedule_action_timeout(countdown_id);
+                    }
+                    if let Some(dealer_turn_id) = dealer_turn_id {
+                        svc.schedule_dealer_turn(dealer_turn_id);
                     }
                     if let Err(e) = svc.persist_settlements(settlements).await {
                         tracing::error!(error = ?e, %user_id, "blackjack deal settlement failed");
@@ -634,7 +717,11 @@ impl BlackjackService {
             return Err(ActionFailure::InvalidPhase("hand is already in progress"));
         }
         let settlements = table.start_round()?;
+        let activity_generation = table.record_activity(user_id);
         self.publish_snapshot_locked(&table);
+        if let Some(activity_generation) = activity_generation {
+            self.schedule_inactivity_kick(user_id, activity_generation);
+        }
         Ok(settlements)
     }
 
@@ -663,8 +750,41 @@ impl BlackjackService {
         }
         let status = table.betting_prompt_with_timer();
         table.reset_to_betting(&status);
+        let activity_generation = table.record_activity(user_id);
         self.publish_snapshot_locked(&table);
+        if let Some(activity_generation) = activity_generation {
+            self.schedule_inactivity_kick(user_id, activity_generation);
+        }
         Ok(())
+    }
+
+    fn schedule_inactivity_kick(&self, user_id: Uuid, activity_generation: u64) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(SEAT_IDLE_TIMEOUT_SECS)).await;
+
+            let kick = {
+                let mut table = svc.table.lock().await;
+                let Some(kick) = table.kick_inactive_user(user_id, activity_generation) else {
+                    return;
+                };
+                svc.publish_snapshot_locked(&table);
+                kick
+            };
+
+            if let Some(dealer_turn_id) = kick.dealer_turn_id {
+                svc.schedule_dealer_turn(dealer_turn_id);
+            }
+            for (left_user_id, seat_index) in &kick.left_seats {
+                let _ = svc.event_tx.send(BlackjackEvent::SeatLeft {
+                    user_id: *left_user_id,
+                    seat_index: *seat_index,
+                });
+            }
+            if let Err(e) = svc.persist_settlements(kick.settlements).await {
+                tracing::error!(error = ?e, %user_id, "blackjack inactivity-kick settlement failed");
+            }
+        });
     }
 
     fn schedule_auto_deal(&self, countdown_id: u64) {
@@ -673,7 +793,7 @@ impl BlackjackService {
             loop {
                 tokio::time::sleep(Duration::from_secs(1)).await;
 
-                let (settlements, action_countdown_id) = {
+                let (settlements, action_countdown_id, dealer_turn_id) = {
                     let mut table = svc.table.lock().await;
                     if !table.countdown_matches(countdown_id) {
                         return;
@@ -695,8 +815,9 @@ impl BlackjackService {
                     match table.start_round_from_countdown(countdown_id) {
                         Ok(settlements) => {
                             let action_countdown_id = table.start_action_countdown_if_needed();
+                            let dealer_turn_id = table.schedule_dealer_turn_if_needed();
                             svc.publish_snapshot_locked(&table);
-                            (settlements, action_countdown_id)
+                            (settlements, action_countdown_id, dealer_turn_id)
                         }
                         Err(failure) => {
                             table.clear_betting_countdown();
@@ -709,6 +830,9 @@ impl BlackjackService {
 
                 if let Some(countdown_id) = action_countdown_id {
                     svc.schedule_action_timeout(countdown_id);
+                }
+                if let Some(dealer_turn_id) = dealer_turn_id {
+                    svc.schedule_dealer_turn(dealer_turn_id);
                 }
                 if let Err(e) = svc.persist_settlements(settlements).await {
                     tracing::error!(error = ?e, "blackjack auto-deal settlement failed");
@@ -724,7 +848,7 @@ impl BlackjackService {
             loop {
                 tokio::time::sleep(Duration::from_secs(1)).await;
 
-                let settlements = {
+                let (settlements, dealer_turn_id) = {
                     let mut table = svc.table.lock().await;
                     if !table.action_countdown_matches(countdown_id) {
                         return;
@@ -736,14 +860,49 @@ impl BlackjackService {
                     }
 
                     let settlements = table.auto_stand_remaining();
+                    let dealer_turn_id = table.schedule_dealer_turn_if_needed();
                     svc.publish_snapshot_locked(&table);
-                    settlements
+                    (settlements, dealer_turn_id)
                 };
 
+                if let Some(dealer_turn_id) = dealer_turn_id {
+                    svc.schedule_dealer_turn(dealer_turn_id);
+                }
                 if let Err(e) = svc.persist_settlements(settlements).await {
                     tracing::error!(error = ?e, "blackjack action-timeout settlement failed");
                 }
                 return;
+            }
+        });
+    }
+
+    fn schedule_dealer_turn(&self, dealer_turn_id: u64) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(Duration::from_millis(DEALER_CARD_DELAY_MS)).await;
+
+                let step = {
+                    let mut table = svc.table.lock().await;
+                    let Some(step) = table.dealer_step(dealer_turn_id) else {
+                        return;
+                    };
+                    svc.publish_snapshot_locked(&table);
+                    step
+                };
+
+                if step.done {
+                    for (left_user_id, seat_index) in &step.left_seats {
+                        let _ = svc.event_tx.send(BlackjackEvent::SeatLeft {
+                            user_id: *left_user_id,
+                            seat_index: *seat_index,
+                        });
+                    }
+                    if let Err(e) = svc.persist_settlements(step.settlements).await {
+                        tracing::error!(error = ?e, "blackjack dealer-turn settlement failed");
+                    }
+                    return;
+                }
             }
         });
     }
@@ -779,10 +938,6 @@ impl BlackjackService {
     }
 }
 
-fn blocked_seat_username(username: &str) -> bool {
-    username.trim().eq_ignore_ascii_case("imred")
-}
-
 struct SharedTableState {
     settings: BlackjackTableSettings,
     shoe: Shoe,
@@ -793,6 +948,8 @@ struct SharedTableState {
     betting_countdown_id: u64,
     action_deadline: Option<Instant>,
     action_countdown_id: u64,
+    dealer_turn_id: u64,
+    dealer_turn_scheduled: bool,
     status_message: String,
 }
 
@@ -809,6 +966,15 @@ struct SeatState {
     last_action: Option<SeatAction>,
     last_net_change: i64,
     missed_deals: u8,
+    last_activity: Instant,
+    activity_generation: u64,
+    deferred_leave_reason: Option<DeferredLeaveReason>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DeferredLeaveReason {
+    Idle,
+    MissedAction,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -833,6 +999,9 @@ impl SeatState {
             last_action: None,
             last_net_change: 0,
             missed_deals: 0,
+            last_activity: Instant::now(),
+            activity_generation: 0,
+            deferred_leave_reason: None,
         }
     }
 
@@ -912,6 +1081,34 @@ fn format_auto_left_notice(seat_indices: &[usize]) -> String {
     format!("{noun} {seats} missed {MAX_MISSED_DEALS} deals and left.")
 }
 
+fn format_idle_left_notice(seat_indices: &[usize]) -> String {
+    let seats = seat_indices
+        .iter()
+        .map(|index| (index + 1).to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let noun = if seat_indices.len() == 1 {
+        "Seat"
+    } else {
+        "Seats"
+    };
+    format!("{noun} {seats} idle for 5m and left.")
+}
+
+fn format_missed_action_left_notice(seat_indices: &[usize]) -> String {
+    let seats = seat_indices
+        .iter()
+        .map(|index| (index + 1).to_string())
+        .collect::<Vec<_>>()
+        .join(", ");
+    let noun = if seat_indices.len() == 1 {
+        "Seat"
+    } else {
+        "Seats"
+    };
+    format!("{noun} {seats} missed the action timer and left.")
+}
+
 impl SharedTableState {
     fn new(settings: BlackjackTableSettings) -> Self {
         Self {
@@ -924,6 +1121,8 @@ impl SharedTableState {
             betting_countdown_id: 0,
             action_deadline: None,
             action_countdown_id: 0,
+            dealer_turn_id: 0,
+            dealer_turn_scheduled: false,
             status_message: "Sit to join, or watch the table.".to_string(),
         }
     }
@@ -1048,6 +1247,63 @@ impl SharedTableState {
             Some(0) => "Action timer expired. Standing remaining hands.".to_string(),
             Some(secs) => format!("Players hit or stand. Auto-stand in {secs}s."),
             None => "Players hit or stand.".to_string(),
+        }
+    }
+
+    fn begin_dealer_turn(&mut self) {
+        self.clear_action_countdown();
+        self.phase = Phase::DealerTurn;
+        self.dealer_turn_id = self.dealer_turn_id.wrapping_add(1);
+        self.dealer_turn_scheduled = false;
+        self.status_message = "Dealer reveals the hole card.".to_string();
+    }
+
+    fn schedule_dealer_turn_if_needed(&mut self) -> Option<u64> {
+        if self.phase == Phase::DealerTurn && !self.dealer_turn_scheduled {
+            self.dealer_turn_scheduled = true;
+            Some(self.dealer_turn_id)
+        } else {
+            None
+        }
+    }
+
+    fn dealer_step(&mut self, dealer_turn_id: u64) -> Option<DealerStep> {
+        if self.phase != Phase::DealerTurn || self.dealer_turn_id != dealer_turn_id {
+            return None;
+        }
+
+        if dealer_must_hit(&self.dealer_hand) {
+            self.dealer_hand.push(self.shoe.draw());
+            let dealer_score = score(&self.dealer_hand);
+            self.status_message = format!("Dealer draws. Total {}.", dealer_score.total);
+            return Some(DealerStep {
+                done: false,
+                settlements: Vec::new(),
+                left_seats: Vec::new(),
+            });
+        }
+
+        Some(self.finish_dealer_turn())
+    }
+
+    fn finish_dealer_turn(&mut self) -> DealerStep {
+        let mut settlements = Vec::new();
+        for index in 0..self.seats.len() {
+            if self.seats[index].has_unresolved_bet() {
+                let outcome = settle(&self.seats[index].hand, &self.dealer_hand);
+                if let Some(settlement) = self.finish_seat(index, outcome) {
+                    settlements.push(settlement);
+                }
+            }
+        }
+        self.phase = Phase::Settling;
+        self.dealer_turn_scheduled = false;
+        self.status_message = "Round settled. Press Space or Enter for next hand.".to_string();
+        let left_seats = self.remove_deferred_leave_seats();
+        DealerStep {
+            done: true,
+            settlements,
+            left_seats,
         }
     }
 
@@ -1184,6 +1440,106 @@ impl SharedTableState {
         self.start_round()
     }
 
+    fn record_activity(&mut self, user_id: Uuid) -> Option<u64> {
+        let seat_index = self.user_seat_index(user_id)?;
+        let seat = &mut self.seats[seat_index];
+        seat.last_activity = Instant::now();
+        seat.activity_generation = seat.activity_generation.wrapping_add(1);
+        Some(seat.activity_generation)
+    }
+
+    fn kick_inactive_user(
+        &mut self,
+        user_id: Uuid,
+        activity_generation: u64,
+    ) -> Option<InactivityKick> {
+        let seat_index = self.user_seat_index(user_id)?;
+        let seat = &self.seats[seat_index];
+        if seat.activity_generation != activity_generation
+            || seat.last_activity.elapsed() < Duration::from_secs(SEAT_IDLE_TIMEOUT_SECS)
+            || seat.pending_bet.is_some()
+        {
+            return None;
+        }
+
+        if self.phase == Phase::PlayerTurn && self.seats[seat_index].has_unresolved_bet() {
+            if !self.seats[seat_index].stood {
+                self.seats[seat_index].stood = true;
+                self.seats[seat_index].last_action = Some(SeatAction::Stand);
+            }
+            self.seats[seat_index].deferred_leave_reason = Some(DeferredLeaveReason::Idle);
+            self.status_message =
+                format!("Seat {} was idle for 5m and auto-stood.", seat_index + 1);
+            let settlements = self.advance_or_finish_round();
+            let dealer_turn_id = self.schedule_dealer_turn_if_needed();
+            return Some(InactivityKick {
+                left_seats: self.remove_deferred_leave_seats(),
+                settlements,
+                dealer_turn_id,
+            });
+        }
+
+        if self.seats[seat_index].bet.is_some()
+            && !matches!(self.phase, Phase::Settling | Phase::DealerTurn)
+        {
+            return None;
+        }
+        if self.phase == Phase::DealerTurn && self.seats[seat_index].bet.is_some() {
+            self.seats[seat_index].deferred_leave_reason = Some(DeferredLeaveReason::Idle);
+            self.status_message = format!(
+                "Seat {} was idle for 5m and will leave after settlement.",
+                seat_index + 1
+            );
+            return Some(InactivityKick {
+                left_seats: Vec::new(),
+                settlements: Vec::new(),
+                dealer_turn_id: None,
+            });
+        }
+
+        self.seats[seat_index] = SeatState::empty();
+        self.status_message = format_idle_left_notice(&[seat_index]);
+        Some(InactivityKick {
+            left_seats: vec![(user_id, seat_index)],
+            settlements: Vec::new(),
+            dealer_turn_id: None,
+        })
+    }
+
+    fn remove_deferred_leave_seats(&mut self) -> Vec<(Uuid, usize)> {
+        let mut left_seats = Vec::new();
+        let mut idle_seats = Vec::new();
+        let mut missed_action_seats = Vec::new();
+        for (index, seat) in self.seats.iter_mut().enumerate() {
+            if let Some(reason) = seat.deferred_leave_reason
+                && (seat.last_outcome.is_some() || self.phase == Phase::Settling)
+                && let Some(user_id) = seat.user_id
+            {
+                match reason {
+                    DeferredLeaveReason::Idle => idle_seats.push(index),
+                    DeferredLeaveReason::MissedAction => missed_action_seats.push(index),
+                }
+                *seat = SeatState::empty();
+                left_seats.push((user_id, index));
+            }
+        }
+        if !idle_seats.is_empty() {
+            self.status_message = format!(
+                "{} {}",
+                self.status_message,
+                format_idle_left_notice(&idle_seats)
+            );
+        }
+        if !missed_action_seats.is_empty() {
+            self.status_message = format!(
+                "{} {}",
+                self.status_message,
+                format_missed_action_left_notice(&missed_action_seats)
+            );
+        }
+        left_seats
+    }
+
     fn record_missed_deals(&mut self) -> Vec<usize> {
         let mut auto_left_seats = Vec::new();
         for (index, seat) in self.seats.iter_mut().enumerate() {
@@ -1308,31 +1664,21 @@ impl SharedTableState {
         }
 
         self.clear_action_countdown();
-        self.phase = Phase::DealerTurn;
-        self.status_message = "Dealer's turn.".to_string();
-        while dealer_must_hit(&self.dealer_hand) {
-            self.dealer_hand.push(self.shoe.draw());
+        if !self.seats.iter().any(SeatState::has_unresolved_bet) {
+            let step = self.finish_dealer_turn();
+            return step.settlements;
         }
 
-        let mut settlements = Vec::new();
-        for index in 0..self.seats.len() {
-            if self.seats[index].has_unresolved_bet() {
-                let outcome = settle(&self.seats[index].hand, &self.dealer_hand);
-                if let Some(settlement) = self.finish_seat(index, outcome) {
-                    settlements.push(settlement);
-                }
-            }
-        }
-        self.phase = Phase::Settling;
-        self.status_message = "Round settled. Press Space or Enter for next hand.".to_string();
-        settlements
+        self.begin_dealer_turn();
+        Vec::new()
     }
 
     fn auto_stand_remaining(&mut self) -> Vec<Settlement> {
         for seat in &mut self.seats {
             if seat.has_unresolved_bet() && !seat.stood {
                 seat.stood = true;
-                seat.last_action = Some(SeatAction::Stand);
+                seat.last_action = Some(SeatAction::MissedAction);
+                seat.deferred_leave_reason = Some(DeferredLeaveReason::MissedAction);
             }
         }
         self.advance_or_finish_round()
@@ -1409,17 +1755,18 @@ impl SharedTableState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::games::cards::{CardRank, CardSuit, PlayingCard};
     use crate::app::rooms::blackjack::state::MIN_BET;
 
     fn user_id() -> Uuid {
         Uuid::now_v7()
     }
 
-    #[test]
-    fn imred_cannot_sit() {
-        assert!(blocked_seat_username("imred"));
-        assert!(blocked_seat_username(" ImRed "));
-        assert!(!blocked_seat_username("notimred"));
+    fn card(rank: CardRank) -> PlayingCard {
+        PlayingCard {
+            rank,
+            suit: CardSuit::Spades,
+        }
     }
 
     #[test]
@@ -1528,6 +1875,88 @@ mod tests {
     }
 
     #[test]
+    fn dealer_turn_draws_one_card_per_step_before_settlement() {
+        let mut table = SharedTableState::new(BlackjackTableSettings::default());
+        let user_id = user_id();
+        let seat_index = table.sit(user_id).expect("seat should be open");
+        table.seats[seat_index].bet = Some(Bet::new(MIN_BET).unwrap());
+        table.seats[seat_index].hand = vec![card(CardRank::Number(10)), card(CardRank::Number(7))];
+        table.dealer_hand = vec![card(CardRank::Number(10)), card(CardRank::Number(6))];
+        table.phase = Phase::PlayerTurn;
+
+        let settlements = table.stand_seat(seat_index).expect("seat can stand");
+        let dealer_turn_id = table
+            .schedule_dealer_turn_if_needed()
+            .expect("dealer turn should be scheduled");
+
+        assert!(settlements.is_empty());
+        assert_eq!(table.phase, Phase::DealerTurn);
+        assert_eq!(table.dealer_hand.len(), 2);
+
+        let step = table
+            .dealer_step(dealer_turn_id)
+            .expect("dealer step should match current turn");
+
+        assert!(!step.done);
+        assert!(step.settlements.is_empty());
+        assert_eq!(table.phase, Phase::DealerTurn);
+        assert_eq!(table.dealer_hand.len(), 3);
+        assert_eq!(table.seats[seat_index].last_outcome, None);
+
+        let mut final_step = None;
+        for _ in 0..10 {
+            let step = table
+                .dealer_step(dealer_turn_id)
+                .expect("dealer turn should still be current");
+            if step.done {
+                final_step = Some(step);
+                break;
+            }
+        }
+        let final_step = final_step.expect("dealer should eventually settle");
+
+        assert_eq!(table.phase, Phase::Settling);
+        assert_eq!(final_step.settlements.len(), 1);
+        assert!(table.seats[seat_index].last_outcome.is_some());
+    }
+
+    #[test]
+    fn action_timeout_removes_unacted_seats_after_settlement() {
+        let mut table = SharedTableState::new(BlackjackTableSettings::default());
+        let user_id = user_id();
+        let seat_index = table.sit(user_id).expect("seat should be open");
+        table.seats[seat_index].bet = Some(Bet::new(MIN_BET).unwrap());
+        table.seats[seat_index].hand = vec![card(CardRank::Number(10)), card(CardRank::Number(7))];
+        table.dealer_hand = vec![card(CardRank::Number(10)), card(CardRank::Queen)];
+        table.phase = Phase::PlayerTurn;
+
+        let settlements = table.auto_stand_remaining();
+        let dealer_turn_id = table
+            .schedule_dealer_turn_if_needed()
+            .expect("dealer turn should be scheduled");
+
+        assert!(settlements.is_empty());
+        assert_eq!(
+            table.seats[seat_index].last_action,
+            Some(SeatAction::MissedAction)
+        );
+        assert_eq!(table.phase, Phase::DealerTurn);
+
+        let step = table
+            .dealer_step(dealer_turn_id)
+            .expect("dealer step should match current turn");
+
+        assert!(step.done);
+        assert_eq!(step.left_seats, vec![(user_id, seat_index)]);
+        assert_eq!(table.user_seat_index(user_id), None);
+        assert!(
+            table
+                .status_message
+                .contains("Seat 1 missed the action timer and left.")
+        );
+    }
+
+    #[test]
     fn seated_player_auto_leaves_after_three_missed_deals() {
         let mut table = SharedTableState::new(BlackjackTableSettings::default());
         let active_user = user_id();
@@ -1556,6 +1985,49 @@ mod tests {
                 .status_message
                 .contains("Seat 2 missed 3 deals and left.")
         );
+    }
+
+    #[test]
+    fn seated_player_auto_leaves_after_five_minutes_idle() {
+        let mut table = SharedTableState::new(BlackjackTableSettings::default());
+        let user_id = user_id();
+        let seat_index = table.sit(user_id).expect("seat should be open");
+        let activity_generation = table.record_activity(user_id).expect("seat exists");
+
+        table.seats[seat_index].last_activity =
+            Instant::now() - Duration::from_secs(SEAT_IDLE_TIMEOUT_SECS + 1);
+        let kick = table
+            .kick_inactive_user(user_id, activity_generation)
+            .expect("idle seat should be kicked");
+
+        assert_eq!(kick.left_seats, vec![(user_id, seat_index)]);
+        assert!(kick.settlements.is_empty());
+        assert_eq!(table.user_seat_index(user_id), None);
+        assert!(
+            table
+                .status_message
+                .contains("Seat 1 idle for 5m and left.")
+        );
+    }
+
+    #[test]
+    fn seated_player_activity_generation_blocks_stale_idle_kick() {
+        let mut table = SharedTableState::new(BlackjackTableSettings::default());
+        let user_id = user_id();
+        let seat_index = table.sit(user_id).expect("seat should be open");
+        let stale_generation = table.record_activity(user_id).expect("seat exists");
+        let fresh_generation = table.record_activity(user_id).expect("seat exists");
+
+        table.seats[seat_index].last_activity =
+            Instant::now() - Duration::from_secs(SEAT_IDLE_TIMEOUT_SECS + 1);
+
+        assert!(
+            table
+                .kick_inactive_user(user_id, stale_generation)
+                .is_none()
+        );
+        assert_eq!(table.user_seat_index(user_id), Some(seat_index));
+        assert_ne!(stale_generation, fresh_generation);
     }
 
     #[test]

--- a/late-ssh/src/app/rooms/blackjack/ui.rs
+++ b/late-ssh/src/app/rooms/blackjack/ui.rs
@@ -629,6 +629,7 @@ fn seat_notice_label(seat: &BlackjackSeat) -> Option<(&'static str, ratatui::sty
         SeatAction::Hit => ("HIT", theme::AMBER()),
         SeatAction::Stand => ("STAND", theme::TEXT_BRIGHT()),
         SeatAction::MissedDeal => ("MISSED", theme::TEXT_DIM()),
+        SeatAction::MissedAction => ("TIMEOUT", theme::ERROR()),
     })
 }
 
@@ -647,6 +648,7 @@ fn seat_notice_subtitle(seat: &BlackjackSeat) -> Option<String> {
             seat.score.map(|score| format!("tot {}", score.total))
         }
         SeatAction::MissedDeal => Some("no bet".to_string()),
+        SeatAction::MissedAction => Some("no action".to_string()),
         SeatAction::Sit => None,
     }
 }
@@ -891,7 +893,7 @@ fn draw_keys_bar(
     if area.height == 0 {
         return;
     }
-    let line = key_line(snapshot.phase, user_seat_index.is_some(), user_is_active);
+    let line = key_line(snapshot, user_seat_index.is_some(), user_is_active);
     frame.render_widget(Paragraph::new(line).alignment(Alignment::Center), area);
 }
 
@@ -958,7 +960,7 @@ fn draw_table_compact(
             theme::AMBER(),
         ),
         Line::from(""),
-        key_line(snapshot.phase, is_seated, user_is_active),
+        key_line(snapshot, is_seated, user_is_active),
     ];
 
     let inner = draw_game_frame(frame, area, "Blackjack", info_lines, show_sidebar);
@@ -1013,14 +1015,14 @@ fn draw_table_compact(
 
 // ──────────────── Shared helpers ────────────────
 
-fn key_line(phase: Phase, is_seated: bool, is_active: bool) -> Line<'static> {
+fn key_line(snapshot: &BlackjackSnapshot, is_seated: bool, is_active: bool) -> Line<'static> {
     if !is_seated {
         return key_hint("s/Enter sit · Esc back", "");
     }
-    match phase {
+    match snapshot.phase {
         Phase::Betting => key_hint(
-            "[ ] chip · Space throw · Backspace pull · Enter/S lock · L leave · Esc back",
-            "",
+            &format!("[ ] chip {}", selected_chip_amount(snapshot)),
+            "· Space throw · Backspace pull · Enter/S lock · L leave · Esc back",
         ),
         Phase::BetPending => key_hint("Esc back", ""),
         Phase::PlayerTurn if is_active => {
@@ -1144,6 +1146,7 @@ fn render_seat_hands_compact(
                     Some(SeatAction::Hit) => " hit",
                     Some(SeatAction::Stand) => " stand",
                     Some(SeatAction::MissedDeal) => " missed",
+                    Some(SeatAction::MissedAction) => " timeout",
                     None => "",
                 },
             };

--- a/late-ssh/src/app/rooms/input.rs
+++ b/late-ssh/src/app/rooms/input.rs
@@ -497,6 +497,7 @@ fn handle_active_room_key(app: &mut App, byte: u8) -> bool {
     };
     let game_kind = room.game_kind;
     let chat_room_id = room.chat_room_id;
+    touch_active_room_activity(app, game_kind);
 
     if byte == 0x1B
         && app
@@ -540,15 +541,31 @@ fn handle_active_room_arrow(app: &mut App, key: u8) -> bool {
     let Some(room) = app.rooms_active_room.as_ref() else {
         return false;
     };
-    crate::app::chat::input::handle_message_arrow_in_room(app, room.chat_room_id, key)
+    let game_kind = room.game_kind;
+    let chat_room_id = room.chat_room_id;
+    touch_active_room_activity(app, game_kind);
+    crate::app::chat::input::handle_message_arrow_in_room(app, chat_room_id, key)
 }
 
 fn handle_active_room_scroll(app: &mut App, delta: isize) -> bool {
     let Some(room) = app.rooms_active_room.as_ref() else {
         return false;
     };
-    crate::app::chat::input::handle_scroll_in_room(app, room.chat_room_id, delta);
+    let game_kind = room.game_kind;
+    let chat_room_id = room.chat_room_id;
+    touch_active_room_activity(app, game_kind);
+    crate::app::chat::input::handle_scroll_in_room(app, chat_room_id, delta);
     true
+}
+
+fn touch_active_room_activity(app: &mut App, game_kind: crate::app::rooms::svc::GameKind) {
+    match game_kind {
+        crate::app::rooms::svc::GameKind::Blackjack => {
+            if let Some(blackjack_state) = &app.blackjack_state {
+                blackjack_state.touch_activity();
+            }
+        }
+    }
 }
 
 fn active_room_page_step(app: &App) -> isize {


### PR DESCRIPTION
## Summary
- Makes blackjack rooms more resilient during slow or abandoned hands by timing out inactive seated players and removing seats that miss required actions.
- Smooths round resolution by pacing dealer draws instead of resolving the dealer turn all at once.
- Improves blackjack UI hints and bot/ghost attribution so the table state is clearer to players.

## What changed
- Shortened the betting lock cap from 60s to 30s.
- Added 5-minute seated-player inactivity tracking, refreshed by active-room input, arrows, and scrolls.
- Auto-stands players who miss the action timer, then removes them after settlement.
- Animates dealer turns one draw at a time before settlement.
- Updates blackjack UI labels and key hints, including selected chip amount and timeout notices.
- Removes the hardcoded `imred` seating block.
- Treats `dealer` as a bot author and improves ghost mention targeting for the triggering user.

## Behavior notes
- Idle players with unresolved hands are auto-stood and deferred for removal until settlement, so active bets can still resolve correctly.
- Stale inactivity timers are ignored via activity generations.
- Dealer settlement now depends on scheduled dealer-step tasks.

## Feature flags
None.

## Screenshots / Video
UI-visible changes are included for blackjack dashboard/table hints and seat timeout labels. Screenshots or video still need to be attached before review.

## Testing
- Automated: Added unit coverage for dealer-step settlement, action-timeout seat removal, idle seat removal, stale idle-kick prevention, ghost mention username preference, and `dealer` bot author matching.
- Manual: Still needed: verify blackjack room flow for sit, bet, idle timeout, missed action timeout, dealer draw pacing, and updated dashboard/table hints in the terminal UI.