### PR TITLE
Add chip-backed betting to poker rooms

### DIFF
--- a/late-ssh/src/app/rooms/CONTEXT.md
+++ b/late-ssh/src/app/rooms/CONTEXT.md
@@ -124,13 +124,15 @@
 ## Poker Runtime
 - `PokerTableManager` is process-local and lazily maps each entered `GameRoom.id` to a `PokerService`.
 - Restarting the SSH process drops in-memory poker state. Existing open `game_rooms` survive, but re-entering creates a fresh table.
-- Poker is a no-stakes Texas Hold'em-style first pass: four seats, one 52-card deck, private two-card hole hands, shared flop/turn/river, check/fold actions, and showdown hand ranking. Chip betting is not wired yet.
-- The service uses one public `watch::Sender<PokerPublicSnapshot>` plus per-user `watch::Sender<PokerPrivateSnapshot>` channels keyed by `user_id`. Public snapshots include seat occupancy, card counts, folded/action state, dealer button, board, phase, active seat, and winners. Private snapshots include only the current user's hole cards.
+- Poker is a fixed-blind Texas Hold'em-style table: four seats, one 52-card deck, private two-card hole hands, shared flop/turn/river, 10/20 blinds, call/check, bet/raise, fold, all-in, side pots, showdown hand ranking, and chip settlement through `ChipService`.
+- The service uses one public `watch::Sender<PokerPublicSnapshot>` plus per-user `watch::Sender<PokerPrivateSnapshot>` channels keyed by `user_id`. Public snapshots include seat occupancy, visible stacks, committed chips, pot/current bet, card counts, folded/all-in/pending state, dealer button, board, phase, active seat, and winners. Private snapshots include the current user's hole cards, balance, call amount, and minimum raise.
 - The deck and all hole cards live only in `SharedState`; clients never receive other users' hole cards. `publish` lazily prunes orphaned private senders where `receiver_count() == 0`.
-- Entering starts as a viewer. `s` or `Enter` sits in the first open seat. Seated players press `n` to deal when the table is waiting or at showdown, `c`/Space/Enter to check when active, `f` to fold, and `l` to leave a seat.
-- The dealer button advances to the next occupied seat each new hand. First action on each street starts left of the button. If all remaining players check through the river, the service evaluates the best five-card hand from each player's two hole cards plus the five-card board; tied best hands share winner display.
-- A seated player who sends no active-room input for 5 minutes is removed from the table. If they were in an active hand, their seat is removed and the hand is reconciled.
-- Poker has no chip-balance hook yet; `ActiveRoomBackend::chip_balance` returns `None`.
+- Entering starts as a viewer. `s` or `Enter` sits in the first open seat. Seated players press `n` to deal when the table is waiting or at showdown, `c`/Space/Enter to check or call when active, `b`/`r` to bet or raise by the selected amount, `[`/`]` or `-`/`+` to adjust that amount, `a` to shove all-in, `f` to fold, and `l` to leave a seat.
+- The dealer button advances to the next funded occupied seat each new hand. Heads-up uses the button as the small blind; larger tables post blinds left of the button. Pre-flop action starts left of the big blind, later streets start left of the button, and when no further betting is possible because all remaining players are all-in, the service runs out the board and settles showdown.
+- Short all-ins smaller than the current call are legal. Short all-in raises update the amount to call but do not reopen raising for players whose action was already closed; those players can only call or fold unless a full raise has reopened action.
+- Side pots are built from each distinct committed-chip level. Each pot is awarded only among eligible non-folded contenders for that level; tied winners split each pot, with odd chips assigned deterministically by seat order.
+- A seated player who sends no active-room input for 5 minutes is removed from the table when idle outside an active hand. During an active hand, inactivity folds the player and reconciles the hand.
+- Poker wires `ActiveRoomBackend::chip_balance`, syncs external chip balance while safely idle, debits chips when they are committed to a pot, credits winning pot shares at settlement, and restores the chip floor for zero-credit losers.
 - `poker/ui.rs` mirrors the Blackjack table thresholds and broad layout: dealer/board block on top, felt divider, four seat panels, status line, and key bar. The current user's panel renders private hole cards face-up from the private snapshot; other players render card backs.
 
 ## Blackjack UI Invariants
@@ -159,7 +161,7 @@
 ## Known Gaps
 - Blackjack table state is not durable across process restart.
 - Poker table state is not durable across process restart.
-- Poker does not yet have chip betting, pots, blinds, all-in side pots, or chip settlement.
+- Poker blind/stake settings are fixed in code at 10/20 and are not configurable from room settings yet.
 - There is no AFK/disconnect cleanup path tied to SSH session lifecycle.
 - Dashboard showcases remain Blackjack-only.
 

--- a/late-ssh/src/app/rooms/CONTEXT.md
+++ b/late-ssh/src/app/rooms/CONTEXT.md
@@ -131,6 +131,7 @@
 - The dealer button advances to the next funded occupied seat each new hand. Heads-up uses the button as the small blind; larger tables post blinds left of the button. Pre-flop action starts left of the big blind, later streets start left of the button, and when no further betting is possible because all remaining players are all-in, the service runs out the board and settles showdown.
 - Short all-ins smaller than the current call are legal. Short all-in raises update the amount to call but do not reopen raising for players whose action was already closed; those players can only call or fold unless a full raise has reopened action.
 - Side pots are built from each distinct committed-chip level. Each pot is awarded only among eligible non-folded contenders for that level; tied winners split each pot, with odd chips assigned deterministically by seat order.
+- Showdown currently auto-reveals every non-folded contender's hole cards. Real poker can allow players to muck at showdown instead of showing if they do not want to contest the pot; this app does not model a `show`/`muck` reveal phase yet.
 - A seated player who sends no active-room input for 5 minutes is removed from the table when idle outside an active hand. During an active hand, inactivity folds the player and reconciles the hand.
 - Poker wires `ActiveRoomBackend::chip_balance`, syncs external chip balance while safely idle, debits chips when they are committed to a pot, credits winning pot shares at settlement, and restores the chip floor for zero-credit losers.
 - `poker/ui.rs` mirrors the Blackjack table thresholds and broad layout: dealer/board block on top, felt divider, four seat panels, status line, and key bar. The current user's panel renders private hole cards face-up from the private snapshot; other players render card backs.
@@ -162,6 +163,7 @@
 - Blackjack table state is not durable across process restart.
 - Poker table state is not durable across process restart.
 - Poker blind/stake settings are fixed in code at 10/20 and are not configurable from room settings yet.
+- Poker showdown reveal is simplified: all non-folded contenders auto-show, with no optional muck flow.
 - There is no AFK/disconnect cleanup path tied to SSH session lifecycle.
 - Dashboard showcases remain Blackjack-only.
 

