### PR TITLE
Add moderation ban and audit listing commands

### DIFF
--- a/late-core/src/models/artboard_ban.rs
+++ b/late-core/src/models/artboard_ban.rs
@@ -16,6 +16,12 @@ crate::model! {
     }
 }
 
+pub struct ArtboardBanListItem {
+    pub ban: ArtboardBan,
+    pub target_username: Option<String>,
+    pub actor_username: Option<String>,
+}
+
 impl ArtboardBan {
     pub async fn find_for_user(client: &Client, target_user_id: Uuid) -> Result<Option<Self>> {
         let row = client
@@ -69,6 +75,36 @@ impl ArtboardBan {
             .map(|row| {
                 let actor_username: Option<String> = row.get("actor_username");
                 (Self::from(row), actor_username)
+            })
+            .collect())
+    }
+
+    pub async fn active_with_usernames(
+        client: &Client,
+        limit: i64,
+    ) -> Result<Vec<ArtboardBanListItem>> {
+        let rows = client
+            .query(
+                "SELECT ab.*, target.username AS target_username, actor.username AS actor_username
+                 FROM artboard_bans ab
+                 LEFT JOIN users target ON target.id = ab.target_user_id
+                 LEFT JOIN users actor ON actor.id = ab.actor_user_id
+                 WHERE ab.expires_at IS NULL OR ab.expires_at > current_timestamp
+                 ORDER BY ab.created DESC
+                 LIMIT $1",
+                &[&limit],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let target_username: Option<String> = row.get("target_username");
+                let actor_username: Option<String> = row.get("actor_username");
+                ArtboardBanListItem {
+                    ban: Self::from(row),
+                    target_username,
+                    actor_username,
+                }
             })
             .collect())
     }

--- a/late-core/src/models/moderation_audit_log.rs
+++ b/late-core/src/models/moderation_audit_log.rs
@@ -16,7 +16,43 @@ crate::model! {
     }
 }
 
+pub struct ModerationAuditLogListItem {
+    pub log: ModerationAuditLog,
+    pub actor_username: Option<String>,
+    pub target_username: Option<String>,
+}
+
 impl ModerationAuditLog {
+    pub async fn recent_with_usernames(
+        client: &tokio_postgres::Client,
+        limit: i64,
+    ) -> Result<Vec<ModerationAuditLogListItem>> {
+        let rows = client
+            .query(
+                "SELECT mal.*, actor.username AS actor_username, target.username AS target_username
+                 FROM moderation_audit_log mal
+                 LEFT JOIN users actor ON actor.id = mal.actor_user_id
+                 LEFT JOIN users target
+                   ON target.id = mal.target_id AND mal.target_kind = 'user'
+                 ORDER BY mal.created DESC
+                 LIMIT $1",
+                &[&limit],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let actor_username: Option<String> = row.get("actor_username");
+                let target_username: Option<String> = row.get("target_username");
+                ModerationAuditLogListItem {
+                    log: Self::from(row),
+                    actor_username,
+                    target_username,
+                }
+            })
+            .collect())
+    }
+
     pub async fn record_if(
         client: &impl GenericClient,
         should_record: bool,

--- a/late-core/src/models/room_ban.rs
+++ b/late-core/src/models/room_ban.rs
@@ -17,6 +17,13 @@ crate::model! {
     }
 }
 
+pub struct RoomBanListItem {
+    pub ban: RoomBan,
+    pub room_slug: Option<String>,
+    pub target_username: Option<String>,
+    pub actor_username: Option<String>,
+}
+
 impl RoomBan {
     pub async fn find_for_room_and_user(
         client: &Client,
@@ -64,6 +71,52 @@ impl RoomBan {
         )
     }
 
+    pub async fn active_with_usernames(
+        client: &Client,
+        limit: i64,
+    ) -> Result<Vec<RoomBanListItem>> {
+        let rows = client
+            .query(
+                "SELECT rb.*, room.slug AS room_slug,
+                        target.username AS target_username,
+                        actor.username AS actor_username
+                 FROM room_bans rb
+                 LEFT JOIN chat_rooms room ON room.id = rb.room_id
+                 LEFT JOIN users target ON target.id = rb.target_user_id
+                 LEFT JOIN users actor ON actor.id = rb.actor_user_id
+                 WHERE rb.expires_at IS NULL OR rb.expires_at > current_timestamp
+                 ORDER BY rb.created DESC
+                 LIMIT $1",
+                &[&limit],
+            )
+            .await?;
+        Ok(rows.into_iter().map(Self::list_item_from_row).collect())
+    }
+
+    pub async fn active_for_room_with_usernames(
+        client: &Client,
+        room_id: Uuid,
+        limit: i64,
+    ) -> Result<Vec<RoomBanListItem>> {
+        let rows = client
+            .query(
+                "SELECT rb.*, room.slug AS room_slug,
+                        target.username AS target_username,
+                        actor.username AS actor_username
+                 FROM room_bans rb
+                 LEFT JOIN chat_rooms room ON room.id = rb.room_id
+                 LEFT JOIN users target ON target.id = rb.target_user_id
+                 LEFT JOIN users actor ON actor.id = rb.actor_user_id
+                 WHERE rb.room_id = $1
+                   AND (rb.expires_at IS NULL OR rb.expires_at > current_timestamp)
+                 ORDER BY rb.created DESC
+                 LIMIT $2",
+                &[&room_id, &limit],
+            )
+            .await?;
+        Ok(rows.into_iter().map(Self::list_item_from_row).collect())
+    }
+
     pub async fn activate(
         client: &impl GenericClient,
         room_id: Uuid,
@@ -108,5 +161,17 @@ impl RoomBan {
             )
             .await?;
         Ok(count)
+    }
+
+    fn list_item_from_row(row: tokio_postgres::Row) -> RoomBanListItem {
+        let room_slug: Option<String> = row.get("room_slug");
+        let target_username: Option<String> = row.get("target_username");
+        let actor_username: Option<String> = row.get("actor_username");
+        RoomBanListItem {
+            ban: Self::from(row),
+            room_slug,
+            target_username,
+            actor_username,
+        }
     }
 }

