### PR TITLE
Allow B/P audio keyboard shortcuts on screen 2

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1044,8 +1044,8 @@ Toast notification is hidden by default (0 rows). When active, it appears as a 3
 | `?` | Bonsai modal | Open help modal on the Bonsai section |
 | `L` / `C` / `A` / `Z` | Dashboard | Vote genre |
 | `b` then `1` / `2` / `3` / `4` | Dashboard | Activate a dashboard chord: Blackjack room, current daily game, current News wire article, or `#announcements` |
-| `P` | Dashboard | Show browser-pairing QR (copies pairing URL) |
-| `B` | Dashboard | Open CLI install/build-source modal |
+| `P` | Dashboard / Chat | Show browser-pairing QR (copies pairing URL) |
+| `B` | Dashboard / Chat | Open CLI install/build-source modal |
 | Dashboard chat keys | Dashboard | See `late-ssh/src/app/chat/CONTEXT.md`. |
 | `Enter` | Games lobby | Launch selected game |
 | `Esc` | Active game | Exit back to Arcade lobby |

--- a/late-cli/CONTEXT.md
+++ b/late-cli/CONTEXT.md
@@ -385,8 +385,8 @@ Relevant TUI controls:
 - `m`: toggle mute on paired client
 - `+` / `=`: volume up on paired client
 - `-` / `_`: volume down on paired client
-- `P`: dashboard browser-pairing QR
-- `B`: dashboard CLI install/build-source modal
+- `P`: dashboard/chat browser-pairing QR
+- `B`: dashboard/chat CLI install/build-source modal
 
 ---
 

--- a/late-ssh/src/app/common/sidebar.rs
+++ b/late-ssh/src/app/common/sidebar.rs
@@ -20,6 +20,7 @@ pub struct SidebarProps<'a> {
     pub game_selection: usize,
     pub is_playing_game: bool,
     pub visualizer: &'a Visualizer,
+    pub show_audio_shortcuts: bool,
     pub now_playing: Option<&'a NowPlaying>,
     pub paired_client: Option<&'a ClientAudioState>,
     pub online_count: usize,
