### PR TITLE
Add Poker Game Rooms

### DIFF
--- a/GAMES.md
+++ b/GAMES.md
@@ -2,7 +2,7 @@
 
 This guide is for contributors who want to add a new multiplayer game room to
 late.sh. By the end you should know what to write, where it lives, and which
-patterns the existing games (Blackjack, Tic-Tac-Toe) already prove out.
+patterns the existing games (Blackjack, Poker, Tic-Tac-Toe) already prove out.
 
 If anything here disagrees with the code, trust the code and please open a PR
 to fix this file.
@@ -26,6 +26,8 @@ game's own runtime. You will not touch the rooms layer.
 Live reference implementations:
 
 - `late-ssh/src/app/rooms/tictactoe/` — minimal example, ~6 small files
+- `late-ssh/src/app/rooms/poker/` — asymmetric-info example with public table
+  state plus per-user private hole-card state
 - `late-ssh/src/app/rooms/blackjack/` — complex example with chips, settlements,
   AFK timer
 - `late-ssh/src/app/rooms/CONTEXT.md` — internal architecture notes
@@ -302,12 +304,12 @@ re-validates against the truth under the lock. Be defensive in `SharedState`
 methods: turn checks, occupancy checks, "are you actually seated" checks.
 Stale-cache races are normal and harmless if you validate.
 
-### Asymmetric-info games (poker-style)
+### Asymmetric-info games
 