--- a/late-core/src/models/server_ban.rs
+++ b/late-core/src/models/server_ban.rs
@@ -29,6 +29,12 @@ pub struct ServerBanActivation<'a> {
     pub expires_at: Option<DateTime<Utc>>,
 }
 
+pub struct ServerBanListItem {
+    pub ban: ServerBan,
+    pub target_username: Option<String>,
+    pub actor_username: Option<String>,
+}
+
 impl ServerBan {
     pub async fn activate(
         client: &impl GenericClient,
@@ -95,6 +101,36 @@ impl ServerBan {
             .map(|row| {
                 let actor_username: Option<String> = row.get("actor_username");
                 (Self::from(row), actor_username)
+            })
+            .collect())
+    }
+
+    pub async fn active_with_usernames(
+        client: &Client,
+        limit: i64,
+    ) -> Result<Vec<ServerBanListItem>> {
+        let rows = client
+            .query(
+                "SELECT sb.*, target.username AS target_username, actor.username AS actor_username
+                 FROM server_bans sb
+                 LEFT JOIN users target ON target.id = sb.target_user_id
+                 LEFT JOIN users actor ON actor.id = sb.actor_user_id
+                 WHERE sb.expires_at IS NULL OR sb.expires_at > current_timestamp
+                 ORDER BY sb.created DESC
+                 LIMIT $1",
+                &[&limit],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let target_username: Option<String> = row.get("target_username");
+                let actor_username: Option<String> = row.get("actor_username");
+                ServerBanListItem {
+                    ban: Self::from(row),
+                    target_username,
+                    actor_username,
+                }
             })
             .collect())
     }

--- a/late-ssh/src/app/chat/CONTEXT.md
+++ b/late-ssh/src/app/chat/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: late.sh SSH chat, synthetic chat feeds, and dashboard/room chat surfaces
 - Primary audience: LLM agents working in `late-ssh/src/app/chat`
-- Last updated: 2026-04-30
+- Last updated: 2026-05-02
 - Status: Active
 - Parent context: `../../../../CONTEXT.md`
 
@@ -54,7 +54,8 @@ late-ssh/tests/chat/
 Core models used by chat live in `late-core/src/models/`:
 `chat_room.rs`, `chat_room_member.rs`, `chat_message.rs`, `chat_message_reaction.rs`,
 `notification.rs`, `article.rs`, `article_feed_read.rs`, `showcase.rs`, and
-`showcase_feed_read.rs`.
+`showcase_feed_read.rs`. Chat-owned moderation commands also use `room_ban.rs`,
+`server_ban.rs`, `artboard_ban.rs`, and `moderation_audit_log.rs`.
 
 ---
 
@@ -155,7 +156,7 @@ Game rooms stay in `ChatState.rooms` for embedded Rooms chat, but `is_chat_list_
 
 Room navigation:
 - `h`/`l`, left/right arrows, `Ctrl+P`/`Ctrl+N` switch room selection.
-- `Space` activates room-jump mode, assigning keys from `ROOM_JUMP_KEYS`.
+- `Space` activates room-jump mode, assigning keys from `ROOM_JUMP_KEYS`. Jumping to the already selected room/synthetic entry still re-runs the entry's read/list side effects so stale unread badges clear.
 - While composing on the Chat page, `Ctrl+N`/`Ctrl+P` switch real rooms while preserving draft text and dropping reply/edit state.
 - Synthetic entries are selected with booleans (`news_selected`, `notifications_selected`, `discover_selected`, `showcase_selected`), not `selected_room_id`.
 
@@ -217,6 +218,7 @@ User commands:
 - `/leave` leaves the selected non-permanent room.
 - `/list` lists public rooms.
 - `/members` lists selected-room members.
+- `/mod` opens the moderation command modal; `/mod ...` in chat is rejected because commands run only in the modal.
 - `/music` opens music help.
 - `/private #room` creates a private topic room and joins the caller.
 - `/public #room` opens or creates an opt-in public room for the caller only (`auto_join=false`).
@@ -227,6 +229,24 @@ Admin commands:
 - `/create-room #room` creates/promotes a permanent auto-join room and bulk-adds existing users.
 - `/delete-room #room` deletes a permanent room.
 - `/fill-room #room` bulk-adds all users to an existing public room and flips `auto_join=true`; private rooms cannot be filled.
+
+Moderation modal commands:
+- `help [command]`
+- `user @name`
+- `bans [server|artboard|room #slug] [limit]`
+- `audit [limit]`
+- `room kick #slug @name [reason...]`
+- `room ban #slug @name [duration] [reason...]`
+- `room unban #slug @name`
+- `server kick @name [reason...]`
+- `server ban @name [duration] [reason...]`
+- `server unban @name`
+- `artboard ban @name [duration] [reason...]`
+- `artboard unban @name`
+- `grant mod @name`
+- `revoke mod @name`
+
+Moderation list limits default to 25 and cap at 100. Durations use positive `s/m/h/d` suffixes.
 
 Reply mode:
 - Captures `ReplyTarget { message_id, author, preview }`.