@@ -45,7 +46,7 @@ pub fn draw_sidebar(frame: &mut Frame, area: Rect, props: &SidebarProps<'_>) {
     .split(area);
 
     draw_clock_card(frame, layout[0], props.clock_text);
-    visualizer.render(frame, layout[1]);
+    visualizer.render(frame, layout[1], props.show_audio_shortcuts);
     draw_now_playing(frame, layout[2], now_playing, paired_client);
     draw_status(frame, layout[3], online_count, props.activity);
     crate::app::bonsai::ui::draw_bonsai(frame, layout[4], props.bonsai, props.audio_beat);

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -244,7 +244,7 @@ fn overview_lines() -> Vec<String> {
         "  m                 mute paired client",
         "  + / -             paired client volume",
         "",
-        "Dashboard",
+        "Dashboard / Chat",
         "  P                 show browser pairing QR",
         "  B                 open CLI install / BUILD SOURCE modal",
         "",
@@ -544,7 +544,7 @@ Don't trust the install script? Build from source:
 
 Option 2: Browser pairing
 
-On the Dashboard, press `P` to open a QR code + copy the pairing URL. The browser connects to your session via a token-based WebSocket, streams audio, and feeds visualizer frames back to the sidebar.
+On the Dashboard or Chat screen, press `P` to open a QR code + copy the pairing URL. The browser connects to your session via a token-based WebSocket, streams audio, and feeds visualizer frames back to the sidebar.
 
 Both options give you:
   m = mute | +/- = volume | visualizer in the sidebar

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -1512,6 +1512,24 @@ fn handle_global_key(app: &mut App, ctx: InputContext, byte: u8) -> bool {
     }
 
     match byte {
+        b'B' if matches!(ctx.screen, Screen::Dashboard | Screen::Chat)
+            && !ctx.chat_composing
+            && !ctx.news_composing
+            && !ctx.showcase_composing
+            && !ctx.work_composing =>
+        {
+            dashboard::input::open_cli_install_modal(app);
+            true
+        }
+        b'P' if matches!(ctx.screen, Screen::Dashboard | Screen::Chat)
+            && !ctx.chat_composing
+            && !ctx.news_composing
+            && !ctx.showcase_composing
+            && !ctx.work_composing =>
+        {
+            dashboard::input::open_browser_pairing_qr(app);
+            true
+        }
         b'q' | b'Q' => {
             if ctx.screen == Screen::Artboard
                 && app

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -714,6 +714,7 @@ impl App {
                     game_selection: ctx.game_selection,
                     is_playing_game: ctx.is_playing_game,
                     visualizer: ctx.visualizer,
+                    show_audio_shortcuts: matches!(screen, Screen::Dashboard | Screen::Chat),
                     now_playing: ctx.now_playing,
                     paired_client: ctx.paired_client,
                     online_count: ctx.online_count,

--- a/late-ssh/src/app/visualizer.rs
+++ b/late-ssh/src/app/visualizer.rs
@@ -67,7 +67,7 @@ impl Visualizer {
         self.beat = (self.beat * 0.9).max(0.0);
     }
 
-    pub fn render(&self, frame: &mut Frame, area: Rect) {
+    pub fn render(&self, frame: &mut Frame, area: Rect, show_audio_shortcuts: bool) {
         let border = if self.has_viz {
             theme::BORDER_ACTIVE()
         } else {
@@ -88,7 +88,7 @@ impl Visualizer {
         if !self.has_viz {
             let dim = Style::default().fg(theme::TEXT_DIM());
             let key = Style::default().fg(theme::AMBER());
-            let lines = vec![
+            let mut lines = vec![
                 Line::from(""),
                 Line::from(Span::styled("No audio paired", dim)),
                 Line::from(""),
@@ -97,15 +97,19 @@ impl Visualizer {
                     Span::styled("/music", key),
                     Span::styled(" in chat", dim),
                 ]),
-                Line::from(""),
-                Line::from(Span::styled("On dashboard:", dim)),
-                Line::from(vec![
-                    Span::styled("B", key),
-                    Span::styled(" cli  ", dim),
-                    Span::styled("P", key),
-                    Span::styled(" web", dim),
-                ]),
             ];
+            if show_audio_shortcuts {
+                lines.extend([
+                    Line::from(""),
+                    Line::from(Span::styled("Dashboard/chat:", dim)),
+                    Line::from(vec![
+                        Span::styled("B", key),
+                        Span::styled(" cli  ", dim),
+                        Span::styled("P", key),
+                        Span::styled(" web", dim),
+                    ]),
+                ]);
+            }
             frame.render_widget(Paragraph::new(lines), inner);
             return;
         }
@@ -203,6 +207,48 @@ impl Visualizer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn render_disconnected(show_audio_shortcuts: bool) -> String {
+        let width = 24;
+        let height = 10;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let viz = Visualizer::new();
+
+        terminal
+            .draw(|frame| viz.render(frame, Rect::new(0, 0, width, height), show_audio_shortcuts))
+            .expect("draw");
+
+        let buffer = terminal.backend().buffer();
+        let mut rendered = String::new();
+        for y in 0..height {
+            for x in 0..width {
+                rendered.push_str(buffer[(x, y)].symbol());
+            }
+            rendered.push('\n');
+        }
+        rendered
+    }
+
+    #[test]
+    fn disconnected_visualizer_can_show_audio_shortcuts() {
+        let rendered = render_disconnected(true);
+
+        assert!(rendered.contains("Dashboard/chat:"));
+        assert!(rendered.contains("B cli"));
+        assert!(rendered.contains("P web"));
+    }
+
+    #[test]
+    fn disconnected_visualizer_can_hide_audio_shortcuts() {
+        let rendered = render_disconnected(false);
+
+        assert!(rendered.contains("No audio paired"));
+        assert!(!rendered.contains("Dashboard/chat:"));
+        assert!(!rendered.contains("B cli"));
+        assert!(!rendered.contains("P web"));
+    }
 
     #[test]
     fn resample_same_size() {

--- a/late-ssh/tests/app_dashboard_flow.rs
+++ b/late-ssh/tests/app_dashboard_flow.rs
@@ -40,6 +40,16 @@ async fn uppercase_b_on_dashboard_opens_cli_install_modal() {
 }
 
 #[tokio::test]
+async fn uppercase_b_opens_cli_install_modal_on_chat() {
+    let (_test_db, mut app) = make_app_harness().await;
+
+    app.handle_input(b"2");
+    wait_for_render_contains(&mut app, " Chat ").await;
+    app.handle_input(b"B");
+    wait_for_render_contains(&mut app, "build from source").await;
+}
+
+#[tokio::test]
 async fn mouse_move_does_not_close_cli_install_modal() {
     let (_test_db, mut app) = make_app_harness().await;
 
@@ -54,16 +64,14 @@ async fn mouse_move_does_not_close_cli_install_modal() {
 }
 
 #[tokio::test]
-async fn uppercase_p_only_opens_pairing_qr_on_dashboard() {
+async fn uppercase_p_opens_pairing_qr_on_dashboard_and_chat() {
     let (_test_db, mut app) = make_app_harness().await;
 
     app.handle_input(b"2");
     wait_for_render_contains(&mut app, " Chat ").await;
     app.handle_input(b"P");
-    assert!(
-        !render_plain(&mut app).contains("Scan to pair audio"),
-        "uppercase P should not open the pairing QR outside Dashboard"
-    );
+    wait_for_render_contains(&mut app, "Scan to pair audio").await;
+    app.handle_input(b"x");
 
     app.handle_input(b"1");
     wait_for_render_contains(&mut app, " Dashboard ").await;


### PR DESCRIPTION
Since visualizer hints B/P on screen 2, enable them there.

Decided to hide visualizer B/P keyboard hints on screen 3-5 where they don't work and might conflict

And update help docs and regression tests