-The current pattern publishes the same snapshot to all sessions. Games like
-poker, where each player sees a different view (own hole cards visible,
-others' hidden), are supported by the existing trait surface without changes.
-See the "Future: Asymmetric-Info Games" section in
+Most simple games publish the same snapshot to all sessions. Poker now proves
+the pattern for games where each player sees a different view (own hole cards
+visible, others' hidden), without changing the room trait surface. See the
+"Asymmetric-Info Game Pattern" section in
 `late-ssh/src/app/rooms/CONTEXT.md` for the recommended split-channel pattern.
 
 Short version: one `watch::Sender<PublicSnapshot>` plus a

--- a/late-core/src/models/game_room.rs
+++ b/late-core/src/models/game_room.rs
@@ -8,15 +8,17 @@ use uuid::Uuid;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum GameKind {
     Blackjack,
+    Poker,
     TicTacToe,
 }
 
 impl GameKind {
-    pub const ALL: [Self; 2] = [Self::Blackjack, Self::TicTacToe];
+    pub const ALL: [Self; 3] = [Self::Blackjack, Self::Poker, Self::TicTacToe];
 
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Blackjack => "blackjack",
+            Self::Poker => "poker",
             Self::TicTacToe => "tictactoe",
         }
     }
@@ -34,6 +36,7 @@ impl TryFrom<&str> for GameKind {
     fn try_from(value: &str) -> Result<Self, Self::Error> {
         match value {
             "blackjack" => Ok(Self::Blackjack),
+            "poker" => Ok(Self::Poker),
             "tictactoe" => Ok(Self::TicTacToe),
             _ => Err(anyhow::anyhow!("unknown game kind: {}", value)),
         }

--- a/late-ssh/src/app/rooms/CONTEXT.md
+++ b/late-ssh/src/app/rooms/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Scope: `late-ssh/src/app/rooms`
-- Last updated: 2026-05-06
+- Last updated: 2026-05-07
 - Purpose: local working context for the persistent game-room directory and trait-backed room game runtimes.
 
 ## Source Map
@@ -54,9 +54,9 @@
 - Create/search input limits: room name max 48 chars, search query max 32 chars, default create names come from `RoomGameRegistry`, and pasted text is passed through paste-marker sanitization.
 
 ## Access Policy
-- Room creation is open to every user. The 3-non-closed-tables-per-creator-per-game-kind cap is enforced server-side in `RoomsService::create_game_room`; over-cap attempts surface to the client via `RoomsEvent::Error` (banner). There is no client-side `can_create_room` gate anymore.
+- Room creation is open to every user for Blackjack and Tic-Tac-Toe. Poker creation is admin/moderator-only through `input.rs::can_create_room`. The 3-non-closed-tables-per-creator-per-game-kind cap is enforced server-side in `RoomsService::create_game_room`; over-cap attempts surface to the client via `RoomsEvent::Error` (banner).
 - Room deletion is admin-only in `input.rs` (`can_delete_room`).
-- Room entry is currently open to every user: `can_enter_room` returns `true` for admin, mod, and ordinary users. Older root-context notes that only admins/mods can enter are stale.
+- Room entry is open to every user for Blackjack and Tic-Tac-Toe. Poker entry is admin/moderator-only through `input.rs::can_enter_room`.
 - Create modal lets any user pick a real game kind. Blackjack-specific pace/stake fields render only when Blackjack is selected; Poker and Tic-Tac-Toe use empty JSON settings.
 
 ## Active Room and Chat

--- a/late-ssh/src/app/rooms/CONTEXT.md
+++ b/late-ssh/src/app/rooms/CONTEXT.md
@@ -2,13 +2,13 @@
 
 ## Metadata
 - Scope: `late-ssh/src/app/rooms`
-- Last updated: 2026-05-05
+- Last updated: 2026-05-06
 - Purpose: local working context for the persistent game-room directory and trait-backed room game runtimes.
 
 ## Source Map
 - `mod.rs` only declares modules. Keep it declaration-only; do not add `pub use` re-exports.
 - `backend.rs` defines the room-game traits: `RoomGameManager` for static/table-manager behavior and `ActiveRoomBackend` for per-session active-room behavior.
-- `registry.rs` owns the process-local `RoomGameRegistry` and dispatches `GameKind` to Blackjack/Tic-Tac-Toe managers.
+- `registry.rs` owns the process-local `RoomGameRegistry` and dispatches `GameKind` to Blackjack/Poker/Tic-Tac-Toe managers.
 - `svc.rs` owns persistent room creation/listing/deletion over `game_rooms` plus associated `chat_rooms(kind='game')`. It stores opaque `settings: serde_json::Value`; games parse their own settings. Slug prefixes and human-readable labels are resolved from `RoomGameRegistry` at the call site and passed into room creation; `svc.rs` does not match on `GameKind` for either.
 - `state.rs` drains `RoomsService` snapshots/events into `App` fields, clamps list selection, and refreshes the active room copy.
 - `input.rs` routes the room directory, create form, search mode, active table, and embedded room-chat keys.
@@ -20,13 +20,17 @@
 - `blackjack/ui.rs` renders the Blackjack table in fancy or compact layouts.
 - `blackjack/settings.rs` serializes table pace/stake settings into `game_rooms.settings`.
 - `blackjack/player.rs` loads username and chip balance data for seated players.
+- `poker/manager.rs` maps `GameRoom.id` to process-local `PokerService` instances.
+- `poker/svc.rs` is the authoritative in-memory Poker table runtime and owns the public/private snapshot split.
+- `poker/state.rs` is the per-session Poker client wrapper that drains both public table state and private hole-card state.
+- `poker/ui.rs` renders the Blackjack-shaped Poker table with dealer/board top and four seats below.
 - `tictactoe/manager.rs` maps `GameRoom.id` to process-local `TicTacToeService` instances.
 - `tictactoe/svc.rs` is the authoritative in-memory Tic-Tac-Toe board runtime.
 - `tictactoe/state.rs` is the per-session Tic-Tac-Toe client wrapper.
 - `tictactoe/ui.rs` renders the Tic-Tac-Toe board and seats.
 
 ## Persistence Model
-- `late_core::models::game_room::GameKind` is a Rust enum over text. It currently has `Blackjack` and `TicTacToe`.
+- `late_core::models::game_room::GameKind` is a Rust enum over text. It currently has `Blackjack`, `Poker`, and `TicTacToe`.
 - A game room persists in `game_rooms`; its chat pane is backed by a unique `chat_room_id` pointing at `chat_rooms(kind='game', visibility='public', auto_join=false, game_kind, slug)`.
 - `GameRoom::create_with_chat_room` creates the chat room and game room in one SQL CTE. `RoomsService::create_game_room` then joins the fixed dealer user to that game chat.
 - `RoomsService` publishes `RoomsSnapshot { rooms: Vec<RoomListItem> }` through `watch` and transient `RoomsEvent` values through `broadcast`.
@@ -53,7 +57,7 @@
 - Room creation is open to every user. The 3-non-closed-tables-per-creator-per-game-kind cap is enforced server-side in `RoomsService::create_game_room`; over-cap attempts surface to the client via `RoomsEvent::Error` (banner). There is no client-side `can_create_room` gate anymore.
 - Room deletion is admin-only in `input.rs` (`can_delete_room`).
 - Room entry is currently open to every user: `can_enter_room` returns `true` for admin, mod, and ordinary users. Older root-context notes that only admins/mods can enter are stale.
-- Create modal lets any user pick a real game kind. Blackjack-specific pace/stake fields render only when Blackjack is selected; Tic-Tac-Toe uses empty JSON settings.
+- Create modal lets any user pick a real game kind. Blackjack-specific pace/stake fields render only when Blackjack is selected; Poker and Tic-Tac-Toe use empty JSON settings.
 
 ## Active Room and Chat
 - Entering a room calls:
@@ -66,7 +70,7 @@
 - The bottom pane is no longer just a placeholder; `render.rs` builds `EmbeddedRoomChatView` from the associated game chat room and `rooms/ui.rs` calls `chat::ui::draw_embedded_room_chat`.
 - Active room key routing lets embedded chat own composer/message actions first for keys like `i`, `j/k`, scroll, reactions, copy, reply/edit/delete, and selection escape.
 - Arrow keys are routed to the active game backend first; only if the backend declines (returns `false`) do they fall through to embedded chat message selection. Backends that don't override `handle_arrow` (e.g. Blackjack) keep the prior chat-first behavior.
-- The active `ActiveRoomBackend` receives remaining game keys. `q` is normalized to `Esc` inside active Blackjack rooms by its backend implementation.
+- The active `ActiveRoomBackend` receives remaining game keys. `q` leaves active Blackjack/Poker rooms by their backend/input implementations.
 - The outer Rooms title appends active-room status from backend `title_details`: room name, seated count, role/seat label, and optional chip balance.
 - `App.active_room_game` is the single per-session active game backend. Do not add per-game `Option<State>` fields to `App`.
 
@@ -117,6 +121,18 @@
 - `preferred_game_height` returns `min(area.height * 9 / 20, 19)` — the game caps at 19 rows (enough for the 11×5 cell tier: 17 board rows + 2 border rows) so the embedded chat below it keeps the rest of the active-room area.
 - Tic-Tac-Toe has no chip-balance hook; `ActiveRoomBackend::chip_balance` returns `None`.
 
+## Poker Runtime
+- `PokerTableManager` is process-local and lazily maps each entered `GameRoom.id` to a `PokerService`.
+- Restarting the SSH process drops in-memory poker state. Existing open `game_rooms` survive, but re-entering creates a fresh table.
+- Poker is a no-stakes Texas Hold'em-style first pass: four seats, one 52-card deck, private two-card hole hands, shared flop/turn/river, check/fold actions, and showdown hand ranking. Chip betting is not wired yet.
+- The service uses one public `watch::Sender<PokerPublicSnapshot>` plus per-user `watch::Sender<PokerPrivateSnapshot>` channels keyed by `user_id`. Public snapshots include seat occupancy, card counts, folded/action state, dealer button, board, phase, active seat, and winners. Private snapshots include only the current user's hole cards.
+- The deck and all hole cards live only in `SharedState`; clients never receive other users' hole cards. `publish` lazily prunes orphaned private senders where `receiver_count() == 0`.
+- Entering starts as a viewer. `s` or `Enter` sits in the first open seat. Seated players press `n` to deal when the table is waiting or at showdown, `c`/Space/Enter to check when active, `f` to fold, and `l` to leave a seat.
+- The dealer button advances to the next occupied seat each new hand. First action on each street starts left of the button. If all remaining players check through the river, the service evaluates the best five-card hand from each player's two hole cards plus the five-card board; tied best hands share winner display.
+- A seated player who sends no active-room input for 5 minutes is removed from the table. If they were in an active hand, their seat is removed and the hand is reconciled.
+- Poker has no chip-balance hook yet; `ActiveRoomBackend::chip_balance` returns `None`.
+- `poker/ui.rs` mirrors the Blackjack table thresholds and broad layout: dealer/board block on top, felt divider, four seat panels, status line, and key bar. The current user's panel renders private hole cards face-up from the private snapshot; other players render card backs.
+
 ## Blackjack UI Invariants
 - `blackjack/ui.rs` chooses render tier from area dimensions:
   - Fancy path when `area.height >= FANCY_MIN_HEIGHT` and `area.width >= FANCY_MIN_WIDTH`.
@@ -133,8 +149,8 @@
 - Main Chat room-list rendering skips game rooms, so game-backed rooms do not appear as normal chat rooms or favorites.
 - Room entry requests a chat tail; live broadcasts then keep the embedded chat updated like other room-explicit chat flows.
 
-## Future: Asymmetric-Info Games (Poker-Shape)
-- Current games (Blackjack, TTT) publish one `watch::Sender<Snapshot>` and every session sees the same snapshot. Poker-style games where each user sees a different view (own hole cards visible, others hidden) are supported by the existing trait surface without changes.
+## Asymmetric-Info Game Pattern
+- Blackjack and TTT publish one `watch::Sender<Snapshot>` and every session sees the same snapshot. Poker proves the split-channel pattern for games where each user sees a different view.
 - Pattern: split the snapshot into a public part and a per-user private part. Service holds one `watch::Sender<PublicSnapshot>` plus a `HashMap<Uuid, watch::Sender<PrivateSnapshot>>` keyed by user_id. Per-session `State` caches both and drains both in `tick()`.
 - `RoomGameManager::enter` already receives `user_id`, so the manager can register a private channel for the entering user and bind the receiver into the returned `Box<dyn ActiveRoomBackend>`. Rooms layer never sees the split.
 - Cleanup of orphaned private channels (session disconnect drops the receiver but not the sender): prefer lazy GC inside the service's `publish` path — prune entries where `tx.receiver_count() == 0`.
@@ -142,8 +158,10 @@
 
 ## Known Gaps
 - Blackjack table state is not durable across process restart.
+- Poker table state is not durable across process restart.
+- Poker does not yet have chip betting, pots, blinds, all-in side pots, or chip settlement.
 - There is no AFK/disconnect cleanup path tied to SSH session lifecycle.
-- Blackjack and Tic-Tac-Toe are real. Dashboard showcases remain Blackjack-only.
+- Dashboard showcases remain Blackjack-only.
 
 ## Test Guidance
 - Pure rules in `filter.rs`, `settings.rs`, `blackjack/state.rs`, and key-routing helpers can use inline unit tests.

--- a/late-ssh/src/app/rooms/filter.rs
+++ b/late-ssh/src/app/rooms/filter.rs
@@ -12,6 +12,7 @@ impl RoomsFilter {
         match self {
             Self::All => "All",
             Self::Kind(GameKind::Blackjack) => "Blackjack",
+            Self::Kind(GameKind::Poker) => "Poker",
             Self::Kind(GameKind::TicTacToe) => "Tic-Tac-Toe",
         }
     }
@@ -61,12 +62,14 @@ mod tests {
     #[test]
     fn all_matches_everything() {
         assert!(RoomsFilter::All.matches_real(GameKind::Blackjack));
+        assert!(RoomsFilter::All.matches_real(GameKind::Poker));
         assert!(RoomsFilter::All.matches_real(GameKind::TicTacToe));
     }
 
     #[test]
     fn kind_filter_matches_only_that_kind() {
         assert!(RoomsFilter::Kind(GameKind::Blackjack).matches_real(GameKind::Blackjack));
+        assert!(!RoomsFilter::Kind(GameKind::Blackjack).matches_real(GameKind::Poker));
         assert!(!RoomsFilter::Kind(GameKind::Blackjack).matches_real(GameKind::TicTacToe));
     }
 }

--- a/late-ssh/src/app/rooms/input.rs
+++ b/late-ssh/src/app/rooms/input.rs
@@ -5,6 +5,7 @@ use crate::app::{
     rooms::{
         backend::{CreateModalAction, CreateRoomFlow, InputAction},
         filter::RoomsFilter,
+        svc::GameKind,
     },
     state::App,
 };
@@ -237,10 +238,15 @@ fn handle_create_picker_event(app: &mut App, kind_index: usize, event: &ParsedIn
 
 fn submit_create_modal(
     app: &mut App,
-    game_kind: crate::app::rooms::svc::GameKind,
+    game_kind: GameKind,
     display_name: String,
     settings: serde_json::Value,
 ) {
+    if !can_create_room(app.is_admin, app.is_moderator, game_kind) {
+        app.banner = Some(Banner::error(&role_gate_message("create", game_kind)));
+        return;
+    }
+
     let display_name = display_name.trim().to_string();
     if display_name.is_empty() {
         app.banner = Some(Banner::error("Table name is required."));
@@ -278,6 +284,10 @@ fn open_selected_create_modal(app: &mut App, kind_index: usize) {
     else {
         return;
     };
+    if !can_create_room(app.is_admin, app.is_moderator, kind) {
+        app.banner = Some(Banner::error(&role_gate_message("create", kind)));
+        return;
+    }
     let modal = app.room_game_registry.open_create_modal(kind);
     app.rooms_create_flow = Some(CreateRoomFlow::Game { kind, modal });
 }
@@ -436,8 +446,8 @@ fn enter_selected_room(app: &mut App) {
 }
 
 pub(crate) fn enter_room(app: &mut App, room: crate::app::rooms::svc::RoomListItem) -> bool {
-    if !can_enter_room(app.is_admin, app.is_moderator) {
-        app.banner = Some(Banner::error("Rooms are locked for now."));
+    if !can_enter_room(app.is_admin, app.is_moderator, room.game_kind) {
+        app.banner = Some(Banner::error(&role_gate_message("enter", room.game_kind)));
         return false;
     }
 
@@ -573,14 +583,25 @@ fn can_delete_room(is_admin: bool) -> bool {
     is_admin
 }
 
-fn can_enter_room(is_admin: bool, is_moderator: bool) -> bool {
-    let _ = (is_admin, is_moderator);
-    true
+fn can_create_room(is_admin: bool, is_moderator: bool, game_kind: GameKind) -> bool {
+    !matches!(game_kind, GameKind::Poker) || is_admin || is_moderator
+}
+
+fn can_enter_room(is_admin: bool, is_moderator: bool, game_kind: GameKind) -> bool {
+    !matches!(game_kind, GameKind::Poker) || is_admin || is_moderator
+}
+
+fn role_gate_message(action: &'static str, game_kind: GameKind) -> String {
+    match game_kind {
+        GameKind::Poker => format!("Only admins and moderators can {action} Poker rooms."),
+        _ => format!("You cannot {action} this room."),
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{can_delete_room, can_enter_room};
+    use super::{can_create_room, can_delete_room, can_enter_room};
+    use crate::app::rooms::svc::GameKind;
 
     #[test]
     fn room_deletion_stays_admin_only() {
@@ -589,10 +610,27 @@ mod tests {
     }
 
     #[test]
-    fn room_entry_allows_all_users() {
-        assert!(can_enter_room(true, false));
-        assert!(can_enter_room(false, true));
-        assert!(can_enter_room(true, true));
-        assert!(can_enter_room(false, false));
+    fn blackjack_creation_and_entry_allow_all_users() {
+        assert!(can_create_room(false, false, GameKind::Blackjack));
+        assert!(can_enter_room(false, false, GameKind::Blackjack));
+    }
+
+    #[test]
+    fn tictactoe_creation_and_entry_allow_all_users() {
+        assert!(can_create_room(false, false, GameKind::TicTacToe));
+        assert!(can_enter_room(false, false, GameKind::TicTacToe));
+    }
+
+    #[test]
+    fn poker_creation_and_entry_require_admin_or_moderator() {
+        assert!(can_create_room(true, false, GameKind::Poker));
+        assert!(can_create_room(false, true, GameKind::Poker));
+        assert!(can_create_room(true, true, GameKind::Poker));
+        assert!(!can_create_room(false, false, GameKind::Poker));
+
+        assert!(can_enter_room(true, false, GameKind::Poker));
+        assert!(can_enter_room(false, true, GameKind::Poker));
+        assert!(can_enter_room(true, true, GameKind::Poker));
+        assert!(!can_enter_room(false, false, GameKind::Poker));
     }
 }

--- a/late-ssh/src/app/rooms/mod.rs
+++ b/late-ssh/src/app/rooms/mod.rs
@@ -2,6 +2,7 @@ pub mod backend;
 pub mod blackjack;
 pub mod filter;
 pub mod input;
+pub mod poker;
 pub mod registry;
 pub mod state;
 pub mod svc;

--- a/late-ssh/src/app/rooms/poker/create_modal.rs
+++ b/late-ssh/src/app/rooms/poker/create_modal.rs
@@ -1,0 +1,215 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+use crate::app::{
+    common::theme,
+    input::{ParsedInput, sanitize_paste_markers},
+    rooms::backend::{CreateModalAction, CreateRoomModal},
+};
+
+const DISPLAY_NAME_MAX_LEN: usize = 48;
+const MODAL_WIDTH: u16 = 60;
+const MODAL_HEIGHT: u16 = 12;
+const LABEL_WIDTH: usize = 10;
+
+pub struct PokerCreateModal {
+    display_name: String,
+    error: Option<String>,
+}
+
+impl PokerCreateModal {
+    pub fn new(default_name: impl Into<String>) -> Self {
+        Self {
+            display_name: default_name.into(),
+            error: None,
+        }
+    }
+
+    fn push_name_char(&mut self, ch: char) {
+        if ch.is_control() || self.display_name.chars().count() >= DISPLAY_NAME_MAX_LEN {
+            return;
+        }
+        self.error = None;
+        self.display_name.push(ch);
+    }
+
+    fn submit(&mut self) -> CreateModalAction {
+        let display_name = self.display_name.trim().to_string();
+        if display_name.is_empty() {
+            self.error = Some("Table name is required.".to_string());
+            return CreateModalAction::Continue;
+        }
+
+        CreateModalAction::Submit {
+            display_name,
+            settings: serde_json::json!({}),
+        }
+    }
+}
+
+impl CreateRoomModal for PokerCreateModal {
+    fn draw(&self, frame: &mut Frame, area: Rect) {
+        let modal_area = centered_rect(
+            area,
+            MODAL_WIDTH.min(area.width),
+            MODAL_HEIGHT.min(area.height),
+        );
+        frame.render_widget(Clear, modal_area);
+
+        let block = Block::default()
+            .title(" New Poker Room ")
+            .title_style(
+                Style::default()
+                    .fg(theme::AMBER_GLOW())
+                    .add_modifier(Modifier::BOLD),
+            )
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(theme::BORDER_ACTIVE()));
+        let inner = block.inner(modal_area);
+        frame.render_widget(block, modal_area);
+
+        let layout = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(0),
+            Constraint::Length(1),
+        ])
+        .split(inner);
+
+        let width = inner.width as usize;
+        frame.render_widget(Paragraph::new(section_heading("Table")), layout[1]);
+        frame.render_widget(
+            Paragraph::new(field_row(
+                "Name",
+                ValueSpan {
+                    text: format!("{}█", self.display_name),
+                    style: Style::default()
+                        .fg(theme::AMBER())
+                        .add_modifier(Modifier::BOLD),
+                },
+                width,
+            )),
+            layout[3],
+        );
+
+        let footer = self
+            .error
+            .as_ref()
+            .map(|message| {
+                Line::from(vec![
+                    Span::raw("  "),
+                    Span::styled(message.clone(), Style::default().fg(theme::ERROR())),
+                ])
+            })
+            .unwrap_or_else(footer_line);
+        frame.render_widget(Paragraph::new(footer), layout[5]);
+    }
+
+    fn handle_event(&mut self, event: &ParsedInput) -> CreateModalAction {
+        match event {
+            ParsedInput::Byte(0x1B) => CreateModalAction::Cancel,
+            ParsedInput::Byte(b'\r' | b'\n') => self.submit(),
+            ParsedInput::Byte(0x08 | 0x7F) => {
+                self.error = None;
+                self.display_name.pop();
+                CreateModalAction::Continue
+            }
+            ParsedInput::Byte(0x17) => {
+                self.error = None;
+                self.display_name.clear();
+                CreateModalAction::Continue
+            }
+            ParsedInput::Char(ch) => {
+                self.push_name_char(*ch);
+                CreateModalAction::Continue
+            }
+            ParsedInput::Byte(byte) => {
+                if byte.is_ascii_graphic() || *byte == b' ' {
+                    self.push_name_char(*byte as char);
+                }
+                CreateModalAction::Continue
+            }
+            ParsedInput::Paste(bytes) => {
+                let pasted = String::from_utf8_lossy(bytes);
+                for ch in sanitize_paste_markers(&pasted).chars() {
+                    self.push_name_char(ch);
+                }
+                CreateModalAction::Continue
+            }
+            _ => CreateModalAction::Continue,
+        }
+    }
+}
+
+fn footer_line() -> Line<'static> {
+    Line::from(vec![
+        Span::raw("  "),
+        Span::styled("Enter", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" create  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("Esc", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" cancel", Style::default().fg(theme::TEXT_DIM())),
+    ])
+}
+
+fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
+    Rect {
+        x: area.x + area.width.saturating_sub(width) / 2,
+        y: area.y + area.height.saturating_sub(height) / 2,
+        width,
+        height,
+    }
+}
+
+fn section_heading(title: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled("  -- ", Style::default().fg(theme::BORDER())),
+        Span::styled(
+            title.to_string(),
+            Style::default()
+                .fg(theme::AMBER())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(" --", Style::default().fg(theme::BORDER())),
+    ])
+}
+
+struct ValueSpan {
+    text: String,
+    style: Style,
+}
+
+fn field_row(label: &str, value: ValueSpan, width: usize) -> Line<'static> {
+    let prefix = " > ".to_string();
+    let label_text = format!("{label:<LABEL_WIDTH$}");
+    let used = prefix.chars().count() + label_text.chars().count() + value.text.chars().count();
+    let padding = width.saturating_sub(used.min(width));
+
+    Line::from(vec![
+        Span::styled(
+            prefix,
+            Style::default()
+                .fg(theme::AMBER_GLOW())
+                .bg(theme::BG_SELECTION())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            label_text,
+            Style::default()
+                .fg(theme::TEXT_BRIGHT())
+                .bg(theme::BG_SELECTION())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(value.text, value.style.bg(theme::BG_SELECTION())),
+        Span::styled(
+            " ".repeat(padding),
+            Style::default().bg(theme::BG_SELECTION()),
+        ),
+    ])
+}

--- a/late-ssh/src/app/rooms/poker/input.rs
+++ b/late-ssh/src/app/rooms/poker/input.rs
@@ -1,0 +1,35 @@
+use crate::app::rooms::{backend::InputAction, poker::state::State};
+
+pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
+    if !state.is_seated() {
+        return match byte {
+            b's' | b'S' | b'\r' | b'\n' => {
+                state.sit();
+                InputAction::Handled
+            }
+            0x1B | b'q' | b'Q' => InputAction::Leave,
+            _ => InputAction::Ignored,
+        };
+    }
+
+    match byte {
+        0x1B | b'q' | b'Q' => InputAction::Leave,
+        b'l' | b'L' => {
+            state.leave_seat();
+            InputAction::Handled
+        }
+        b'n' | b'N' => {
+            state.start_hand();
+            InputAction::Handled
+        }
+        b'f' | b'F' => {
+            state.fold();
+            InputAction::Handled
+        }
+        b'c' | b'C' | b' ' | b'\r' | b'\n' => {
+            state.check();
+            InputAction::Handled
+        }
+        _ => InputAction::Ignored,
+    }
+}

--- a/late-ssh/src/app/rooms/poker/manager.rs
+++ b/late-ssh/src/app/rooms/poker/manager.rs
@@ -1,0 +1,147 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+};
+
+use late_core::MutexRecover;
+use uuid::Uuid;
+
+use crate::app::rooms::{
+    backend::{ActiveRoomBackend, CreateRoomModal, DirectoryHints, DirectoryMeta, RoomGameManager},
+    poker::{create_modal::PokerCreateModal, state::State, svc::PokerService},
+    svc::{GameKind, RoomListItem},
+};
+
+#[derive(Clone)]
+pub struct PokerTableManager {
+    tables: Arc<Mutex<HashMap<Uuid, PokerService>>>,
+}
+
+impl PokerTableManager {
+    pub fn new() -> Self {
+        Self {
+            tables: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    pub fn get_or_create(&self, room_id: Uuid) -> PokerService {
+        let mut tables = self.tables.lock_recover();
+        tables
+            .entry(room_id)
+            .or_insert_with(|| PokerService::new(room_id))
+            .clone()
+    }
+}
+
+impl Default for PokerTableManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RoomGameManager for PokerTableManager {
+    fn kind(&self) -> GameKind {
+        GameKind::Poker
+    }
+
+    fn label(&self) -> &'static str {
+        "Poker"
+    }
+
+    fn slug_prefix(&self) -> &'static str {
+        "pk"
+    }
+
+    fn default_room_name(&self) -> &'static str {
+        "Poker Table"
+    }
+
+    fn default_settings(&self) -> serde_json::Value {
+        serde_json::json!({})
+    }
+
+    fn open_create_modal(&self) -> Box<dyn CreateRoomModal> {
+        Box::new(PokerCreateModal::new(self.default_room_name()))
+    }
+
+    fn directory_meta(&self, _room: &RoomListItem) -> DirectoryMeta {
+        DirectoryMeta {
+            seats: 4,
+            pace: "turn-based".to_string(),
+            stakes: "no stakes".to_string(),
+        }
+    }
+
+    fn directory_hints(&self, room_id: Uuid) -> Option<DirectoryHints> {
+        let snapshot = self.tables.lock_recover().get(&room_id)?.current_snapshot();
+        let occupied = snapshot
+            .seats
+            .iter()
+            .filter(|seat| seat.user_id.is_some())
+            .count();
+        Some(DirectoryHints { occupied, total: 4 })
+    }
+
+    fn enter(
+        &self,
+        room: &RoomListItem,
+        user_id: Uuid,
+        _chip_balance: i64,
+    ) -> Box<dyn ActiveRoomBackend> {
+        Box::new(State::new(self.get_or_create(room.id), user_id))
+    }
+}
+
+impl ActiveRoomBackend for State {
+    fn room_id(&self) -> Uuid {
+        self.room_id()
+    }
+
+    fn tick(&mut self) {
+        State::tick(self);
+    }
+
+    fn touch_activity(&self) {
+        State::touch_activity(self);
+    }
+
+    fn handle_key(&mut self, byte: u8) -> crate::app::rooms::backend::InputAction {
+        crate::app::rooms::poker::input::handle_key(self, byte)
+    }
+
+    fn preferred_game_height(&self, area: ratatui::layout::Rect) -> u16 {
+        let fancy = crate::app::rooms::poker::ui::fancy_game_height(area);
+        if fancy > 0 {
+            fancy
+        } else {
+            area.height.saturating_mul(7) / 10
+        }
+    }
+
+    fn draw(
+        &self,
+        frame: &mut ratatui::Frame,
+        area: ratatui::layout::Rect,
+        ctx: crate::app::rooms::backend::GameDrawCtx<'_>,
+    ) {
+        crate::app::rooms::poker::ui::draw_game(frame, area, self, ctx.usernames);
+    }
+
+    fn title_details(&self) -> Option<crate::app::rooms::backend::RoomTitleDetails> {
+        let snapshot = self.public_snapshot();
+        let occupied = snapshot
+            .seats
+            .iter()
+            .filter(|seat| seat.user_id.is_some())
+            .count();
+        let role = self
+            .seat_index()
+            .map(|index| format!("seat {}", index + 1))
+            .unwrap_or_else(|| "viewer".to_string());
+        Some(crate::app::rooms::backend::RoomTitleDetails {
+            seated: Some(format!("{occupied}/4 seated")),
+            role: Some(format!("{role} · {}", snapshot.phase.label())),
+            balance: None,
+        })
+    }
+}

--- a/late-ssh/src/app/rooms/poker/mod.rs
+++ b/late-ssh/src/app/rooms/poker/mod.rs
@@ -1,0 +1,6 @@
+pub mod create_modal;
+pub mod input;
+pub mod manager;
+pub mod state;
+pub mod svc;
+pub mod ui;

--- a/late-ssh/src/app/rooms/poker/state.rs
+++ b/late-ssh/src/app/rooms/poker/state.rs
@@ -1,0 +1,96 @@
+use tokio::sync::watch;
+use uuid::Uuid;
+
+use super::svc::{PokerPrivateSnapshot, PokerPublicSnapshot, PokerService};
+
+pub struct State {
+    user_id: Uuid,
+    public_snapshot: PokerPublicSnapshot,
+    private_snapshot: PokerPrivateSnapshot,
+    svc: PokerService,
+    public_rx: watch::Receiver<PokerPublicSnapshot>,
+    private_rx: watch::Receiver<PokerPrivateSnapshot>,
+}
+
+impl State {
+    pub fn new(svc: PokerService, user_id: Uuid) -> Self {
+        let public_rx = svc.subscribe_public();
+        let private_rx = svc.subscribe_private(user_id);
+        let public_snapshot = public_rx.borrow().clone();
+        let private_snapshot = private_rx.borrow().clone();
+        Self {
+            user_id,
+            public_snapshot,
+            private_snapshot,
+            svc,
+            public_rx,
+            private_rx,
+        }
+    }
+
+    pub fn room_id(&self) -> Uuid {
+        self.svc.room_id()
+    }
+
+    pub fn tick(&mut self) {
+        if self.public_rx.has_changed().unwrap_or(false) {
+            self.public_snapshot = self.public_rx.borrow_and_update().clone();
+        }
+        if self.private_rx.has_changed().unwrap_or(false) {
+            self.private_snapshot = self.private_rx.borrow_and_update().clone();
+        }
+    }
+
+    pub fn public_snapshot(&self) -> &PokerPublicSnapshot {
+        &self.public_snapshot
+    }
+
+    pub fn private_snapshot(&self) -> &PokerPrivateSnapshot {
+        &self.private_snapshot
+    }
+
+    pub fn user_id(&self) -> Uuid {
+        self.user_id
+    }
+
+    pub fn seat_index(&self) -> Option<usize> {
+        self.public_snapshot
+            .seats
+            .iter()
+            .position(|seat| seat.user_id == Some(self.user_id))
+    }
+
+    pub fn is_seated(&self) -> bool {
+        self.seat_index().is_some()
+    }
+
+    pub fn can_act(&self) -> bool {
+        self.seat_index() == self.public_snapshot.active_seat
+    }
+
+    pub fn sit(&self) {
+        self.svc.sit_task(self.user_id);
+    }
+
+    pub fn leave_seat(&self) {
+        self.svc.leave_seat_task(self.user_id);
+    }
+
+    pub fn start_hand(&self) {
+        self.svc.start_hand_task(self.user_id);
+    }
+
+    pub fn check(&self) {
+        self.svc.check_task(self.user_id);
+    }
+
+    pub fn fold(&self) {
+        self.svc.fold_task(self.user_id);
+    }
+
+    pub fn touch_activity(&self) {
+        if self.is_seated() {
+            self.svc.touch_activity_task(self.user_id);
+        }
+    }
+}

--- a/late-ssh/src/app/rooms/poker/svc.rs
+++ b/late-ssh/src/app/rooms/poker/svc.rs
@@ -43,6 +43,7 @@ pub struct PokerSeat {
     pub index: usize,
     pub user_id: Option<Uuid>,
     pub card_count: usize,
+    pub revealed_cards: Option<Vec<PlayingCard>>,
     pub folded: bool,
     pub in_hand: bool,
     pub last_action: Option<PokerAction>,
@@ -335,14 +336,27 @@ impl SharedState {
 
     fn seat_snapshot(&self, index: usize) -> PokerSeat {
         let card_count = self.hole_cards[index].len();
+        let revealed_cards = self.revealed_cards_for(index);
         PokerSeat {
             index,
             user_id: self.seats[index],
             card_count,
+            revealed_cards,
             folded: card_count > 0 && self.folded[index],
             in_hand: card_count > 0 && self.seats[index].is_some(),
             last_action: self.last_action[index],
         }
+    }
+
+    fn revealed_cards_for(&self, index: usize) -> Option<Vec<PlayingCard>> {
+        if self.phase != PokerPhase::Showdown
+            || self.seats[index].is_none()
+            || self.folded[index]
+            || self.hole_cards[index].len() != 2
+        {
+            return None;
+        }
+        Some(self.hole_cards[index].clone())
     }
 
     fn sit(&mut self, user_id: Uuid) {

--- a/late-ssh/src/app/rooms/poker/svc.rs
+++ b/late-ssh/src/app/rooms/poker/svc.rs
@@ -1,0 +1,965 @@
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex as StdMutex},
+    time::{Duration, Instant},
+};
+
+use late_core::MutexRecover;
+use rand_core::{OsRng, RngCore};
+use tokio::sync::{Mutex, watch};
+use uuid::Uuid;
+
+use crate::app::games::cards::{CardRank, CardSuit, PlayingCard};
+
+pub const MAX_SEATS: usize = 4;
+
+const SEAT_IDLE_TIMEOUT_SECS: u64 = 5 * 60;
+
+#[derive(Clone)]
+pub struct PokerService {
+    room_id: Uuid,
+    public_tx: watch::Sender<PokerPublicSnapshot>,
+    public_rx: watch::Receiver<PokerPublicSnapshot>,
+    private_txs: Arc<StdMutex<HashMap<Uuid, watch::Sender<PokerPrivateSnapshot>>>>,
+    state: Arc<Mutex<SharedState>>,
+}
+
+#[derive(Clone, Debug)]
+pub struct PokerPublicSnapshot {
+    pub room_id: Uuid,
+    pub seats: Vec<PokerSeat>,
+    pub community: Vec<PlayingCard>,
+    pub dealer_button: Option<usize>,
+    pub active_seat: Option<usize>,
+    pub phase: PokerPhase,
+    pub hand_number: u64,
+    pub winners: Vec<usize>,
+    pub winning_rank: Option<String>,
+    pub status_message: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct PokerSeat {
+    pub index: usize,
+    pub user_id: Option<Uuid>,
+    pub card_count: usize,
+    pub folded: bool,
+    pub in_hand: bool,
+    pub last_action: Option<PokerAction>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct PokerPrivateSnapshot {
+    pub hole_cards: Vec<PlayingCard>,
+    pub notice: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PokerPhase {
+    Waiting,
+    PreFlop,
+    Flop,
+    Turn,
+    River,
+    Showdown,
+}
+
+impl PokerPhase {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Waiting => "Waiting",
+            Self::PreFlop => "Pre-Flop",
+            Self::Flop => "Flop",
+            Self::Turn => "Turn",
+            Self::River => "River",
+            Self::Showdown => "Showdown",
+        }
+    }
+
+    fn is_action_phase(self) -> bool {
+        matches!(self, Self::PreFlop | Self::Flop | Self::Turn | Self::River)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PokerAction {
+    Check,
+    Fold,
+}
+
+impl PokerAction {
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Check => "Check",
+            Self::Fold => "Fold",
+        }
+    }
+}
+
+impl PokerService {
+    pub fn new(room_id: Uuid) -> Self {
+        let state = SharedState::new(room_id);
+        let initial_snapshot = state.public_snapshot();
+        let (public_tx, public_rx) = watch::channel(initial_snapshot);
+        Self {
+            room_id,
+            public_tx,
+            public_rx,
+            private_txs: Arc::new(StdMutex::new(HashMap::new())),
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    pub fn room_id(&self) -> Uuid {
+        self.room_id
+    }
+
+    pub fn subscribe_public(&self) -> watch::Receiver<PokerPublicSnapshot> {
+        self.public_rx.clone()
+    }
+
+    pub fn subscribe_private(&self, user_id: Uuid) -> watch::Receiver<PokerPrivateSnapshot> {
+        let mut private_txs = self.private_txs.lock_recover();
+        if let Some(tx) = private_txs.get(&user_id) {
+            return tx.subscribe();
+        }
+
+        let (tx, rx) = watch::channel(PokerPrivateSnapshot::default());
+        private_txs.insert(user_id, tx.clone());
+        drop(private_txs);
+
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let state = svc.state.lock().await;
+            svc.publish_private_to(&state, user_id, &tx);
+        });
+
+        rx
+    }
+
+    pub fn current_snapshot(&self) -> PokerPublicSnapshot {
+        self.public_rx.borrow().clone()
+    }
+
+    pub fn sit_task(&self, user_id: Uuid) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let activity_generation = {
+                let mut state = svc.state.lock().await;
+                state.sit(user_id);
+                let activity_generation = state.record_activity(user_id);
+                svc.publish(&state);
+                activity_generation
+            };
+            if let Some(activity_generation) = activity_generation {
+                svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+        });
+    }
+
+    pub fn leave_seat_task(&self, user_id: Uuid) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let mut state = svc.state.lock().await;
+            state.leave(user_id);
+            svc.publish(&state);
+        });
+    }
+
+    pub fn start_hand_task(&self, user_id: Uuid) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let activity_generation = {
+                let mut state = svc.state.lock().await;
+                state.start_hand(user_id);
+                let activity_generation = state.record_activity(user_id);
+                svc.publish(&state);
+                activity_generation
+            };
+            if let Some(activity_generation) = activity_generation {
+                svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+        });
+    }
+
+    pub fn check_task(&self, user_id: Uuid) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let activity_generation = {
+                let mut state = svc.state.lock().await;
+                state.player_action(user_id, PokerAction::Check);
+                let activity_generation = state.record_activity(user_id);
+                svc.publish(&state);
+                activity_generation
+            };
+            if let Some(activity_generation) = activity_generation {
+                svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+        });
+    }
+
+    pub fn fold_task(&self, user_id: Uuid) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let activity_generation = {
+                let mut state = svc.state.lock().await;
+                state.player_action(user_id, PokerAction::Fold);
+                let activity_generation = state.record_activity(user_id);
+                svc.publish(&state);
+                activity_generation
+            };
+            if let Some(activity_generation) = activity_generation {
+                svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+        });
+    }
+
+    pub fn touch_activity_task(&self, user_id: Uuid) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let activity_generation = {
+                let mut state = svc.state.lock().await;
+                state.record_activity(user_id)
+            };
+            if let Some(activity_generation) = activity_generation {
+                svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+        });
+    }
+
+    fn schedule_inactivity_kick(&self, user_id: Uuid, activity_generation: u64) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(SEAT_IDLE_TIMEOUT_SECS)).await;
+
+            let mut state = svc.state.lock().await;
+            if state.kick_inactive_user(user_id, activity_generation) {
+                svc.publish(&state);
+            }
+        });
+    }
+
+    fn publish(&self, state: &SharedState) {
+        let _ = self.public_tx.send(state.public_snapshot());
+
+        let mut private_txs = self.private_txs.lock_recover();
+        private_txs.retain(|_, tx| tx.receiver_count() > 0);
+        for (user_id, tx) in private_txs.iter() {
+            self.publish_private_to(state, *user_id, tx);
+        }
+    }
+
+    fn publish_private_to(
+        &self,
+        state: &SharedState,
+        user_id: Uuid,
+        tx: &watch::Sender<PokerPrivateSnapshot>,
+    ) {
+        let _ = tx.send(state.private_snapshot_for(user_id));
+    }
+}
+
+struct SharedState {
+    room_id: Uuid,
+    seats: [Option<Uuid>; MAX_SEATS],
+    hole_cards: [Vec<PlayingCard>; MAX_SEATS],
+    folded: [bool; MAX_SEATS],
+    acted_this_street: [bool; MAX_SEATS],
+    last_action: [Option<PokerAction>; MAX_SEATS],
+    community: Vec<PlayingCard>,
+    deck: Vec<PlayingCard>,
+    dealer_button: Option<usize>,
+    active_seat: Option<usize>,
+    phase: PokerPhase,
+    hand_number: u64,
+    winners: Vec<usize>,
+    winning_rank: Option<String>,
+    status_message: String,
+    last_activity: [Instant; MAX_SEATS],
+    activity_generation: [u64; MAX_SEATS],
+}
+
+impl SharedState {
+    fn new(room_id: Uuid) -> Self {
+        let now = Instant::now();
+        Self {
+            room_id,
+            seats: [None; MAX_SEATS],
+            hole_cards: std::array::from_fn(|_| Vec::new()),
+            folded: [false; MAX_SEATS],
+            acted_this_street: [false; MAX_SEATS],
+            last_action: [None; MAX_SEATS],
+            community: Vec::new(),
+            deck: Vec::new(),
+            dealer_button: None,
+            active_seat: None,
+            phase: PokerPhase::Waiting,
+            hand_number: 0,
+            winners: Vec::new(),
+            winning_rank: None,
+            status_message: "Take a seat. Two players can deal a hand.".to_string(),
+            last_activity: [now; MAX_SEATS],
+            activity_generation: [0; MAX_SEATS],
+        }
+    }
+
+    fn public_snapshot(&self) -> PokerPublicSnapshot {
+        PokerPublicSnapshot {
+            room_id: self.room_id,
+            seats: (0..MAX_SEATS)
+                .map(|index| self.seat_snapshot(index))
+                .collect(),
+            community: self.community.clone(),
+            dealer_button: self.dealer_button,
+            active_seat: self.active_seat,
+            phase: self.phase,
+            hand_number: self.hand_number,
+            winners: self.winners.clone(),
+            winning_rank: self.winning_rank.clone(),
+            status_message: self.status_message.clone(),
+        }
+    }
+
+    fn private_snapshot_for(&self, user_id: Uuid) -> PokerPrivateSnapshot {
+        let Some(index) = self.seat_index(user_id) else {
+            return PokerPrivateSnapshot::default();
+        };
+        let hole_cards = self.hole_cards[index].clone();
+        let notice = if hole_cards.is_empty() {
+            None
+        } else {
+            Some("Your hole cards are private.".to_string())
+        };
+        PokerPrivateSnapshot { hole_cards, notice }
+    }
+
+    fn seat_snapshot(&self, index: usize) -> PokerSeat {
+        let card_count = self.hole_cards[index].len();
+        PokerSeat {
+            index,
+            user_id: self.seats[index],
+            card_count,
+            folded: card_count > 0 && self.folded[index],
+            in_hand: card_count > 0 && self.seats[index].is_some(),
+            last_action: self.last_action[index],
+        }
+    }
+
+    fn sit(&mut self, user_id: Uuid) {
+        if self.seat_index(user_id).is_some() {
+            return;
+        }
+        let Some(index) = self.seats.iter().position(Option::is_none) else {
+            self.status_message = "Poker table is full.".to_string();
+            return;
+        };
+        self.seats[index] = Some(user_id);
+        self.status_message = if self.occupied_count() >= 2 {
+            "Press n to deal a hand.".to_string()
+        } else {
+            "Waiting for a second player.".to_string()
+        };
+    }
+
+    fn leave(&mut self, user_id: Uuid) {
+        let Some(index) = self.seat_index(user_id) else {
+            return;
+        };
+        self.remove_seat(index);
+        if self.phase == PokerPhase::Waiting {
+            self.status_message = if self.occupied_count() == 0 {
+                "Take a seat. Two players can deal a hand.".to_string()
+            } else {
+                "Waiting for players.".to_string()
+            };
+        } else if self.phase != PokerPhase::Showdown {
+            self.status_message = format!("Seat {} left the hand.", index + 1);
+        }
+    }
+
+    fn start_hand(&mut self, user_id: Uuid) {
+        if self.seat_index(user_id).is_none() {
+            self.status_message = "Sit before dealing a hand.".to_string();
+            return;
+        }
+        if !matches!(self.phase, PokerPhase::Waiting | PokerPhase::Showdown) {
+            self.status_message = "Finish the current hand first.".to_string();
+            return;
+        }
+        if self.occupied_count() < 2 {
+            self.status_message = "Need at least two players to deal.".to_string();
+            return;
+        }
+
+        self.deck = fresh_deck();
+        shuffle(&mut self.deck);
+        self.community.clear();
+        self.hole_cards = std::array::from_fn(|_| Vec::new());
+        self.folded = [false; MAX_SEATS];
+        self.acted_this_street = [false; MAX_SEATS];
+        self.last_action = [None; MAX_SEATS];
+        self.winners.clear();
+        self.winning_rank = None;
+
+        let dealer = self
+            .dealer_button
+            .and_then(|index| self.next_occupied_after(index))
+            .or_else(|| self.seat_index(user_id))
+            .or_else(|| self.occupied_indices().into_iter().next())
+            .unwrap_or(0);
+        self.dealer_button = Some(dealer);
+
+        let occupied = self.occupied_indices();
+        for _ in 0..2 {
+            for index in &occupied {
+                if let Some(card) = self.deck.pop() {
+                    self.hole_cards[*index].push(card);
+                }
+            }
+        }
+
+        self.phase = PokerPhase::PreFlop;
+        self.hand_number = self.hand_number.saturating_add(1);
+        self.active_seat = self.next_active_after(dealer);
+        self.status_message = match self.active_seat {
+            Some(index) => format!("Hand {} dealt. Seat {} acts.", self.hand_number, index + 1),
+            None => "Hand dealt.".to_string(),
+        };
+    }
+
+    fn player_action(&mut self, user_id: Uuid, action: PokerAction) {
+        if !self.phase.is_action_phase() {
+            self.status_message = "No poker action is pending.".to_string();
+            return;
+        }
+        let Some(index) = self.seat_index(user_id) else {
+            self.status_message = "Sit before playing.".to_string();
+            return;
+        };
+        if self.active_seat != Some(index) {
+            self.status_message = match self.active_seat {
+                Some(active) => format!("Seat {} acts now.", active + 1),
+                None => "No active player.".to_string(),
+            };
+            return;
+        }
+        if self.hole_cards[index].len() != 2 || self.folded[index] {
+            self.status_message = "You are not in this hand.".to_string();
+            return;
+        }
+
+        match action {
+            PokerAction::Check => {
+                self.acted_this_street[index] = true;
+                self.last_action[index] = Some(PokerAction::Check);
+            }
+            PokerAction::Fold => {
+                self.folded[index] = true;
+                self.acted_this_street[index] = true;
+                self.last_action[index] = Some(PokerAction::Fold);
+            }
+        }
+
+        self.advance_after_action(index);
+    }
+
+    fn advance_after_action(&mut self, acted_index: usize) {
+        let active_players = self.active_player_indices();
+        if active_players.len() == 1 {
+            self.finish_by_fold(active_players[0]);
+            return;
+        }
+        if active_players.is_empty() {
+            self.phase = PokerPhase::Waiting;
+            self.active_seat = None;
+            self.status_message = "Hand ended. Waiting for players.".to_string();
+            return;
+        }
+
+        if self.street_complete() {
+            self.advance_street();
+            return;
+        }
+
+        self.active_seat = self.next_active_after(acted_index);
+        self.status_message = match self.active_seat {
+            Some(index) => format!("Seat {} acts.", index + 1),
+            None => "Waiting for action.".to_string(),
+        };
+    }
+
+    fn advance_street(&mut self) {
+        self.acted_this_street = [false; MAX_SEATS];
+        match self.phase {
+            PokerPhase::PreFlop => {
+                self.deal_community(3);
+                self.phase = PokerPhase::Flop;
+                self.set_first_action_for_new_street("Flop dealt");
+            }
+            PokerPhase::Flop => {
+                self.deal_community(1);
+                self.phase = PokerPhase::Turn;
+                self.set_first_action_for_new_street("Turn dealt");
+            }
+            PokerPhase::Turn => {
+                self.deal_community(1);
+                self.phase = PokerPhase::River;
+                self.set_first_action_for_new_street("River dealt");
+            }
+            PokerPhase::River => self.finish_showdown(),
+            _ => {}
+        }
+    }
+
+    fn set_first_action_for_new_street(&mut self, prefix: &'static str) {
+        let dealer = self.dealer_button.unwrap_or(0);
+        self.active_seat = self.next_active_after(dealer);
+        self.status_message = match self.active_seat {
+            Some(index) => format!("{prefix}. Seat {} acts.", index + 1),
+            None => format!("{prefix}."),
+        };
+    }
+
+    fn finish_by_fold(&mut self, winner: usize) {
+        self.phase = PokerPhase::Showdown;
+        self.active_seat = None;
+        self.winners = vec![winner];
+        self.winning_rank = None;
+        self.status_message = format!("Seat {} wins by fold. Press n for next hand.", winner + 1);
+    }
+
+    fn finish_showdown(&mut self) {
+        let contenders = self.active_player_indices();
+        if contenders.is_empty() {
+            self.phase = PokerPhase::Waiting;
+            self.active_seat = None;
+            self.status_message = "No contenders remain.".to_string();
+            return;
+        }
+
+        let mut scored = Vec::with_capacity(contenders.len());
+        for index in contenders {
+            let mut cards = self.hole_cards[index].clone();
+            cards.extend(self.community.iter().copied());
+            scored.push((index, evaluate_best_hand(&cards)));
+        }
+        let Some(best) = scored.iter().map(|(_, hand)| hand.value).max() else {
+            return;
+        };
+        self.winners = scored
+            .iter()
+            .filter_map(|(index, hand)| (hand.value == best).then_some(*index))
+            .collect();
+        self.winning_rank = scored
+            .iter()
+            .find_map(|(_, hand)| (hand.value == best).then_some(hand.label.to_string()));
+        self.phase = PokerPhase::Showdown;
+        self.active_seat = None;
+
+        let winners = seat_list(&self.winners);
+        let rank = self
+            .winning_rank
+            .as_deref()
+            .unwrap_or("best hand")
+            .to_string();
+        self.status_message = format!("{winners} win with {rank}. Press n for next hand.");
+    }
+
+    fn remove_seat(&mut self, index: usize) {
+        self.seats[index] = None;
+        self.hole_cards[index].clear();
+        self.folded[index] = false;
+        self.acted_this_street[index] = false;
+        self.last_action[index] = None;
+
+        if self.occupied_count() == 0 {
+            self.dealer_button = None;
+        }
+
+        if !self.phase.is_action_phase() {
+            return;
+        }
+
+        let active_players = self.active_player_indices();
+        match active_players.len() {
+            0 => {
+                self.phase = PokerPhase::Waiting;
+                self.active_seat = None;
+            }
+            1 => self.finish_by_fold(active_players[0]),
+            _ if self.active_seat == Some(index) => {
+                if self.street_complete() {
+                    self.advance_street();
+                } else {
+                    self.active_seat = self.next_active_after(index);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn deal_community(&mut self, count: usize) {
+        for _ in 0..count {
+            if let Some(card) = self.deck.pop() {
+                self.community.push(card);
+            }
+        }
+    }
+
+    fn street_complete(&self) -> bool {
+        self.active_player_indices()
+            .into_iter()
+            .all(|index| self.acted_this_street[index])
+    }
+
+    fn occupied_count(&self) -> usize {
+        self.seats.iter().filter(|seat| seat.is_some()).count()
+    }
+
+    fn occupied_indices(&self) -> Vec<usize> {
+        self.seats
+            .iter()
+            .enumerate()
+            .filter_map(|(index, seat)| seat.is_some().then_some(index))
+            .collect()
+    }
+
+    fn active_player_indices(&self) -> Vec<usize> {
+        (0..MAX_SEATS)
+            .filter(|index| {
+                self.seats[*index].is_some()
+                    && self.hole_cards[*index].len() == 2
+                    && !self.folded[*index]
+            })
+            .collect()
+    }
+
+    fn next_occupied_after(&self, start: usize) -> Option<usize> {
+        (1..=MAX_SEATS)
+            .map(|offset| (start + offset) % MAX_SEATS)
+            .find(|index| self.seats[*index].is_some())
+    }
+
+    fn next_active_after(&self, start: usize) -> Option<usize> {
+        (1..=MAX_SEATS)
+            .map(|offset| (start + offset) % MAX_SEATS)
+            .find(|index| {
+                self.seats[*index].is_some()
+                    && self.hole_cards[*index].len() == 2
+                    && !self.folded[*index]
+            })
+    }
+
+    fn seat_index(&self, user_id: Uuid) -> Option<usize> {
+        self.seats.iter().position(|seat| *seat == Some(user_id))
+    }
+
+    fn record_activity(&mut self, user_id: Uuid) -> Option<u64> {
+        let seat_index = self.seat_index(user_id)?;
+        self.last_activity[seat_index] = Instant::now();
+        self.activity_generation[seat_index] = self.activity_generation[seat_index].wrapping_add(1);
+        Some(self.activity_generation[seat_index])
+    }
+
+    fn kick_inactive_user(&mut self, user_id: Uuid, activity_generation: u64) -> bool {
+        let Some(seat_index) = self.seat_index(user_id) else {
+            return false;
+        };
+        if self.activity_generation[seat_index] != activity_generation
+            || self.last_activity[seat_index].elapsed()
+                < Duration::from_secs(SEAT_IDLE_TIMEOUT_SECS)
+        {
+            return false;
+        }
+
+        self.remove_seat(seat_index);
+        if self.phase == PokerPhase::Waiting {
+            self.status_message = format!("Seat {} idle for 5m and left.", seat_index + 1);
+        } else if self.phase != PokerPhase::Showdown {
+            self.status_message = format!("Seat {} idle for 5m and folded.", seat_index + 1);
+        }
+        true
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+struct HandValue {
+    category: u8,
+    ranks: [u8; 5],
+}
+
+struct EvaluatedHand {
+    value: HandValue,
+    label: &'static str,
+}
+
+fn evaluate_best_hand(cards: &[PlayingCard]) -> EvaluatedHand {
+    let ranks = rank_counts(cards);
+
+    if let Some(high) = straight_flush_high(cards) {
+        return evaluated(8, &[high], "straight flush");
+    }
+
+    let quads = ranks_with_count_at_least(&ranks, 4);
+    if let Some(quad) = quads.first().copied() {
+        let kicker = highest_excluding(&ranks, &[quad], 1);
+        return evaluated(7, &[quad, kicker[0]], "four of a kind");
+    }
+
+    let trips = ranks_with_count_at_least(&ranks, 3);
+    let pairs = ranks_with_count_at_least(&ranks, 2);
+    if let Some(trip) = trips.first().copied()
+        && let Some(pair) = pairs
+            .iter()
+            .copied()
+            .find(|rank| *rank != trip)
+            .or_else(|| trips.iter().copied().find(|rank| *rank != trip))
+    {
+        return evaluated(6, &[trip, pair], "full house");
+    }
+
+    if let Some(flush) = flush_ranks(cards) {
+        return evaluated(5, &flush[..5], "flush");
+    }
+
+    if let Some(high) = straight_high(ranks.keys().copied().collect()) {
+        return evaluated(4, &[high], "straight");
+    }
+
+    if let Some(trip) = trips.first().copied() {
+        let kickers = highest_excluding(&ranks, &[trip], 2);
+        return evaluated(3, &[trip, kickers[0], kickers[1]], "three of a kind");
+    }
+
+    if pairs.len() >= 2 {
+        let high_pair = pairs[0];
+        let low_pair = pairs[1];
+        let kicker = highest_excluding(&ranks, &[high_pair, low_pair], 1);
+        return evaluated(2, &[high_pair, low_pair, kicker[0]], "two pair");
+    }
+
+    if let Some(pair) = pairs.first().copied() {
+        let kickers = highest_excluding(&ranks, &[pair], 3);
+        return evaluated(1, &[pair, kickers[0], kickers[1], kickers[2]], "one pair");
+    }
+
+    let high_cards = highest_excluding(&ranks, &[], 5);
+    evaluated(0, &high_cards, "high card")
+}
+
+fn evaluated(category: u8, ranks: &[u8], label: &'static str) -> EvaluatedHand {
+    let mut normalized = [0; 5];
+    for (index, rank) in ranks.iter().copied().take(5).enumerate() {
+        normalized[index] = rank;
+    }
+    EvaluatedHand {
+        value: HandValue {
+            category,
+            ranks: normalized,
+        },
+        label,
+    }
+}
+
+fn rank_counts(cards: &[PlayingCard]) -> HashMap<u8, u8> {
+    let mut counts = HashMap::new();
+    for card in cards {
+        *counts.entry(rank_value(card.rank)).or_insert(0) += 1;
+    }
+    counts
+}
+
+fn ranks_with_count_at_least(counts: &HashMap<u8, u8>, count: u8) -> Vec<u8> {
+    let mut ranks = counts
+        .iter()
+        .filter_map(|(rank, rank_count)| (*rank_count >= count).then_some(*rank))
+        .collect::<Vec<_>>();
+    ranks.sort_unstable_by(|a, b| b.cmp(a));
+    ranks
+}
+
+fn highest_excluding(counts: &HashMap<u8, u8>, excluded: &[u8], count: usize) -> Vec<u8> {
+    let mut ranks = counts
+        .keys()
+        .copied()
+        .filter(|rank| !excluded.contains(rank))
+        .collect::<Vec<_>>();
+    ranks.sort_unstable_by(|a, b| b.cmp(a));
+    ranks.truncate(count);
+    while ranks.len() < count {
+        ranks.push(0);
+    }
+    ranks
+}
+
+fn flush_ranks(cards: &[PlayingCard]) -> Option<Vec<u8>> {
+    for suit in [
+        CardSuit::Hearts,
+        CardSuit::Diamonds,
+        CardSuit::Clubs,
+        CardSuit::Spades,
+    ] {
+        let mut ranks = cards
+            .iter()
+            .filter_map(|card| (card.suit == suit).then_some(rank_value(card.rank)))
+            .collect::<Vec<_>>();
+        if ranks.len() < 5 {
+            continue;
+        }
+        ranks.sort_unstable_by(|a, b| b.cmp(a));
+        return Some(ranks);
+    }
+    None
+}
+
+fn straight_flush_high(cards: &[PlayingCard]) -> Option<u8> {
+    let mut best = None;
+    for suit in [
+        CardSuit::Hearts,
+        CardSuit::Diamonds,
+        CardSuit::Clubs,
+        CardSuit::Spades,
+    ] {
+        let ranks = cards
+            .iter()
+            .filter_map(|card| (card.suit == suit).then_some(rank_value(card.rank)))
+            .collect::<Vec<_>>();
+        if let Some(high) = straight_high(ranks) {
+            best = best.max(Some(high));
+        }
+    }
+    best
+}
+
+fn straight_high(mut ranks: Vec<u8>) -> Option<u8> {
+    ranks.sort_unstable();
+    ranks.dedup();
+    if ranks.contains(&14) {
+        ranks.insert(0, 1);
+    }
+
+    let mut run = 1;
+    let mut best = None;
+    for index in 1..ranks.len() {
+        if ranks[index] == ranks[index - 1] + 1 {
+            run += 1;
+            if run >= 5 {
+                best = Some(ranks[index]);
+            }
+        } else {
+            run = 1;
+        }
+    }
+    best
+}
+
+fn rank_value(rank: CardRank) -> u8 {
+    match rank {
+        CardRank::Ace => 14,
+        CardRank::Number(value) => value,
+        CardRank::Jack => 11,
+        CardRank::Queen => 12,
+        CardRank::King => 13,
+    }
+}
+
+fn seat_list(seats: &[usize]) -> String {
+    match seats {
+        [] => "No seats".to_string(),
+        [seat] => format!("Seat {}", seat + 1),
+        _ => {
+            let labels = seats
+                .iter()
+                .map(|seat| (seat + 1).to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("Seats {labels}")
+        }
+    }
+}
+
+fn fresh_deck() -> Vec<PlayingCard> {
+    let mut cards = Vec::with_capacity(52);
+    for suit in [
+        CardSuit::Hearts,
+        CardSuit::Diamonds,
+        CardSuit::Clubs,
+        CardSuit::Spades,
+    ] {
+        cards.push(PlayingCard {
+            suit,
+            rank: CardRank::Ace,
+        });
+        for value in 2..=10 {
+            cards.push(PlayingCard {
+                suit,
+                rank: CardRank::Number(value),
+            });
+        }
+        cards.push(PlayingCard {
+            suit,
+            rank: CardRank::Jack,
+        });
+        cards.push(PlayingCard {
+            suit,
+            rank: CardRank::Queen,
+        });
+        cards.push(PlayingCard {
+            suit,
+            rank: CardRank::King,
+        });
+    }
+    cards
+}
+
+fn shuffle(cards: &mut [PlayingCard]) {
+    for idx in (1..cards.len()).rev() {
+        let swap_idx = (OsRng.next_u64() as usize) % (idx + 1);
+        cards.swap(idx, swap_idx);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn c(rank: CardRank, suit: CardSuit) -> PlayingCard {
+        PlayingCard { rank, suit }
+    }
+
+    #[test]
+    fn ace_low_straight_is_scored_as_five_high() {
+        let hand = evaluate_best_hand(&[
+            c(CardRank::Ace, CardSuit::Spades),
+            c(CardRank::Number(2), CardSuit::Hearts),
+            c(CardRank::Number(3), CardSuit::Clubs),
+            c(CardRank::Number(4), CardSuit::Diamonds),
+            c(CardRank::Number(5), CardSuit::Spades),
+            c(CardRank::King, CardSuit::Hearts),
+            c(CardRank::Queen, CardSuit::Hearts),
+        ]);
+
+        assert_eq!(hand.value.category, 4);
+        assert_eq!(hand.value.ranks[0], 5);
+    }
+
+    #[test]
+    fn full_house_beats_flush() {
+        let full_house = evaluate_best_hand(&[
+            c(CardRank::Ace, CardSuit::Spades),
+            c(CardRank::Ace, CardSuit::Hearts),
+            c(CardRank::Ace, CardSuit::Clubs),
+            c(CardRank::King, CardSuit::Diamonds),
+            c(CardRank::King, CardSuit::Spades),
+        ]);
+        let flush = evaluate_best_hand(&[
+            c(CardRank::Ace, CardSuit::Hearts),
+            c(CardRank::Number(9), CardSuit::Hearts),
+            c(CardRank::Number(7), CardSuit::Hearts),
+            c(CardRank::Number(4), CardSuit::Hearts),
+            c(CardRank::Number(2), CardSuit::Hearts),
+        ]);
+
+        assert!(full_house.value > flush.value);
+    }
+}

--- a/late-ssh/src/app/rooms/poker/ui.rs
+++ b/late-ssh/src/app/rooms/poker/ui.rs
@@ -1,0 +1,783 @@
+use std::collections::HashMap;
+
+use ratatui::{
+    Frame,
+    layout::{Alignment, Constraint, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Paragraph},
+};
+use uuid::Uuid;
+
+use crate::app::{
+    common::theme,
+    games::{
+        cards::{AsciiCardTheme, CardSuit, PlayingCard},
+        ui::key_hint,
+    },
+    rooms::poker::{
+        state::State,
+        svc::{PokerAction, PokerPhase, PokerPublicSnapshot, PokerSeat},
+    },
+};
+
+const FANCY_MIN_HEIGHT: u16 = 19;
+const FANCY_MIN_WIDTH: u16 = 60;
+const SEAT_PANEL_WIDTH: u16 = 12;
+const SEAT_PANEL_HEIGHT: u16 = 7;
+const SEAT_PANEL_WIDTH_OUTLINE: u16 = 22;
+const SEAT_PANEL_HEIGHT_OUTLINE: u16 = 11;
+const DEALER_BLOCK_HEIGHT: u16 = 9;
+const ULTRA_FANCY_MIN_WIDTH: u16 = 96;
+const ULTRA_FANCY_MIN_HEIGHT: u16 = 23;
+
+pub fn fancy_game_height(area: Rect) -> u16 {
+    if area.height < FANCY_MIN_HEIGHT || area.width < FANCY_MIN_WIDTH {
+        return 0;
+    }
+    let panel_h = if area.height >= ULTRA_FANCY_MIN_HEIGHT && area.width >= ULTRA_FANCY_MIN_WIDTH {
+        SEAT_PANEL_HEIGHT_OUTLINE
+    } else {
+        SEAT_PANEL_HEIGHT
+    };
+    DEALER_BLOCK_HEIGHT + 1 + panel_h + 2
+}
+
+pub fn draw_game(frame: &mut Frame, area: Rect, state: &State, usernames: &HashMap<Uuid, String>) {
+    let snapshot = state.public_snapshot();
+    if area.height >= FANCY_MIN_HEIGHT && area.width >= FANCY_MIN_WIDTH {
+        draw_table_fancy(frame, area, state, snapshot, usernames);
+    } else {
+        draw_table_compact(frame, area, state, snapshot, usernames);
+    }
+}
+
+fn draw_table_fancy(
+    frame: &mut Frame,
+    area: Rect,
+    state: &State,
+    snapshot: &PokerPublicSnapshot,
+    usernames: &HashMap<Uuid, String>,
+) {
+    let seat_count = snapshot.seats.len() as u16;
+    let outline_strip_w = seat_count
+        .saturating_mul(SEAT_PANEL_WIDTH_OUTLINE)
+        .saturating_add(seat_count.saturating_sub(1).saturating_mul(2));
+    let ultra = area.width >= ULTRA_FANCY_MIN_WIDTH
+        && area.height >= ULTRA_FANCY_MIN_HEIGHT
+        && area.width >= outline_strip_w;
+    let panel_w = if ultra {
+        SEAT_PANEL_WIDTH_OUTLINE
+    } else {
+        SEAT_PANEL_WIDTH
+    };
+    let panel_h = if ultra {
+        SEAT_PANEL_HEIGHT_OUTLINE
+    } else {
+        SEAT_PANEL_HEIGHT
+    };
+    let card_theme = if ultra {
+        AsciiCardTheme::Outline
+    } else {
+        AsciiCardTheme::Minimal
+    };
+
+    let rows = Layout::vertical([
+        Constraint::Length(DEALER_BLOCK_HEIGHT),
+        Constraint::Length(1),
+        Constraint::Length(panel_h),
+        Constraint::Length(1),
+        Constraint::Length(1),
+    ])
+    .split(area);
+
+    draw_dealer_block(frame, rows[0], snapshot);
+    draw_felt_divider(frame, rows[1], snapshot);
+    draw_seats_strip(
+        frame, rows[2], state, snapshot, panel_w, card_theme, usernames,
+    );
+    draw_status_line(frame, rows[3], snapshot);
+    draw_keys_bar(frame, rows[4], state, snapshot);
+}
+
+fn draw_dealer_block(frame: &mut Frame, area: Rect, snapshot: &PokerPublicSnapshot) {
+    if area.height < 4 {
+        return;
+    }
+
+    let card_theme = AsciiCardTheme::Outline;
+    let card_h = card_theme.card_height() as u16;
+    let label_area = Rect {
+        x: area.x,
+        y: area.y,
+        width: area.width,
+        height: 1,
+    };
+    let cards_area = Rect {
+        x: area.x,
+        y: area.y + 2,
+        width: area.width,
+        height: card_h,
+    };
+    let phase_area = Rect {
+        x: area.x,
+        y: (cards_area.y + card_h).min(area.y + area.height - 1),
+        width: area.width,
+        height: 1,
+    };
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "-- DEALER / BOARD --",
+            Style::default()
+                .fg(theme::AMBER())
+                .add_modifier(Modifier::BOLD),
+        )))
+        .alignment(Alignment::Center),
+        label_area,
+    );
+    draw_community_cards(frame, cards_area, snapshot, card_theme);
+
+    let hand = if snapshot.hand_number == 0 {
+        "waiting".to_string()
+    } else {
+        format!("hand {} - {}", snapshot.hand_number, snapshot.phase.label())
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            hand,
+            Style::default().fg(theme::TEXT_DIM()),
+        )))
+        .alignment(Alignment::Center),
+        phase_area,
+    );
+}
+
+fn draw_community_cards(
+    frame: &mut Frame,
+    area: Rect,
+    snapshot: &PokerPublicSnapshot,
+    card_theme: AsciiCardTheme,
+) {
+    let card_w = card_width(card_theme) as u16;
+    let card_h = card_theme.card_height() as u16;
+    let total_cards = 5usize;
+    let gap: u16 = 2;
+    let total_w = card_w * total_cards as u16 + gap * (total_cards as u16 - 1);
+    let start_x = area.x + area.width.saturating_sub(total_w) / 2;
+
+    for index in 0..total_cards {
+        let x = start_x + (card_w + gap) * index as u16;
+        if x >= area.x + area.width {
+            break;
+        }
+        let card_area = Rect {
+            x,
+            y: area.y,
+            width: card_w.min(area.x + area.width - x),
+            height: card_h,
+        };
+        match snapshot.community.get(index) {
+            Some(card) => render_card_lines(
+                frame,
+                card_area,
+                &card_theme.render_face_lines(*card),
+                card_color(*card),
+            ),
+            None => render_card_lines(
+                frame,
+                card_area,
+                &card_theme.render_empty_lines(),
+                theme::TEXT_DIM(),
+            ),
+        }
+    }
+}
+
+fn draw_felt_divider(frame: &mut Frame, area: Rect, snapshot: &PokerPublicSnapshot) {
+    if area.height == 0 || area.width < 4 {
+        return;
+    }
+    let label = match snapshot.dealer_button {
+        Some(index) => format!("button seat {}", index + 1),
+        None => "waiting for dealer button".to_string(),
+    };
+    let chip_w = label.chars().count() + 6;
+    let side_each = (area.width as usize).saturating_sub(chip_w) / 2;
+    let half_pattern = "- ".repeat(side_each / 2);
+    let line = Line::from(vec![
+        Span::styled(
+            half_pattern.clone(),
+            Style::default().fg(theme::AMBER_DIM()),
+        ),
+        Span::styled("-[ ", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(label, Style::default().fg(theme::AMBER())),
+        Span::styled(" ]-", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(half_pattern, Style::default().fg(theme::AMBER_DIM())),
+    ]);
+    frame.render_widget(Paragraph::new(line).alignment(Alignment::Center), area);
+}
+
+fn draw_seats_strip(
+    frame: &mut Frame,
+    area: Rect,
+    state: &State,
+    snapshot: &PokerPublicSnapshot,
+    panel_w: u16,
+    card_theme: AsciiCardTheme,
+    usernames: &HashMap<Uuid, String>,
+) {
+    if area.height == 0 || snapshot.seats.is_empty() {
+        return;
+    }
+
+    let count = snapshot.seats.len() as u16;
+    let total_w = panel_w * count + count.saturating_sub(1) * 2;
+    let start_x = area.x + area.width.saturating_sub(total_w) / 2;
+
+    for seat in &snapshot.seats {
+        let x = start_x + (panel_w + 2) * seat.index as u16;
+        if x + panel_w > area.x + area.width {
+            break;
+        }
+        let panel_area = Rect {
+            x,
+            y: area.y,
+            width: panel_w,
+            height: area.height,
+        };
+        if card_theme == AsciiCardTheme::Outline {
+            draw_seat_panel_outline(frame, panel_area, state, snapshot, seat, usernames);
+        } else {
+            draw_seat_panel(frame, panel_area, state, snapshot, seat, usernames);
+        }
+    }
+}
+
+fn draw_seat_panel_outline(
+    frame: &mut Frame,
+    area: Rect,
+    state: &State,
+    snapshot: &PokerPublicSnapshot,
+    seat: &PokerSeat,
+    usernames: &HashMap<Uuid, String>,
+) {
+    let is_you = state.seat_index() == Some(seat.index);
+    let is_active = snapshot.active_seat == Some(seat.index);
+    let is_winner = snapshot.winners.contains(&seat.index);
+    let border_color = seat_border_color(seat, is_you, is_active, is_winner);
+
+    let block = Block::default()
+        .title(format!(" Seat {} ", seat.index + 1))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border_color));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height < 8 {
+        draw_seat_panel_inner(frame, inner, state, snapshot, seat, usernames);
+        return;
+    }
+
+    let rows = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(5),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Min(1),
+    ])
+    .split(inner);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(identity_span(seat, is_you, usernames)))
+            .alignment(Alignment::Center),
+        rows[0],
+    );
+    draw_seat_cards(frame, rows[1], state, seat, AsciiCardTheme::Outline);
+    frame.render_widget(
+        Paragraph::new(seat_status_line(state, snapshot, seat)).alignment(Alignment::Center),
+        rows[2],
+    );
+    frame.render_widget(
+        Paragraph::new(seat_badge_line(snapshot, seat)).alignment(Alignment::Center),
+        rows[3],
+    );
+    if is_winner {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "WINNER",
+                Style::default()
+                    .fg(theme::SUCCESS())
+                    .add_modifier(Modifier::BOLD),
+            )))
+            .alignment(Alignment::Center),
+            rows[4],
+        );
+    }
+}
+
+fn draw_seat_panel(
+    frame: &mut Frame,
+    area: Rect,
+    state: &State,
+    snapshot: &PokerPublicSnapshot,
+    seat: &PokerSeat,
+    usernames: &HashMap<Uuid, String>,
+) {
+    let is_you = state.seat_index() == Some(seat.index);
+    let is_active = snapshot.active_seat == Some(seat.index);
+    let is_winner = snapshot.winners.contains(&seat.index);
+    let block = Block::default()
+        .title(format!(" Seat {} ", seat.index + 1))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(seat_border_color(seat, is_you, is_active, is_winner)));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    draw_seat_panel_inner(frame, inner, state, snapshot, seat, usernames);
+}
+
+fn draw_seat_panel_inner(
+    frame: &mut Frame,
+    area: Rect,
+    state: &State,
+    snapshot: &PokerPublicSnapshot,
+    seat: &PokerSeat,
+    usernames: &HashMap<Uuid, String>,
+) {
+    if area.height == 0 {
+        return;
+    }
+    let is_you = state.seat_index() == Some(seat.index);
+    let mut lines = vec![
+        Line::from(identity_span(seat, is_you, usernames)).alignment(Alignment::Center),
+        compact_seat_cards_line(state, seat).alignment(Alignment::Center),
+        seat_status_line(state, snapshot, seat).alignment(Alignment::Center),
+        seat_badge_line(snapshot, seat).alignment(Alignment::Center),
+    ];
+    if snapshot.winners.contains(&seat.index) {
+        lines.push(
+            Line::from(Span::styled(
+                "WINNER",
+                Style::default()
+                    .fg(theme::SUCCESS())
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .alignment(Alignment::Center),
+        );
+    }
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn seat_border_color(
+    seat: &PokerSeat,
+    is_you: bool,
+    is_active: bool,
+    is_winner: bool,
+) -> ratatui::style::Color {
+    if is_winner {
+        theme::SUCCESS()
+    } else if is_you {
+        theme::SUCCESS()
+    } else if is_active {
+        theme::AMBER()
+    } else if seat.user_id.is_some() {
+        theme::TEXT()
+    } else {
+        theme::BORDER_DIM()
+    }
+}
+
+fn identity_span(
+    seat: &PokerSeat,
+    is_you: bool,
+    usernames: &HashMap<Uuid, String>,
+) -> Span<'static> {
+    let Some(user_id) = seat.user_id else {
+        return Span::styled("open", Style::default().fg(theme::TEXT_DIM()));
+    };
+    let name = usernames
+        .get(&user_id)
+        .cloned()
+        .unwrap_or_else(|| "player".to_string());
+    let display = if is_you { format!("> {name}") } else { name };
+    let style = if is_you {
+        Style::default()
+            .fg(theme::SUCCESS())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT())
+    };
+    Span::styled(display, style)
+}
+
+fn draw_seat_cards(
+    frame: &mut Frame,
+    area: Rect,
+    state: &State,
+    seat: &PokerSeat,
+    theme_card: AsciiCardTheme,
+) {
+    let card_w = card_width(theme_card) as u16;
+    let card_h = theme_card.card_height() as u16;
+    let gap: u16 = 1;
+    let visible_count = seat.card_count.max(2).min(2);
+    let total_w = card_w * visible_count as u16 + gap * (visible_count as u16).saturating_sub(1);
+    let start_x = area.x + area.width.saturating_sub(total_w) / 2;
+    let card_y = area.y + area.height.saturating_sub(card_h) / 2;
+    let is_you = state.seat_index() == Some(seat.index);
+    let private_cards = &state.private_snapshot().hole_cards;
+
+    for index in 0..visible_count {
+        let x = start_x + (card_w + gap) * index as u16;
+        if x + card_w > area.x + area.width {
+            break;
+        }
+        let card_area = Rect {
+            x,
+            y: card_y,
+            width: card_w,
+            height: card_h,
+        };
+        if is_you && let Some(card) = private_cards.get(index) {
+            render_card_lines(
+                frame,
+                card_area,
+                &theme_card.render_face_lines(*card),
+                card_color(*card),
+            );
+        } else if seat.card_count > index {
+            render_card_lines(
+                frame,
+                card_area,
+                &theme_card.render_back_lines(),
+                if seat.folded {
+                    theme::TEXT_DIM()
+                } else {
+                    theme::TEXT_BRIGHT()
+                },
+            );
+        } else {
+            render_card_lines(
+                frame,
+                card_area,
+                &theme_card.render_empty_lines(),
+                theme::TEXT_DIM(),
+            );
+        }
+    }
+}
+
+fn compact_seat_cards_line(state: &State, seat: &PokerSeat) -> Line<'static> {
+    if seat.user_id.is_none() {
+        return Line::from(Span::styled(
+            "press s",
+            Style::default()
+                .fg(theme::AMBER_DIM())
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    if seat.card_count == 0 {
+        return Line::from(Span::styled(
+            "waiting",
+            Style::default().fg(theme::TEXT_DIM()),
+        ));
+    }
+    let is_you = state.seat_index() == Some(seat.index);
+    let mut spans = Vec::new();
+    let card_theme = AsciiCardTheme::Minimal;
+    for index in 0..seat.card_count.min(2) {
+        if index > 0 {
+            spans.push(Span::raw(" "));
+        }
+        if is_you && let Some(card) = state.private_snapshot().hole_cards.get(index) {
+            spans.push(Span::styled(
+                format!("[{}]", card_theme.render_face_compact(*card).trim()),
+                Style::default().fg(card_color(*card)),
+            ));
+        } else {
+            spans.push(Span::styled(
+                format!("[{}]", card_theme.render_back_compact().trim()),
+                Style::default().fg(if seat.folded {
+                    theme::TEXT_DIM()
+                } else {
+                    theme::TEXT_BRIGHT()
+                }),
+            ));
+        }
+    }
+    Line::from(spans)
+}
+
+fn seat_status_line(
+    state: &State,
+    snapshot: &PokerPublicSnapshot,
+    seat: &PokerSeat,
+) -> Line<'static> {
+    if seat.user_id.is_none() {
+        return Line::from(Span::styled(
+            "to sit",
+            Style::default().fg(theme::TEXT_DIM()),
+        ));
+    }
+    if snapshot.winners.contains(&seat.index) {
+        return Line::from(Span::styled(
+            "showdown",
+            Style::default()
+                .fg(theme::SUCCESS())
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    if seat.folded {
+        return Line::from(Span::styled(
+            "folded",
+            Style::default().fg(theme::TEXT_DIM()),
+        ));
+    }
+    if snapshot.active_seat == Some(seat.index) {
+        let label = if state.seat_index() == Some(seat.index) {
+            "your turn"
+        } else {
+            "acting..."
+        };
+        return Line::from(Span::styled(
+            label,
+            Style::default()
+                .fg(theme::AMBER())
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    if let Some(action) = seat.last_action {
+        return Line::from(Span::styled(
+            action.label().to_ascii_lowercase(),
+            Style::default().fg(theme::TEXT()),
+        ));
+    }
+    if seat.in_hand {
+        Line::from(Span::styled("in hand", Style::default().fg(theme::TEXT())))
+    } else {
+        Line::from(Span::styled(
+            "seated",
+            Style::default().fg(theme::TEXT_DIM()),
+        ))
+    }
+}
+
+fn seat_badge_line(snapshot: &PokerPublicSnapshot, seat: &PokerSeat) -> Line<'static> {
+    let mut spans = Vec::new();
+    if snapshot.dealer_button == Some(seat.index) {
+        spans.push(Span::styled(
+            "button",
+            Style::default()
+                .fg(theme::AMBER())
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
+    if seat.in_hand && !seat.folded && !snapshot.winners.contains(&seat.index) {
+        if !spans.is_empty() {
+            spans.push(Span::raw("  "));
+        }
+        spans.push(Span::styled(
+            snapshot.phase.label(),
+            Style::default().fg(theme::TEXT_DIM()),
+        ));
+    }
+    if spans.is_empty() {
+        spans.push(Span::raw(""));
+    }
+    Line::from(spans)
+}
+
+fn draw_status_line(frame: &mut Frame, area: Rect, snapshot: &PokerPublicSnapshot) {
+    if area.height == 0 {
+        return;
+    }
+    let tone = if snapshot.phase == PokerPhase::Showdown {
+        theme::SUCCESS()
+    } else {
+        theme::TEXT()
+    };
+    let line = Line::from(vec![
+        Span::styled("* ", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(snapshot.status_message.clone(), Style::default().fg(tone)),
+    ]);
+    frame.render_widget(Paragraph::new(line).alignment(Alignment::Center), area);
+}
+
+fn draw_keys_bar(frame: &mut Frame, area: Rect, state: &State, snapshot: &PokerPublicSnapshot) {
+    if area.height == 0 {
+        return;
+    }
+    frame.render_widget(
+        Paragraph::new(key_line(state, snapshot)).alignment(Alignment::Center),
+        area,
+    );
+}
+
+fn draw_table_compact(
+    frame: &mut Frame,
+    area: Rect,
+    state: &State,
+    snapshot: &PokerPublicSnapshot,
+    usernames: &HashMap<Uuid, String>,
+) {
+    let block = Block::default()
+        .title(" Poker ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::BORDER()));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let mut lines = vec![
+        Line::from(vec![
+            Span::styled("Board: ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(
+                render_cards_compact(&snapshot.community),
+                Style::default().fg(theme::TEXT_BRIGHT()),
+            ),
+        ]),
+        Line::from(vec![
+            Span::styled("Phase: ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(
+                snapshot.phase.label(),
+                Style::default()
+                    .fg(theme::AMBER())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ]),
+        Line::raw(""),
+    ];
+    lines.extend(snapshot.seats.iter().map(|seat| {
+        let is_you = state.seat_index() == Some(seat.index);
+        compact_seat_line(state, snapshot, seat, is_you, usernames)
+    }));
+    lines.push(Line::raw(""));
+    lines.push(Line::from(Span::styled(
+        snapshot.status_message.clone(),
+        Style::default().fg(theme::TEXT()),
+    )));
+    lines.push(key_line(state, snapshot));
+
+    frame.render_widget(Paragraph::new(lines), inner);
+}
+
+fn compact_seat_line(
+    state: &State,
+    snapshot: &PokerPublicSnapshot,
+    seat: &PokerSeat,
+    is_you: bool,
+    usernames: &HashMap<Uuid, String>,
+) -> Line<'static> {
+    let label = if is_you {
+        format!("Seat {} You", seat.index + 1)
+    } else {
+        format!("Seat {}", seat.index + 1)
+    };
+    let name = seat
+        .user_id
+        .and_then(|user_id| usernames.get(&user_id).cloned())
+        .unwrap_or_else(|| "open".to_string());
+    let label_style = if is_you {
+        Style::default().fg(theme::SUCCESS())
+    } else if snapshot.active_seat == Some(seat.index) {
+        Style::default().fg(theme::AMBER())
+    } else {
+        Style::default().fg(theme::TEXT_DIM())
+    };
+    let cards = compact_seat_cards_text(state, seat);
+    let action = seat
+        .last_action
+        .map(action_label)
+        .unwrap_or(if seat.folded { "folded" } else { "" });
+    Line::from(vec![
+        Span::styled(format!("{label:<11}"), label_style),
+        Span::styled(format!("{name:<12}"), Style::default().fg(theme::TEXT())),
+        Span::styled(cards, Style::default().fg(theme::TEXT_BRIGHT())),
+        Span::raw(" "),
+        Span::styled(action.to_string(), Style::default().fg(theme::TEXT_DIM())),
+    ])
+}
+
+fn compact_seat_cards_text(state: &State, seat: &PokerSeat) -> String {
+    if seat.card_count == 0 {
+        return ".".to_string();
+    }
+    let is_you = state.seat_index() == Some(seat.index);
+    let theme_card = AsciiCardTheme::Minimal;
+    (0..seat.card_count.min(2))
+        .map(|index| {
+            if is_you && let Some(card) = state.private_snapshot().hole_cards.get(index) {
+                format!("[{}]", theme_card.render_face_compact(*card).trim())
+            } else {
+                format!("[{}]", theme_card.render_back_compact().trim())
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn key_line(state: &State, snapshot: &PokerPublicSnapshot) -> Line<'static> {
+    if !state.is_seated() {
+        return key_hint("s/Enter sit - Esc back", "");
+    }
+    match snapshot.phase {
+        PokerPhase::Waiting | PokerPhase::Showdown => {
+            key_hint("N deal next - L leave - Esc back", "")
+        }
+        PokerPhase::PreFlop | PokerPhase::Flop | PokerPhase::Turn | PokerPhase::River
+            if state.can_act() =>
+        {
+            key_hint("C/Space check - F fold - L leave - Esc back", "")
+        }
+        PokerPhase::PreFlop | PokerPhase::Flop | PokerPhase::Turn | PokerPhase::River => {
+            key_hint("waiting action - L leave - Esc back", "")
+        }
+    }
+}
+
+fn action_label(action: PokerAction) -> &'static str {
+    match action {
+        PokerAction::Check => "check",
+        PokerAction::Fold => "fold",
+    }
+}
+
+fn render_cards_compact(cards: &[PlayingCard]) -> String {
+    if cards.is_empty() {
+        return ". . . . .".to_string();
+    }
+    let theme_card = AsciiCardTheme::Minimal;
+    cards
+        .iter()
+        .map(|card| format!("[{}]", theme_card.render_face_compact(*card).trim()))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn render_card_lines(
+    frame: &mut Frame,
+    area: Rect,
+    lines: &[String],
+    color: ratatui::style::Color,
+) {
+    let style = Style::default().fg(color);
+    let lines = lines
+        .iter()
+        .map(|raw| Line::from(Span::styled(raw.clone(), style)))
+        .collect::<Vec<_>>();
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn card_width(theme_card: AsciiCardTheme) -> usize {
+    match theme_card {
+        AsciiCardTheme::Minimal => 3,
+        AsciiCardTheme::Boxed => 5,
+        AsciiCardTheme::Outline => 9,
+    }
+}
+
+fn card_color(card: PlayingCard) -> ratatui::style::Color {
+    match card.suit {
+        CardSuit::Hearts | CardSuit::Diamonds => theme::ERROR(),
+        CardSuit::Clubs | CardSuit::Spades => theme::TEXT_BRIGHT(),
+    }
+}

--- a/late-ssh/src/app/rooms/poker/ui.rs
+++ b/late-ssh/src/app/rooms/poker/ui.rs
@@ -436,12 +436,12 @@ fn draw_seat_cards(
             width: card_w,
             height: card_h,
         };
-        if is_you && let Some(card) = private_cards.get(index) {
+        if let Some(card) = revealed_or_private_card(seat, private_cards, is_you, index) {
             render_card_lines(
                 frame,
                 card_area,
-                &theme_card.render_face_lines(*card),
-                card_color(*card),
+                &theme_card.render_face_lines(card),
+                card_color(card),
             );
         } else if seat.card_count > index {
             render_card_lines(
@@ -487,10 +487,12 @@ fn compact_seat_cards_line(state: &State, seat: &PokerSeat) -> Line<'static> {
         if index > 0 {
             spans.push(Span::raw(" "));
         }
-        if is_you && let Some(card) = state.private_snapshot().hole_cards.get(index) {
+        if let Some(card) =
+            revealed_or_private_card(seat, &state.private_snapshot().hole_cards, is_you, index)
+        {
             spans.push(Span::styled(
-                format!("[{}]", card_theme.render_face_compact(*card).trim()),
-                Style::default().fg(card_color(*card)),
+                format!("[{}]", card_theme.render_face_compact(card).trim()),
+                Style::default().fg(card_color(card)),
             ));
         } else {
             spans.push(Span::styled(
@@ -703,14 +705,29 @@ fn compact_seat_cards_text(state: &State, seat: &PokerSeat) -> String {
     let theme_card = AsciiCardTheme::Minimal;
     (0..seat.card_count.min(2))
         .map(|index| {
-            if is_you && let Some(card) = state.private_snapshot().hole_cards.get(index) {
-                format!("[{}]", theme_card.render_face_compact(*card).trim())
+            if let Some(card) =
+                revealed_or_private_card(seat, &state.private_snapshot().hole_cards, is_you, index)
+            {
+                format!("[{}]", theme_card.render_face_compact(card).trim())
             } else {
                 format!("[{}]", theme_card.render_back_compact().trim())
             }
         })
         .collect::<Vec<_>>()
         .join(" ")
+}
+
+fn revealed_or_private_card(
+    seat: &PokerSeat,
+    private_cards: &[PlayingCard],
+    is_you: bool,
+    index: usize,
+) -> Option<PlayingCard> {
+    seat.revealed_cards
+        .as_ref()
+        .and_then(|cards| cards.get(index))
+        .copied()
+        .or_else(|| is_you.then(|| private_cards.get(index).copied()).flatten())
 }
 
 fn key_line(state: &State, snapshot: &PokerPublicSnapshot) -> Line<'static> {

--- a/late-ssh/src/app/rooms/poker/ui.rs
+++ b/late-ssh/src/app/rooms/poker/ui.rs
@@ -374,9 +374,7 @@ fn seat_border_color(
     is_active: bool,
     is_winner: bool,
 ) -> ratatui::style::Color {
-    if is_winner {
-        theme::SUCCESS()
-    } else if is_you {
+    if is_winner || is_you {
         theme::SUCCESS()
     } else if is_active {
         theme::AMBER()
@@ -420,7 +418,7 @@ fn draw_seat_cards(
     let card_w = card_width(theme_card) as u16;
     let card_h = theme_card.card_height() as u16;
     let gap: u16 = 1;
-    let visible_count = seat.card_count.max(2).min(2);
+    let visible_count = 2;
     let total_w = card_w * visible_count as u16 + gap * (visible_count as u16).saturating_sub(1);
     let start_x = area.x + area.width.saturating_sub(total_w) / 2;
     let card_y = area.y + area.height.saturating_sub(card_h) / 2;

--- a/late-ssh/src/app/rooms/registry.rs
+++ b/late-ssh/src/app/rooms/registry.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 use super::{
     backend::{ActiveRoomBackend, CreateRoomModal, DirectoryHints, DirectoryMeta, RoomGameManager},
     blackjack::manager::BlackjackTableManager,
+    poker::manager::PokerTableManager,
     svc::{GameKind, RoomListItem},
     tictactoe::manager::TicTacToeTableManager,
 };
@@ -11,13 +12,19 @@ use super::{
 #[derive(Clone)]
 pub struct RoomGameRegistry {
     blackjack: BlackjackTableManager,
+    poker: PokerTableManager,
     tictactoe: TicTacToeTableManager,
 }
 
 impl RoomGameRegistry {
-    pub fn new(blackjack: BlackjackTableManager, tictactoe: TicTacToeTableManager) -> Self {
+    pub fn new(
+        blackjack: BlackjackTableManager,
+        poker: PokerTableManager,
+        tictactoe: TicTacToeTableManager,
+    ) -> Self {
         Self {
             blackjack,
+            poker,
             tictactoe,
         }
     }
@@ -25,6 +32,7 @@ impl RoomGameRegistry {
     pub fn manager(&self, kind: GameKind) -> &dyn RoomGameManager {
         match kind {
             GameKind::Blackjack => &self.blackjack,
+            GameKind::Poker => &self.poker,
             GameKind::TicTacToe => &self.tictactoe,
         }
     }

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -151,8 +151,10 @@ async fn main() -> anyhow::Result<()> {
         );
     let tictactoe_table_manager =
         late_ssh::app::rooms::tictactoe::manager::TicTacToeTableManager::new();
+    let poker_table_manager = late_ssh::app::rooms::poker::manager::PokerTableManager::new();
     let room_game_registry = late_ssh::app::rooms::registry::RoomGameRegistry::new(
         blackjack_table_manager.clone(),
+        poker_table_manager,
         tictactoe_table_manager,
     );
     let sudoku_service = late_ssh::app::games::sudoku::svc::SudokuService::new(

--- a/late-ssh/tests/helpers/mod.rs
+++ b/late-ssh/tests/helpers/mod.rs
@@ -24,6 +24,7 @@ use late_ssh::app::games::twenty_forty_eight::svc::TwentyFortyEightService;
 use late_ssh::app::profile::svc::ProfileService;
 use late_ssh::app::rooms::blackjack::manager::BlackjackTableManager;
 use late_ssh::app::rooms::blackjack::player::BlackjackPlayerDirectory;
+use late_ssh::app::rooms::poker::manager::PokerTableManager;
 use late_ssh::app::rooms::registry::RoomGameRegistry;
 use late_ssh::app::rooms::svc::RoomsService;
 use late_ssh::app::rooms::tictactoe::manager::TicTacToeTableManager;
@@ -57,7 +58,11 @@ fn test_room_game_registry(db: Db) -> RoomGameRegistry {
     let chip_service = ChipService::new(db.clone());
     let blackjack_table_manager =
         BlackjackTableManager::new(chip_service, BlackjackPlayerDirectory::new(db));
-    RoomGameRegistry::new(blackjack_table_manager, TicTacToeTableManager::new())
+    RoomGameRegistry::new(
+        blackjack_table_manager,
+        PokerTableManager::new(),
+        TicTacToeTableManager::new(),
+    )
 }
 
 pub fn test_config(db_config: late_core::db::DbConfig) -> Config {
@@ -174,6 +179,7 @@ pub fn test_app_state(db: Db, config: Config) -> State {
         blackjack_table_manager: blackjack_table_manager.clone(),
         room_game_registry: RoomGameRegistry::new(
             blackjack_table_manager,
+            PokerTableManager::new(),
             TicTacToeTableManager::new(),
         ),
         dartboard_server,


### PR DESCRIPTION
## Summary
- Adds a new no-stakes Poker room type so users can create, join, and play a first-pass Texas Hold'em-style table inside game rooms.
- This also proves the asymmetric-info room pattern: shared public table state plus per-user private hole-card state.

## What changed
- Poker is now available in the game kind registry, room filters, room creation flow, and directory metadata.
- Adds a four-seat Poker table with sit/leave, deal, check, fold, dealer button rotation, community cards, showdown winners, and responsive terminal UI.
- Keeps each player's hole cards private while showing other players' card backs and public hand progress.
- Updates game-room docs and architecture notes to include Poker and the split public/private snapshot pattern.

## Behavior notes
- Poker table state is process-local and resets if the SSH process restarts.
- This first pass has no betting, blinds, pots, chip settlement, or all-in handling.
- Seated players are removed after 5 minutes without active-room input; active hands are reconciled after removal.

## Feature flags
- None

## Screenshots / Video
- Required for this UI-visible change; screenshots or video still need to be attached before review.

## Testing
- Automated coverage added for Poker hand evaluation and room filtering with the new Poker kind.
- Verification attempted with `cargo test -p late-ssh poker` and `cargo test -p late-ssh rooms::filter`; both currently fail to compile because shared test helpers still construct `RoomGameRegistry::new` without a `PokerTableManager`.
- Manual verification still needed: create a Poker room, seat two players, deal a hand, check/fold through showdown, and confirm each session only sees its own hole cards.