@@ -265,7 +285,7 @@ Keys:
 - Enter jumps from a reply to its loaded target.
 - `f` enters reaction leader mode.
 - `f` again while reaction leader is active opens reaction-owner overlay.
-- Digits `1..8` while reaction leader is active toggle reactions.
+- Digits `1..8` while reaction leader is active toggle reactions, exit reaction leader mode, and keep the message selected.
 - `Ctrl+P` toggles selected-message pin state; admin only.
 
 Selection deltas are message-based, not row-based. Positive means older, negative means newer.
@@ -326,7 +346,7 @@ Synthetic entries are selected from the room list but are not normal `ChatRoom`s
 
 - Backed by `notifications` joined with actor, room, and message preview data.
 - Snapshot is user-targeted; consumers must ignore snapshots where `snapshot.user_id != current_user`.
-- Selecting Mentions lists notifications and marks all read optimistically.
+- Selecting Mentions lists notifications and marks all read optimistically; re-selecting Mentions through room-jump or mouse does the same.
 - Enter jumps to the referenced room/message when possible.
 
 ### Discover

--- a/late-ssh/src/app/chat/news/state.rs
+++ b/late-ssh/src/app/chat/news/state.rs
@@ -115,7 +115,7 @@ impl State {
     }
 
     pub fn mark_read(&mut self) {
-        self.marker_read_at = self.last_read_at;
+        self.marker_read_at = Some(Utc::now());
         self.unread_count = 0;
         self.article_service.mark_read_task(self.user_id);
     }
