### PR TITLE
Fix bonsai watering race

### DIFF
--- a/late-core/src/models/bonsai.rs
+++ b/late-core/src/models/bonsai.rs
@@ -70,6 +70,34 @@ impl Tree {
         Ok(())
     }
 
+    pub async fn water_and_add_growth_if_available(
+        client: &Client,
+        user_id: Uuid,
+        today: NaiveDate,
+        unlimited: bool,
+    ) -> Result<bool> {
+        let row = client
+            .query_opt(
+                "UPDATE bonsai_trees
+                 SET last_watered = $2,
+                     growth_points = LEAST(
+                         growth_points + 10 + CASE
+                             WHEN $2::date - last_watered = 1 THEN 5
+                             ELSE 0
+                         END,
+                         $3
+                     ),
+                     updated = current_timestamp
+                 WHERE user_id = $1
+                   AND is_alive = true
+                   AND ($4 OR last_watered IS DISTINCT FROM $2)
+                 RETURNING user_id",
+                &[&user_id, &today, &MAX_GROWTH_POINTS, &unlimited],
+            )
+            .await?;
+        Ok(row.is_some())
+    }
+
     pub async fn add_growth(client: &Client, user_id: Uuid, points: i32) -> Result<()> {
         client
             .execute(

--- a/late-core/tests/bonsai.rs
+++ b/late-core/tests/bonsai.rs
@@ -6,6 +6,8 @@ use late_core::{
     },
     test_utils::test_db,
 };
+use std::sync::Arc;
+use tokio::sync::Barrier;
 
 #[tokio::test]
 async fn ensure_and_find_by_user_round_trip() {
@@ -89,4 +91,54 @@ async fn tree_mutations_and_graveyard_round_trip() {
     assert_eq!(respawned.seed, 99);
     assert!(respawned.created >= old_created);
     assert!(respawned.updated >= respawned.created - Duration::seconds(1));
+}
+
+#[tokio::test]
+async fn concurrent_water_attempts_only_grant_growth_once() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let user = User::create(
+        &client,
+        UserParams {
+            fingerprint: "bonsai-model-concurrent-water".to_string(),
+            username: "bonsai-model-concurrent-water".to_string(),
+            settings: serde_json::json!({}),
+        },
+    )
+    .await
+    .expect("create user");
+    let today = Utc::now().date_naive();
+
+    Tree::ensure(&client, user.id, 22).await.expect("ensure");
+
+    let task_count = 12;
+    let barrier = Arc::new(Barrier::new(task_count));
+    let mut handles = Vec::new();
+    for _ in 0..task_count {
+        let db = test_db.db.clone();
+        let barrier = Arc::clone(&barrier);
+        let user_id = user.id;
+        handles.push(tokio::spawn(async move {
+            let client = db.get().await.expect("db client");
+            barrier.wait().await;
+            Tree::water_and_add_growth_if_available(&client, user_id, today, false)
+                .await
+                .expect("water")
+        }));
+    }
+
+    let mut successful_waters = 0;
+    for handle in handles {
+        if handle.await.expect("join water task") {
+            successful_waters += 1;
+        }
+    }
+
+    let tree = Tree::find_by_user_id(&client, user.id)
+        .await
+        .expect("find tree")
+        .expect("tree");
+    assert_eq!(successful_waters, 1);
+    assert_eq!(tree.last_watered, Some(today));
+    assert_eq!(tree.growth_points, 10);
 }

--- a/late-ssh/src/app/bonsai/svc.rs
+++ b/late-ssh/src/app/bonsai/svc.rs
@@ -96,27 +96,10 @@ impl BonsaiService {
         let client = self.db.get().await?;
         let today = chrono::Utc::now().date_naive();
 
-        let tree = Tree::find_by_user_id(&client, user_id).await?;
-        let Some(tree) = tree else {
-            return Ok(false);
-        };
-        if !tree.is_alive {
+        if !Tree::water_and_add_growth_if_available(&client, user_id, today, unlimited).await? {
             return Ok(false);
         }
-        if !unlimited && tree.last_watered == Some(today) {
-            return Ok(false); // Already watered today
-        }
-
-        Tree::water(&client, user_id, today).await?;
         DailyCare::mark_watered(&client, user_id, today).await?;
-
-        // Grant growth points: base 10, bonus if consecutive day
-        let bonus = if let Some(last) = tree.last_watered {
-            if (today - last).num_days() == 1 { 5 } else { 0 }
-        } else {
-            0
-        };
-        Tree::add_growth(&client, user_id, 10 + bonus).await?;
 
         // Grant chips for watering
         late_core::models::chips::UserChips::add_bonus(


### PR DESCRIPTION
## Summary

Fixes #110 by moving bonsai watering eligibility and growth granting into a single conditional database update. This prevents multiple open sessions from each winning the same daily watering window.

## Details

The previous flow read `last_watered`, then updated the tree and granted growth in separate statements. Concurrent sessions could all read the pre-watered row before any one updated it. The new model helper updates `last_watered` and growth atomically, and the SSH service only marks daily care, grants chips, and emits activity when that update succeeds.

## Testing

- `cargo test -p late-core --test bonsai`
- `cargo test -p late-ssh --test bonsai`
- `cargo check -p late-ssh`
- pre-commit `rustfmt` and `clippy`
