### PR TITLE
Add Admin Moderation Commands for User Renames and Artboard Restores

### DIFF
--- a/late-core/src/models/artboard.rs
+++ b/late-core/src/models/artboard.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, Utc};
+use deadpool_postgres::GenericClient;
 use serde_json::Value;
 use tokio_postgres::Client;
 
@@ -89,6 +90,27 @@ impl Snapshot {
             .execute(
                 "DELETE FROM artboard_snapshots WHERE board_key = $1",
                 &[&board_key],
+            )
+            .await?;
+        Ok(count)
+    }
+
+    pub async fn copy_board_key(
+        client: &impl GenericClient,
+        source_key: &str,
+        target_key: &str,
+    ) -> Result<u64> {
+        let count = client
+            .execute(
+                "INSERT INTO artboard_snapshots (board_key, canvas, provenance)
+                 SELECT $1, canvas, provenance
+                 FROM artboard_snapshots
+                 WHERE board_key = $2
+                 ON CONFLICT (board_key) DO UPDATE
+                 SET canvas = EXCLUDED.canvas,
+                     provenance = EXCLUDED.provenance,
+                     updated = current_timestamp",
+                &[&target_key, &source_key],
             )
             .await?;
         Ok(count)

--- a/late-core/src/models/bonsai.rs
+++ b/late-core/src/models/bonsai.rs
@@ -70,6 +70,25 @@ impl Tree {
         Ok(())
     }
 
+    pub async fn set_recorded_dates(
+        client: &Client,
+        user_id: Uuid,
+        timestamp: DateTime<Utc>,
+        last_watered: Option<NaiveDate>,
+    ) -> Result<()> {
+        client
+            .execute(
+                "UPDATE bonsai_trees
+                 SET created = $2,
+                     updated = $2,
+                     last_watered = $3
+                 WHERE user_id = $1",
+                &[&user_id, &timestamp, &last_watered],
+            )
+            .await?;
+        Ok(())
+    }
+
     pub async fn water_and_add_growth_if_available(
         client: &Client,
         user_id: Uuid,

--- a/late-core/src/models/chat_message.rs
+++ b/late-core/src/models/chat_message.rs
@@ -176,7 +176,11 @@ impl ChatMessage {
         Ok(row.map(Self::from))
     }
 
-    pub async fn edit(client: &impl GenericClient, message_id: Uuid, body: &str) -> Result<Self> {
+    pub async fn edit_after_authorization(
+        client: &impl GenericClient,
+        message_id: Uuid,
+        body: &str,
+    ) -> Result<Self> {
         let body = body.trim();
         if body.is_empty() {
             bail!("message body cannot be empty");

--- a/late-core/src/models/chat_message.rs
+++ b/late-core/src/models/chat_message.rs
@@ -1,5 +1,6 @@
 use anyhow::{Result, bail};
 use chrono::{DateTime, Utc};
+use deadpool_postgres::GenericClient;
 use std::collections::HashMap;
 use tokio_postgres::Client;
 use uuid::Uuid;
@@ -152,7 +153,7 @@ impl ChatMessage {
     }
 
     pub async fn edit_by_author(
-        client: &Client,
+        client: &impl GenericClient,
         message_id: Uuid,
         user_id: Uuid,
         body: &str,
@@ -175,7 +176,30 @@ impl ChatMessage {
         Ok(row.map(Self::from))
     }
 
-    pub async fn delete_by_author(client: &Client, message_id: Uuid, user_id: Uuid) -> Result<u64> {
+    pub async fn edit(client: &impl GenericClient, message_id: Uuid, body: &str) -> Result<Self> {
+        let body = body.trim();
+        if body.is_empty() {
+            bail!("message body cannot be empty");
+        }
+
+        let row = client
+            .query_one(
+                "UPDATE chat_messages
+                 SET body = $1, updated = current_timestamp
+                 WHERE id = $2
+                 RETURNING *",
+                &[&body, &message_id],
+            )
+            .await?;
+
+        Ok(Self::from(row))
+    }
+
+    pub async fn delete_by_author(
+        client: &impl GenericClient,
+        message_id: Uuid,
+        user_id: Uuid,
+    ) -> Result<u64> {
         let count = client
             .execute(
                 "DELETE FROM chat_messages WHERE id = $1 AND user_id = $2",
@@ -185,7 +209,7 @@ impl ChatMessage {
         Ok(count)
     }
 
-    pub async fn delete_by_admin(client: &Client, message_id: Uuid) -> Result<u64> {
+    pub async fn delete_by_admin(client: &impl GenericClient, message_id: Uuid) -> Result<u64> {
         let count = client
             .execute("DELETE FROM chat_messages WHERE id = $1", &[&message_id])
             .await?;

--- a/late-core/src/models/user.rs
+++ b/late-core/src/models/user.rs
@@ -302,6 +302,24 @@ impl User {
         Ok(())
     }
 
+    pub async fn rename(
+        client: &impl GenericClient,
+        user_id: Uuid,
+        username: &str,
+    ) -> Result<Self> {
+        let username = sanitize_username_input(username);
+        let row = client
+            .query_one(
+                "UPDATE users
+                 SET username = $1, updated = current_timestamp
+                 WHERE id = $2
+                 RETURNING *",
+                &[&username, &user_id],
+            )
+            .await?;
+        Ok(Self::from(row))
+    }
+
     async fn settings_for_user(client: &Client, user_id: Uuid) -> Result<Value> {
         let row = client
             .query_opt("SELECT settings FROM users WHERE id = $1", &[&user_id])

--- a/late-ssh/src/app/chat/feeds/state.rs
+++ b/late-ssh/src/app/chat/feeds/state.rs
@@ -79,7 +79,6 @@ impl State {
 
     pub fn list(&self) {
         self.service.list_task(self.user_id);
-        self.service.refresh_unread_count_task(self.user_id);
     }
 
     pub fn mark_read(&mut self) {

--- a/late-ssh/src/app/chat/news/state.rs
+++ b/late-ssh/src/app/chat/news/state.rs
@@ -61,7 +61,6 @@ impl State {
 
     pub fn list_articles(&self) {
         self.article_service.list_articles_task();
-        self.article_service.refresh_unread_count_task(self.user_id);
     }
 
     pub fn selected_index(&self) -> usize {

--- a/late-ssh/src/app/chat/showcase/state.rs
+++ b/late-ssh/src/app/chat/showcase/state.rs
@@ -131,7 +131,6 @@ impl State {
 
     pub fn list(&self) {
         self.service.list_task();
-        self.refresh_unread_count();
     }
 
     pub fn refresh_unread_count(&self) {

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -29,6 +29,7 @@ use serde_json::json;
 use tokio::sync::{Semaphore, broadcast, mpsc, watch};
 use tracing::{Instrument, info_span};
 
+use crate::app::artboard::provenance::SharedArtboardProvenance;
 use crate::app::bonsai::state::stage_for;
 use crate::authz::{Caps, Permissions, Tier};
 use crate::metrics;
@@ -57,6 +58,8 @@ pub struct ChatService {
     active_users: Option<ActiveUsers>,
     session_registry: Option<SessionRegistry>,
     force_admin: bool,
+    dartboard_server: Option<dartboard_local::ServerHandle>,
+    dartboard_provenance: Option<SharedArtboardProvenance>,
     username_refresh_started: Arc<AtomicBool>,
     refresh_sessions: Arc<Mutex<HashMap<Uuid, ChatRefreshSession>>>,
     refresh_scheduler_started: Arc<AtomicBool>,
@@ -313,6 +316,8 @@ impl ChatService {
             active_users: None,
             session_registry: None,
             force_admin: false,
+            dartboard_server: None,
+            dartboard_provenance: None,
             username_refresh_started: Arc::new(AtomicBool::new(false)),
             refresh_sessions: Arc::new(Mutex::new(HashMap::new())),
             refresh_scheduler_started: Arc::new(AtomicBool::new(false)),
@@ -339,6 +344,16 @@ impl ChatService {
 
     pub fn with_force_admin(mut self, force_admin: bool) -> Self {
         self.force_admin = force_admin;
+        self
+    }
+
+    pub fn with_artboard_handles(
+        mut self,
+        server: dartboard_local::ServerHandle,
+        provenance: SharedArtboardProvenance,
+    ) -> Self {
+        self.dartboard_server = Some(server);
+        self.dartboard_provenance = Some(provenance);
         self
     }
 
@@ -392,12 +407,18 @@ impl ChatService {
     }
 
     fn moderation_service(&self) -> ModerationService {
-        ModerationService::new(
+        let service = ModerationService::new(
             self.db.clone(),
             self.moderation_session_effects(),
             self.moderation_event_tx.clone(),
             self.force_admin,
-        )
+        );
+        match (&self.dartboard_server, &self.dartboard_provenance) {
+            (Some(server), Some(provenance)) => {
+                service.with_artboard_handles(server.clone(), provenance.clone())
+            }
+            _ => service,
+        }
     }
 
     async fn refresh_username_directory(&self) -> Result<()> {
@@ -1113,16 +1134,7 @@ impl ChatService {
         ensure_message_permission(permissions, is_owner, Caps::EDIT_OTHER_MESSAGE, target_tier)?;
 
         let tx = client.transaction().await?;
-        let row = tx
-            .query_one(
-                "UPDATE chat_messages
-                 SET body = $1, updated = current_timestamp
-                 WHERE id = $2
-                 RETURNING *",
-                &[&new_body, &message_id],
-            )
-            .await?;
-        let updated = ChatMessage::from(row);
+        let updated = ChatMessage::edit(&tx, message_id, &new_body).await?;
         ModerationAuditLog::record_if(
             &tx,
             permissions.should_audit(is_owner),
@@ -1948,14 +1960,9 @@ impl ChatService {
         )?;
         let tx = client.transaction().await?;
         let count = if is_owner {
-            tx.execute(
-                "DELETE FROM chat_messages WHERE id = $1 AND user_id = $2",
-                &[&message_id, &user_id],
-            )
-            .await?
+            ChatMessage::delete_by_author(&tx, message_id, user_id).await?
         } else {
-            tx.execute("DELETE FROM chat_messages WHERE id = $1", &[&message_id])
-                .await?
+            ChatMessage::delete_by_admin(&tx, message_id).await?
         };
         if count == 0 {
             anyhow::bail!("Cannot delete this message");

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -29,13 +29,12 @@ use serde_json::json;
 use tokio::sync::{Semaphore, broadcast, mpsc, watch};
 use tracing::{Instrument, info_span};
 
-use crate::app::artboard::provenance::SharedArtboardProvenance;
 use crate::app::bonsai::state::stage_for;
 use crate::authz::{Caps, Permissions, Tier};
 use crate::metrics;
 use crate::moderation::event::ModerationEvent;
 use crate::moderation::service::{
-    ModerationService, ensure_message_permission, target_tier_for_user_id,
+    ModerationInfra, ModerationService, ensure_message_permission, target_tier_for_user_id,
 };
 use crate::moderation::session_effects::ModerationSessionEffects;
 use crate::session::SessionRegistry;
@@ -57,9 +56,7 @@ pub struct ChatService {
     notification_svc: super::notifications::svc::NotificationService,
     active_users: Option<ActiveUsers>,
     session_registry: Option<SessionRegistry>,
-    force_admin: bool,
-    dartboard_server: Option<dartboard_local::ServerHandle>,
-    dartboard_provenance: Option<SharedArtboardProvenance>,
+    moderation_infra: ModerationInfra,
     username_refresh_started: Arc<AtomicBool>,
     refresh_sessions: Arc<Mutex<HashMap<Uuid, ChatRefreshSession>>>,
     refresh_scheduler_started: Arc<AtomicBool>,
@@ -315,9 +312,7 @@ impl ChatService {
             notification_svc,
             active_users: None,
             session_registry: None,
-            force_admin: false,
-            dartboard_server: None,
-            dartboard_provenance: None,
+            moderation_infra: ModerationInfra::default(),
             username_refresh_started: Arc::new(AtomicBool::new(false)),
             refresh_sessions: Arc::new(Mutex::new(HashMap::new())),
             refresh_scheduler_started: Arc::new(AtomicBool::new(false)),
@@ -343,17 +338,12 @@ impl ChatService {
     }
 
     pub fn with_force_admin(mut self, force_admin: bool) -> Self {
-        self.force_admin = force_admin;
+        self.moderation_infra = self.moderation_infra.with_force_admin(force_admin);
         self
     }
 
-    pub fn with_artboard_handles(
-        mut self,
-        server: dartboard_local::ServerHandle,
-        provenance: SharedArtboardProvenance,
-    ) -> Self {
-        self.dartboard_server = Some(server);
-        self.dartboard_provenance = Some(provenance);
+    pub fn with_moderation_infra(mut self, moderation_infra: ModerationInfra) -> Self {
+        self.moderation_infra = moderation_infra;
         self
     }
 
@@ -407,18 +397,12 @@ impl ChatService {
     }
 
     fn moderation_service(&self) -> ModerationService {
-        let service = ModerationService::new(
+        ModerationService::new(
             self.db.clone(),
             self.moderation_session_effects(),
             self.moderation_event_tx.clone(),
-            self.force_admin,
-        );
-        match (&self.dartboard_server, &self.dartboard_provenance) {
-            (Some(server), Some(provenance)) => {
-                service.with_artboard_handles(server.clone(), provenance.clone())
-            }
-            _ => service,
-        }
+            self.moderation_infra.clone(),
+        )
     }
 
     async fn refresh_username_directory(&self) -> Result<()> {
@@ -1134,7 +1118,7 @@ impl ChatService {
         ensure_message_permission(permissions, is_owner, Caps::EDIT_OTHER_MESSAGE, target_tier)?;
 
         let tx = client.transaction().await?;
-        let updated = ChatMessage::edit(&tx, message_id, &new_body).await?;
+        let updated = ChatMessage::edit_after_authorization(&tx, message_id, new_body).await?;
         ModerationAuditLog::record_if(
             &tx,
             permissions.should_audit(is_owner),

--- a/late-ssh/src/app/chat/work/state.rs
+++ b/late-ssh/src/app/chat/work/state.rs
@@ -150,7 +150,6 @@ impl State {
 
     pub fn list(&self) {
         self.service.list_task();
-        self.refresh_unread_count();
     }
 
     pub fn refresh_unread_count(&self) {

--- a/late-ssh/src/dartboard.rs
+++ b/late-ssh/src/dartboard.rs
@@ -1,5 +1,5 @@
 use std::{
-    sync::{Arc, Mutex, mpsc},
+    sync::{Arc, Mutex, OnceLock, mpsc},
     thread,
     time::{Duration, Instant},
 };
@@ -142,8 +142,36 @@ pub async fn flush_server_snapshot(
     server: &ServerHandle,
     shared_provenance: &SharedArtboardProvenance,
 ) -> anyhow::Result<()> {
-    let canvas = server.canvas_snapshot();
-    let provenance = clone_shared_provenance(shared_provenance);
+    let (canvas, provenance) = {
+        let _guard = persistence_lock().lock_recover();
+        (
+            server.canvas_snapshot(),
+            clone_shared_provenance(shared_provenance),
+        )
+    };
+    save_canvas_snapshot_for_key(db, Snapshot::MAIN_BOARD_KEY, &canvas, &provenance).await
+}
+
+pub async fn restore_live_artboard(
+    db: &Db,
+    server: &ServerHandle,
+    shared_provenance: &SharedArtboardProvenance,
+    canvas: Canvas,
+    provenance: ArtboardProvenance,
+) -> anyhow::Result<()> {
+    {
+        let _guard = persistence_lock().lock_recover();
+        let mut shared = shared_provenance.lock_recover();
+        *shared = provenance.clone();
+        drop(shared);
+        server.submit_op_for(
+            SYSTEM_ROLLOVER_USER_ID,
+            SYSTEM_ROLLOVER_CLIENT_OP_ID,
+            CanvasOp::Replace {
+                canvas: canvas.clone(),
+            },
+        );
+    }
     save_canvas_snapshot_for_key(db, Snapshot::MAIN_BOARD_KEY, &canvas, &provenance).await
 }
 
@@ -313,19 +341,7 @@ pub async fn rollover_daily_snapshot_for_day(
 
         let blank = blank_canvas();
         let blank_provenance = ArtboardProvenance::default();
-        {
-            let mut shared = shared_provenance.lock_recover();
-            *shared = blank_provenance.clone();
-        }
-        server.submit_op_for(
-            SYSTEM_ROLLOVER_USER_ID,
-            SYSTEM_ROLLOVER_CLIENT_OP_ID,
-            CanvasOp::Replace {
-                canvas: blank.clone(),
-            },
-        );
-        save_canvas_snapshot_for_key(db, Snapshot::MAIN_BOARD_KEY, &blank, &blank_provenance)
-            .await?;
+        restore_live_artboard(db, server, shared_provenance, blank, blank_provenance).await?;
         save_canvas_snapshot_for_key(db, &monthly_key, &archived.canvas, &archived.provenance)
             .await?;
         tracing::info!(board_key = %monthly_key, "saved monthly artboard snapshot");
@@ -383,6 +399,7 @@ fn flush_dirty_canvas(
     shared_provenance: &SharedArtboardProvenance,
     runtime: &tokio::runtime::Handle,
 ) -> bool {
+    let _guard = persistence_lock().lock_recover();
     let canvas = {
         let mut state = persist_state.lock_recover();
         if !state.dirty {
@@ -407,6 +424,11 @@ fn flush_dirty_canvas(
 
     tracing::debug!("persisted artboard snapshot");
     persist_state.lock_recover().dirty
+}
+
+fn persistence_lock() -> &'static Mutex<()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
 }
 
 fn persist_canvas(

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -24,6 +24,7 @@ use late_ssh::{
     app::profile::svc::ProfileService,
     app::vote::svc::VoteService,
     config::Config,
+    moderation::service::ModerationInfra,
     session::SessionRegistry,
     ssh,
     state::{ActivityEvent, State},
@@ -194,8 +195,11 @@ async fn main() -> anyhow::Result<()> {
         initial_dartboard.map(|snapshot| snapshot.canvas),
         dartboard_provenance.clone(),
     );
-    let chat_service =
-        chat_service.with_artboard_handles(dartboard_server.clone(), dartboard_provenance.clone());
+    let chat_service = chat_service.with_moderation_infra(
+        ModerationInfra::default()
+            .with_force_admin(config.force_admin)
+            .with_artboard_handles(dartboard_server.clone(), dartboard_provenance.clone()),
+    );
     let leaderboard_service =
         late_ssh::app::games::leaderboard::svc::LeaderboardService::new(db.clone());
     let nonogram_library = match late_ssh::app::games::nonogram::state::load_default_library() {

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -194,6 +194,8 @@ async fn main() -> anyhow::Result<()> {
         initial_dartboard.map(|snapshot| snapshot.canvas),
         dartboard_provenance.clone(),
     );
+    let chat_service =
+        chat_service.with_artboard_handles(dartboard_server.clone(), dartboard_provenance.clone());
     let leaderboard_service =
         late_ssh::app::games::leaderboard::svc::LeaderboardService::new(db.clone());
     let nonogram_library = match late_ssh::app::games::nonogram::state::load_default_library() {

--- a/late-ssh/src/moderation/command.rs
+++ b/late-ssh/src/moderation/command.rs
@@ -19,6 +19,10 @@ pub(crate) enum ModCommand {
         slug: String,
         new_slug: String,
     },
+    RenameUser {
+        username: String,
+        new_username: String,
+    },
     RoomAction {
         action: RoomModAction,
         slug: String,
@@ -170,6 +174,7 @@ pub(crate) fn parse_mod_command(input: &str) -> Result<ModCommand> {
         "bans" => parse_bans_mod_command(&rest),
         "audit" => parse_audit_mod_command(&rest),
         "rename-room" => parse_rename_room_mod_command(&rest),
+        "rename-user" => parse_rename_user_mod_command(&rest),
         "room" => parse_room_mod_command(&rest),
         "server" => parse_server_mod_command(&rest),
         "artboard" => parse_artboard_mod_command(&rest),
@@ -247,6 +252,16 @@ fn parse_rename_room_mod_command(parts: &[&str]) -> Result<ModCommand> {
     Ok(ModCommand::RenameRoom {
         slug: required_slug(parts.first().copied(), "usage: rename-room #old #new")?,
         new_slug: required_slug(parts.get(1).copied(), "usage: rename-room #old #new")?,
+    })
+}
+
+fn parse_rename_user_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    if parts.len() != 2 {
+        anyhow::bail!("usage: rename-user @old @new");
+    }
+    Ok(ModCommand::RenameUser {
+        username: required_username(parts.first().copied(), "usage: rename-user @old @new")?,
+        new_username: required_username(parts.get(1).copied(), "usage: rename-user @old @new")?,
     })
 }
 
@@ -499,6 +514,7 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "bans [server|artboard|room #slug] [limit]",
             "audit [limit]",
             "rename-room #old #new",
+            "rename-user @old @new",
             "room kick #slug @name [reason...]",
             "room ban #slug @name [duration] [reason...]",
             "room unban #slug @name",
@@ -549,6 +565,12 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "rename-room #old #new",
             "Renames a non-DM room by changing its #slug.",
             "Moderator or admin only. #general is reserved and cannot be renamed.",
+        ],
+        "rename-user" => &[
+            "rename-user @old @new",
+            "Renames a user account.",
+            "@old: existing username. @new: desired username; sanitized with normal username rules.",
+            "Admin only. Writes a moderation audit entry.",
         ],
         "room" => &[
             "room <kick|ban|unban> #slug @name",
@@ -755,6 +777,19 @@ mod tests {
         );
         assert!(parse_mod_command("rename-room #old").is_err());
         assert!(parse_mod_command("rename-room #old #new extra").is_err());
+    }
+
+    #[test]
+    fn parses_rename_user_command() {
+        assert_eq!(
+            parse_mod_command("rename-user @Old @New.Name").unwrap(),
+            ModCommand::RenameUser {
+                username: "Old".to_string(),
+                new_username: "New.Name".to_string(),
+            }
+        );
+        assert!(parse_mod_command("rename-user @old").is_err());
+        assert!(parse_mod_command("rename-user @old @new extra").is_err());
     }
 
     #[test]

--- a/late-ssh/src/moderation/command.rs
+++ b/late-ssh/src/moderation/command.rs
@@ -38,6 +38,10 @@ pub(crate) enum ModCommand {
         duration: Option<chrono::Duration>,
         reason: String,
     },
+    ArtboardRestore {
+        date: Option<chrono::NaiveDate>,
+        reason: String,
+    },
     Role {
         action: RoleAction,
         username: String,
@@ -304,8 +308,11 @@ fn parse_server_mod_command(parts: &[&str]) -> Result<ModCommand> {
 
 fn parse_artboard_mod_command(parts: &[&str]) -> Result<ModCommand> {
     let Some(first) = parts.first().copied() else {
-        anyhow::bail!("usage: artboard <ban|unban> @name");
+        anyhow::bail!("usage: artboard <ban|unban|restore> ...");
     };
+    if first == "restore" {
+        return parse_artboard_restore_mod_command(&parts[1..]);
+    }
     let action = match first {
         "ban" => ArtboardAction::Ban,
         "unban" => ArtboardAction::Unban,
@@ -321,6 +328,20 @@ fn parse_artboard_mod_command(parts: &[&str]) -> Result<ModCommand> {
         action,
         username,
         duration,
+        reason: parts.get(reason_start..).unwrap_or_default().join(" "),
+    })
+}
+
+fn parse_artboard_restore_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    let (date, reason_start) = match parts.first().copied() {
+        Some(value) => match chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+            Ok(date) => (Some(date), 1),
+            Err(_) => (None, 0),
+        },
+        None => (None, 0),
+    };
+    Ok(ModCommand::ArtboardRestore {
+        date,
         reason: parts.get(reason_start..).unwrap_or_default().join(" "),
     })
 }
@@ -486,6 +507,7 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "server unban @name",
             "artboard ban @name [duration] [reason...]",
             "artboard unban @name",
+            "artboard restore [YYYY-MM-DD] [reason...]",
             "grant mod @name",
             "revoke mod @name",
             "",
@@ -572,9 +594,9 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "@name: username.",
         ],
         "artboard" => &[
-            "artboard <ban|unban> @name",
-            "Controls whether a user may use the artboard.",
-            "Subcommands: artboard ban, artboard unban.",
+            "artboard <ban|unban|restore> ...",
+            "Controls artboard access and snapshots.",
+            "Subcommands: artboard ban, artboard unban, artboard restore.",
         ],
         "artboard ban" => &[
             "artboard ban @name [duration] [reason...]",
@@ -587,6 +609,12 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "artboard unban @name",
             "Removes an artboard ban for a user.",
             "@name: username.",
+        ],
+        "artboard restore" => &[
+            "artboard restore [YYYY-MM-DD] [reason...]",
+            "Restores live Artboard from a daily UTC snapshot.",
+            "date: optional daily snapshot date; defaults to previous UTC day.",
+            "Admin only. Writes a moderation audit entry and backs up the previous main row.",
         ],
         "grant" => &[
             "grant mod @name",
@@ -810,6 +838,24 @@ mod tests {
             ModCommand::Audit { limit: 5 }
         );
         assert!(parse_mod_command("audit nope").is_err());
+    }
+
+    #[test]
+    fn parses_artboard_restore_command() {
+        assert_eq!(
+            parse_mod_command("artboard restore 2026-05-06 rollback vandalism").unwrap(),
+            ModCommand::ArtboardRestore {
+                date: Some(chrono::NaiveDate::from_ymd_opt(2026, 5, 6).unwrap()),
+                reason: "rollback vandalism".to_string(),
+            }
+        );
+        assert_eq!(
+            parse_mod_command("artboard restore rollback latest").unwrap(),
+            ModCommand::ArtboardRestore {
+                date: None,
+                reason: "rollback latest".to_string(),
+            }
+        );
     }
 
     #[test]

--- a/late-ssh/src/moderation/command.rs
+++ b/late-ssh/src/moderation/command.rs
@@ -355,10 +355,11 @@ fn parse_artboard_restore_mod_command(parts: &[&str]) -> Result<ModCommand> {
         },
         None => (None, 0),
     };
-    Ok(ModCommand::ArtboardRestore {
-        date,
-        reason: parts.get(reason_start..).unwrap_or_default().join(" "),
-    })
+    let reason = parts.get(reason_start..).unwrap_or_default().join(" ");
+    if reason.trim().is_empty() {
+        anyhow::bail!("usage: artboard restore [YYYY-MM-DD] <reason...>");
+    }
+    Ok(ModCommand::ArtboardRestore { date, reason })
 }
 
 fn parse_role_mod_command(mod_action: RoleAction, parts: &[&str]) -> Result<ModCommand> {
@@ -633,9 +634,10 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "@name: username.",
         ],
         "artboard restore" => &[
-            "artboard restore [YYYY-MM-DD] [reason...]",
+            "artboard restore [YYYY-MM-DD] <reason...>",
             "Restores live Artboard from a daily UTC snapshot.",
             "date: optional daily snapshot date; defaults to previous UTC day.",
+            "reason: required audit text.",
             "Admin only. Writes a moderation audit entry and backs up the previous main row.",
         ],
         "grant" => &[
@@ -891,6 +893,8 @@ mod tests {
                 reason: "rollback latest".to_string(),
             }
         );
+        assert!(parse_mod_command("artboard restore").is_err());
+        assert!(parse_mod_command("artboard restore 2026-05-06").is_err());
     }
 
     #[test]

--- a/late-ssh/src/moderation/event.rs
+++ b/late-ssh/src/moderation/event.rs
@@ -21,6 +21,13 @@ pub enum ModerationEvent {
         old_slug: String,
         new_slug: String,
     },
+    UserRenamed {
+        actor_user_id: Uuid,
+        target_user_id: Uuid,
+        old_username: String,
+        new_username: String,
+        active_user_updated: bool,
+    },
     ServerUserAction {
         actor_user_id: Uuid,
         target_user_id: Uuid,

--- a/late-ssh/src/moderation/event.rs
+++ b/late-ssh/src/moderation/event.rs
@@ -38,6 +38,12 @@ pub enum ModerationEvent {
         reason: String,
         notified_sessions: usize,
     },
+    ArtboardRestored {
+        actor_user_id: Uuid,
+        source_key: String,
+        backup_key: Option<String>,
+        reason: String,
+    },
     RoleAction {
         actor_user_id: Uuid,
         target_user_id: Uuid,

--- a/late-ssh/src/moderation/policy.rs
+++ b/late-ssh/src/moderation/policy.rs
@@ -39,6 +39,7 @@ bitflags! {
         const OPEN_MOD_SURFACE = 1 << 13;
         const VIEW_STAFF_INFO = 1 << 14;
         const RENAME_ROOM = 1 << 15;
+        const RESTORE_ARTBOARD = 1 << 16;
     }
 }
 

--- a/late-ssh/src/moderation/policy.rs
+++ b/late-ssh/src/moderation/policy.rs
@@ -40,6 +40,7 @@ bitflags! {
         const VIEW_STAFF_INFO = 1 << 14;
         const RENAME_ROOM = 1 << 15;
         const RESTORE_ARTBOARD = 1 << 16;
+        const RENAME_USER = 1 << 17;
     }
 }
 

--- a/late-ssh/src/moderation/service.rs
+++ b/late-ssh/src/moderation/service.rs
@@ -13,7 +13,7 @@ use late_core::{
         moderation_audit_log::{ModerationAuditLog, ModerationAuditLogListItem},
         room_ban::{RoomBan, RoomBanListItem},
         server_ban::{ServerBan, ServerBanActivation, ServerBanListItem},
-        user::User,
+        user::{User, sanitize_username_input},
     },
 };
 use serde_json::json;
@@ -88,6 +88,13 @@ impl ModerationService {
             ModCommand::Audit { limit } => self.list_audit(permissions, limit).await,
             ModCommand::RenameRoom { slug, new_slug } => {
                 self.rename_room(actor_user_id, permissions, &slug, &new_slug)
+                    .await
+            }
+            ModCommand::RenameUser {
+                username,
+                new_username,
+            } => {
+                self.rename_user(actor_user_id, permissions, &username, &new_username)
                     .await
             }
             ModCommand::RoomAction {
@@ -303,6 +310,64 @@ impl ModerationService {
             new_slug: new_slug.clone(),
         });
         Ok(vec![format!("renamed #{current_slug} to #{new_slug}")])
+    }
+
+    async fn rename_user(
+        &self,
+        actor_user_id: Uuid,
+        permissions: Permissions,
+        username: &str,
+        new_username: &str,
+    ) -> Result<Vec<String>> {
+        if !permissions.has(Caps::RENAME_USER) {
+            anyhow::bail!("admin only");
+        }
+
+        let mut client = self.db.get().await?;
+        let target = find_user_by_mod_name(&client, username).await?;
+        let old_username = target.username.clone();
+        let new_username = sanitize_username_input(new_username);
+        if old_username.eq_ignore_ascii_case(&new_username) {
+            return Ok(vec![format!("@{old_username} already has that username")]);
+        }
+        if User::find_by_username(&client, &new_username)
+            .await?
+            .is_some()
+        {
+            anyhow::bail!("username already taken: @{new_username}");
+        }
+
+        let tx = client.transaction().await?;
+        let updated = User::rename(&tx, target.id, &new_username).await?;
+        ModerationAuditLog::record(
+            &tx,
+            actor_user_id,
+            "rename_user",
+            "user",
+            Some(target.id),
+            json!({
+                "old_username": old_username,
+                "new_username": updated.username,
+            }),
+        )
+        .await?;
+        tx.commit().await?;
+
+        let active_user_updated = self
+            .effects
+            .update_active_username(target.id, &updated.username);
+        let _ = self.event_tx.send(ModerationEvent::UserRenamed {
+            actor_user_id,
+            target_user_id: target.id,
+            old_username: old_username.clone(),
+            new_username: updated.username.clone(),
+            active_user_updated,
+        });
+
+        Ok(vec![format!(
+            "renamed @{old_username} to @{}",
+            updated.username
+        )])
     }
 
     async fn room_action(

--- a/late-ssh/src/moderation/service.rs
+++ b/late-ssh/src/moderation/service.rs
@@ -1,8 +1,7 @@
 use anyhow::Result;
 use chrono::{NaiveDate, Utc};
-use dartboard_core::{Canvas, CanvasOp};
+use dartboard_core::Canvas;
 use late_core::{
-    MutexRecover,
     db::Db,
     models::{
         artboard::Snapshot as ArtboardSnapshot,
@@ -18,10 +17,12 @@ use late_core::{
 };
 use serde_json::json;
 use tokio::sync::broadcast;
+use tokio_postgres::error::SqlState;
 use uuid::Uuid;
 
 use crate::app::artboard::provenance::{ArtboardProvenance, SharedArtboardProvenance};
 use crate::authz::{Caps, Permissions, Tier};
+use crate::dartboard;
 use crate::moderation::command::{
     ArtboardAction, BanListScope, ModCommand, RoleAction, RoomModAction, ServerUserAction,
     mod_help_lines, normalize_mod_slug, parse_mod_command, strip_user_prefix,
@@ -34,9 +35,19 @@ pub(crate) struct ModerationService {
     db: Db,
     effects: ModerationSessionEffects,
     event_tx: broadcast::Sender<ModerationEvent>,
+    infra: ModerationInfra,
+}
+
+#[derive(Clone, Default)]
+pub struct ModerationInfra {
     force_admin: bool,
-    dartboard_server: Option<dartboard_local::ServerHandle>,
-    dartboard_provenance: Option<SharedArtboardProvenance>,
+    artboard: Option<ArtboardRestoreHandles>,
+}
+
+#[derive(Clone)]
+struct ArtboardRestoreHandles {
+    server: dartboard_local::ServerHandle,
+    provenance: SharedArtboardProvenance,
 }
 
 struct RoomModRequest {
@@ -52,28 +63,46 @@ impl ModerationService {
         db: Db,
         effects: ModerationSessionEffects,
         event_tx: broadcast::Sender<ModerationEvent>,
-        force_admin: bool,
+        infra: ModerationInfra,
     ) -> Self {
         Self {
             db,
             effects,
             event_tx,
-            force_admin,
-            dartboard_server: None,
-            dartboard_provenance: None,
+            infra,
         }
     }
+}
 
-    pub(crate) fn with_artboard_handles(
+impl ModerationInfra {
+    pub fn with_force_admin(mut self, force_admin: bool) -> Self {
+        self.force_admin = force_admin;
+        self
+    }
+
+    pub fn with_artboard_handles(
         mut self,
         server: dartboard_local::ServerHandle,
         provenance: SharedArtboardProvenance,
     ) -> Self {
-        self.dartboard_server = Some(server);
-        self.dartboard_provenance = Some(provenance);
+        self.artboard = Some(ArtboardRestoreHandles { server, provenance });
         self
     }
 
+    fn force_admin(&self) -> bool {
+        self.force_admin
+    }
+
+    fn artboard_handles(
+        &self,
+    ) -> Option<(&dartboard_local::ServerHandle, &SharedArtboardProvenance)> {
+        self.artboard
+            .as_ref()
+            .map(|handles| (&handles.server, &handles.provenance))
+    }
+}
+
+impl ModerationService {
     pub(crate) async fn run_command(
         &self,
         actor_user_id: Uuid,
@@ -338,7 +367,13 @@ impl ModerationService {
         }
 
         let tx = client.transaction().await?;
-        let updated = User::rename(&tx, target.id, &new_username).await?;
+        let updated = match User::rename(&tx, target.id, &new_username).await {
+            Ok(updated) => updated,
+            Err(error) if is_unique_violation(&error) => {
+                anyhow::bail!("username already taken: @{new_username}");
+            }
+            Err(error) => return Err(error),
+        };
         ModerationAuditLog::record(
             &tx,
             actor_user_id,
@@ -644,19 +679,16 @@ impl ModerationService {
         if !permissions.has(Caps::RESTORE_ARTBOARD) {
             anyhow::bail!("admin only");
         }
-        let server = self
-            .dartboard_server
-            .as_ref()
-            .ok_or_else(|| anyhow::anyhow!("artboard restore is unavailable"))?;
-        let shared_provenance = self
-            .dartboard_provenance
-            .as_ref()
+        let (server, shared_provenance) = self
+            .infra
+            .artboard_handles()
             .ok_or_else(|| anyhow::anyhow!("artboard restore is unavailable"))?;
         let date = date.unwrap_or_else(previous_utc_day);
         let source_key = daily_artboard_key(date);
         let backup_key = format!(
-            "restore-backup:main:{}",
-            Utc::now().format("%Y%m%dT%H%M%SZ")
+            "restore-backup:main:{}:{}",
+            Utc::now().format("%Y%m%dT%H%M%S%.fZ"),
+            Uuid::now_v7()
         );
 
         let mut client = self.db.get().await?;
@@ -671,12 +703,6 @@ impl ModerationService {
             ArtboardSnapshot::copy_board_key(&tx, ArtboardSnapshot::MAIN_BOARD_KEY, &backup_key)
                 .await?
                 > 0;
-        let restored =
-            ArtboardSnapshot::copy_board_key(&tx, &source_key, ArtboardSnapshot::MAIN_BOARD_KEY)
-                .await?;
-        if restored == 0 {
-            anyhow::bail!("artboard snapshot not found: {source_key}");
-        }
         ModerationAuditLog::record(
             &tx,
             actor_user_id,
@@ -692,17 +718,8 @@ impl ModerationService {
         .await?;
         tx.commit().await?;
 
-        {
-            let mut shared = shared_provenance.lock_recover();
-            *shared = provenance;
-        }
-        server.submit_op_for(
-            0,
-            0,
-            CanvasOp::Replace {
-                canvas: canvas.clone(),
-            },
-        );
+        dartboard::restore_live_artboard(&self.db, server, shared_provenance, canvas, provenance)
+            .await?;
 
         let _ = self.event_tx.send(ModerationEvent::ArtboardRestored {
             actor_user_id,
@@ -751,7 +768,10 @@ impl ModerationService {
         )
         .await?;
         tx.commit().await?;
-        let permissions = Permissions::new(target.is_admin || self.force_admin, new_is_moderator);
+        let permissions = Permissions::new(
+            target.is_admin || self.infra.force_admin(),
+            new_is_moderator,
+        );
         let notified_sessions = self
             .effects
             .notify_permissions_changed(target.id, permissions)
@@ -984,6 +1004,13 @@ fn previous_utc_day() -> NaiveDate {
 
 fn daily_artboard_key(date: NaiveDate) -> String {
     format!("daily:{date}")
+}
+
+fn is_unique_violation(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .filter_map(|cause| cause.downcast_ref::<tokio_postgres::Error>())
+        .any(|error| error.code() == Some(&SqlState::UNIQUE_VIOLATION))
 }
 
 async fn find_user_by_mod_name(client: &tokio_postgres::Client, username: &str) -> Result<User> {

--- a/late-ssh/src/moderation/service.rs
+++ b/late-ssh/src/moderation/service.rs
@@ -1,8 +1,11 @@
 use anyhow::Result;
-use chrono::Utc;
+use chrono::{NaiveDate, Utc};
+use dartboard_core::{Canvas, CanvasOp};
 use late_core::{
+    MutexRecover,
     db::Db,
     models::{
+        artboard::Snapshot as ArtboardSnapshot,
         artboard_ban::{ArtboardBan, ArtboardBanListItem},
         chat_room::ChatRoom,
         chat_room_member::ChatRoomMember,
@@ -17,6 +20,7 @@ use serde_json::json;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
+use crate::app::artboard::provenance::{ArtboardProvenance, SharedArtboardProvenance};
 use crate::authz::{Caps, Permissions, Tier};
 use crate::moderation::command::{
     ArtboardAction, BanListScope, ModCommand, RoleAction, RoomModAction, ServerUserAction,
@@ -31,6 +35,8 @@ pub(crate) struct ModerationService {
     effects: ModerationSessionEffects,
     event_tx: broadcast::Sender<ModerationEvent>,
     force_admin: bool,
+    dartboard_server: Option<dartboard_local::ServerHandle>,
+    dartboard_provenance: Option<SharedArtboardProvenance>,
 }
 
 struct RoomModRequest {
@@ -53,7 +59,19 @@ impl ModerationService {
             effects,
             event_tx,
             force_admin,
+            dartboard_server: None,
+            dartboard_provenance: None,
         }
+    }
+
+    pub(crate) fn with_artboard_handles(
+        mut self,
+        server: dartboard_local::ServerHandle,
+        provenance: SharedArtboardProvenance,
+    ) -> Self {
+        self.dartboard_server = Some(server);
+        self.dartboard_provenance = Some(provenance);
+        self
     }
 
     pub(crate) async fn run_command(
@@ -123,6 +141,10 @@ impl ModerationService {
                     reason,
                 )
                 .await
+            }
+            ModCommand::ArtboardRestore { date, reason } => {
+                self.artboard_restore(actor_user_id, permissions, date, reason)
+                    .await
             }
             ModCommand::Role { action, username } => {
                 self.role(actor_user_id, permissions, action, &username)
@@ -547,6 +569,90 @@ impl ModerationService {
         )])
     }
 
+    async fn artboard_restore(
+        &self,
+        actor_user_id: Uuid,
+        permissions: Permissions,
+        date: Option<NaiveDate>,
+        reason: String,
+    ) -> Result<Vec<String>> {
+        if !permissions.has(Caps::RESTORE_ARTBOARD) {
+            anyhow::bail!("admin only");
+        }
+        let server = self
+            .dartboard_server
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("artboard restore is unavailable"))?;
+        let shared_provenance = self
+            .dartboard_provenance
+            .as_ref()
+            .ok_or_else(|| anyhow::anyhow!("artboard restore is unavailable"))?;
+        let date = date.unwrap_or_else(previous_utc_day);
+        let source_key = daily_artboard_key(date);
+        let backup_key = format!(
+            "restore-backup:main:{}",
+            Utc::now().format("%Y%m%dT%H%M%SZ")
+        );
+
+        let mut client = self.db.get().await?;
+        let source = ArtboardSnapshot::find_by_board_key(&client, &source_key)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("artboard snapshot not found: {source_key}"))?;
+        let canvas: Canvas = serde_json::from_value(source.canvas.clone())?;
+        let provenance: ArtboardProvenance = serde_json::from_value(source.provenance.clone())?;
+
+        let tx = client.transaction().await?;
+        let backed_up =
+            ArtboardSnapshot::copy_board_key(&tx, ArtboardSnapshot::MAIN_BOARD_KEY, &backup_key)
+                .await?
+                > 0;
+        let restored =
+            ArtboardSnapshot::copy_board_key(&tx, &source_key, ArtboardSnapshot::MAIN_BOARD_KEY)
+                .await?;
+        if restored == 0 {
+            anyhow::bail!("artboard snapshot not found: {source_key}");
+        }
+        ModerationAuditLog::record(
+            &tx,
+            actor_user_id,
+            "artboard_restore",
+            "artboard",
+            None,
+            json!({
+                "source_key": source_key.clone(),
+                "backup_key": backed_up.then_some(backup_key.clone()),
+                "reason": reason.clone(),
+            }),
+        )
+        .await?;
+        tx.commit().await?;
+
+        {
+            let mut shared = shared_provenance.lock_recover();
+            *shared = provenance;
+        }
+        server.submit_op_for(
+            0,
+            0,
+            CanvasOp::Replace {
+                canvas: canvas.clone(),
+            },
+        );
+
+        let _ = self.event_tx.send(ModerationEvent::ArtboardRestored {
+            actor_user_id,
+            source_key: source_key.clone(),
+            backup_key: backed_up.then_some(backup_key.clone()),
+            reason,
+        });
+
+        let mut lines = vec![format!("restored artboard from {source_key}")];
+        if backed_up {
+            lines.push(format!("backup: {backup_key}"));
+        }
+        Ok(lines)
+    }
+
     async fn role(
         &self,
         actor_user_id: Uuid,
@@ -802,6 +908,17 @@ fn format_reason(reason: &str) -> &str {
 
 fn user_label(username: &str) -> String {
     format!("@{username}")
+}
+
+fn previous_utc_day() -> NaiveDate {
+    Utc::now()
+        .date_naive()
+        .pred_opt()
+        .expect("UTC date overflow")
+}
+
+fn daily_artboard_key(date: NaiveDate) -> String {
+    format!("daily:{date}")
 }
 
 async fn find_user_by_mod_name(client: &tokio_postgres::Client, username: &str) -> Result<User> {

--- a/late-ssh/src/moderation/session_effects.rs
+++ b/late-ssh/src/moderation/session_effects.rs
@@ -131,6 +131,18 @@ impl ModerationSessionEffects {
         notified
     }
 
+    pub(crate) fn update_active_username(&self, user_id: Uuid, username: &str) -> bool {
+        let Some(active_users) = self.active_users.as_ref() else {
+            return false;
+        };
+        let mut guard = active_users.lock_recover();
+        let Some(user) = guard.get_mut(&user_id) else {
+            return false;
+        };
+        user.username = username.to_string();
+        true
+    }
+
     async fn send(&self, token: &str, msg: SessionMessage) -> bool {
         let Some(registry) = self.session_registry.as_ref() else {
             return false;

--- a/late-ssh/tests/bonsai/svc.rs
+++ b/late-ssh/tests/bonsai/svc.rs
@@ -29,17 +29,14 @@ async fn ensure_tree_kills_stale_tree_records_grave_and_emits_activity() {
     let client = test_db.db.get().await.expect("db client");
     let user = create_test_user(&test_db.db, "bonsai-withered").await;
     Tree::ensure(&client, user.id, 77).await.expect("ensure");
-    client
-        .execute(
-            "UPDATE bonsai_trees
-             SET created = current_timestamp - interval '8 days',
-                 updated = current_timestamp - interval '8 days',
-                 last_watered = current_date - 8
-             WHERE user_id = $1",
-            &[&user.id],
-        )
-        .await
-        .expect("age tree");
+    Tree::set_recorded_dates(
+        &client,
+        user.id,
+        chrono::Utc::now() - chrono::Duration::days(8),
+        Some(chrono::Utc::now().date_naive() - chrono::Duration::days(8)),
+    )
+    .await
+    .expect("age tree");
 
     let (tx, mut rx) = broadcast::channel::<ActivityEvent>(16);
     let svc = BonsaiService::new(test_db.db.clone(), tx);

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -1,16 +1,21 @@
+use dartboard_core::{Canvas, Pos};
 use late_core::models::{
+    artboard::Snapshot as ArtboardSnapshot,
     artboard_ban::ArtboardBan,
     chat_message::{ChatMessage, ChatMessageParams},
     chat_room::{ChatRoom, ChatRoomParams},
     chat_room_member::ChatRoomMember,
+    moderation_audit_log::ModerationAuditLog,
     profile::{Profile, ProfileParams},
     room_ban::RoomBan,
     server_ban::ServerBan,
     user::User,
 };
+use late_ssh::app::artboard::provenance::ArtboardProvenance;
 use late_ssh::app::chat::notifications::svc::NotificationService;
 use late_ssh::app::chat::svc::{ChatEvent, ChatService};
 use late_ssh::authz::Permissions;
+use late_ssh::dartboard;
 use late_ssh::moderation::command::ServerUserAction;
 use late_ssh::moderation::event::ModerationEvent;
 use late_ssh::session::{SessionMessage, SessionRegistry};
@@ -1291,18 +1296,15 @@ async fn admin_delete_event_carries_admin_user_id_not_author() {
         other => panic!("expected MessageDeleted, got {other:?}"),
     }
 
-    let audit_count: i64 = client
-        .query_one(
-            "SELECT COUNT(*)
-             FROM moderation_audit_log
-             WHERE actor_user_id = $1
-               AND action = 'message_delete'
-               AND target_id = $2",
-            &[&admin.id, &msg.id],
-        )
-        .await
-        .expect("audit count")
-        .get(0);
+    let audit = ModerationAuditLog::all(&client).await.expect("audit log");
+    let audit_count = audit
+        .iter()
+        .filter(|entry| {
+            entry.actor_user_id == admin.id
+                && entry.action == "message_delete"
+                && entry.target_id == Some(msg.id)
+        })
+        .count();
     assert_eq!(audit_count, 1);
 }
 
@@ -1566,17 +1568,15 @@ async fn mod_room_ban_command_bans_kicks_and_audits() {
             .await
             .expect("membership lookup")
     );
-    let audit_count: i64 = client
-        .query_one(
-            "SELECT COUNT(*) FROM moderation_audit_log
-             WHERE actor_user_id = $1
-               AND action = 'room_ban'
-               AND target_id = $2",
-            &[&actor.id, &target.id],
-        )
-        .await
-        .expect("audit count")
-        .get(0);
+    let audit = ModerationAuditLog::all(&client).await.expect("audit log");
+    let audit_count = audit
+        .iter()
+        .filter(|entry| {
+            entry.actor_user_id == actor.id
+                && entry.action == "room_ban"
+                && entry.target_id == Some(target.id)
+        })
+        .count();
     assert_eq!(audit_count, 1);
 }
 
@@ -1654,20 +1654,18 @@ async fn mod_rename_room_command_updates_slug_and_audits() {
         other => panic!("expected room renamed moderation event, got {other:?}"),
     }
 
-    let audit_count: i64 = client
-        .query_one(
-            "SELECT COUNT(*) FROM moderation_audit_log
-             WHERE actor_user_id = $1
-               AND action = 'rename_room'
-               AND target_kind = 'room'
-               AND target_id = $2
-               AND metadata->>'old_slug' = 'rename-room-old'
-               AND metadata->>'new_slug' = 'rename-room-new'",
-            &[&actor.id, &room.id],
-        )
-        .await
-        .expect("audit count")
-        .get(0);
+    let audit = ModerationAuditLog::all(&client).await.expect("audit log");
+    let audit_count = audit
+        .iter()
+        .filter(|entry| {
+            entry.actor_user_id == actor.id
+                && entry.action == "rename_room"
+                && entry.target_kind == "room"
+                && entry.target_id == Some(room.id)
+                && entry.metadata["old_slug"] == "rename-room-old"
+                && entry.metadata["new_slug"] == "rename-room-new"
+        })
+        .count();
     assert_eq!(audit_count, 1);
 }
 
@@ -1740,17 +1738,15 @@ async fn mod_server_kick_command_terminates_active_sessions_and_audits() {
         other => panic!("expected terminate message, got {other:?}"),
     }
 
-    let audit_count: i64 = client
-        .query_one(
-            "SELECT COUNT(*) FROM moderation_audit_log
-             WHERE actor_user_id = $1
-               AND action = 'server_kick'
-               AND target_id = $2",
-            &[&actor.id, &target.id],
-        )
-        .await
-        .expect("audit count")
-        .get(0);
+    let audit = ModerationAuditLog::all(&client).await.expect("audit log");
+    let audit_count = audit
+        .iter()
+        .filter(|entry| {
+            entry.actor_user_id == actor.id
+                && entry.action == "server_kick"
+                && entry.target_id == Some(target.id)
+        })
+        .count();
     assert_eq!(audit_count, 1);
 }
 
@@ -1861,17 +1857,15 @@ async fn mod_server_ban_command_bans_and_terminates_active_sessions() {
         Some(target.fingerprint.as_str())
     );
 
-    let audit_count: i64 = client
-        .query_one(
-            "SELECT COUNT(*) FROM moderation_audit_log
-             WHERE actor_user_id = $1
-               AND action = 'server_ban'
-               AND target_id = $2",
-            &[&actor.id, &target.id],
-        )
-        .await
-        .expect("audit count")
-        .get(0);
+    let audit = ModerationAuditLog::all(&client).await.expect("audit log");
+    let audit_count = audit
+        .iter()
+        .filter(|entry| {
+            entry.actor_user_id == actor.id
+                && entry.action == "server_ban"
+                && entry.target_id == Some(target.id)
+        })
+        .count();
     assert_eq!(audit_count, 1);
 }
 
@@ -1951,6 +1945,143 @@ async fn mod_artboard_ban_command_notifies_active_sessions() {
             .await
             .expect("artboard ban lookup")
     );
+}
+
+#[tokio::test]
+async fn admin_artboard_restore_command_restores_daily_snapshot_and_audits() {
+    let test_db = new_test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let actor = create_test_user(&test_db.db, "artboard_restore_actor").await;
+
+    let mut main_canvas = Canvas::with_size(dartboard::CANVAS_WIDTH, dartboard::CANVAS_HEIGHT);
+    let _ = main_canvas.put_glyph(Pos { x: 0, y: 0 }, 'M');
+    let mut main_provenance = ArtboardProvenance::default();
+    main_provenance.set_username(Pos { x: 0, y: 0 }, "main_owner");
+
+    let mut daily_canvas = Canvas::with_size(dartboard::CANVAS_WIDTH, dartboard::CANVAS_HEIGHT);
+    let _ = daily_canvas.put_glyph(Pos { x: 0, y: 0 }, 'D');
+    let mut daily_provenance = ArtboardProvenance::default();
+    daily_provenance.set_username(Pos { x: 0, y: 0 }, "daily_owner");
+
+    ArtboardSnapshot::upsert(
+        &client,
+        ArtboardSnapshot::MAIN_BOARD_KEY,
+        serde_json::to_value(&main_canvas).expect("serialize main canvas"),
+        serde_json::to_value(&main_provenance).expect("serialize main provenance"),
+    )
+    .await
+    .expect("insert main snapshot");
+    ArtboardSnapshot::upsert(
+        &client,
+        "daily:2026-05-06",
+        serde_json::to_value(&daily_canvas).expect("serialize daily canvas"),
+        serde_json::to_value(&daily_provenance).expect("serialize daily provenance"),
+    )
+    .await
+    .expect("insert daily snapshot");
+
+    let shared_provenance = main_provenance.shared();
+    let server = dartboard::spawn_persistent_server_with_interval(
+        test_db.db.clone(),
+        Some(main_canvas),
+        shared_provenance.clone(),
+        Duration::from_secs(3600),
+    );
+    let service = ChatService::new(
+        test_db.db.clone(),
+        NotificationService::new(test_db.db.clone()),
+    )
+    .with_artboard_handles(server.clone(), shared_provenance.clone());
+    let mut events = service.subscribe_events();
+    let mut moderation_events = service.subscribe_moderation_events();
+
+    let request_id = Uuid::now_v7();
+    service.run_mod_command_task(
+        actor.id,
+        Permissions::new(true, false),
+        request_id,
+        "artboard restore 2026-05-06 rollback vandalism".to_string(),
+    );
+
+    let event = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("event timeout")
+        .expect("event");
+    match event {
+        ChatEvent::ModCommandOutput {
+            request_id: got_request,
+            lines,
+            success,
+            ..
+        } => {
+            assert_eq!(got_request, request_id);
+            assert!(success, "unexpected mod command failure: {lines:?}");
+            assert_eq!(lines[0], "restored artboard from daily:2026-05-06");
+            assert!(
+                lines
+                    .get(1)
+                    .is_some_and(|line| line.starts_with("backup: restore-backup:main:")),
+                "missing backup line: {lines:?}"
+            );
+        }
+        other => panic!("expected ModCommandOutput, got {other:?}"),
+    }
+
+    let moderation_event = timeout(Duration::from_secs(2), moderation_events.recv())
+        .await
+        .expect("moderation event timeout")
+        .expect("moderation event");
+    match moderation_event {
+        ModerationEvent::ArtboardRestored {
+            actor_user_id,
+            source_key,
+            backup_key,
+            reason,
+        } => {
+            assert_eq!(actor_user_id, actor.id);
+            assert_eq!(source_key, "daily:2026-05-06");
+            assert!(backup_key.is_some());
+            assert_eq!(reason, "rollback vandalism");
+        }
+        other => panic!("expected artboard restored moderation event, got {other:?}"),
+    }
+
+    let live_canvas = server.canvas_snapshot();
+    assert_eq!(live_canvas.get(Pos { x: 0, y: 0 }), 'D');
+    assert_eq!(
+        shared_provenance
+            .lock()
+            .expect("shared provenance lock")
+            .username_at(&live_canvas, Pos { x: 0, y: 0 }),
+        Some("daily_owner")
+    );
+
+    let main_snapshot =
+        ArtboardSnapshot::find_by_board_key(&client, ArtboardSnapshot::MAIN_BOARD_KEY)
+            .await
+            .expect("load restored main")
+            .expect("restored main exists");
+    let persisted_canvas: Canvas =
+        serde_json::from_value(main_snapshot.canvas).expect("decode persisted canvas");
+    assert_eq!(persisted_canvas.get(Pos { x: 0, y: 0 }), 'D');
+
+    let backups = ArtboardSnapshot::list_by_board_key_prefix(&client, "restore-backup:main:")
+        .await
+        .expect("backup snapshots");
+    assert_eq!(backups.len(), 1);
+
+    let audit = ModerationAuditLog::all(&client).await.expect("audit log");
+    let audit_count = audit
+        .iter()
+        .filter(|entry| {
+            entry.actor_user_id == actor.id
+                && entry.action == "artboard_restore"
+                && entry.target_kind == "artboard"
+                && entry.metadata["source_key"] == "daily:2026-05-06"
+                && entry.metadata["reason"] == "rollback vandalism"
+        })
+        .count();
+    assert_eq!(audit_count, 1);
 }
 
 #[tokio::test]

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -1670,6 +1670,114 @@ async fn mod_rename_room_command_updates_slug_and_audits() {
 }
 
 #[tokio::test]
+async fn admin_rename_user_command_updates_username_active_user_and_audits() {
+    let test_db = new_test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let actor = create_test_user(&test_db.db, "rename_user_actor").await;
+    let target = create_test_user(&test_db.db, "rename_user_old").await;
+    let active_users = Arc::new(Mutex::new(HashMap::from([(
+        target.id,
+        ActiveUser {
+            username: target.username.clone(),
+            fingerprint: Some(target.fingerprint.clone()),
+            peer_ip: None,
+            sessions: Vec::new(),
+            connection_count: 1,
+            last_login_at: std::time::Instant::now(),
+        },
+    )])));
+    let service = ChatService::new_with_active_users(
+        test_db.db.clone(),
+        NotificationService::new(test_db.db.clone()),
+        active_users.clone(),
+    );
+    let mut events = service.subscribe_events();
+    let mut moderation_events = service.subscribe_moderation_events();
+
+    let request_id = Uuid::now_v7();
+    service.run_mod_command_task(
+        actor.id,
+        Permissions::new(true, false),
+        request_id,
+        "rename-user @rename_user_old @rename_user_new".to_string(),
+    );
+
+    let event = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("event timeout")
+        .expect("event");
+    match event {
+        ChatEvent::ModCommandOutput {
+            request_id: got_request,
+            lines,
+            success,
+            ..
+        } => {
+            assert_eq!(got_request, request_id);
+            assert!(success, "unexpected mod command failure: {lines:?}");
+            assert_eq!(lines, vec!["renamed @rename_user_old to @rename_user_new"]);
+        }
+        other => panic!("expected ModCommandOutput, got {other:?}"),
+    }
+
+    let moderation_event = timeout(Duration::from_secs(2), moderation_events.recv())
+        .await
+        .expect("moderation event timeout")
+        .expect("moderation event");
+    match moderation_event {
+        ModerationEvent::UserRenamed {
+            actor_user_id,
+            target_user_id,
+            old_username,
+            new_username,
+            active_user_updated,
+        } => {
+            assert_eq!(actor_user_id, actor.id);
+            assert_eq!(target_user_id, target.id);
+            assert_eq!(old_username, "rename_user_old");
+            assert_eq!(new_username, "rename_user_new");
+            assert!(active_user_updated);
+        }
+        other => panic!("expected user renamed moderation event, got {other:?}"),
+    }
+
+    assert!(
+        User::find_by_username(&client, "rename_user_old")
+            .await
+            .expect("old username lookup")
+            .is_none()
+    );
+    let renamed = User::find_by_username(&client, "rename_user_new")
+        .await
+        .expect("new username lookup")
+        .expect("renamed user exists");
+    assert_eq!(renamed.id, target.id);
+    assert_eq!(
+        active_users
+            .lock()
+            .expect("active users lock")
+            .get(&target.id)
+            .expect("active target")
+            .username,
+        "rename_user_new"
+    );
+
+    let audit = ModerationAuditLog::all(&client).await.expect("audit log");
+    let audit_count = audit
+        .iter()
+        .filter(|entry| {
+            entry.actor_user_id == actor.id
+                && entry.action == "rename_user"
+                && entry.target_kind == "user"
+                && entry.target_id == Some(target.id)
+                && entry.metadata["old_username"] == "rename_user_old"
+                && entry.metadata["new_username"] == "rename_user_new"
+        })
+        .count();
+    assert_eq!(audit_count, 1);
+}
+
+#[tokio::test]
 async fn mod_server_kick_command_terminates_active_sessions_and_audits() {
     let test_db = new_test_db().await;
     let client = test_db.db.get().await.expect("db client");

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -1,4 +1,4 @@
-use dartboard_core::{Canvas, Pos};
+use dartboard_core::{Canvas, CanvasOp, Pos, RgbColor};
 use late_core::models::{
     artboard::Snapshot as ArtboardSnapshot,
     artboard_ban::ArtboardBan,
@@ -18,12 +18,13 @@ use late_ssh::authz::Permissions;
 use late_ssh::dartboard;
 use late_ssh::moderation::command::ServerUserAction;
 use late_ssh::moderation::event::ModerationEvent;
+use late_ssh::moderation::service::ModerationInfra;
 use late_ssh::session::{SessionMessage, SessionRegistry};
 use late_ssh::state::{ActiveSession, ActiveUser};
 use std::collections::HashMap;
 use std::net::IpAddr;
 use std::sync::{Arc, Mutex};
-use tokio::time::{Duration, timeout};
+use tokio::time::{Duration, sleep, timeout};
 use uuid::Uuid;
 
 use super::helpers::new_test_db;
@@ -2093,13 +2094,24 @@ async fn admin_artboard_restore_command_restores_daily_snapshot_and_audits() {
         test_db.db.clone(),
         Some(main_canvas),
         shared_provenance.clone(),
-        Duration::from_secs(3600),
+        Duration::from_millis(10),
+    );
+    server.submit_op_for(
+        0,
+        1,
+        CanvasOp::PaintCell {
+            pos: Pos { x: 0, y: 0 },
+            ch: 'O',
+            fg: RgbColor::new(1, 2, 3),
+        },
     );
     let service = ChatService::new(
         test_db.db.clone(),
         NotificationService::new(test_db.db.clone()),
     )
-    .with_artboard_handles(server.clone(), shared_provenance.clone());
+    .with_moderation_infra(
+        ModerationInfra::default().with_artboard_handles(server.clone(), shared_provenance.clone()),
+    );
     let mut events = service.subscribe_events();
     let mut moderation_events = service.subscribe_moderation_events();
 
@@ -2169,6 +2181,15 @@ async fn admin_artboard_restore_command_restores_daily_snapshot_and_audits() {
             .await
             .expect("load restored main")
             .expect("restored main exists");
+    let persisted_canvas: Canvas =
+        serde_json::from_value(main_snapshot.canvas).expect("decode persisted canvas");
+    assert_eq!(persisted_canvas.get(Pos { x: 0, y: 0 }), 'D');
+    sleep(Duration::from_millis(50)).await;
+    let main_snapshot =
+        ArtboardSnapshot::find_by_board_key(&client, ArtboardSnapshot::MAIN_BOARD_KEY)
+            .await
+            .expect("reload restored main")
+            .expect("restored main still exists");
     let persisted_canvas: Canvas =
         serde_json::from_value(main_snapshot.canvas).expect("decode persisted canvas");
     assert_eq!(persisted_canvas.get(Pos { x: 0, y: 0 }), 'D');


### PR DESCRIPTION
## Summary
- Adds admin-only recovery tools for operational moderation: renaming user accounts and restoring the live Artboard from a saved daily snapshot.
- Keeps these actions auditable and observable through moderation events, command output, and active-session updates where applicable.
- Reduces redundant unread-count refreshes when chat/news/showcase/work lists are loaded.

## What changed
- Added `rename-user @old @new` so admins can rename an account using the normal username sanitization rules.
- Added `artboard restore [YYYY-MM-DD] [reason...]` so admins can restore the live Artboard from a daily UTC snapshot.
- Artboard restores now back up the previous main board snapshot before replacing it, update live canvas/provenance state, and emit a moderation event.
- User renames update the persisted user record, active user directory entry when present, audit log, and moderation event stream.
- Moderation help text now documents the new commands.

## Behavior notes
- Both new commands are admin-only.
- `artboard restore` defaults to the previous UTC day when no date is provided.
- Artboard restore is unavailable unless the chat moderation service has live Artboard server/provenance handles.
- The previous main Artboard row is saved under a `restore-backup:main:*` key when present.

## Feature flags
None.

## Screenshots / Video
UI-visible moderation command/help output changed. Screenshots or terminal capture still need to be attached before review.

## Testing
Automated:
- Added parser coverage for `rename-user` and `artboard restore`.
- Added integration coverage for admin user rename, including active user update, moderation event, persisted username, and audit log.
- Added integration coverage for Artboard restore, including live canvas/provenance update, persisted snapshot replacement, backup creation, moderation event, and audit log.
- Updated related tests to use model helpers for audit/tree setup paths.

Manual:
- Not included in the diff.