@@ -261,6 +261,9 @@ impl State {
                     } if self.user_id == user_id => {
                         self.unread_count = unread_count;
                         self.last_read_at = last_read_at;
+                        if unread_count == 0 {
+                            self.marker_read_at = last_read_at;
+                        }
                     }
                     ArticleEvent::NewArticlesAvailable {
                         user_id,

--- a/late-ssh/src/app/chat/notifications/state.rs
+++ b/late-ssh/src/app/chat/notifications/state.rs
@@ -67,7 +67,7 @@ impl State {
     }
 
     pub fn mark_read(&mut self) {
-        self.marker_read_at = self.last_read_at;
+        self.marker_read_at = Some(Utc::now());
         self.unread_count = 0;
         self.service.mark_all_read_task(self.user_id);
     }
@@ -99,6 +99,9 @@ impl State {
                     } if user_id == self.user_id => {
                         self.unread_count = unread_count;
                         self.last_read_at = last_read_at;
+                        if unread_count == 0 {
+                            self.marker_read_at = last_read_at;
+                        }
                     }
                     NotificationEvent::NewMention {
                         user_id,

--- a/late-ssh/src/app/chat/showcase/state.rs
+++ b/late-ssh/src/app/chat/showcase/state.rs
@@ -137,7 +137,7 @@ impl State {
     }
 
     pub fn mark_read(&mut self) {
-        self.marker_read_at = self.last_read_at;
+        self.marker_read_at = Some(Utc::now());
         self.unread_count = 0;
         self.service.mark_read_task(self.user_id);
     }
@@ -399,6 +399,9 @@ impl State {
                     } if self.user_id == user_id => {
                         self.unread_count = unread_count;
                         self.last_read_at = last_read_at;
+                        if unread_count == 0 {
+                            self.marker_read_at = last_read_at;
+                        }
                     }
                     ShowcaseEvent::NewShowcasesAvailable {
                         user_id,

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -638,7 +638,6 @@ impl ChatState {
         let message = self.selected_message_in_room(room_id)?;
         self.service
             .toggle_message_reaction_task(self.user_id, message.id, kind);
-        self.selected_message_id = None;
         None
     }
 
@@ -748,30 +747,22 @@ impl ChatState {
         match slot {
             RoomSlot::News => {
                 let changed = !self.news_selected;
-                if changed {
-                    self.select_news();
-                }
+                self.select_news();
                 changed
             }
             RoomSlot::Notifications => {
                 let changed = !self.notifications_selected;
-                if changed {
-                    self.select_notifications();
-                }
+                self.select_notifications();
                 changed
             }
             RoomSlot::Discover => {
                 let changed = !self.discover_selected;
-                if changed {
-                    self.select_discover();
-                }
+                self.select_discover();
                 changed
             }
             RoomSlot::Showcase => {
                 let changed = !self.showcase_selected;
-                if changed {
-                    self.select_showcase();
-                }
+                self.select_showcase();
                 changed
             }
             RoomSlot::Room(next_id) => {
@@ -792,6 +783,9 @@ impl ChatState {
                 self.discover_selected = false;
                 self.showcase_selected = false;
                 self.selected_room_id = Some(next_id);
+                if !changed {
+                    self.mark_room_read(next_id);
+                }
                 changed
             }
         }

--- a/late-ssh/src/app/profile_modal/ui.rs
+++ b/late-ssh/src/app/profile_modal/ui.rs
@@ -21,7 +21,7 @@ const MODAL_WIDTH: u16 = 92;
 const MODAL_HEIGHT: u16 = 28;
 // Match the right-sidebar bonsai card width (see common/sidebar.rs).
 const BONSAI_CARD_WIDTH: u16 = 24;
-const FETCH_STRIP_HEIGHT: u16 = 4;
+const FETCH_STRIP_HEIGHT: u16 = 5;
 
 pub fn draw(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     let popup = centered_rect(MODAL_WIDTH, MODAL_HEIGHT, area);
@@ -180,20 +180,26 @@ fn draw_late_fetch_strip(frame: &mut Frame, area: Rect, state: &ProfileModalStat
     };
 
     let inner_w = inner.width as usize;
-    let col_w = inner_w / 3;
+    let col_w = inner_w / 2;
 
-    let row1 = Line::from(format_three_cells(
+    let row1 = Line::from(format_two_cells(
         ("created", &created),
-        ("ide", &ide),
-        ("os", &os),
+        ("theme", &theme_label),
         col_w,
         label,
         value,
         dim,
     ));
-    let row2 = Line::from(format_three_cells(
-        ("theme", &theme_label),
+    let row2 = Line::from(format_two_cells(
+        ("ide", &ide),
         ("terminal", &terminal),
+        col_w,
+        label,
+        value,
+        dim,
+    ));
+    let row3 = Line::from(format_two_cells(
+        ("os", &os),
         ("langs", &langs),
         col_w,
         label,
@@ -201,30 +207,28 @@ fn draw_late_fetch_strip(frame: &mut Frame, area: Rect, state: &ProfileModalStat
         dim,
     ));
 
-    frame.render_widget(Paragraph::new(vec![row1, row2]), inner);
+    frame.render_widget(Paragraph::new(vec![row1, row2, row3]), inner);
 }
 
-#[allow(clippy::too_many_arguments)]
-fn format_three_cells(
+fn format_two_cells(
     a: (&str, &str),
     b: (&str, &str),
-    c: (&str, &str),
     col_w: usize,
     label_style: Style,
     value_style: Style,
     sep_style: Style,
 ) -> Vec<Span<'static>> {
     let mut spans = Vec::new();
-    for (i, (label, value)) in [a, b, c].into_iter().enumerate() {
+    for (i, (label, value)) in [a, b].into_iter().enumerate() {
         if i > 0 {
             spans.push(Span::styled("│ ", sep_style));
         }
         let label_padded = format!("{label:<9} ");
         let used = label_padded.chars().count() + value.chars().count();
-        let pad = col_w.saturating_sub(used + if i < 2 { 2 } else { 0 });
+        let pad = col_w.saturating_sub(used + if i == 0 { 2 } else { 0 });
         spans.push(Span::styled(label_padded, label_style));
         spans.push(Span::styled(value.to_string(), value_style));
-        if i < 2 {
+        if i == 0 {
             spans.push(Span::raw(" ".repeat(pad)));
         }
     }

--- a/late-ssh/src/moderation/command.rs
+++ b/late-ssh/src/moderation/command.rs
@@ -8,6 +8,13 @@ pub(crate) enum ModCommand {
     User {
         username: String,
     },
+    Bans {
+        scope: BanListScope,
+        limit: i64,
+    },
+    Audit {
+        limit: i64,
+    },
     RoomAction {
         action: RoomModAction,
         slug: String,
@@ -31,6 +38,14 @@ pub(crate) enum ModCommand {
         action: RoleAction,
         username: String,
     },
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum BanListScope {
+    All,
+    Server,
+    Room { slug: String },
+    Artboard,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -144,6 +159,8 @@ pub(crate) fn parse_mod_command(input: &str) -> Result<ModCommand> {
         "user" => Ok(ModCommand::User {
             username: required_username(rest.first().copied(), "usage: user @name")?,
         }),
+        "bans" => parse_bans_mod_command(&rest),
+        "audit" => parse_audit_mod_command(&rest),
         "room" => parse_room_mod_command(&rest),
         "server" => parse_server_mod_command(&rest),
         "artboard" => parse_artboard_mod_command(&rest),
@@ -151,6 +168,67 @@ pub(crate) fn parse_mod_command(input: &str) -> Result<ModCommand> {
         "revoke" => parse_role_mod_command(RoleAction::RevokeMod, &rest),
         _ => anyhow::bail!("unknown mod command: {head}"),
     }
+}
+
+fn parse_bans_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    let Some(first) = parts.first().copied() else {
+        return Ok(ModCommand::Bans {
+            scope: BanListScope::All,
+            limit: DEFAULT_LIST_LIMIT,
+        });
+    };
+
+    if let Some(limit) = parse_limit(first)? {
+        if parts.len() > 1 {
+            anyhow::bail!("usage: bans [server|artboard|room #slug] [limit]");
+        }
+        return Ok(ModCommand::Bans {
+            scope: BanListScope::All,
+            limit,
+        });
+    }
+
+    match first {
+        "server" => {
+            if parts.len() > 2 {
+                anyhow::bail!("usage: bans server [limit]");
+            }
+            Ok(ModCommand::Bans {
+                scope: BanListScope::Server,
+                limit: optional_limit(parts.get(1).copied())?,
+            })
+        }
+        "artboard" => {
+            if parts.len() > 2 {
+                anyhow::bail!("usage: bans artboard [limit]");
+            }
+            Ok(ModCommand::Bans {
+                scope: BanListScope::Artboard,
+                limit: optional_limit(parts.get(1).copied())?,
+            })
+        }
+        "room" => {
+            if parts.len() > 3 {
+                anyhow::bail!("usage: bans room #slug [limit]");
+            }
+            Ok(ModCommand::Bans {
+                scope: BanListScope::Room {
+                    slug: required_slug(parts.get(1).copied(), "usage: bans room #slug [limit]")?,
+                },
+                limit: optional_limit(parts.get(2).copied())?,
+            })
+        }
+        _ => anyhow::bail!("unknown bans scope: {first}"),
+    }
+}
+
+fn parse_audit_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    if parts.len() > 1 {
+        anyhow::bail!("usage: audit [limit]");
+    }
+    Ok(ModCommand::Audit {
+        limit: optional_limit(parts.first().copied())?,
+    })
 }
 
 fn parse_room_mod_command(parts: &[&str]) -> Result<ModCommand> {
@@ -288,6 +366,26 @@ fn parse_mod_duration(value: &str) -> Result<Option<chrono::Duration>> {
     Ok(Some(duration))
 }
 
+const DEFAULT_LIST_LIMIT: i64 = 25;
+const MAX_LIST_LIMIT: i64 = 100;
+
+fn optional_limit(value: Option<&str>) -> Result<i64> {
+    let Some(value) = value else {
+        return Ok(DEFAULT_LIST_LIMIT);
+    };
+    parse_limit(value)?.ok_or_else(|| anyhow::anyhow!("limit must be a positive number"))
+}
+
+fn parse_limit(value: &str) -> Result<Option<i64>> {
+    let Ok(limit) = value.parse::<i64>() else {
+        return Ok(None);
+    };
+    if limit <= 0 {
+        anyhow::bail!("limit must be positive");
+    }
+    Ok(Some(limit.min(MAX_LIST_LIMIT)))
+}
+
 fn nonempty(value: String) -> Option<String> {
     let value = value.trim();
     (!value.is_empty()).then(|| value.to_string())
@@ -362,6 +460,8 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
         return help_lines(&[
             "help [command]",
             "user @name",
+            "bans [server|artboard|room #slug] [limit]",
+            "audit [limit]",
             "room kick #slug @name [reason...]",
             "room ban #slug @name [duration] [reason...]",
             "room unban #slug @name",
@@ -387,6 +487,25 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "user @name",
             "Shows one user's id, roles, timestamps, and active server/artboard ban flags.",
             "@name: username, with or without @.",
+        ],
+        "bans" => &[
+            "bans [server|artboard|room #slug] [limit]",
+            "Lists current active bans. Without a scope, shows server, artboard, and room bans.",
+            "limit: optional positive number; capped at 100; default 25.",
+        ],
+        "bans server" => &[
+            "bans server [limit]",
+            "Lists active server bans with actor, expiry, and reason.",
+        ],
+        "bans artboard" => &[
+            "bans artboard [limit]",
+            "Lists active artboard bans with actor, expiry, and reason.",
+        ],
+        "bans room" => &["bans room #slug [limit]", "Lists active bans for one room."],
+        "audit" => &[
+            "audit [limit]",
+            "Lists recent moderation audit log entries.",
+            "limit: optional positive number; capped at 100; default 25.",
         ],
         "room" => &[
             "room <kick|ban|unban> #slug @name",
@@ -520,12 +639,16 @@ mod tests {
     }
 
     #[test]
-    fn command_help_rejects_deferred_topics() {
+    fn command_help_explains_audit_arguments() {
         let lines = mod_help_lines(Some("audit"));
 
         assert!(
-            lines.iter().any(|line| line == "unknown help topic: audit"),
-            "audit help should be deferred: {lines:?}"
+            lines.iter().any(|line| line == "audit [limit]"),
+            "audit help should be available: {lines:?}"
+        );
+        assert!(
+            lines.iter().any(|line| line.contains("capped at 100")),
+            "audit help should explain limit bounds: {lines:?}"
         );
     }
 
@@ -603,6 +726,49 @@ mod tests {
             }
         );
         assert!(parse_mod_command("server disconnect @alice").is_err());
+    }
+
+    #[test]
+    fn parses_ban_listing_commands() {
+        assert_eq!(
+            parse_mod_command("bans").unwrap(),
+            ModCommand::Bans {
+                scope: BanListScope::All,
+                limit: DEFAULT_LIST_LIMIT,
+            }
+        );
+        assert_eq!(
+            parse_mod_command("bans room #lobby 200").unwrap(),
+            ModCommand::Bans {
+                scope: BanListScope::Room {
+                    slug: "lobby".to_string()
+                },
+                limit: MAX_LIST_LIMIT,
+            }
+        );
+        assert_eq!(
+            parse_mod_command("bans server 3").unwrap(),
+            ModCommand::Bans {
+                scope: BanListScope::Server,
+                limit: 3,
+            }
+        );
+        assert!(parse_mod_command("bans topic").is_err());
+    }
+
+    #[test]
+    fn parses_audit_listing_commands() {
+        assert_eq!(
+            parse_mod_command("audit").unwrap(),
+            ModCommand::Audit {
+                limit: DEFAULT_LIST_LIMIT,
+            }
+        );
+        assert_eq!(
+            parse_mod_command("audit 5").unwrap(),
+            ModCommand::Audit { limit: 5 }
+        );
+        assert!(parse_mod_command("audit nope").is_err());
     }
 
     #[test]

--- a/late-ssh/src/moderation/service.rs
+++ b/late-ssh/src/moderation/service.rs
@@ -3,12 +3,12 @@ use chrono::Utc;
 use late_core::{
     db::Db,
     models::{
-        artboard_ban::ArtboardBan,
+        artboard_ban::{ArtboardBan, ArtboardBanListItem},
         chat_room::ChatRoom,
         chat_room_member::ChatRoomMember,
-        moderation_audit_log::ModerationAuditLog,
-        room_ban::RoomBan,
-        server_ban::{ServerBan, ServerBanActivation},
+        moderation_audit_log::{ModerationAuditLog, ModerationAuditLogListItem},
+        room_ban::{RoomBan, RoomBanListItem},
+        server_ban::{ServerBan, ServerBanActivation, ServerBanListItem},
         user::User,
     },
 };
@@ -18,8 +18,8 @@ use uuid::Uuid;
 
 use crate::authz::{Caps, Permissions, Tier};
 use crate::moderation::command::{
-    ArtboardAction, ModCommand, RoleAction, RoomModAction, ServerUserAction, mod_help_lines,
-    normalize_mod_slug, parse_mod_command, strip_user_prefix,
+    ArtboardAction, BanListScope, ModCommand, RoleAction, RoomModAction, ServerUserAction,
+    mod_help_lines, normalize_mod_slug, parse_mod_command, strip_user_prefix,
 };
 use crate::moderation::event::ModerationEvent;
 use crate::moderation::session_effects::ModerationSessionEffects;
@@ -65,6 +65,8 @@ impl ModerationService {
         match command {
             ModCommand::Help { topic } => Ok(mod_help_lines(topic.as_deref())),
             ModCommand::User { username } => self.user_detail(permissions, &username).await,
+            ModCommand::Bans { scope, limit } => self.list_bans(permissions, scope, limit).await,
+            ModCommand::Audit { limit } => self.list_audit(permissions, limit).await,
             ModCommand::RoomAction {
                 action,
                 slug,
@@ -140,6 +142,88 @@ impl ModerationService {
             format!("server_banned: {}", server_ban.is_some()),
             format!("artboard_banned: {}", artboard_ban.is_some()),
         ])
+    }
+
+    async fn list_bans(
+        &self,
+        permissions: Permissions,
+        scope: BanListScope,
+        limit: i64,
+    ) -> Result<Vec<String>> {
+        ensure_mod_surface(permissions)?;
+        let client = self.db.get().await?;
+        match scope {
+            BanListScope::All => {
+                let server = ServerBan::active_with_usernames(&client, limit).await?;
+                let artboard = ArtboardBan::active_with_usernames(&client, limit).await?;
+                let room = RoomBan::active_with_usernames(&client, limit).await?;
+                if server.is_empty() && artboard.is_empty() && room.is_empty() {
+                    return Ok(vec!["no active bans".to_string()]);
+                }
+                let mut lines = vec![format!("active bans (limit {limit} per section)")];
+                append_section(
+                    &mut lines,
+                    "server bans",
+                    server
+                        .iter()
+                        .map(format_server_ban_item)
+                        .collect::<Vec<_>>(),
+                );
+                append_section(
+                    &mut lines,
+                    "artboard bans",
+                    artboard
+                        .iter()
+                        .map(format_artboard_ban_item)
+                        .collect::<Vec<_>>(),
+                );
+                append_section(
+                    &mut lines,
+                    "room bans",
+                    room.iter().map(format_room_ban_item).collect::<Vec<_>>(),
+                );
+                Ok(lines)
+            }
+            BanListScope::Server => {
+                let items = ServerBan::active_with_usernames(&client, limit).await?;
+                Ok(single_section(
+                    "active server bans",
+                    "no active server bans",
+                    items.iter().map(format_server_ban_item).collect(),
+                ))
+            }
+            BanListScope::Artboard => {
+                let items = ArtboardBan::active_with_usernames(&client, limit).await?;
+                Ok(single_section(
+                    "active artboard bans",
+                    "no active artboard bans",
+                    items.iter().map(format_artboard_ban_item).collect(),
+                ))
+            }
+            BanListScope::Room { slug } => {
+                let room = find_room_by_mod_slug(&client, &slug).await?;
+                let room_slug = room.slug.clone().unwrap_or_else(|| room.kind.clone());
+                let items =
+                    RoomBan::active_for_room_with_usernames(&client, room.id, limit).await?;
+                Ok(single_section(
+                    &format!("active room bans for #{room_slug}"),
+                    &format!("no active room bans for #{room_slug}"),
+                    items.iter().map(format_room_ban_item).collect(),
+                ))
+            }
+        }
+    }
+
+    async fn list_audit(&self, permissions: Permissions, limit: i64) -> Result<Vec<String>> {
+        ensure_has(permissions, Caps::VIEW_STAFF_INFO)?;
+        let client = self.db.get().await?;
+        let items = ModerationAuditLog::recent_with_usernames(&client, limit).await?;
+        if items.is_empty() {
+            return Ok(vec!["no audit log entries".to_string()]);
+        }
+        let mut lines = vec![format!("recent audit log entries (limit {limit})")];
+        lines.extend(items.iter().map(format_audit_log_item));
+        Ok(lines)
     }
 
     async fn room_action(
@@ -522,6 +606,145 @@ pub(crate) const fn cap_for_server_ban(duration: Option<chrono::Duration>) -> Ca
     } else {
         Caps::PERMA_BAN_USER
     }
+}
+
+fn single_section(title: &str, empty: &str, items: Vec<String>) -> Vec<String> {
+    if items.is_empty() {
+        vec![empty.to_string()]
+    } else {
+        let mut lines = vec![format!("{title}:")];
+        lines.extend(items);
+        lines
+    }
+}
+
+fn append_section(lines: &mut Vec<String>, title: &str, items: Vec<String>) {
+    lines.push(format!("{title}:"));
+    if items.is_empty() {
+        lines.push("- none".to_string());
+    } else {
+        lines.extend(items);
+    }
+}
+
+fn format_server_ban_item(item: &ServerBanListItem) -> String {
+    let target = item
+        .target_username
+        .as_deref()
+        .or(item.ban.snapshot_username.as_deref())
+        .map(user_label)
+        .unwrap_or_else(|| item.ban.target_user_id.to_string());
+    let actor = item
+        .actor_username
+        .as_deref()
+        .map(user_label)
+        .unwrap_or_else(|| item.ban.actor_user_id.to_string());
+    let ip = item
+        .ban
+        .ip_address
+        .as_deref()
+        .map(|ip| format!(" ip: {ip}"))
+        .unwrap_or_default();
+    format!(
+        "- {target} by {actor} expires: {}{} reason: {}",
+        format_expires_at(item.ban.expires_at),
+        ip,
+        format_reason(&item.ban.reason)
+    )
+}
+
+fn format_artboard_ban_item(item: &ArtboardBanListItem) -> String {
+    let target = item
+        .target_username
+        .as_deref()
+        .map(user_label)
+        .unwrap_or_else(|| item.ban.target_user_id.to_string());
+    let actor = item
+        .actor_username
+        .as_deref()
+        .map(user_label)
+        .unwrap_or_else(|| item.ban.actor_user_id.to_string());
+    format!(
+        "- {target} by {actor} expires: {} reason: {}",
+        format_expires_at(item.ban.expires_at),
+        format_reason(&item.ban.reason)
+    )
+}
+
+fn format_room_ban_item(item: &RoomBanListItem) -> String {
+    let room = item
+        .room_slug
+        .as_deref()
+        .map(|slug| format!("#{slug}"))
+        .unwrap_or_else(|| item.ban.room_id.to_string());
+    let target = item
+        .target_username
+        .as_deref()
+        .map(user_label)
+        .unwrap_or_else(|| item.ban.target_user_id.to_string());
+    let actor = item
+        .actor_username
+        .as_deref()
+        .map(user_label)
+        .unwrap_or_else(|| item.ban.actor_user_id.to_string());
+    format!(
+        "- {room} {target} by {actor} expires: {} reason: {}",
+        format_expires_at(item.ban.expires_at),
+        format_reason(&item.ban.reason)
+    )
+}
+
+fn format_audit_log_item(item: &ModerationAuditLogListItem) -> String {
+    let actor = item
+        .actor_username
+        .as_deref()
+        .map(user_label)
+        .unwrap_or_else(|| item.log.actor_user_id.to_string());
+    let target = if item.log.target_kind == "user" {
+        item.target_username
+            .as_deref()
+            .map(user_label)
+            .or_else(|| item.log.target_id.map(|id| id.to_string()))
+            .unwrap_or_else(|| "none".to_string())
+    } else {
+        item.log
+            .target_id
+            .map(|id| format!("{}:{id}", item.log.target_kind))
+            .unwrap_or_else(|| item.log.target_kind.clone())
+    };
+    let metadata = if item
+        .log
+        .metadata
+        .as_object()
+        .is_some_and(|map| map.is_empty())
+    {
+        String::new()
+    } else {
+        format!(" metadata: {}", item.log.metadata)
+    };
+    format!(
+        "- {} {actor} {} target: {target}{metadata}",
+        item.log.created.format("%Y-%m-%d %H:%M UTC"),
+        item.log.action
+    )
+}
+
+fn format_expires_at(expires_at: Option<chrono::DateTime<Utc>>) -> String {
+    expires_at
+        .map(|expires_at| expires_at.format("%Y-%m-%d %H:%M UTC").to_string())
+        .unwrap_or_else(|| "permanent".to_string())
+}
+
+fn format_reason(reason: &str) -> &str {
+    if reason.trim().is_empty() {
+        "-"
+    } else {
+        reason.trim()
+    }
+}
+
+fn user_label(username: &str) -> String {
+    format!("@{username}")
 }
 
 async fn find_user_by_mod_name(client: &tokio_postgres::Client, username: &str) -> Result<User> {

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -553,8 +553,12 @@ async fn chat_reaction_leader_uses_digits_without_switching_screens() {
     .await;
     let plain = render_plain(&mut app);
     assert!(
-        plain.contains("Type a message · j/k select"),
-        "message selection should clear after reacting: {plain:?}"
+        plain.contains("▸reaction target"),
+        "message selection should stay after reacting: {plain:?}"
+    );
+    assert!(
+        !plain.contains("1 👍"),
+        "reaction picker should close after reacting: {plain:?}"
     );
 }
 

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -1864,6 +1864,165 @@ async fn mod_artboard_ban_command_notifies_active_sessions() {
 }
 
 #[tokio::test]
+async fn mod_bans_command_lists_active_bans() {
+    let test_db = new_test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let service = ChatService::new(
+        test_db.db.clone(),
+        NotificationService::new(test_db.db.clone()),
+    );
+    let mut events = service.subscribe_events();
+
+    let actor = create_test_user(&test_db.db, "list_bans_actor").await;
+    let server_target = create_test_user(&test_db.db, "list_server_target").await;
+    let artboard_target = create_test_user(&test_db.db, "list_artboard_target").await;
+    let room_target = create_test_user(&test_db.db, "list_room_target").await;
+    let room = ChatRoom::get_or_create_public_room(&client, "list-bans-room")
+        .await
+        .expect("create room");
+
+    for command in [
+        "server ban @list_server_target 1h server reason",
+        "artboard ban @list_artboard_target 1h art reason",
+        "room ban #list-bans-room @list_room_target 1h room reason",
+    ] {
+        service.run_mod_command_task(
+            actor.id,
+            Permissions::new(false, true),
+            Uuid::now_v7(),
+            command.to_string(),
+        );
+        let event = timeout(Duration::from_secs(2), events.recv())
+            .await
+            .expect("event timeout")
+            .expect("event");
+        assert!(matches!(
+            event,
+            ChatEvent::ModCommandOutput { success: true, .. }
+        ));
+    }
+
+    let request_id = Uuid::now_v7();
+    service.run_mod_command_task(
+        actor.id,
+        Permissions::new(false, true),
+        request_id,
+        "bans 10".to_string(),
+    );
+
+    let event = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("event timeout")
+        .expect("event");
+    match event {
+        ChatEvent::ModCommandOutput {
+            request_id: got_request,
+            lines,
+            success,
+            ..
+        } => {
+            assert_eq!(got_request, request_id);
+            assert!(success, "unexpected mod command failure: {lines:?}");
+            assert!(lines.iter().any(|line| line == "server bans:"));
+            assert!(
+                lines
+                    .iter()
+                    .any(|line| line.contains("@list_server_target"))
+            );
+            assert!(lines.iter().any(|line| line == "artboard bans:"));
+            assert!(
+                lines
+                    .iter()
+                    .any(|line| line.contains("@list_artboard_target"))
+            );
+            assert!(lines.iter().any(|line| line == "room bans:"));
+            assert!(lines.iter().any(|line| line.contains("#list-bans-room")));
+            assert!(lines.iter().any(|line| line.contains("@list_room_target")));
+        }
+        other => panic!("expected ModCommandOutput, got {other:?}"),
+    }
+
+    assert!(
+        RoomBan::is_active_for_room_and_user(&client, room.id, room_target.id)
+            .await
+            .expect("room ban lookup")
+    );
+    assert!(
+        ServerBan::find_active_for_user_id(&client, server_target.id)
+            .await
+            .expect("server ban lookup")
+            .is_some()
+    );
+    assert!(
+        ArtboardBan::is_active_for_user(&client, artboard_target.id)
+            .await
+            .expect("artboard ban lookup")
+    );
+}
+
+#[tokio::test]
+async fn mod_audit_command_lists_recent_audit_entries() {
+    let test_db = new_test_db().await;
+    let service = ChatService::new(
+        test_db.db.clone(),
+        NotificationService::new(test_db.db.clone()),
+    );
+    let mut events = service.subscribe_events();
+
+    let actor = create_test_user(&test_db.db, "list_audit_actor").await;
+    let _target = create_test_user(&test_db.db, "list_audit_target").await;
+
+    service.run_mod_command_task(
+        actor.id,
+        Permissions::new(false, true),
+        Uuid::now_v7(),
+        "server kick @list_audit_target audit reason".to_string(),
+    );
+    let event = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("event timeout")
+        .expect("event");
+    assert!(matches!(
+        event,
+        ChatEvent::ModCommandOutput { success: true, .. }
+    ));
+
+    let request_id = Uuid::now_v7();
+    service.run_mod_command_task(
+        actor.id,
+        Permissions::new(false, true),
+        request_id,
+        "audit 5".to_string(),
+    );
+
+    let event = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("event timeout")
+        .expect("event");
+    match event {
+        ChatEvent::ModCommandOutput {
+            request_id: got_request,
+            lines,
+            success,
+            ..
+        } => {
+            assert_eq!(got_request, request_id);
+            assert!(success, "unexpected mod command failure: {lines:?}");
+            assert!(
+                lines
+                    .iter()
+                    .any(|line| line == "recent audit log entries (limit 5)")
+            );
+            assert!(lines.iter().any(|line| line.contains("@list_audit_actor")
+                && line.contains("server_kick")
+                && line.contains("@list_audit_target")
+                && line.contains("audit reason")));
+        }
+        other => panic!("expected ModCommandOutput, got {other:?}"),
+    }
+}
+
+#[tokio::test]
 async fn mod_room_ban_command_notifies_target_sessions_to_drop_room() {
     let test_db = new_test_db().await;
     let client = test_db.db.get().await.expect("db client");


### PR DESCRIPTION
## Summary
- Gives moderators an in-chat way to inspect active server, artboard, and room bans without leaving the moderation modal.
- Adds a recent audit log view so staff can verify moderation actions and context from the SSH chat surface.
- Fixes a few chat interaction rough edges around unread clearing, reaction selection, and profile metadata layout.

## What changed
- Added `/mod bans` with optional scopes for `server`, `artboard`, and `room #slug`, plus optional list limits.
- Added `/mod audit` to show recent moderation audit entries with actor, action, target, and metadata.
- Updated moderation help and chat context docs for the new commands.
- Preserved selected message focus after toggling a reaction while still closing the reaction picker.
- Re-runs read/list side effects when re-selecting synthetic feeds or the current room so stale unread badges clear.
- Adjusted the profile modal late-fetch strip from three cramped columns to two columns across three rows.

## Behavior notes
- Moderation list limits default to `25` and are capped at `100`.
- Active ban listings only include non-expired bans.
- Audit listing requires staff-info visibility; ban listing requires moderation surface access.

## Feature flags
None.

## Screenshots / Video
UI-visible terminal changes are included. Screenshots or video still need to be attached before review.

## Testing
Automated:
- Added parser coverage for `bans` and `audit` moderation commands and help text.
- Added chat service coverage for listing active bans and recent audit entries.
- Updated input-flow coverage for reaction picker behavior.

Manual:
- Not documented in the diff.