--- a/late-ssh/src/app/rooms/poker/input.rs
+++ b/late-ssh/src/app/rooms/poker/input.rs
@@ -14,6 +14,14 @@ pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
 
     match byte {
         0x1B | b'q' | b'Q' => InputAction::Leave,
+        b'[' | b'-' => {
+            state.decrease_raise();
+            InputAction::Handled
+        }
+        b']' | b'+' | b'=' => {
+            state.increase_raise();
+            InputAction::Handled
+        }
         b'l' | b'L' => {
             state.leave_seat();
             InputAction::Handled
@@ -26,8 +34,16 @@ pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
             state.fold();
             InputAction::Handled
         }
+        b'b' | b'B' | b'r' | b'R' => {
+            state.bet_or_raise();
+            InputAction::Handled
+        }
+        b'a' | b'A' => {
+            state.all_in();
+            InputAction::Handled
+        }
         b'c' | b'C' | b' ' | b'\r' | b'\n' => {
-            state.check();
+            state.call_or_check();
             InputAction::Handled
         }
         _ => InputAction::Ignored,

--- a/late-ssh/src/app/rooms/poker/manager.rs
+++ b/late-ssh/src/app/rooms/poker/manager.rs
@@ -6,20 +6,31 @@ use std::{
 use late_core::MutexRecover;
 use uuid::Uuid;
 
-use crate::app::rooms::{
-    backend::{ActiveRoomBackend, CreateRoomModal, DirectoryHints, DirectoryMeta, RoomGameManager},
-    poker::{create_modal::PokerCreateModal, state::State, svc::PokerService},
-    svc::{GameKind, RoomListItem},
+use crate::app::{
+    games::chips::svc::ChipService,
+    rooms::{
+        backend::{
+            ActiveRoomBackend, CreateRoomModal, DirectoryHints, DirectoryMeta, RoomGameManager,
+        },
+        poker::{
+            create_modal::PokerCreateModal,
+            state::State,
+            svc::{BIG_BLIND, PokerService, SMALL_BLIND},
+        },
+        svc::{GameKind, RoomListItem},
+    },
 };
 
 #[derive(Clone)]
 pub struct PokerTableManager {
+    chip_svc: ChipService,
     tables: Arc<Mutex<HashMap<Uuid, PokerService>>>,
 }
 
 impl PokerTableManager {
-    pub fn new() -> Self {
+    pub fn new(chip_svc: ChipService) -> Self {
         Self {
+            chip_svc,
             tables: Arc::new(Mutex::new(HashMap::new())),
         }
     }
@@ -28,14 +39,8 @@ impl PokerTableManager {
         let mut tables = self.tables.lock_recover();
         tables
             .entry(room_id)
-            .or_insert_with(|| PokerService::new(room_id))
+            .or_insert_with(|| PokerService::new(room_id, self.chip_svc.clone()))
             .clone()
-    }
-}
-
-impl Default for PokerTableManager {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -68,7 +73,7 @@ impl RoomGameManager for PokerTableManager {
         DirectoryMeta {
             seats: 4,
             pace: "turn-based".to_string(),
-            stakes: "no stakes".to_string(),
+            stakes: format!("{SMALL_BLIND}/{BIG_BLIND} blinds"),
         }
     }
 
@@ -86,9 +91,13 @@ impl RoomGameManager for PokerTableManager {
         &self,
         room: &RoomListItem,
         user_id: Uuid,
-        _chip_balance: i64,
+        chip_balance: i64,
     ) -> Box<dyn ActiveRoomBackend> {
-        Box::new(State::new(self.get_or_create(room.id), user_id))
+        Box::new(State::new(
+            self.get_or_create(room.id),
+            user_id,
+            chip_balance,
+        ))
     }
 }
 
@@ -141,7 +150,19 @@ impl ActiveRoomBackend for State {
         Some(crate::app::rooms::backend::RoomTitleDetails {
             seated: Some(format!("{occupied}/4 seated")),
             role: Some(format!("{role} · {}", snapshot.phase.label())),
-            balance: None,
+            balance: Some(self.balance()),
         })
+    }
+
+    fn chip_balance(&self) -> Option<i64> {
+        Some(self.balance())
+    }
+
+    fn can_sync_external_chip_balance(&self) -> bool {
+        State::can_sync_external_chip_balance(self)
+    }
+
+    fn sync_external_chip_balance(&mut self, balance: i64) {
+        State::sync_external_chip_balance(self, balance);
     }
 }

--- a/late-ssh/src/app/rooms/poker/state.rs
+++ b/late-ssh/src/app/rooms/poker/state.rs
@@ -1,7 +1,9 @@
 use tokio::sync::watch;
 use uuid::Uuid;
 
-use super::svc::{PokerPrivateSnapshot, PokerPublicSnapshot, PokerService};
+use super::svc::{BIG_BLIND, PokerPhase, PokerPrivateSnapshot, PokerPublicSnapshot, PokerService};
+
+const RAISE_STEP: i64 = BIG_BLIND;
 
 pub struct State {
     user_id: Uuid,
@@ -10,10 +12,12 @@ pub struct State {
     svc: PokerService,
     public_rx: watch::Receiver<PokerPublicSnapshot>,
     private_rx: watch::Receiver<PokerPrivateSnapshot>,
+    balance: i64,
+    selected_raise: i64,
 }
 
 impl State {
-    pub fn new(svc: PokerService, user_id: Uuid) -> Self {
+    pub fn new(svc: PokerService, user_id: Uuid, balance: i64) -> Self {
         let public_rx = svc.subscribe_public();
         let private_rx = svc.subscribe_private(user_id);
         let public_snapshot = public_rx.borrow().clone();
@@ -25,6 +29,8 @@ impl State {
             svc,
             public_rx,
             private_rx,
+            balance,
+            selected_raise: BIG_BLIND,
         }
     }
 
@@ -38,6 +44,9 @@ impl State {
         }
         if self.private_rx.has_changed().unwrap_or(false) {
             self.private_snapshot = self.private_rx.borrow_and_update().clone();
+            if let Some(balance) = self.private_snapshot.balance {
+                self.balance = balance;
+            }
         }
     }
 
@@ -69,7 +78,7 @@ impl State {
     }
 
     pub fn sit(&self) {
-        self.svc.sit_task(self.user_id);
+        self.svc.sit_task(self.user_id, self.balance);
     }
 
     pub fn leave_seat(&self) {
@@ -80,8 +89,17 @@ impl State {
         self.svc.start_hand_task(self.user_id);
     }
 
-    pub fn check(&self) {
-        self.svc.check_task(self.user_id);
+    pub fn call_or_check(&self) {
+        self.svc.call_or_check_task(self.user_id);
+    }
+
+    pub fn bet_or_raise(&self) {
+        self.svc
+            .bet_or_raise_task(self.user_id, self.selected_raise);
+    }
+
+    pub fn all_in(&self) {
+        self.svc.all_in_task(self.user_id);
     }
 
     pub fn fold(&self) {
@@ -92,5 +110,49 @@ impl State {
         if self.is_seated() {
             self.svc.touch_activity_task(self.user_id);
         }
+    }
+
+    pub fn balance(&self) -> i64 {
+        self.balance
+    }
+
+    pub fn selected_raise(&self) -> i64 {
+        self.selected_raise
+    }
+
+    pub fn increase_raise(&mut self) {
+        self.selected_raise = self.selected_raise.saturating_add(RAISE_STEP);
+    }
+
+    pub fn decrease_raise(&mut self) {
+        self.selected_raise = (self.selected_raise - RAISE_STEP).max(BIG_BLIND);
+    }
+
+    pub fn to_call(&self) -> i64 {
+        self.private_snapshot.to_call
+    }
+
+    pub fn min_raise(&self) -> i64 {
+        self.private_snapshot.min_raise.max(BIG_BLIND)
+    }
+
+    pub fn can_raise(&self) -> bool {
+        self.private_snapshot.can_raise
+    }
+
+    pub fn can_all_in(&self) -> bool {
+        self.can_raise() || (self.to_call() > 0 && self.balance <= self.to_call())
+    }
+
+    pub fn can_sync_external_chip_balance(&self) -> bool {
+        matches!(
+            self.public_snapshot.phase,
+            PokerPhase::Waiting | PokerPhase::Showdown
+        ) && !self.public_snapshot.settlement_pending
+    }
+
+    pub fn sync_external_chip_balance(&mut self, balance: i64) {
+        self.balance = balance;
+        self.svc.sync_balance_task(self.user_id, balance);
     }
 }

--- a/late-ssh/src/app/rooms/poker/svc.rs
+++ b/late-ssh/src/app/rooms/poker/svc.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex as StdMutex},
     time::{Duration, Instant},
 };
@@ -9,15 +9,21 @@ use rand_core::{OsRng, RngCore};
 use tokio::sync::{Mutex, watch};
 use uuid::Uuid;
 
-use crate::app::games::cards::{CardRank, CardSuit, PlayingCard};
+use crate::app::games::{
+    cards::{CardRank, CardSuit, PlayingCard},
+    chips::svc::ChipService,
+};
 
 pub const MAX_SEATS: usize = 4;
+pub const SMALL_BLIND: i64 = 10;
+pub const BIG_BLIND: i64 = 20;
 
 const SEAT_IDLE_TIMEOUT_SECS: u64 = 5 * 60;
 
 #[derive(Clone)]
 pub struct PokerService {
     room_id: Uuid,
+    chip_svc: ChipService,
     public_tx: watch::Sender<PokerPublicSnapshot>,
     public_rx: watch::Receiver<PokerPublicSnapshot>,
     private_txs: Arc<StdMutex<HashMap<Uuid, watch::Sender<PokerPrivateSnapshot>>>>,
@@ -36,6 +42,12 @@ pub struct PokerPublicSnapshot {
     pub winners: Vec<usize>,
     pub winning_rank: Option<String>,
     pub status_message: String,
+    pub pot: i64,
+    pub current_bet: i64,
+    pub min_raise: i64,
+    pub small_blind: i64,
+    pub big_blind: i64,
+    pub settlement_pending: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -47,17 +59,27 @@ pub struct PokerSeat {
     pub folded: bool,
     pub in_hand: bool,
     pub last_action: Option<PokerAction>,
+    pub balance: i64,
+    pub committed: i64,
+    pub street_bet: i64,
+    pub all_in: bool,
+    pub pending: bool,
 }
 
 #[derive(Clone, Debug, Default)]
 pub struct PokerPrivateSnapshot {
     pub hole_cards: Vec<PlayingCard>,
     pub notice: Option<String>,
+    pub balance: Option<i64>,
+    pub to_call: i64,
+    pub min_raise: i64,
+    pub can_raise: bool,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PokerPhase {
     Waiting,
+    PostingBlinds,
     PreFlop,
     Flop,
     Turn,
@@ -69,6 +91,7 @@ impl PokerPhase {
     pub fn label(self) -> &'static str {
         match self {
             Self::Waiting => "Waiting",
+            Self::PostingBlinds => "Blinds",
             Self::PreFlop => "Pre-Flop",
             Self::Flop => "Flop",
             Self::Turn => "Turn",
@@ -84,26 +107,39 @@ impl PokerPhase {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PokerAction {
+    SmallBlind,
+    BigBlind,
     Check,
+    Call,
+    Bet,
+    Raise,
     Fold,
+    AllIn,
 }
 
 impl PokerAction {
     pub fn label(self) -> &'static str {
         match self {
+            Self::SmallBlind => "Small blind",
+            Self::BigBlind => "Big blind",
             Self::Check => "Check",
+            Self::Call => "Call",
+            Self::Bet => "Bet",
+            Self::Raise => "Raise",
             Self::Fold => "Fold",
+            Self::AllIn => "All-in",
         }
     }
 }
 
 impl PokerService {
-    pub fn new(room_id: Uuid) -> Self {
+    pub fn new(room_id: Uuid, chip_svc: ChipService) -> Self {
         let state = SharedState::new(room_id);
         let initial_snapshot = state.public_snapshot();
         let (public_tx, public_rx) = watch::channel(initial_snapshot);
         Self {
             room_id,
+            chip_svc,
             public_tx,
             public_rx,
             private_txs: Arc::new(StdMutex::new(HashMap::new())),
@@ -142,12 +178,12 @@ impl PokerService {
         self.public_rx.borrow().clone()
     }
 
-    pub fn sit_task(&self, user_id: Uuid) {
+    pub fn sit_task(&self, user_id: Uuid, balance: i64) {
         let svc = self.clone();
         tokio::spawn(async move {
             let activity_generation = {
                 let mut state = svc.state.lock().await;
-                state.sit(user_id);
+                state.sit(user_id, balance);
                 let activity_generation = state.record_activity(user_id);
                 svc.publish(&state);
                 activity_generation
@@ -161,56 +197,114 @@ impl PokerService {
     pub fn leave_seat_task(&self, user_id: Uuid) {
         let svc = self.clone();
         tokio::spawn(async move {
-            let mut state = svc.state.lock().await;
-            state.leave(user_id);
-            svc.publish(&state);
+            let settlements = {
+                let mut state = svc.state.lock().await;
+                let settlements = state.leave(user_id);
+                svc.publish(&state);
+                settlements
+            };
+            if !settlements.is_empty() {
+                svc.persist_settlements_task(settlements);
+            }
         });
     }
 
     pub fn start_hand_task(&self, user_id: Uuid) {
         let svc = self.clone();
         tokio::spawn(async move {
-            let activity_generation = {
+            let (activity_generation, requests) = {
                 let mut state = svc.state.lock().await;
-                state.start_hand(user_id);
+                let requests = state.start_hand(user_id);
                 let activity_generation = state.record_activity(user_id);
                 svc.publish(&state);
-                activity_generation
+                (activity_generation, requests)
             };
             if let Some(activity_generation) = activity_generation {
                 svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+            for request in requests {
+                svc.commit_request_task(request);
             }
         });
     }
 
-    pub fn check_task(&self, user_id: Uuid) {
+    pub fn call_or_check_task(&self, user_id: Uuid) {
         let svc = self.clone();
         tokio::spawn(async move {
-            let activity_generation = {
+            let (activity_generation, outcome) = {
                 let mut state = svc.state.lock().await;
-                state.player_action(user_id, PokerAction::Check);
+                let outcome = state.call_or_check(user_id);
                 let activity_generation = state.record_activity(user_id);
                 svc.publish(&state);
-                activity_generation
+                (activity_generation, outcome)
             };
             if let Some(activity_generation) = activity_generation {
                 svc.schedule_inactivity_kick(user_id, activity_generation);
             }
+            svc.handle_action_outcome(outcome);
+        });
+    }
+
+    pub fn bet_or_raise_task(&self, user_id: Uuid, raise_by: i64) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let (activity_generation, outcome) = {
+                let mut state = svc.state.lock().await;
+                let outcome = state.bet_or_raise(user_id, raise_by);
+                let activity_generation = state.record_activity(user_id);
+                svc.publish(&state);
+                (activity_generation, outcome)
+            };
+            if let Some(activity_generation) = activity_generation {
+                svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+            svc.handle_action_outcome(outcome);
+        });
+    }
+
+    pub fn all_in_task(&self, user_id: Uuid) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let (activity_generation, outcome) = {
+                let mut state = svc.state.lock().await;
+                let outcome = state.all_in(user_id);
+                let activity_generation = state.record_activity(user_id);
+                svc.publish(&state);
+                (activity_generation, outcome)
+            };
+            if let Some(activity_generation) = activity_generation {
+                svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+            svc.handle_action_outcome(outcome);
         });
     }
 
     pub fn fold_task(&self, user_id: Uuid) {
         let svc = self.clone();
         tokio::spawn(async move {
-            let activity_generation = {
+            let (activity_generation, settlements) = {
                 let mut state = svc.state.lock().await;
-                state.player_action(user_id, PokerAction::Fold);
+                let settlements = state.fold(user_id);
                 let activity_generation = state.record_activity(user_id);
                 svc.publish(&state);
-                activity_generation
+                (activity_generation, settlements)
             };
             if let Some(activity_generation) = activity_generation {
                 svc.schedule_inactivity_kick(user_id, activity_generation);
+            }
+            if !settlements.is_empty() {
+                svc.persist_settlements_task(settlements);
+            }
+        });
+    }
+
+    pub fn sync_balance_task(&self, user_id: Uuid, balance: i64) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let mut state = svc.state.lock().await;
+            let state_changed = state.sync_balance(user_id, balance);
+            if state_changed {
+                svc.publish(&state);
             }
         });
     }
@@ -228,14 +322,108 @@ impl PokerService {
         });
     }
 
+    fn handle_action_outcome(&self, outcome: ActionOutcome) {
+        match outcome {
+            ActionOutcome::None => {}
+            ActionOutcome::Commit(request) => self.commit_request_task(request),
+            ActionOutcome::Settlements(settlements) => {
+                if !settlements.is_empty() {
+                    self.persist_settlements_task(settlements);
+                }
+            }
+        }
+    }
+
+    fn commit_request_task(&self, request: CommitRequest) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let result = svc
+                .chip_svc
+                .debit_bet(request.user_id, request.amount)
+                .await;
+            let settlements = {
+                let mut state = svc.state.lock().await;
+                let settlements = match result {
+                    Ok(Some(new_balance)) => state.apply_commit_success(request, new_balance),
+                    Ok(None) => state.apply_commit_failure(
+                        request,
+                        "Not enough chips available for that action.".to_string(),
+                    ),
+                    Err(e) => {
+                        tracing::error!(
+                            error = ?e,
+                            user_id = %request.user_id,
+                            amount = request.amount,
+                            "poker chip debit failed"
+                        );
+                        state.apply_commit_failure(
+                            request,
+                            "Chip debit failed. Try again.".to_string(),
+                        )
+                    }
+                };
+                svc.publish(&state);
+                settlements
+            };
+            if !settlements.is_empty() {
+                svc.persist_settlements_task(settlements);
+            }
+        });
+    }
+
+    fn persist_settlements_task(&self, settlements: Vec<PokerSettlement>) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            let mut updates = Vec::with_capacity(settlements.len());
+            let mut failed = false;
+            for settlement in settlements {
+                let result = if settlement.credit == 0 {
+                    svc.chip_svc.restore_floor(settlement.user_id).await
+                } else {
+                    svc.chip_svc
+                        .credit_payout(settlement.user_id, settlement.credit)
+                        .await
+                };
+
+                match result {
+                    Ok(new_balance) => updates.push((settlement.user_id, new_balance)),
+                    Err(e) => {
+                        failed = true;
+                        tracing::error!(
+                            error = ?e,
+                            user_id = %settlement.user_id,
+                            credit = settlement.credit,
+                            "poker settlement failed"
+                        );
+                    }
+                }
+            }
+
+            let mut state = svc.state.lock().await;
+            if failed {
+                state.settlement_failed();
+            } else {
+                state.complete_settlements(updates);
+            }
+            svc.publish(&state);
+        });
+    }
+
     fn schedule_inactivity_kick(&self, user_id: Uuid, activity_generation: u64) {
         let svc = self.clone();
         tokio::spawn(async move {
             tokio::time::sleep(Duration::from_secs(SEAT_IDLE_TIMEOUT_SECS)).await;
 
-            let mut state = svc.state.lock().await;
-            if state.kick_inactive_user(user_id, activity_generation) {
-                svc.publish(&state);
+            let (changed, settlements) = {
+                let mut state = svc.state.lock().await;
+                let (changed, settlements) = state.kick_inactive_user(user_id, activity_generation);
+                if changed {
+                    svc.publish(&state);
+                }
+                (changed, settlements)
+            };
+            if changed && !settlements.is_empty() {
+                svc.persist_settlements_task(settlements);
             }
         });
     }
@@ -263,21 +451,36 @@ impl PokerService {
 struct SharedState {
     room_id: Uuid,
     seats: [Option<Uuid>; MAX_SEATS],
+    balances: [i64; MAX_SEATS],
     hole_cards: [Vec<PlayingCard>; MAX_SEATS],
     folded: [bool; MAX_SEATS],
+    all_in: [bool; MAX_SEATS],
     acted_this_street: [bool; MAX_SEATS],
     last_action: [Option<PokerAction>; MAX_SEATS],
+    leave_after_hand: [bool; MAX_SEATS],
+    committed: [i64; MAX_SEATS],
+    street_bet: [i64; MAX_SEATS],
+    pending_commit: [Option<PendingCommit>; MAX_SEATS],
     community: Vec<PlayingCard>,
     deck: Vec<PlayingCard>,
     dealer_button: Option<usize>,
+    small_blind_seat: Option<usize>,
+    big_blind_seat: Option<usize>,
     active_seat: Option<usize>,
     phase: PokerPhase,
     hand_number: u64,
     winners: Vec<usize>,
     winning_rank: Option<String>,
     status_message: String,
+    current_bet: i64,
+    min_raise: i64,
+    pending_blinds: usize,
+    settlement_pending: bool,
+    showdown_reveals: bool,
+    last_balances: HashMap<Uuid, i64>,
     last_activity: [Instant; MAX_SEATS],
     activity_generation: [u64; MAX_SEATS],
+    next_request_id: u64,
 }
 
 impl SharedState {
@@ -286,21 +489,36 @@ impl SharedState {
         Self {
             room_id,
             seats: [None; MAX_SEATS],
+            balances: [0; MAX_SEATS],
             hole_cards: std::array::from_fn(|_| Vec::new()),
             folded: [false; MAX_SEATS],
+            all_in: [false; MAX_SEATS],
             acted_this_street: [false; MAX_SEATS],
             last_action: [None; MAX_SEATS],
+            leave_after_hand: [false; MAX_SEATS],
+            committed: [0; MAX_SEATS],
+            street_bet: [0; MAX_SEATS],
+            pending_commit: [None; MAX_SEATS],
             community: Vec::new(),
             deck: Vec::new(),
             dealer_button: None,
+            small_blind_seat: None,
+            big_blind_seat: None,
             active_seat: None,
             phase: PokerPhase::Waiting,
             hand_number: 0,
             winners: Vec::new(),
             winning_rank: None,
             status_message: "Take a seat. Two players can deal a hand.".to_string(),
+            current_bet: 0,
+            min_raise: BIG_BLIND,
+            pending_blinds: 0,
+            settlement_pending: false,
+            showdown_reveals: false,
+            last_balances: HashMap::new(),
             last_activity: [now; MAX_SEATS],
             activity_generation: [0; MAX_SEATS],
+            next_request_id: 0,
         }
     }
 
@@ -318,20 +536,45 @@ impl SharedState {
             winners: self.winners.clone(),
             winning_rank: self.winning_rank.clone(),
             status_message: self.status_message.clone(),
+            pot: self.pot(),
+            current_bet: self.current_bet,
+            min_raise: self.min_raise,
+            small_blind: SMALL_BLIND,
+            big_blind: BIG_BLIND,
+            settlement_pending: self.settlement_pending,
         }
     }
 
     fn private_snapshot_for(&self, user_id: Uuid) -> PokerPrivateSnapshot {
-        let Some(index) = self.seat_index(user_id) else {
-            return PokerPrivateSnapshot::default();
-        };
-        let hole_cards = self.hole_cards[index].clone();
-        let notice = if hole_cards.is_empty() {
-            None
-        } else {
+        let seat_index = self.seat_index(user_id);
+        let hole_cards = seat_index
+            .map(|index| self.hole_cards[index].clone())
+            .unwrap_or_default();
+        let notice = if !hole_cards.is_empty() && self.showdown_reveals {
+            Some("Showdown cards are public.".to_string())
+        } else if !hole_cards.is_empty() {
             Some("Your hole cards are private.".to_string())
+        } else {
+            None
         };
-        PokerPrivateSnapshot { hole_cards, notice }
+        let balance = seat_index
+            .map(|index| self.balances[index])
+            .or_else(|| self.last_balances.get(&user_id).copied());
+        let to_call = seat_index
+            .map(|index| self.to_call(index))
+            .unwrap_or_default();
+        let can_raise = seat_index
+            .map(|index| self.can_raise(index))
+            .unwrap_or_default();
+
+        PokerPrivateSnapshot {
+            hole_cards,
+            notice,
+            balance,
+            to_call,
+            min_raise: self.min_raise,
+            can_raise,
+        }
     }
 
     fn seat_snapshot(&self, index: usize) -> PokerSeat {
@@ -345,11 +588,17 @@ impl SharedState {
             folded: card_count > 0 && self.folded[index],
             in_hand: card_count > 0 && self.seats[index].is_some(),
             last_action: self.last_action[index],
+            balance: self.balances[index],
+            committed: self.committed[index],
+            street_bet: self.street_bet[index],
+            all_in: self.all_in[index],
+            pending: self.pending_commit[index].is_some(),
         }
     }
 
     fn revealed_cards_for(&self, index: usize) -> Option<Vec<PlayingCard>> {
         if self.phase != PokerPhase::Showdown
+            || !self.showdown_reveals
             || self.seats[index].is_none()
             || self.folded[index]
             || self.hole_cards[index].len() != 2
@@ -359,8 +608,13 @@ impl SharedState {
         Some(self.hole_cards[index].clone())
     }
 
-    fn sit(&mut self, user_id: Uuid) {
-        if self.seat_index(user_id).is_some() {
+    fn sit(&mut self, user_id: Uuid, balance: i64) {
+        if let Some(index) = self.seat_index(user_id) {
+            self.sync_balance_at(index, user_id, balance);
+            return;
+        }
+        if self.phase.is_action_phase() || self.phase == PokerPhase::PostingBlinds {
+            self.status_message = "Wait for the hand to finish before sitting.".to_string();
             return;
         }
         let Some(index) = self.seats.iter().position(Option::is_none) else {
@@ -368,41 +622,97 @@ impl SharedState {
             return;
         };
         self.seats[index] = Some(user_id);
-        self.status_message = if self.occupied_count() >= 2 {
+        self.sync_balance_at(index, user_id, balance);
+        self.status_message = if self.playable_indices().len() >= 2 {
             "Press n to deal a hand.".to_string()
         } else {
-            "Waiting for a second player.".to_string()
+            "Waiting for a second funded player.".to_string()
         };
     }
 
-    fn leave(&mut self, user_id: Uuid) {
+    fn sync_balance(&mut self, user_id: Uuid, balance: i64) -> bool {
+        self.last_balances.insert(user_id, balance.max(0));
         let Some(index) = self.seat_index(user_id) else {
-            return;
+            return false;
         };
-        self.remove_seat(index);
-        if self.phase == PokerPhase::Waiting {
-            self.status_message = if self.occupied_count() == 0 {
-                "Take a seat. Two players can deal a hand.".to_string()
-            } else {
-                "Waiting for players.".to_string()
-            };
-        } else if self.phase != PokerPhase::Showdown {
-            self.status_message = format!("Seat {} left the hand.", index + 1);
+        if !self.can_sync_seat_balance(index) {
+            return false;
         }
+        self.sync_balance_at(index, user_id, balance);
+        true
     }
 
-    fn start_hand(&mut self, user_id: Uuid) {
+    fn sync_balance_at(&mut self, index: usize, user_id: Uuid, balance: i64) {
+        let balance = balance.max(0);
+        self.balances[index] = balance;
+        self.last_balances.insert(user_id, balance);
+    }
+
+    fn can_sync_seat_balance(&self, index: usize) -> bool {
+        !self.settlement_pending
+            && !self.phase.is_action_phase()
+            && self.phase != PokerPhase::PostingBlinds
+            && self.pending_commit[index].is_none()
+    }
+
+    fn leave(&mut self, user_id: Uuid) -> Vec<PokerSettlement> {
+        let Some(index) = self.seat_index(user_id) else {
+            return Vec::new();
+        };
+        if self.pending_commit[index].is_some() || self.settlement_pending {
+            self.status_message = "Wait for pending chips to settle before leaving.".to_string();
+            return Vec::new();
+        }
+        if self.phase == PokerPhase::PostingBlinds {
+            self.status_message = "Blinds are posting. Wait a moment before leaving.".to_string();
+            return Vec::new();
+        }
+        if self.phase.is_action_phase() && self.hole_cards[index].len() == 2 {
+            self.folded[index] = true;
+            self.acted_this_street[index] = true;
+            self.last_action[index] = Some(PokerAction::Fold);
+            self.leave_after_hand[index] = true;
+            if self.active_seat == Some(index) {
+                return self.advance_after_action(index);
+            }
+            if self.active_player_indices().len() == 1 {
+                return self.finish_by_fold(self.active_player_indices()[0]);
+            }
+            self.status_message = format!("Seat {} folded and will sit out.", index + 1);
+            return Vec::new();
+        }
+
+        self.remove_seat(index);
+        self.status_message = if self.occupied_count() == 0 {
+            "Take a seat. Two players can deal a hand.".to_string()
+        } else {
+            "Seat left the table.".to_string()
+        };
+        Vec::new()
+    }
+
+    fn start_hand(&mut self, user_id: Uuid) -> Vec<CommitRequest> {
         if self.seat_index(user_id).is_none() {
             self.status_message = "Sit before dealing a hand.".to_string();
-            return;
+            return Vec::new();
+        }
+        if self.settlement_pending {
+            self.status_message = "Settling the previous pot.".to_string();
+            return Vec::new();
         }
         if !matches!(self.phase, PokerPhase::Waiting | PokerPhase::Showdown) {
             self.status_message = "Finish the current hand first.".to_string();
-            return;
+            return Vec::new();
         }
-        if self.occupied_count() < 2 {
-            self.status_message = "Need at least two players to deal.".to_string();
-            return;
+        if self.pending_commit.iter().any(Option::is_some) {
+            self.status_message = "Wait for pending chip actions.".to_string();
+            return Vec::new();
+        }
+
+        let playable = self.playable_indices();
+        if playable.len() < 2 {
+            self.status_message = "Need at least two funded players to deal.".to_string();
+            return Vec::new();
         }
 
         self.deck = fresh_deck();
@@ -410,165 +720,495 @@ impl SharedState {
         self.community.clear();
         self.hole_cards = std::array::from_fn(|_| Vec::new());
         self.folded = [false; MAX_SEATS];
+        self.all_in = [false; MAX_SEATS];
         self.acted_this_street = [false; MAX_SEATS];
         self.last_action = [None; MAX_SEATS];
+        self.leave_after_hand = [false; MAX_SEATS];
+        self.committed = [0; MAX_SEATS];
+        self.street_bet = [0; MAX_SEATS];
+        self.pending_commit = [None; MAX_SEATS];
         self.winners.clear();
         self.winning_rank = None;
+        self.current_bet = 0;
+        self.min_raise = BIG_BLIND;
+        self.pending_blinds = 0;
+        self.settlement_pending = false;
+        self.showdown_reveals = false;
+        self.active_seat = None;
 
         let dealer = self
             .dealer_button
-            .and_then(|index| self.next_occupied_after(index))
-            .or_else(|| self.seat_index(user_id))
-            .or_else(|| self.occupied_indices().into_iter().next())
+            .and_then(|index| self.next_playable_after(index))
+            .or_else(|| {
+                self.seat_index(user_id)
+                    .filter(|index| self.balances[*index] > 0)
+            })
+            .or_else(|| playable.first().copied())
             .unwrap_or(0);
         self.dealer_button = Some(dealer);
 
-        let occupied = self.occupied_indices();
+        let playable = self.playable_indices();
         for _ in 0..2 {
-            for index in &occupied {
+            for index in &playable {
                 if let Some(card) = self.deck.pop() {
                     self.hole_cards[*index].push(card);
                 }
             }
         }
 
-        self.phase = PokerPhase::PreFlop;
+        let (small_blind, big_blind) = self.blind_seats_for(dealer);
+        self.small_blind_seat = Some(small_blind);
+        self.big_blind_seat = Some(big_blind);
+        self.phase = PokerPhase::PostingBlinds;
         self.hand_number = self.hand_number.saturating_add(1);
-        self.active_seat = self.next_active_after(dealer);
-        self.status_message = match self.active_seat {
-            Some(index) => format!("Hand {} dealt. Seat {} acts.", self.hand_number, index + 1),
-            None => "Hand dealt.".to_string(),
-        };
+
+        let mut requests = Vec::new();
+        if let Some(request) =
+            self.prepare_forced_commit(small_blind, CommitKind::SmallBlind, SMALL_BLIND)
+        {
+            requests.push(request);
+        }
+        if big_blind != small_blind
+            && let Some(request) =
+                self.prepare_forced_commit(big_blind, CommitKind::BigBlind, BIG_BLIND)
+        {
+            requests.push(request);
+        }
+        self.pending_blinds = requests.len();
+        self.status_message = format!(
+            "Hand {} dealt. Posting {}/{} blinds.",
+            self.hand_number, SMALL_BLIND, BIG_BLIND
+        );
+
+        requests
     }
 
-    fn player_action(&mut self, user_id: Uuid, action: PokerAction) {
+    fn prepare_forced_commit(
+        &mut self,
+        index: usize,
+        kind: CommitKind,
+        blind: i64,
+    ) -> Option<CommitRequest> {
+        if self.seats[index].is_none() || self.hole_cards[index].len() != 2 {
+            return None;
+        }
+        let amount = blind.min(self.balances[index]).max(0);
+        if amount == 0 {
+            self.folded[index] = true;
+            self.last_action[index] = Some(PokerAction::Fold);
+            return None;
+        }
+        let target_bet = self.street_bet[index] + amount;
+        Some(self.set_pending_commit(index, kind, amount, target_bet, target_bet))
+    }
+
+    fn call_or_check(&mut self, user_id: Uuid) -> ActionOutcome {
+        let Some(index) = self.validate_active_user(user_id) else {
+            return ActionOutcome::None;
+        };
+        let to_call = self.to_call(index);
+        if to_call == 0 {
+            self.acted_this_street[index] = true;
+            self.last_action[index] = Some(PokerAction::Check);
+            return ActionOutcome::Settlements(self.advance_after_action(index));
+        }
+
+        let amount = to_call.min(self.balances[index]);
+        if amount <= 0 {
+            self.status_message = "No chips available to call.".to_string();
+            return ActionOutcome::None;
+        }
+        let target_bet = self.street_bet[index] + amount;
+        let kind = if amount == self.balances[index] {
+            CommitKind::AllIn
+        } else {
+            CommitKind::Call
+        };
+        ActionOutcome::Commit(self.set_pending_commit(index, kind, amount, target_bet, 0))
+    }
+
+    fn bet_or_raise(&mut self, user_id: Uuid, raise_by: i64) -> ActionOutcome {
+        let Some(index) = self.validate_active_user(user_id) else {
+            return ActionOutcome::None;
+        };
+        if !self.can_raise(index) {
+            self.status_message =
+                "A short all-in did not reopen raising. Call or fold.".to_string();
+            return ActionOutcome::None;
+        }
+        if self.balances[index] <= 0 {
+            self.status_message = "No chips available to bet.".to_string();
+            return ActionOutcome::None;
+        }
+
+        let raise_by = raise_by.max(self.min_raise).max(BIG_BLIND);
+        let max_target = self.street_bet[index] + self.balances[index];
+        let target_bet = if self.current_bet == 0 {
+            raise_by.min(max_target)
+        } else {
+            (self.current_bet + raise_by).min(max_target)
+        };
+        if target_bet <= self.current_bet && target_bet < max_target {
+            self.status_message = format!("Raise must be at least {}.", self.min_raise);
+            return ActionOutcome::None;
+        }
+
+        let amount = target_bet - self.street_bet[index];
+        if amount <= 0 {
+            self.status_message = "Nothing to bet.".to_string();
+            return ActionOutcome::None;
+        }
+        let raise_size = (target_bet - self.current_bet).max(0);
+        let kind = if amount == self.balances[index] {
+            CommitKind::AllIn
+        } else {
+            CommitKind::BetRaise
+        };
+        ActionOutcome::Commit(self.set_pending_commit(index, kind, amount, target_bet, raise_size))
+    }
+
+    fn all_in(&mut self, user_id: Uuid) -> ActionOutcome {
+        let Some(index) = self.validate_active_user(user_id) else {
+            return ActionOutcome::None;
+        };
+        let amount = self.balances[index];
+        if amount <= 0 {
+            self.status_message = "No chips available to shove.".to_string();
+            return ActionOutcome::None;
+        }
+        let target_bet = self.street_bet[index] + amount;
+        if target_bet > self.current_bet && !self.can_raise(index) {
+            self.status_message =
+                "A short all-in did not reopen raising. Call or fold.".to_string();
+            return ActionOutcome::None;
+        }
+        let raise_size = (target_bet - self.current_bet).max(0);
+        ActionOutcome::Commit(self.set_pending_commit(
+            index,
+            CommitKind::AllIn,
+            amount,
+            target_bet,
+            raise_size,
+        ))
+    }
+
+    fn fold(&mut self, user_id: Uuid) -> Vec<PokerSettlement> {
+        let Some(index) = self.validate_active_user(user_id) else {
+            return Vec::new();
+        };
+        self.folded[index] = true;
+        self.acted_this_street[index] = true;
+        self.last_action[index] = Some(PokerAction::Fold);
+        self.advance_after_action(index)
+    }
+
+    fn validate_active_user(&mut self, user_id: Uuid) -> Option<usize> {
         if !self.phase.is_action_phase() {
             self.status_message = "No poker action is pending.".to_string();
-            return;
+            return None;
         }
         let Some(index) = self.seat_index(user_id) else {
             self.status_message = "Sit before playing.".to_string();
-            return;
+            return None;
         };
+        if self.pending_commit[index].is_some() {
+            self.status_message = "Waiting for chip debit.".to_string();
+            return None;
+        }
         if self.active_seat != Some(index) {
             self.status_message = match self.active_seat {
                 Some(active) => format!("Seat {} acts now.", active + 1),
                 None => "No active player.".to_string(),
             };
-            return;
+            return None;
         }
-        if self.hole_cards[index].len() != 2 || self.folded[index] {
-            self.status_message = "You are not in this hand.".to_string();
-            return;
+        if self.hole_cards[index].len() != 2 || self.folded[index] || self.all_in[index] {
+            self.status_message = "You are not in this action.".to_string();
+            return None;
         }
-
-        match action {
-            PokerAction::Check => {
-                self.acted_this_street[index] = true;
-                self.last_action[index] = Some(PokerAction::Check);
-            }
-            PokerAction::Fold => {
-                self.folded[index] = true;
-                self.acted_this_street[index] = true;
-                self.last_action[index] = Some(PokerAction::Fold);
-            }
-        }
-
-        self.advance_after_action(index);
+        Some(index)
     }
 
-    fn advance_after_action(&mut self, acted_index: usize) {
+    fn set_pending_commit(
+        &mut self,
+        index: usize,
+        kind: CommitKind,
+        amount: i64,
+        target_bet: i64,
+        raise_size: i64,
+    ) -> CommitRequest {
+        self.next_request_id = self.next_request_id.wrapping_add(1);
+        let request = CommitRequest {
+            request_id: self.next_request_id,
+            user_id: self.seats[index].expect("pending commit requires seated user"),
+            seat_index: index,
+            amount,
+        };
+        self.pending_commit[index] = Some(PendingCommit {
+            request_id: request.request_id,
+            kind,
+            amount,
+            target_bet,
+            raise_size,
+        });
+        self.status_message = format!("Seat {} committing {} chips.", index + 1, amount);
+        request
+    }
+
+    fn apply_commit_success(
+        &mut self,
+        request: CommitRequest,
+        new_balance: i64,
+    ) -> Vec<PokerSettlement> {
+        if self.pending_commit[request.seat_index]
+            .is_none_or(|pending| pending.request_id != request.request_id)
+        {
+            return Vec::new();
+        }
+        let Some(pending) = self.pending_commit[request.seat_index].take() else {
+            return Vec::new();
+        };
+        let index = request.seat_index;
+        let Some(user_id) = self.seats[index] else {
+            return Vec::new();
+        };
+
+        self.balances[index] = new_balance.max(0);
+        self.last_balances.insert(user_id, self.balances[index]);
+        self.committed[index] += pending.amount;
+        self.street_bet[index] += pending.amount;
+        if self.balances[index] == 0 {
+            self.all_in[index] = true;
+        }
+
+        let old_current_bet = self.current_bet;
+        let was_raise = pending.target_bet > old_current_bet;
+        if was_raise {
+            let raise_size = pending.raise_size.max(pending.target_bet - old_current_bet);
+            let full_raise = raise_size >= self.min_raise;
+            self.current_bet = pending.target_bet;
+            if full_raise {
+                self.min_raise = raise_size;
+            }
+            if full_raise && self.phase.is_action_phase() {
+                self.reset_other_action_flags(index);
+            }
+        }
+
+        self.acted_this_street[index] =
+            !matches!(pending.kind, CommitKind::SmallBlind | CommitKind::BigBlind);
+        self.last_action[index] = Some(self.action_for_commit(pending.kind, old_current_bet));
+
+        if self.phase == PokerPhase::PostingBlinds {
+            self.pending_blinds = self.pending_blinds.saturating_sub(1);
+            if self.pending_blinds == 0 {
+                return self.finish_blind_posting();
+            }
+            self.status_message = format!("Posted blind for seat {}.", index + 1);
+            return Vec::new();
+        }
+
+        self.advance_after_action(index)
+    }
+
+    fn apply_commit_failure(
+        &mut self,
+        request: CommitRequest,
+        message: String,
+    ) -> Vec<PokerSettlement> {
+        if self.pending_commit[request.seat_index]
+            .is_none_or(|pending| pending.request_id != request.request_id)
+        {
+            return Vec::new();
+        }
+        self.pending_commit[request.seat_index] = None;
+
+        if self.phase == PokerPhase::PostingBlinds {
+            self.folded[request.seat_index] = true;
+            self.last_action[request.seat_index] = Some(PokerAction::Fold);
+            self.pending_blinds = self.pending_blinds.saturating_sub(1);
+            self.status_message = format!(
+                "Seat {} could not post a blind and folded.",
+                request.seat_index + 1
+            );
+            if self.pending_blinds == 0 {
+                return self.finish_blind_posting();
+            }
+            return Vec::new();
+        }
+
+        self.status_message = message;
+        Vec::new()
+    }
+
+    fn action_for_commit(&self, kind: CommitKind, old_current_bet: i64) -> PokerAction {
+        match kind {
+            CommitKind::SmallBlind => PokerAction::SmallBlind,
+            CommitKind::BigBlind => PokerAction::BigBlind,
+            CommitKind::Call => PokerAction::Call,
+            CommitKind::BetRaise if old_current_bet == 0 => PokerAction::Bet,
+            CommitKind::BetRaise => PokerAction::Raise,
+            CommitKind::AllIn => PokerAction::AllIn,
+        }
+    }
+
+    fn reset_other_action_flags(&mut self, actor: usize) {
+        for index in 0..MAX_SEATS {
+            if index != actor && self.hole_cards[index].len() == 2 && !self.folded[index] {
+                self.acted_this_street[index] = false;
+            }
+        }
+    }
+
+    fn finish_blind_posting(&mut self) -> Vec<PokerSettlement> {
+        self.current_bet = self.street_bet.iter().copied().max().unwrap_or_default();
+        self.min_raise = BIG_BLIND;
         let active_players = self.active_player_indices();
         if active_players.len() == 1 {
-            self.finish_by_fold(active_players[0]);
-            return;
+            return self.finish_by_fold(active_players[0]);
+        }
+        if active_players.is_empty() {
+            self.phase = PokerPhase::Waiting;
+            self.active_seat = None;
+            self.status_message = "Hand ended before action.".to_string();
+            return Vec::new();
+        }
+
+        self.phase = PokerPhase::PreFlop;
+        let start = self.big_blind_seat.or(self.dealer_button).unwrap_or(0);
+        self.active_seat = self.next_action_after(start);
+        if self.active_seat.is_none() && self.street_complete() {
+            self.deal_remaining_community();
+            return self.finish_showdown();
+        }
+        self.status_message = match self.active_seat {
+            Some(index) => format!("Blinds posted. Seat {} acts.", index + 1),
+            None => "Blinds posted.".to_string(),
+        };
+        Vec::new()
+    }
+
+    fn advance_after_action(&mut self, acted_index: usize) -> Vec<PokerSettlement> {
+        let active_players = self.active_player_indices();
+        if active_players.len() == 1 {
+            return self.finish_by_fold(active_players[0]);
         }
         if active_players.is_empty() {
             self.phase = PokerPhase::Waiting;
             self.active_seat = None;
             self.status_message = "Hand ended. Waiting for players.".to_string();
-            return;
+            return Vec::new();
         }
 
         if self.street_complete() {
-            self.advance_street();
-            return;
+            if self.should_runout_to_showdown() {
+                self.deal_remaining_community();
+                return self.finish_showdown();
+            }
+            return self.advance_street();
         }
 
-        self.active_seat = self.next_active_after(acted_index);
+        self.active_seat = self.next_action_after(acted_index);
         self.status_message = match self.active_seat {
             Some(index) => format!("Seat {} acts.", index + 1),
             None => "Waiting for action.".to_string(),
         };
+        Vec::new()
     }
 
-    fn advance_street(&mut self) {
+    fn advance_street(&mut self) -> Vec<PokerSettlement> {
         self.acted_this_street = [false; MAX_SEATS];
+        self.street_bet = [0; MAX_SEATS];
+        self.current_bet = 0;
+        self.min_raise = BIG_BLIND;
+
         match self.phase {
             PokerPhase::PreFlop => {
                 self.deal_community(3);
                 self.phase = PokerPhase::Flop;
-                self.set_first_action_for_new_street("Flop dealt");
+                self.set_first_action_for_new_street("Flop dealt")
             }
             PokerPhase::Flop => {
                 self.deal_community(1);
                 self.phase = PokerPhase::Turn;
-                self.set_first_action_for_new_street("Turn dealt");
+                self.set_first_action_for_new_street("Turn dealt")
             }
             PokerPhase::Turn => {
                 self.deal_community(1);
                 self.phase = PokerPhase::River;
-                self.set_first_action_for_new_street("River dealt");
+                self.set_first_action_for_new_street("River dealt")
             }
             PokerPhase::River => self.finish_showdown(),
-            _ => {}
+            _ => Vec::new(),
         }
     }
 
-    fn set_first_action_for_new_street(&mut self, prefix: &'static str) {
+    fn set_first_action_for_new_street(&mut self, prefix: &'static str) -> Vec<PokerSettlement> {
+        if self.should_runout_to_showdown() {
+            self.deal_remaining_community();
+            return self.finish_showdown();
+        }
+
         let dealer = self.dealer_button.unwrap_or(0);
-        self.active_seat = self.next_active_after(dealer);
+        self.active_seat = self.next_action_after(dealer);
         self.status_message = match self.active_seat {
             Some(index) => format!("{prefix}. Seat {} acts.", index + 1),
             None => format!("{prefix}."),
         };
+        Vec::new()
     }
 
-    fn finish_by_fold(&mut self, winner: usize) {
+    fn finish_by_fold(&mut self, winner: usize) -> Vec<PokerSettlement> {
         self.phase = PokerPhase::Showdown;
         self.active_seat = None;
         self.winners = vec![winner];
         self.winning_rank = None;
-        self.status_message = format!("Seat {} wins by fold. Press n for next hand.", winner + 1);
+        self.showdown_reveals = false;
+
+        let settlements = self.settlements_for_single_winner(winner);
+        self.settlement_pending = !settlements.is_empty();
+        self.status_message = if settlements.is_empty() {
+            format!("Seat {} wins by fold. Press n for next hand.", winner + 1)
+        } else {
+            format!(
+                "Seat {} wins {} by fold. Settling pot.",
+                winner + 1,
+                self.pot()
+            )
+        };
+        settlements
     }
 
-    fn finish_showdown(&mut self) {
+    fn finish_showdown(&mut self) -> Vec<PokerSettlement> {
         let contenders = self.active_player_indices();
         if contenders.is_empty() {
             self.phase = PokerPhase::Waiting;
             self.active_seat = None;
             self.status_message = "No contenders remain.".to_string();
-            return;
+            return Vec::new();
         }
 
-        let mut scored = Vec::with_capacity(contenders.len());
-        for index in contenders {
-            let mut cards = self.hole_cards[index].clone();
-            cards.extend(self.community.iter().copied());
-            scored.push((index, evaluate_best_hand(&cards)));
+        let awards = self.calculate_pot_awards();
+        let mut winners = HashSet::new();
+        for award in &awards {
+            for winner in &award.winners {
+                winners.insert(*winner);
+            }
         }
-        let Some(best) = scored.iter().map(|(_, hand)| hand.value).max() else {
-            return;
-        };
-        self.winners = scored
+        self.winners = winners.into_iter().collect();
+        self.winners.sort_unstable();
+
+        self.winning_rank = contenders
             .iter()
-            .filter_map(|(index, hand)| (hand.value == best).then_some(*index))
-            .collect();
-        self.winning_rank = scored
-            .iter()
-            .find_map(|(_, hand)| (hand.value == best).then_some(hand.label.to_string()));
+            .map(|index| self.evaluate_seat(*index))
+            .max_by_key(|hand| hand.value)
+            .map(|hand| hand.label.to_string());
         self.phase = PokerPhase::Showdown;
         self.active_seat = None;
+        self.showdown_reveals = true;
+
+        let settlements = self.settlements_from_awards(&awards);
+        self.settlement_pending = !settlements.is_empty();
 
         let winners = seat_list(&self.winners);
         let rank = self
@@ -576,40 +1216,146 @@ impl SharedState {
             .as_deref()
             .unwrap_or("best hand")
             .to_string();
-        self.status_message = format!("{winners} win with {rank}. Press n for next hand.");
+        self.status_message = if settlements.is_empty() {
+            format!("{winners} win with {rank}. Press n for next hand.")
+        } else {
+            format!("{winners} win {} with {rank}. Settling pot.", self.pot())
+        };
+        settlements
     }
 
-    fn remove_seat(&mut self, index: usize) {
-        self.seats[index] = None;
-        self.hole_cards[index].clear();
-        self.folded[index] = false;
-        self.acted_this_street[index] = false;
-        self.last_action[index] = None;
+    fn calculate_pot_awards(&self) -> Vec<PotAward> {
+        let side_pots = self.side_pots();
+        let mut awards = Vec::with_capacity(side_pots.len());
 
-        if self.occupied_count() == 0 {
-            self.dealer_button = None;
-        }
-
-        if !self.phase.is_action_phase() {
-            return;
-        }
-
-        let active_players = self.active_player_indices();
-        match active_players.len() {
-            0 => {
-                self.phase = PokerPhase::Waiting;
-                self.active_seat = None;
+        for pot in side_pots {
+            if pot.eligible.is_empty() || pot.amount <= 0 {
+                continue;
             }
-            1 => self.finish_by_fold(active_players[0]),
-            _ if self.active_seat == Some(index) => {
-                if self.street_complete() {
-                    self.advance_street();
-                } else {
-                    self.active_seat = self.next_active_after(index);
-                }
+            let mut scored = Vec::with_capacity(pot.eligible.len());
+            for index in pot.eligible {
+                scored.push((index, self.evaluate_seat(index)));
             }
-            _ => {}
+            let Some(best) = scored.iter().map(|(_, hand)| hand.value).max() else {
+                continue;
+            };
+            let winners = scored
+                .iter()
+                .filter_map(|(index, hand)| (hand.value == best).then_some(*index))
+                .collect::<Vec<_>>();
+            awards.push(PotAward {
+                amount: pot.amount,
+                winners,
+            });
         }
+
+        awards
+    }
+
+    fn side_pots(&self) -> Vec<SidePot> {
+        let mut levels = self
+            .committed
+            .iter()
+            .copied()
+            .filter(|amount| *amount > 0)
+            .collect::<Vec<_>>();
+        levels.sort_unstable();
+        levels.dedup();
+
+        let mut pots = Vec::new();
+        let mut previous = 0;
+        for level in levels {
+            let contributors = (0..MAX_SEATS)
+                .filter(|index| self.committed[*index] >= level)
+                .collect::<Vec<_>>();
+            let amount = (level - previous) * contributors.len() as i64;
+            let eligible = contributors
+                .iter()
+                .copied()
+                .filter(|index| {
+                    self.seats[*index].is_some()
+                        && self.hole_cards[*index].len() == 2
+                        && !self.folded[*index]
+                })
+                .collect::<Vec<_>>();
+            pots.push(SidePot { amount, eligible });
+            previous = level;
+        }
+        pots
+    }
+
+    fn settlements_from_awards(&self, awards: &[PotAward]) -> Vec<PokerSettlement> {
+        let mut credits = [0; MAX_SEATS];
+        for award in awards {
+            if award.amount <= 0 || award.winners.is_empty() {
+                continue;
+            }
+            let mut winners = award.winners.clone();
+            winners.sort_unstable();
+            let share = award.amount / winners.len() as i64;
+            let remainder = award.amount % winners.len() as i64;
+            for (offset, winner) in winners.into_iter().enumerate() {
+                let odd_chip = if (offset as i64) < remainder { 1 } else { 0 };
+                credits[winner] += share + odd_chip;
+            }
+        }
+
+        (0..MAX_SEATS)
+            .filter_map(|index| {
+                let user_id = self.seats[index]?;
+                (self.committed[index] > 0).then_some(PokerSettlement {
+                    user_id,
+                    credit: credits[index],
+                })
+            })
+            .collect()
+    }
+
+    fn settlements_for_single_winner(&self, winner: usize) -> Vec<PokerSettlement> {
+        let pot = self.pot();
+        (0..MAX_SEATS)
+            .filter_map(|index| {
+                let user_id = self.seats[index]?;
+                (self.committed[index] > 0).then_some(PokerSettlement {
+                    user_id,
+                    credit: if index == winner { pot } else { 0 },
+                })
+            })
+            .collect()
+    }
+
+    fn complete_settlements(&mut self, updates: Vec<(Uuid, i64)>) {
+        for (user_id, balance) in updates {
+            self.last_balances.insert(user_id, balance);
+            if let Some(index) = self.seat_index(user_id) {
+                self.balances[index] = balance;
+            }
+        }
+        for index in 0..MAX_SEATS {
+            if self.leave_after_hand[index] {
+                self.remove_seat(index);
+            }
+        }
+        self.settlement_pending = false;
+        self.status_message = if self.winners.is_empty() {
+            "Pot settled. Press n for next hand.".to_string()
+        } else {
+            format!(
+                "{} settled. Press n for next hand.",
+                seat_list(&self.winners)
+            )
+        };
+    }
+
+    fn settlement_failed(&mut self) {
+        self.settlement_pending = false;
+        self.status_message = "Poker settlement failed. Check logs before continuing.".to_string();
+    }
+
+    fn evaluate_seat(&self, index: usize) -> EvaluatedHand {
+        let mut cards = self.hole_cards[index].clone();
+        cards.extend(self.community.iter().copied());
+        evaluate_best_hand(&cards)
     }
 
     fn deal_community(&mut self, count: usize) {
@@ -620,21 +1366,53 @@ impl SharedState {
         }
     }
 
+    fn deal_remaining_community(&mut self) {
+        while self.community.len() < 5 {
+            self.deal_community(1);
+        }
+    }
+
     fn street_complete(&self) -> bool {
-        self.active_player_indices()
-            .into_iter()
-            .all(|index| self.acted_this_street[index])
+        let active_players = self.active_player_indices();
+        !active_players.is_empty()
+            && active_players.into_iter().all(|index| {
+                self.all_in[index]
+                    || (self.acted_this_street[index] && self.street_bet[index] >= self.current_bet)
+            })
+    }
+
+    fn should_runout_to_showdown(&self) -> bool {
+        self.active_player_indices().len() > 1 && self.actionable_player_indices().len() <= 1
+    }
+
+    fn pot(&self) -> i64 {
+        self.committed.iter().sum()
+    }
+
+    fn to_call(&self, index: usize) -> i64 {
+        self.current_bet.saturating_sub(self.street_bet[index])
+    }
+
+    fn can_raise(&self, index: usize) -> bool {
+        self.phase.is_action_phase()
+            && self.seats[index].is_some()
+            && self.hole_cards[index].len() == 2
+            && !self.folded[index]
+            && !self.all_in[index]
+            && !self.acted_this_street[index]
     }
 
     fn occupied_count(&self) -> usize {
         self.seats.iter().filter(|seat| seat.is_some()).count()
     }
 
-    fn occupied_indices(&self) -> Vec<usize> {
+    fn playable_indices(&self) -> Vec<usize> {
         self.seats
             .iter()
             .enumerate()
-            .filter_map(|(index, seat)| seat.is_some().then_some(index))
+            .filter_map(|(index, seat)| {
+                (seat.is_some() && self.balances[index] > 0).then_some(index)
+            })
             .collect()
     }
 
@@ -648,24 +1426,65 @@ impl SharedState {
             .collect()
     }
 
-    fn next_occupied_after(&self, start: usize) -> Option<usize> {
-        (1..=MAX_SEATS)
-            .map(|offset| (start + offset) % MAX_SEATS)
-            .find(|index| self.seats[*index].is_some())
+    fn actionable_player_indices(&self) -> Vec<usize> {
+        self.active_player_indices()
+            .into_iter()
+            .filter(|index| !self.all_in[*index])
+            .collect()
     }
 
-    fn next_active_after(&self, start: usize) -> Option<usize> {
+    fn next_playable_after(&self, start: usize) -> Option<usize> {
+        (1..=MAX_SEATS)
+            .map(|offset| (start + offset) % MAX_SEATS)
+            .find(|index| self.seats[*index].is_some() && self.balances[*index] > 0)
+    }
+
+    fn next_action_after(&self, start: usize) -> Option<usize> {
         (1..=MAX_SEATS)
             .map(|offset| (start + offset) % MAX_SEATS)
             .find(|index| {
                 self.seats[*index].is_some()
                     && self.hole_cards[*index].len() == 2
                     && !self.folded[*index]
+                    && !self.all_in[*index]
             })
+    }
+
+    fn blind_seats_for(&self, dealer: usize) -> (usize, usize) {
+        let occupied = self.playable_indices();
+        if occupied.len() == 2 {
+            let big = self.next_playable_after(dealer).unwrap_or(dealer);
+            return (dealer, big);
+        }
+
+        let small = self.next_playable_after(dealer).unwrap_or(dealer);
+        let big = self.next_playable_after(small).unwrap_or(small);
+        (small, big)
     }
 
     fn seat_index(&self, user_id: Uuid) -> Option<usize> {
         self.seats.iter().position(|seat| *seat == Some(user_id))
+    }
+
+    fn remove_seat(&mut self, index: usize) {
+        if let Some(user_id) = self.seats[index] {
+            self.last_balances.insert(user_id, self.balances[index]);
+        }
+        self.seats[index] = None;
+        self.balances[index] = 0;
+        self.hole_cards[index].clear();
+        self.folded[index] = false;
+        self.all_in[index] = false;
+        self.acted_this_street[index] = false;
+        self.last_action[index] = None;
+        self.leave_after_hand[index] = false;
+        self.committed[index] = 0;
+        self.street_bet[index] = 0;
+        self.pending_commit[index] = None;
+
+        if self.occupied_count() == 0 {
+            self.dealer_button = None;
+        }
     }
 
     fn record_activity(&mut self, user_id: Uuid) -> Option<u64> {
@@ -675,25 +1494,96 @@ impl SharedState {
         Some(self.activity_generation[seat_index])
     }
 
-    fn kick_inactive_user(&mut self, user_id: Uuid, activity_generation: u64) -> bool {
+    fn kick_inactive_user(
+        &mut self,
+        user_id: Uuid,
+        activity_generation: u64,
+    ) -> (bool, Vec<PokerSettlement>) {
         let Some(seat_index) = self.seat_index(user_id) else {
-            return false;
+            return (false, Vec::new());
         };
         if self.activity_generation[seat_index] != activity_generation
             || self.last_activity[seat_index].elapsed()
                 < Duration::from_secs(SEAT_IDLE_TIMEOUT_SECS)
         {
-            return false;
+            return (false, Vec::new());
         }
 
-        self.remove_seat(seat_index);
-        if self.phase == PokerPhase::Waiting {
-            self.status_message = format!("Seat {} idle for 5m and left.", seat_index + 1);
-        } else if self.phase != PokerPhase::Showdown {
+        if self.phase.is_action_phase() && self.hole_cards[seat_index].len() == 2 {
+            self.folded[seat_index] = true;
+            self.acted_this_street[seat_index] = true;
+            self.last_action[seat_index] = Some(PokerAction::Fold);
+            self.leave_after_hand[seat_index] = true;
+            let settlements = if self.active_seat == Some(seat_index) {
+                self.advance_after_action(seat_index)
+            } else if self.active_player_indices().len() == 1 {
+                self.finish_by_fold(self.active_player_indices()[0])
+            } else {
+                Vec::new()
+            };
             self.status_message = format!("Seat {} idle for 5m and folded.", seat_index + 1);
+            return (true, settlements);
         }
-        true
+
+        if !self.phase.is_action_phase()
+            && self.phase != PokerPhase::PostingBlinds
+            && !self.settlement_pending
+        {
+            self.remove_seat(seat_index);
+            self.status_message = format!("Seat {} idle for 5m and left.", seat_index + 1);
+            return (true, Vec::new());
+        }
+
+        (false, Vec::new())
     }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CommitRequest {
+    request_id: u64,
+    user_id: Uuid,
+    seat_index: usize,
+    amount: i64,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PendingCommit {
+    request_id: u64,
+    kind: CommitKind,
+    amount: i64,
+    target_bet: i64,
+    raise_size: i64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CommitKind {
+    SmallBlind,
+    BigBlind,
+    Call,
+    BetRaise,
+    AllIn,
+}
+
+enum ActionOutcome {
+    None,
+    Commit(CommitRequest),
+    Settlements(Vec<PokerSettlement>),
+}
+
+#[derive(Clone, Debug)]
+struct PokerSettlement {
+    user_id: Uuid,
+    credit: i64,
+}
+
+struct SidePot {
+    amount: i64,
+    eligible: Vec<usize>,
+}
+
+struct PotAward {
+    amount: i64,
+    winners: Vec<usize>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -941,6 +1831,23 @@ mod tests {
         PlayingCard { rank, suit }
     }
 
+    fn uid(value: u128) -> Uuid {
+        Uuid::from_u128(value)
+    }
+
+    fn seat_player(state: &mut SharedState, index: usize, user: Uuid, cards: Vec<PlayingCard>) {
+        state.seats[index] = Some(user);
+        state.balances[index] = 1_000;
+        state.hole_cards[index] = cards;
+    }
+
+    fn credits_by_user(settlements: Vec<PokerSettlement>) -> HashMap<Uuid, i64> {
+        settlements
+            .into_iter()
+            .map(|settlement| (settlement.user_id, settlement.credit))
+            .collect()
+    }
+
     #[test]
     fn ace_low_straight_is_scored_as_five_high() {
         let hand = evaluate_best_hand(&[
@@ -975,5 +1882,251 @@ mod tests {
         ]);
 
         assert!(full_house.value > flush.value);
+    }
+
+    #[test]
+    fn side_pots_pay_short_all_in_and_side_winner() {
+        let mut state = SharedState::new(uid(100));
+        seat_player(
+            &mut state,
+            0,
+            uid(1),
+            vec![
+                c(CardRank::Ace, CardSuit::Spades),
+                c(CardRank::Ace, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            1,
+            uid(2),
+            vec![
+                c(CardRank::King, CardSuit::Spades),
+                c(CardRank::King, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            2,
+            uid(3),
+            vec![
+                c(CardRank::Queen, CardSuit::Spades),
+                c(CardRank::Queen, CardSuit::Hearts),
+            ],
+        );
+        state.community = vec![
+            c(CardRank::Number(2), CardSuit::Clubs),
+            c(CardRank::Number(4), CardSuit::Diamonds),
+            c(CardRank::Number(7), CardSuit::Clubs),
+            c(CardRank::Number(9), CardSuit::Diamonds),
+            c(CardRank::Jack, CardSuit::Clubs),
+        ];
+        state.committed = [50, 100, 100, 0];
+
+        let settlements = state.finish_showdown();
+        let credits = credits_by_user(settlements);
+
+        assert_eq!(credits.get(&uid(1)), Some(&150));
+        assert_eq!(credits.get(&uid(2)), Some(&100));
+        assert_eq!(credits.get(&uid(3)), Some(&0));
+    }
+
+    #[test]
+    fn short_all_in_raise_does_not_reopen_prior_actor_raises() {
+        let mut state = SharedState::new(uid(100));
+        seat_player(
+            &mut state,
+            0,
+            uid(1),
+            vec![
+                c(CardRank::Ace, CardSuit::Spades),
+                c(CardRank::Ace, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            1,
+            uid(2),
+            vec![
+                c(CardRank::King, CardSuit::Spades),
+                c(CardRank::King, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            2,
+            uid(3),
+            vec![
+                c(CardRank::Queen, CardSuit::Spades),
+                c(CardRank::Queen, CardSuit::Hearts),
+            ],
+        );
+        state.phase = PokerPhase::PreFlop;
+        state.active_seat = Some(2);
+        state.current_bet = 100;
+        state.min_raise = 100;
+        state.committed = [100, 100, 0, 0];
+        state.street_bet = [100, 100, 0, 0];
+        state.acted_this_street = [true, true, false, false];
+        state.balances[2] = 150;
+
+        let short_all_in = match state.all_in(uid(3)) {
+            ActionOutcome::Commit(request) => request,
+            _ => panic!("short all-in should commit chips"),
+        };
+        assert_eq!(short_all_in.amount, 150);
+
+        let settlements = state.apply_commit_success(short_all_in, 0);
+
+        assert!(settlements.is_empty());
+        assert_eq!(state.current_bet, 150);
+        assert_eq!(state.min_raise, 100);
+        assert_eq!(state.active_seat, Some(0));
+        assert!(state.acted_this_street[0]);
+        assert!(state.acted_this_street[1]);
+        assert!(!state.can_raise(0));
+
+        assert!(matches!(
+            state.bet_or_raise(uid(1), 100),
+            ActionOutcome::None
+        ));
+        let call = match state.call_or_check(uid(1)) {
+            ActionOutcome::Commit(request) => request,
+            _ => panic!("prior actor should still be able to call the extra chips"),
+        };
+        assert_eq!(call.amount, 50);
+    }
+
+    #[test]
+    fn four_way_all_in_side_pots_pay_each_level() {
+        let mut state = SharedState::new(uid(100));
+        seat_player(
+            &mut state,
+            0,
+            uid(1),
+            vec![
+                c(CardRank::Ace, CardSuit::Spades),
+                c(CardRank::Ace, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            1,
+            uid(2),
+            vec![
+                c(CardRank::King, CardSuit::Spades),
+                c(CardRank::King, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            2,
+            uid(3),
+            vec![
+                c(CardRank::Queen, CardSuit::Spades),
+                c(CardRank::Queen, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            3,
+            uid(4),
+            vec![
+                c(CardRank::Jack, CardSuit::Spades),
+                c(CardRank::Jack, CardSuit::Hearts),
+            ],
+        );
+        state.community = vec![
+            c(CardRank::Number(2), CardSuit::Clubs),
+            c(CardRank::Number(4), CardSuit::Diamonds),
+            c(CardRank::Number(7), CardSuit::Clubs),
+            c(CardRank::Number(9), CardSuit::Diamonds),
+            c(CardRank::Number(10), CardSuit::Clubs),
+        ];
+        state.committed = [25, 50, 100, 200];
+
+        let credits = credits_by_user(state.finish_showdown());
+
+        assert_eq!(credits.get(&uid(1)), Some(&100));
+        assert_eq!(credits.get(&uid(2)), Some(&75));
+        assert_eq!(credits.get(&uid(3)), Some(&100));
+        assert_eq!(credits.get(&uid(4)), Some(&100));
+    }
+
+    #[test]
+    fn tied_side_pot_splits_only_among_eligible_players() {
+        let mut state = SharedState::new(uid(100));
+        seat_player(
+            &mut state,
+            0,
+            uid(1),
+            vec![
+                c(CardRank::Ace, CardSuit::Spades),
+                c(CardRank::King, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            1,
+            uid(2),
+            vec![
+                c(CardRank::Queen, CardSuit::Spades),
+                c(CardRank::Jack, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            2,
+            uid(3),
+            vec![
+                c(CardRank::Number(10), CardSuit::Spades),
+                c(CardRank::Number(9), CardSuit::Hearts),
+            ],
+        );
+        state.community = vec![
+            c(CardRank::Number(2), CardSuit::Clubs),
+            c(CardRank::Number(3), CardSuit::Diamonds),
+            c(CardRank::Number(4), CardSuit::Clubs),
+            c(CardRank::Number(5), CardSuit::Diamonds),
+            c(CardRank::Number(6), CardSuit::Clubs),
+        ];
+        state.committed = [50, 100, 100, 0];
+
+        let credits = credits_by_user(state.finish_showdown());
+
+        assert_eq!(credits.get(&uid(1)), Some(&50));
+        assert_eq!(credits.get(&uid(2)), Some(&100));
+        assert_eq!(credits.get(&uid(3)), Some(&100));
+    }
+
+    #[test]
+    fn fold_win_does_not_reveal_winner_cards() {
+        let mut state = SharedState::new(uid(100));
+        seat_player(
+            &mut state,
+            0,
+            uid(1),
+            vec![
+                c(CardRank::Ace, CardSuit::Spades),
+                c(CardRank::Ace, CardSuit::Hearts),
+            ],
+        );
+        seat_player(
+            &mut state,
+            1,
+            uid(2),
+            vec![
+                c(CardRank::King, CardSuit::Spades),
+                c(CardRank::King, CardSuit::Hearts),
+            ],
+        );
+        state.committed = [20, 20, 0, 0];
+        state.folded[1] = true;
+
+        let settlements = state.finish_by_fold(0);
+
+        assert_eq!(settlements.len(), 2);
+        assert!(state.seat_snapshot(0).revealed_cards.is_none());
+        assert_eq!(state.winners, vec![0]);
     }
 }

--- a/late-ssh/src/app/rooms/poker/ui.rs
+++ b/late-ssh/src/app/rooms/poker/ui.rs
@@ -202,6 +202,14 @@ fn draw_felt_divider(frame: &mut Frame, area: Rect, snapshot: &PokerPublicSnapsh
         Some(index) => format!("button seat {}", index + 1),
         None => "waiting for dealer button".to_string(),
     };
+    let label = if snapshot.current_bet > 0 {
+        format!(
+            "{label} · pot {} · bet {}",
+            snapshot.pot, snapshot.current_bet
+        )
+    } else {
+        format!("{label} · pot {}", snapshot.pot)
+    };
     let chip_w = label.chars().count() + 6;
     let side_each = (area.width as usize).saturating_sub(chip_w) / 2;
     let half_pattern = "- ".repeat(side_each / 2);
@@ -284,7 +292,7 @@ fn draw_seat_panel_outline(
         Constraint::Length(5),
         Constraint::Length(1),
         Constraint::Length(1),
-        Constraint::Min(1),
+        Constraint::Length(1),
     ])
     .split(inner);
 
@@ -299,21 +307,13 @@ fn draw_seat_panel_outline(
         rows[2],
     );
     frame.render_widget(
-        Paragraph::new(seat_badge_line(snapshot, seat)).alignment(Alignment::Center),
+        Paragraph::new(seat_bet_balance_line(seat)).alignment(Alignment::Center),
         rows[3],
     );
-    if is_winner {
-        frame.render_widget(
-            Paragraph::new(Line::from(Span::styled(
-                "WINNER",
-                Style::default()
-                    .fg(theme::SUCCESS())
-                    .add_modifier(Modifier::BOLD),
-            )))
-            .alignment(Alignment::Center),
-            rows[4],
-        );
-    }
+    frame.render_widget(
+        Paragraph::new(seat_badge_line(snapshot, seat, is_winner)).alignment(Alignment::Center),
+        rows[4],
+    );
 }
 
 fn draw_seat_panel(
@@ -348,23 +348,14 @@ fn draw_seat_panel_inner(
         return;
     }
     let is_you = state.seat_index() == Some(seat.index);
-    let mut lines = vec![
+    let lines = vec![
         Line::from(identity_span(seat, is_you, usernames)).alignment(Alignment::Center),
         compact_seat_cards_line(state, seat).alignment(Alignment::Center),
         seat_status_line(state, snapshot, seat).alignment(Alignment::Center),
-        seat_badge_line(snapshot, seat).alignment(Alignment::Center),
-    ];
-    if snapshot.winners.contains(&seat.index) {
-        lines.push(
-            Line::from(Span::styled(
-                "WINNER",
-                Style::default()
-                    .fg(theme::SUCCESS())
-                    .add_modifier(Modifier::BOLD),
-            ))
+        seat_bet_balance_line(seat).alignment(Alignment::Center),
+        seat_badge_line(snapshot, seat, snapshot.winners.contains(&seat.index))
             .alignment(Alignment::Center),
-        );
-    }
+    ];
     frame.render_widget(Paragraph::new(lines), area);
 }
 
@@ -519,6 +510,14 @@ fn seat_status_line(
             Style::default().fg(theme::TEXT_DIM()),
         ));
     }
+    if seat.pending {
+        return Line::from(Span::styled(
+            "pending",
+            Style::default()
+                .fg(theme::AMBER())
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
     if snapshot.winners.contains(&seat.index) {
         return Line::from(Span::styled(
             "showdown",
@@ -531,6 +530,14 @@ fn seat_status_line(
         return Line::from(Span::styled(
             "folded",
             Style::default().fg(theme::TEXT_DIM()),
+        ));
+    }
+    if seat.all_in {
+        return Line::from(Span::styled(
+            "all-in",
+            Style::default()
+                .fg(theme::AMBER())
+                .add_modifier(Modifier::BOLD),
         ));
     }
     if snapshot.active_seat == Some(seat.index) {
@@ -562,9 +569,36 @@ fn seat_status_line(
     }
 }
 
-fn seat_badge_line(snapshot: &PokerPublicSnapshot, seat: &PokerSeat) -> Line<'static> {
+fn seat_bet_balance_line(seat: &PokerSeat) -> Line<'static> {
+    if seat.user_id.is_none() {
+        return Line::from(Span::raw(""));
+    }
+    let text = if seat.committed > 0 {
+        format!("bal {} · pot {}", seat.balance, seat.committed)
+    } else {
+        format!("bal {}", seat.balance)
+    };
+    Line::from(Span::styled(text, Style::default().fg(theme::SUCCESS())))
+}
+
+fn seat_badge_line(
+    snapshot: &PokerPublicSnapshot,
+    seat: &PokerSeat,
+    is_winner: bool,
+) -> Line<'static> {
     let mut spans = Vec::new();
+    if is_winner {
+        spans.push(Span::styled(
+            "WINNER",
+            Style::default()
+                .fg(theme::SUCCESS())
+                .add_modifier(Modifier::BOLD),
+        ));
+    }
     if snapshot.dealer_button == Some(seat.index) {
+        if !spans.is_empty() {
+            spans.push(Span::raw("  "));
+        }
         spans.push(Span::styled(
             "button",
             Style::default()
@@ -572,7 +606,7 @@ fn seat_badge_line(snapshot: &PokerPublicSnapshot, seat: &PokerSeat) -> Line<'st
                 .add_modifier(Modifier::BOLD),
         ));
     }
-    if seat.in_hand && !seat.folded && !snapshot.winners.contains(&seat.index) {
+    if seat.in_hand && !seat.folded && !snapshot.winners.contains(&seat.index) && !seat.all_in {
         if !spans.is_empty() {
             spans.push(Span::raw("  "));
         }
@@ -643,6 +677,16 @@ fn draw_table_compact(
                     .fg(theme::AMBER())
                     .add_modifier(Modifier::BOLD),
             ),
+            Span::styled("  Pot: ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(
+                snapshot.pot.to_string(),
+                Style::default().fg(theme::AMBER()),
+            ),
+            Span::styled("  Bet: ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(
+                snapshot.current_bet.to_string(),
+                Style::default().fg(theme::AMBER()),
+            ),
         ]),
         Line::raw(""),
     ];
@@ -688,11 +732,17 @@ fn compact_seat_line(
         .last_action
         .map(action_label)
         .unwrap_or(if seat.folded { "folded" } else { "" });
+    let stack = if seat.user_id.is_some() {
+        format!(" bal {:<5}", seat.balance)
+    } else {
+        String::new()
+    };
     Line::from(vec![
         Span::styled(format!("{label:<11}"), label_style),
         Span::styled(format!("{name:<12}"), Style::default().fg(theme::TEXT())),
         Span::styled(cards, Style::default().fg(theme::TEXT_BRIGHT())),
         Span::raw(" "),
+        Span::styled(stack, Style::default().fg(theme::SUCCESS())),
         Span::styled(action.to_string(), Style::default().fg(theme::TEXT_DIM())),
     ])
 }
@@ -735,13 +785,44 @@ fn key_line(state: &State, snapshot: &PokerPublicSnapshot) -> Line<'static> {
         return key_hint("s/Enter sit - Esc back", "");
     }
     match snapshot.phase {
+        PokerPhase::PostingBlinds => key_hint("posting blinds - L leave - Esc back", ""),
         PokerPhase::Waiting | PokerPhase::Showdown => {
             key_hint("N deal next - L leave - Esc back", "")
         }
         PokerPhase::PreFlop | PokerPhase::Flop | PokerPhase::Turn | PokerPhase::River
             if state.can_act() =>
         {
-            key_hint("C/Space check - F fold - L leave - Esc back", "")
+            if state.to_call() > 0 {
+                if state.can_raise() {
+                    key_hint(
+                        &format!(
+                            "C call {} - R raise +{} - A all-in - F fold - [/] raise",
+                            state.to_call(),
+                            state.selected_raise().max(state.min_raise())
+                        ),
+                        "",
+                    )
+                } else if state.can_all_in() {
+                    key_hint(
+                        &format!("C call {} - A all-in - F fold", state.to_call()),
+                        "",
+                    )
+                } else {
+                    key_hint(&format!("C call {} - F fold", state.to_call()), "")
+                }
+            } else {
+                if state.can_raise() {
+                    key_hint(
+                        &format!(
+                            "C check - B bet {} - A all-in - F fold - [/] bet",
+                            state.selected_raise().max(state.min_raise())
+                        ),
+                        "",
+                    )
+                } else {
+                    key_hint("C check - F fold", "")
+                }
+            }
         }
         PokerPhase::PreFlop | PokerPhase::Flop | PokerPhase::Turn | PokerPhase::River => {
             key_hint("waiting action - L leave - Esc back", "")
@@ -751,8 +832,14 @@ fn key_line(state: &State, snapshot: &PokerPublicSnapshot) -> Line<'static> {
 
 fn action_label(action: PokerAction) -> &'static str {
     match action {
+        PokerAction::SmallBlind => "small blind",
+        PokerAction::BigBlind => "big blind",
         PokerAction::Check => "check",
+        PokerAction::Call => "call",
+        PokerAction::Bet => "bet",
+        PokerAction::Raise => "raise",
         PokerAction::Fold => "fold",
+        PokerAction::AllIn => "all-in",
     }
 }
 

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -152,7 +152,8 @@ async fn main() -> anyhow::Result<()> {
         );
     let tictactoe_table_manager =
         late_ssh::app::rooms::tictactoe::manager::TicTacToeTableManager::new();
-    let poker_table_manager = late_ssh::app::rooms::poker::manager::PokerTableManager::new();
+    let poker_table_manager =
+        late_ssh::app::rooms::poker::manager::PokerTableManager::new(chip_service.clone());
     let room_game_registry = late_ssh::app::rooms::registry::RoomGameRegistry::new(
         blackjack_table_manager.clone(),
         poker_table_manager,

--- a/late-ssh/tests/helpers/mod.rs
+++ b/late-ssh/tests/helpers/mod.rs
@@ -57,10 +57,10 @@ fn test_dartboard_provenance() -> late_ssh::app::artboard::provenance::SharedArt
 fn test_room_game_registry(db: Db) -> RoomGameRegistry {
     let chip_service = ChipService::new(db.clone());
     let blackjack_table_manager =
-        BlackjackTableManager::new(chip_service, BlackjackPlayerDirectory::new(db));
+        BlackjackTableManager::new(chip_service.clone(), BlackjackPlayerDirectory::new(db));
     RoomGameRegistry::new(
         blackjack_table_manager,
-        PokerTableManager::new(),
+        PokerTableManager::new(chip_service),
         TicTacToeTableManager::new(),
     )
 }
@@ -174,12 +174,12 @@ pub fn test_app_state(db: Db, config: Config) -> State {
         minesweeper_service,
         bonsai_service,
         nonogram_library: NonogramLibrary::default(),
-        chip_service,
+        chip_service: chip_service.clone(),
         rooms_service,
         blackjack_table_manager: blackjack_table_manager.clone(),
         room_game_registry: RoomGameRegistry::new(
             blackjack_table_manager,
-            PokerTableManager::new(),
+            PokerTableManager::new(chip_service.clone()),
             TicTacToeTableManager::new(),
         ),
         dartboard_server,


### PR DESCRIPTION
## Summary
Poker rooms now play as real fixed-blind chip games instead of no-stakes hands. Players can post blinds, call, bet or raise, shove all-in, win side pots, and have chip balances debited and credited through the shared chip service.

## What changed
- Added 10/20 blind poker flow with pre-flop blind posting, call/check, bet/raise, fold, and all-in actions.
- Settles pots through `ChipService`, including side pots, split pots, odd chips, failed debit handling, and winner payouts.
- Shows pot, current bet, stack, committed chips, pending actions, all-in state, and updated key hints in the poker SSH UI.
- Keeps external chip balance sync safe by only syncing while the table is idle or at showdown and no settlement is pending.
- Updated poker room metadata and context docs to describe stakes, controls, settlement, and known gaps.

## Behavior notes
- Poker stakes are fixed in code at 10/20 blinds and are not configurable from room settings yet.
- Showdown currently auto-reveals all non-folded contenders; there is no optional muck/show flow.
- During an active hand, inactive seated players are folded and removed after settlement; outside active hands, they leave the table after the idle timeout.
- Short all-ins can increase the call amount without reopening raises unless they meet the full-raise threshold.

## Feature flags
None.

## Screenshots / Video
This changes the visible poker room UI. Screenshots or a short terminal recording still need to be attached before review.

## Testing
- Automated: Added poker service unit coverage for side-pot payouts, four-way all-ins, tied side pots, short all-in raise behavior, and fold wins without revealing cards.
- Manual: Not documented in the diff. Before review, verify a multi-player poker hand through blinds, call/raise/all-in/fold actions, settlement, balance updates, and the updated key hints in the SSH UI.