### PR TITLE
Fix web pairing URL

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1066,7 +1066,7 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `↑` / `↓` / `j` / `k` | Settings modal | Move between rows (Username, IDE, Terminal, OS, Langs, Theme, Background, Right sidebar, Games sidebar, Country, Timezone, DMs, @mentions, Game events, Bell, Cooldown, Format) |
 | `←` / `→` | Settings modal | Cycle the current row's setting (theme, toggles, cooldown, notification format) |
 | `Space` / `Enter` / `e` | Settings modal | Activate row — edit username/system fields/bio, cycle a setting, or open the country/timezone picker |
-| `Alt+Enter` | Settings modal (bio editing) | Insert newline |
+| `Alt+Enter` / `Ctrl+J` | Settings modal (bio editing) | Insert newline |
 | `?` | Settings modal | Open help modal on top |
 | `j` / `k` / `↑` / `↓` | Read-only profile modal | Scroll |
 | `Esc` / `q` | Read-only profile modal | Close |

--- a/infra/service-web.tf
+++ b/infra/service-web.tf
@@ -88,7 +88,7 @@ resource "kubernetes_deployment_v1" "service_web" {
           }
           env {
             name  = "LATE_SSH_PUBLIC_URL"
-            value = "https://api.${var.DOMAIN}"
+            value = "api.${var.DOMAIN}"
           }
           env {
             name  = "LATE_AUDIO_URL"

--- a/late-ssh/src/app/chat/showcase/ui.rs
+++ b/late-ssh/src/app/chat/showcase/ui.rs
@@ -227,9 +227,9 @@ pub fn draw_showcase_composer(frame: &mut Frame, area: Rect, view: &ShowcaseComp
     let title = if !composing {
         " Showcase "
     } else if editing {
-        " Editing · Tab/S+Tab switch · Enter submit · Alt+Enter newline · Esc cancel "
+        " Editing · Tab/S+Tab switch · Enter submit · Alt+Enter/Ctrl+J newline · Esc cancel "
     } else {
-        " New showcase · Tab/S+Tab switch · Enter submit · Alt+Enter newline · Esc cancel "
+        " New showcase · Tab/S+Tab switch · Enter submit · Alt+Enter/Ctrl+J newline · Esc cancel "
     };
     let border_style = if composing {
         Style::default().fg(theme::BORDER_ACTIVE())

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -120,9 +120,11 @@ fn composer_title(view: &ComposerBlockView<'_>, block_width: u16) -> String {
     }
 
     if let Some(author) = view.reply_author {
-        let long =
-            format!(" Reply to @{author} (Enter send, Alt+S stay, Alt+Enter newline, Esc cancel) ");
-        let mid = format!(" Reply to @{author} (⏎ send, Alt+S stay, Alt+⏎ newline, Esc cancel) ");
+        let long = format!(
+            " Reply to @{author} (Enter send, Alt+S stay, Alt+Enter/Ctrl+J newline, Esc cancel) "
+        );
+        let mid =
+            format!(" Reply to @{author} (⏎ send, Alt+S stay, Alt+⏎/Ctrl+J newline, Esc cancel) ");
         let short = format!(" Reply to @{author} (⏎ send, Esc cancel) ");
         let minimal = format!(" Reply to @{author} (Esc) ");
         let name_only = format!(" Reply to @{author} ");
@@ -146,8 +148,8 @@ fn composer_title(view: &ComposerBlockView<'_>, block_width: u16) -> String {
         return pick_title_that_fits(
             block_width,
             &[
-                " Edit message (Enter save, Alt+S stay, Alt+Enter newline, Esc cancel) ",
-                " Edit message (⏎ save, Alt+S stay, Alt+⏎ newline, Esc cancel) ",
+                " Edit message (Enter save, Alt+S stay, Alt+Enter/Ctrl+J newline, Esc cancel) ",
+                " Edit message (⏎ save, Alt+S stay, Alt+⏎/Ctrl+J newline, Esc cancel) ",
                 " Edit message (⏎ save, Esc cancel) ",
                 " Edit message (Esc) ",
                 " Edit message ",
@@ -162,9 +164,9 @@ fn composer_title(view: &ComposerBlockView<'_>, block_width: u16) -> String {
     pick_title_that_fits(
         block_width,
         &[
-            " Compose (Enter send, Alt+S stay, Alt+Enter newline, Esc cancel) ",
-            " (Enter send, Alt+S stay, Alt+Enter newline, Esc cancel) ",
-            " (⏎ send, Alt+S stay, Alt+⏎ newline, Esc cancel) ",
+            " Compose (Enter send, Alt+S stay, Alt+Enter/Ctrl+J newline, Esc cancel) ",
+            " (Enter send, Alt+S stay, Alt+Enter/Ctrl+J newline, Esc cancel) ",
+            " (⏎ send, Alt+S stay, Alt+⏎/Ctrl+J newline, Esc cancel) ",
             " (⏎ send, Esc cancel) ",
             " (Esc cancel) ",
             " Esc ",
@@ -1672,9 +1674,9 @@ mod tests {
     fn composer_title_collapses_across_block_widths() {
         let ta = TextArea::default();
         let view = composer_view(&ta);
-        let full = " Compose (Enter send, Alt+S stay, Alt+Enter newline, Esc cancel) ";
-        let long = " (Enter send, Alt+S stay, Alt+Enter newline, Esc cancel) ";
-        let short = " (⏎ send, Alt+S stay, Alt+⏎ newline, Esc cancel) ";
+        let full = " Compose (Enter send, Alt+S stay, Alt+Enter/Ctrl+J newline, Esc cancel) ";
+        let long = " (Enter send, Alt+S stay, Alt+Enter/Ctrl+J newline, Esc cancel) ";
+        let short = " (⏎ send, Alt+S stay, Alt+⏎/Ctrl+J newline, Esc cancel) ";
         let minimal = " (⏎ send, Esc cancel) ";
         let cancel = " (Esc cancel) ";
         let esc = " Esc ";
@@ -1728,7 +1730,7 @@ mod tests {
         view.reply_author = Some("alice");
         assert_eq!(
             composer_title(&view, 100),
-            " Reply to @alice (Enter send, Alt+S stay, Alt+Enter newline, Esc cancel) "
+            " Reply to @alice (Enter send, Alt+S stay, Alt+Enter/Ctrl+J newline, Esc cancel) "
         );
         // Far too narrow for even the shortest reply form → drops to " Reply ".
         // " Reply " = 7 cols → needs block_w ≥ 9.

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -195,7 +195,7 @@ pub fn chat_help_lines() -> Vec<String> {
         "  Composer fields    title (≤120) · url · tags (comma-sep, ≤8) · description (≤800)",
         "  Tab / Shift+Tab    cycle composer fields",
         "  Enter              submit",
-        "  Alt+Enter          newline (description only)",
+        "  Alt+Enter / Ctrl+J newline (description only)",
         "  Esc                cancel compose",
     ]
     .into_iter()

--- a/late-ssh/src/app/settings_modal/ui.rs
+++ b/late-ssh/src/app/settings_modal/ui.rs
@@ -85,7 +85,7 @@ fn draw_footer(frame: &mut Frame, area: Rect, tab: Tab, editing_bio: bool) {
             spans.extend([
                 Span::styled("Esc", Style::default().fg(theme::AMBER_DIM())),
                 Span::styled(" save & preview  ", Style::default().fg(theme::TEXT_DIM())),
-                Span::styled("Alt+Enter", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled("Alt+Enter/Ctrl+J", Style::default().fg(theme::AMBER_DIM())),
                 Span::styled(" newline  ", Style::default().fg(theme::TEXT_DIM())),
                 Span::styled("Tab/S+Tab", Style::default().fg(theme::AMBER_DIM())),
                 Span::styled(

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -42,7 +42,7 @@ async fn dashboard_chat_compose_blocks_quit_shortcut() {
     app.handle_input(b"i");
     wait_for_render_contains(
         &mut app,
-        "Compose (Enter send, Alt+S stay, Alt+Enter newline, Esc cancel)",
+        "Compose (Enter send, Alt+S stay, Alt+Enter/Ctrl+J newline, Esc cancel)",
     )
     .await;
 
@@ -413,7 +413,7 @@ async fn chat_compose_treats_screen_hotkeys_as_text() {
     wait_for_render_contains(&mut app, "2hey").await;
     wait_for_render_contains(
         &mut app,
-        "Compose (Enter send, Alt+S stay, Alt+Enter newline, Esc cancel)",
+        "Compose (Enter send, Alt+S stay, Alt+Enter/Ctrl+J newline, Esc cancel)",
     )
     .await;
 

--- a/late-web/src/pages/connect/page.html
+++ b/late-web/src/pages/connect/page.html
@@ -149,7 +149,7 @@
                 }
 
                 const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-                const wsUrl = `${protocol}//${this.apiUrl.replace(/^https?:\/\//, '')}/api/ws/pair?token=${this.token}`;
+                const wsUrl = `${protocol}//${this.apiUrl}/api/ws/pair?token=${this.token}`;
 
                 this.ws = new WebSocket(wsUrl);
 

--- a/late-web/src/pages/connect/page.html
+++ b/late-web/src/pages/connect/page.html
@@ -149,7 +149,7 @@
                 }
 
                 const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
-                const wsUrl = `${protocol}//${this.apiUrl}/api/ws/pair?token=${this.token}`;
+                const wsUrl = `${protocol}//${this.apiUrl.replace(/^https?:\/\//, '')}/api/ws/pair?token=${this.token}`;
 
                 this.ws = new WebSocket(wsUrl);
 


### PR DESCRIPTION
The API URL was updated to include `https://` in commit 4e3eeb65406289ebc1f309af684e671e45074958, but the web player was not updated to strip it out when connecting to the websocket. This results in a `NS_ERROR_UNKNOWN_HOST` error as it tries to connect to `wss://https//api.late.sh/api/ws/pair?token=secret`.

This patch simply strips out the added prefix. Tested successfully using an overrides script on the live website, as the bug does not apply to localhost.

<img width="1916" height="1042" alt="image" src="https://github.com/user-attachments/assets/064ab371-0c63-44c4-815d-a4d49c6b631e" />

Note: this might need to be applied to `chat/page.html` as well. I did not include it in this PR as I could not tell if it is still in use or not.
https://github.com/mpiorowski/late-sh/blob/2bfd5703f4f07c95ea3a9c2f048d69bfe032fe15/late-web/src/pages/chat/page.html#L107 
