### PR TITLE
Fix OpenSSH control socket path overflow on macOS

### DIFF
--- a/late-cli/src/ssh.rs
+++ b/late-cli/src/ssh.rs
@@ -363,7 +363,7 @@ fn create_openssh_control_dir() -> Result<PathBuf> {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
-        .as_nanos();
+        .as_secs();
 
     for attempt in 0..100 {
         let dir = base.join(format!("late-ssh-{}-{now}-{attempt}", std::process::id()));


### PR DESCRIPTION
# Summary

`--ssh-mode openssh` is unusable on macOS: the multiplex control socket
path overruns `sockaddr_un.sun_path` (104 bytes on macOS) and the master
exits before it can be connected to, with this output:

```
unix_listener: path "/var/folders/ry/<...>/T/late-ssh-<pid>-<nanos>-0/ctl.<random>" too long for Unix domain socket
Control socket connect(/var/folders/ry/<...>/T/late-ssh-<pid>-<nanos>-0/ctl): No such file or directory
Error: OpenSSH control master exited with status exit status: 255
```

This blocks YubiKey / hardware-backed key users on macOS, since `openssh`
mode is the only mode that supports them.

## Root cause

The control-socket directory name embeds a timestamp computed via
`.as_nanos()` — 19 digits. macOS's per-user TMPDIR
(`/var/folders/<2-char>/<30-char>/T/`) is also long, so the resulting
path adds up:

```
/var/folders/<2>/<30>/T/                          ~49
late-ssh-<pid>-<nanos-19>-<attempt>/              ~37
ctl                                                  3
.<17-char OpenSSH random suffix>                    17
                                                  ----
                                                  ~106  >  104  → overflow
```

Linux is unaffected: `XDG_RUNTIME_DIR` is typically `/run/user/<uid>`
(13 chars) on a desktop, and `/tmp` (4 chars) easily fits.

## Fix

Switch the timestamp from `.as_nanos()` (19 digits) to `.as_secs()`
(10 digits). 9 bytes saved is enough to bring the macOS path under the
limit with ~5 bytes of headroom in the worst case:

```
/var/folders/<2>/<30>/T/late-ssh-<pid-5>-<secs-11>-<attempt-2>/ctl.<suffix-17>
       48        +  1 + 9 + 5+1 + 11 +1 + 2  + 1 + 3 +    17    = 99 chars
```

Uniqueness is already provided by the PID component and the existing
100-attempt retry loop, so seconds-resolution is sufficient — two
concurrent processes have different PIDs by kernel guarantee, and
same-second sequential runs that happen to collide on the directory name
fall through to `attempt=1` automatically.

## Test plan

- [x] `cargo fmt -p late-cli --check`
- [x] `cargo clippy -p late-cli --all-targets -- -D warnings`
- [x] `cargo test -p late-cli --bin late` — 36 passed
- [x] `make check` — 919 tests passed, 0 skipped
- [x] Manual on macOS: `cargo run -p late-cli --bin late -- --ssh-mode openssh` no longer fails with `unix_listener: path ... too long`. Auth proceeds and the control socket is created without overflow.

The change is a single-character timestamp-resolution swap, so no new
unit test was added — happy to add a worst-case path-budget regression
test if you'd like one as a safety net for future format changes.