### PR TITLE
Add Global Room Search Shortcut

### DIFF
--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -88,7 +88,7 @@ pub(crate) enum RoomSlot {
     Work,
 }
 
-pub(super) fn is_chat_list_room(room: &ChatRoom) -> bool {
+pub(crate) fn is_chat_list_room(room: &ChatRoom) -> bool {
     if room.kind == "game" {
         return false;
     }

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -233,7 +233,7 @@ fn empty_composer_placeholder(view: &ComposerBlockView<'_>) -> Paragraph<'static
         ))]
     } else {
         vec![Line::from(Span::styled(
-            "Type a message · j/k select · /binds · or just ask @bot about anything",
+            "Type a message · j/k select · Ctrl+/ jump room · or just ask @bot about anything",
             dim,
         ))]
     };
@@ -2090,7 +2090,8 @@ mod tests {
         view.composing = false;
 
         let placeholder = empty_composer_placeholder(&view);
-        let expected = "Type a message · j/k select · /binds · or just ask @bot about anything";
+        let expected =
+            "Type a message · j/k select · Ctrl+/ jump room · or just ask @bot about anything";
         let width = expected.chars().count() as u16;
         let backend = TestBackend::new(width, 1);
         let mut terminal = Terminal::new(backend).expect("term");

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -129,6 +129,7 @@ pub fn chat_help_lines() -> Vec<String> {
         "  /settings          open your settings modal",
         "  /exit              open quit confirm",
         "  Ctrl+O             open your settings modal anywhere",
+        "  Ctrl+/             search and jump to a room or DM",
         "",
         "Messages",
         "  j / k              select older / newer message",

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -1,6 +1,6 @@
 use super::{
     chat, dashboard, help_modal, icon_picker, mod_modal, profile_modal, quit_confirm,
-    settings_modal, state::App, terminal_help_modal,
+    room_search_modal, settings_modal, state::App, terminal_help_modal,
 };
 use crate::app::common::primitives::Screen;
 use crate::app::common::readline::ctrl_byte_to_input;
@@ -346,6 +346,10 @@ impl Perform for VtCollector {
             'u' if (p0 == Some(127) || p0 == Some(8)) && p1 == Some(5) => {
                 self.events.push(ParsedInput::CtrlBackspace);
             }
+            // Kitty keyboard protocol for Ctrl+/.
+            'u' if p0 == Some(b'/' as u16) && p1 == Some(5) => {
+                self.events.push(ParsedInput::Byte(0x1F));
+            }
             // Shift+Tab: xterm `CSI Z`.
             'Z' if intermediates.is_empty() => {
                 self.events.push(ParsedInput::BackTab);
@@ -608,6 +612,20 @@ fn handle_parsed_input(app: &mut App, event: ParsedInput) {
             app.show_web_chat_qr = false;
             app.web_chat_qr_url = None;
         }
+        return;
+    }
+
+    if is_room_search_shortcut(&event) {
+        if app.room_search_modal_state.is_open() {
+            app.room_search_modal_state.close();
+        } else {
+            open_room_search_modal_globally(app);
+        }
+        return;
+    }
+
+    if app.room_search_modal_state.is_open() {
+        room_search_modal::input::handle_input(app, event);
         return;
     }
 
@@ -1066,6 +1084,10 @@ fn dispatch_escape(app: &mut App) {
     if app.show_web_chat_qr {
         app.show_web_chat_qr = false;
         app.web_chat_qr_url = None;
+        return;
+    }
+    if app.room_search_modal_state.is_open() {
+        app.room_search_modal_state.close();
         return;
     }
     if app.chat.has_news_modal() {
@@ -1568,6 +1590,28 @@ fn reset_composers_for_page_change(app: &mut App) {
     app.chat.showcase.stop_composing();
     app.chat.work.stop_composing();
     app.chat.close_news_modal();
+}
+
+fn is_room_search_shortcut(event: &ParsedInput) -> bool {
+    matches!(event, ParsedInput::Byte(0x1F))
+}
+
+fn open_room_search_modal_globally(app: &mut App) {
+    app.show_help = false;
+    app.show_mod_modal = false;
+    app.show_profile_modal = false;
+    app.show_bonsai_modal = false;
+    app.show_settings = false;
+    app.show_terminal_help = false;
+    app.show_web_chat_qr = false;
+    app.web_chat_qr_url = None;
+    app.show_cli_install_modal = false;
+    app.show_quit_confirm = false;
+    app.icon_picker_open = false;
+    app.chat.close_overlay();
+    app.chat.close_news_modal();
+    app.chat.cancel_room_jump();
+    app.room_search_modal_state.open();
 }
 
 fn open_settings_modal_globally(app: &mut App) {
@@ -2155,6 +2199,7 @@ mod tests {
         );
         assert_eq!(parser.feed(b"\x1b[8;5u"), vec![ParsedInput::CtrlBackspace]);
         assert_eq!(parser.feed(b"\x1b[8;5~"), vec![ParsedInput::CtrlBackspace]);
+        assert_eq!(parser.feed(b"\x1b[47;5u"), vec![ParsedInput::Byte(0x1F)]);
     }
 
     #[test]

--- a/late-ssh/src/app/mod.rs
+++ b/late-ssh/src/app/mod.rs
@@ -14,6 +14,7 @@ pub mod profile;
 pub(crate) mod profile_modal;
 pub(crate) mod quit_confirm;
 mod render;
+pub(crate) mod room_search_modal;
 pub mod rooms;
 pub(crate) mod settings_modal;
 pub mod state;

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -20,7 +20,8 @@ use super::{
         sidebar::{SidebarProps, draw_sidebar, sidebar_clock_text},
         theme,
     },
-    dashboard, help_modal, icon_picker, mod_modal, profile_modal, quit_confirm, settings_modal,
+    dashboard, help_modal, icon_picker, mod_modal, profile_modal, quit_confirm, room_search_modal,
+    settings_modal,
     state::{App, NotificationMode},
     terminal_help_modal,
     visualizer::Visualizer,
@@ -178,6 +179,10 @@ struct DrawContext<'a> {
     show_web_chat_qr: bool,
     web_chat_qr_url: Option<&'a str>,
     show_cli_install_modal: bool,
+    room_search_modal_open: bool,
+    room_search_modal_state: &'a room_search_modal::state::RoomSearchModalState,
+    chat_state: &'a chat::state::ChatState,
+    user_id: uuid::Uuid,
     news_modal: Option<chat::news::ui::ArticleModalView<'a>>,
     is_draining: bool,
     icon_picker_open: bool,
@@ -531,6 +536,10 @@ impl App {
                         show_web_chat_qr: self.show_web_chat_qr,
                         web_chat_qr_url: self.web_chat_qr_url.as_deref(),
                         show_cli_install_modal: self.show_cli_install_modal,
+                        room_search_modal_open: self.room_search_modal_state.is_open(),
+                        room_search_modal_state: &self.room_search_modal_state,
+                        chat_state: &self.chat,
+                        user_id: self.user_id,
                         news_modal,
                         is_draining: self.is_draining.load(std::sync::atomic::Ordering::Relaxed),
                         icon_picker_open: self.icon_picker_open,
@@ -847,6 +856,16 @@ impl App {
 
         if ctx.show_cli_install_modal {
             super::common::cli_install::draw(frame, inner);
+        }
+
+        if ctx.room_search_modal_open {
+            room_search_modal::ui::draw(
+                frame,
+                inner,
+                ctx.room_search_modal_state,
+                ctx.chat_state,
+                ctx.user_id,
+            );
         }
 
         if ctx.icon_picker_open

--- a/late-ssh/src/app/room_search_modal/input.rs
+++ b/late-ssh/src/app/room_search_modal/input.rs
@@ -1,0 +1,51 @@
+use crate::app::{common::primitives::Screen, input::ParsedInput, state::App};
+
+use super::state::filtered_items;
+
+pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
+    let len = filtered_items(&app.chat, app.user_id, app.room_search_modal_state.query()).len();
+    app.room_search_modal_state.clamp(len);
+
+    match event {
+        ParsedInput::Byte(0x1B) => app.room_search_modal_state.close(),
+        ParsedInput::Byte(b'\r' | b'\n') => submit(app),
+        ParsedInput::Byte(0x7F) => app.room_search_modal_state.backspace(),
+        ParsedInput::CtrlBackspace | ParsedInput::Byte(0x08) => {
+            app.room_search_modal_state.delete_word_left();
+        }
+        ParsedInput::Arrow(b'B') => {
+            app.room_search_modal_state.move_selection(1, len);
+        }
+        ParsedInput::Arrow(b'A') | ParsedInput::Byte(0x0B) => {
+            app.room_search_modal_state.move_selection(-1, len);
+        }
+        ParsedInput::PageDown => app.room_search_modal_state.move_selection(8, len),
+        ParsedInput::PageUp => app.room_search_modal_state.move_selection(-8, len),
+        ParsedInput::Char(ch) => app.room_search_modal_state.push(ch),
+        ParsedInput::Byte(byte) if byte.is_ascii_graphic() || byte == b' ' => {
+            app.room_search_modal_state.push(byte as char);
+        }
+        _ => {}
+    }
+
+    let len = filtered_items(&app.chat, app.user_id, app.room_search_modal_state.query()).len();
+    app.room_search_modal_state.clamp(len);
+}
+
+fn submit(app: &mut App) {
+    let items = filtered_items(&app.chat, app.user_id, app.room_search_modal_state.query());
+    let Some(item) = items.get(app.room_search_modal_state.selected()).cloned() else {
+        return;
+    };
+
+    app.chat.reset_composer();
+    app.chat.feeds.stop_processing();
+    app.chat.news.stop_composing();
+    app.chat.showcase.stop_composing();
+    app.chat.work.stop_composing();
+    app.chat.close_news_modal();
+    app.chat.select_room_slot(item.slot);
+    app.room_search_modal_state.close();
+    app.set_screen(Screen::Chat);
+    app.sync_visible_chat_room();
+}

--- a/late-ssh/src/app/room_search_modal/mod.rs
+++ b/late-ssh/src/app/room_search_modal/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod input;
+pub(crate) mod state;
+pub(crate) mod ui;

--- a/late-ssh/src/app/room_search_modal/state.rs
+++ b/late-ssh/src/app/room_search_modal/state.rs
@@ -1,0 +1,232 @@
+use late_core::models::chat_room::ChatRoom;
+use uuid::Uuid;
+
+use crate::app::chat::state::{ChatState, RoomSlot, is_chat_list_room};
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct RoomSearchItem {
+    pub slot: RoomSlot,
+    pub label: String,
+    pub meta: String,
+}
+
+#[derive(Clone, Debug, Default)]
+pub(crate) struct RoomSearchModalState {
+    open: bool,
+    query: String,
+    selected: usize,
+}
+
+impl RoomSearchModalState {
+    pub(crate) fn open(&mut self) {
+        self.open = true;
+        self.query.clear();
+        self.selected = 0;
+    }
+
+    pub(crate) fn close(&mut self) {
+        self.open = false;
+        self.query.clear();
+        self.selected = 0;
+    }
+
+    pub(crate) fn is_open(&self) -> bool {
+        self.open
+    }
+
+    pub(crate) fn query(&self) -> &str {
+        &self.query
+    }
+
+    pub(crate) fn selected(&self) -> usize {
+        self.selected
+    }
+
+    pub(crate) fn push(&mut self, ch: char) {
+        if !ch.is_control() {
+            self.query.push(ch);
+            self.selected = 0;
+        }
+    }
+
+    pub(crate) fn backspace(&mut self) {
+        self.query.pop();
+        self.selected = 0;
+    }
+
+    pub(crate) fn delete_word_left(&mut self) {
+        let trimmed = self.query.trim_end().len();
+        self.query.truncate(trimmed);
+        while self
+            .query
+            .chars()
+            .last()
+            .is_some_and(|ch| !ch.is_whitespace() && ch != '/' && ch != '#' && ch != '@')
+        {
+            self.query.pop();
+        }
+        self.selected = 0;
+    }
+
+    pub(crate) fn move_selection(&mut self, delta: isize, len: usize) {
+        if len == 0 {
+            self.selected = 0;
+            return;
+        }
+        let next = (self.selected as isize + delta).rem_euclid(len as isize) as usize;
+        self.selected = next;
+    }
+
+    pub(crate) fn clamp(&mut self, len: usize) {
+        if len == 0 {
+            self.selected = 0;
+        } else {
+            self.selected = self.selected.min(len - 1);
+        }
+    }
+}
+
+pub(crate) fn search_items(chat: &ChatState, current_user_id: Uuid) -> Vec<RoomSearchItem> {
+    let mut items = Vec::new();
+    for slot in chat.visual_order() {
+        let RoomSlot::Room(room_id) = slot else {
+            continue;
+        };
+        let Some((room, _)) = chat.rooms.iter().find(|(room, _)| room.id == room_id) else {
+            continue;
+        };
+        if !is_chat_list_room(room) {
+            continue;
+        }
+        items.push(RoomSearchItem {
+            slot,
+            label: room_label(room, current_user_id, &chat.usernames),
+            meta: room_meta(room),
+        });
+    }
+    items
+}
+
+pub(crate) fn filtered_items(
+    chat: &ChatState,
+    current_user_id: Uuid,
+    query: &str,
+) -> Vec<RoomSearchItem> {
+    let query = normalize_query(query);
+    let all = search_items(chat, current_user_id);
+    if query.is_empty() {
+        return all;
+    }
+
+    all.into_iter()
+        .filter(|item| {
+            let label = normalize_query(&item.label);
+            let meta = normalize_query(&item.meta);
+            label.contains(&query) || meta.contains(&query)
+        })
+        .collect()
+}
+
+fn room_label(
+    room: &ChatRoom,
+    current_user_id: Uuid,
+    usernames: &std::collections::HashMap<Uuid, String>,
+) -> String {
+    if room.kind == "dm" {
+        return format!("@{}", dm_peer_label(room, current_user_id, usernames));
+    }
+    if let Some(slug) = room.slug.as_deref().filter(|slug| !slug.is_empty()) {
+        return format!("#{slug}");
+    }
+    if let Some(code) = room
+        .language_code
+        .as_deref()
+        .filter(|code| !code.is_empty())
+    {
+        return format!("#lang-{code}");
+    }
+    format!("#{}", room.kind)
+}
+
+fn dm_peer_label(
+    room: &ChatRoom,
+    current_user_id: Uuid,
+    usernames: &std::collections::HashMap<Uuid, String>,
+) -> String {
+    let peer_id = if room.dm_user_a == Some(current_user_id) {
+        room.dm_user_b
+    } else {
+        room.dm_user_a
+    };
+    peer_id
+        .and_then(|id| usernames.get(&id).cloned())
+        .unwrap_or_else(|| "DM".to_string())
+}
+
+fn room_meta(room: &ChatRoom) -> String {
+    match room.kind.as_str() {
+        "dm" => "direct message".to_string(),
+        _ if room.permanent => "core room".to_string(),
+        _ if room.visibility == "private" => "private room".to_string(),
+        _ if room.visibility == "public" => "public room".to_string(),
+        _ => "room".to_string(),
+    }
+}
+
+fn normalize_query(input: &str) -> String {
+    input.trim().trim_start_matches(['#', '@']).to_lowercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn room(kind: &str, visibility: &str, slug: Option<&str>) -> ChatRoom {
+        ChatRoom {
+            id: Uuid::from_u128(1),
+            created: Utc::now(),
+            updated: Utc::now(),
+            kind: kind.to_string(),
+            visibility: visibility.to_string(),
+            auto_join: false,
+            permanent: false,
+            slug: slug.map(str::to_string),
+            language_code: None,
+            dm_user_a: None,
+            dm_user_b: None,
+        }
+    }
+
+    #[test]
+    fn query_ignores_room_prefixes() {
+        assert_eq!(normalize_query("#general"), "general");
+        assert_eq!(normalize_query("@alice"), "alice");
+    }
+
+    #[test]
+    fn delete_word_left_stops_at_room_prefix() {
+        let mut state = RoomSearchModalState::default();
+        state.query = "#general chat".to_string();
+        state.delete_word_left();
+        assert_eq!(state.query, "#general ");
+        state.delete_word_left();
+        assert_eq!(state.query, "#");
+    }
+
+    #[test]
+    fn room_labels_prefix_rooms_and_dms() {
+        let current = Uuid::from_u128(1);
+        let peer = Uuid::from_u128(2);
+        let mut usernames = std::collections::HashMap::new();
+        usernames.insert(peer, "alice".to_string());
+
+        let public = room("topic", "public", Some("rust"));
+        assert_eq!(room_label(&public, current, &usernames), "#rust");
+
+        let mut dm = room("dm", "dm", None);
+        dm.dm_user_a = Some(current);
+        dm.dm_user_b = Some(peer);
+        assert_eq!(room_label(&dm, current, &usernames), "@alice");
+    }
+}

--- a/late-ssh/src/app/room_search_modal/ui.rs
+++ b/late-ssh/src/app/room_search_modal/ui.rs
@@ -1,0 +1,202 @@
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Margin, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
+
+use crate::app::{
+    chat::state::ChatState,
+    common::theme,
+    room_search_modal::state::{RoomSearchModalState, filtered_items},
+};
+use uuid::Uuid;
+
+const MODAL_WIDTH: u16 = 62;
+const MODAL_HEIGHT: u16 = 18;
+
+pub(crate) fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    state: &RoomSearchModalState,
+    chat: &ChatState,
+    user_id: Uuid,
+) {
+    let popup = centered_rect(
+        area,
+        MODAL_WIDTH.min(area.width),
+        MODAL_HEIGHT.min(area.height),
+    );
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title(" Jump To Room ")
+        .title_style(
+            Style::default()
+                .fg(theme::AMBER_GLOW())
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::BORDER_ACTIVE()));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    if inner.height < 5 || inner.width < 20 {
+        frame.render_widget(Paragraph::new("Terminal too small"), inner);
+        return;
+    }
+
+    let layout = Layout::vertical([
+        Constraint::Length(3),
+        Constraint::Min(1),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+
+    draw_query(frame, layout[0], state);
+    draw_results(frame, layout[1], state, chat, user_id);
+    draw_footer(frame, layout[2]);
+}
+
+fn draw_query(frame: &mut Frame, area: Rect, state: &RoomSearchModalState) {
+    let block = Block::default()
+        .title(" Search ")
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::BORDER_ACTIVE()));
+    let inner = block.inner(area).inner(Margin {
+        vertical: 0,
+        horizontal: 1,
+    });
+    frame.render_widget(block, area);
+
+    let mut query = state.query().to_string();
+    query.push('█');
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::styled("/", Style::default().fg(theme::AMBER_DIM())),
+            Span::styled(query, Style::default().fg(theme::TEXT_BRIGHT())),
+        ])),
+        inner,
+    );
+}
+
+fn draw_results(
+    frame: &mut Frame,
+    area: Rect,
+    state: &RoomSearchModalState,
+    chat: &ChatState,
+    user_id: Uuid,
+) {
+    let items = filtered_items(chat, user_id, state.query());
+    let selected = state.selected();
+    if items.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                "  No matching rooms",
+                Style::default().fg(theme::TEXT_DIM()),
+            ))),
+            area,
+        );
+        return;
+    }
+
+    let height = area.height as usize;
+    let start = selected
+        .saturating_sub(height.saturating_sub(1))
+        .min(items.len().saturating_sub(height));
+    let width = area.width as usize;
+    let lines: Vec<Line<'static>> = items
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(height)
+        .map(|(index, item)| {
+            let active = index == selected;
+            let marker = if active { ">" } else { " " };
+            let style = if active {
+                Style::default()
+                    .fg(theme::AMBER_GLOW())
+                    .bg(theme::BG_SELECTION())
+                    .add_modifier(Modifier::BOLD)
+            } else {
+                Style::default().fg(theme::TEXT())
+            };
+            let meta_style = if active {
+                Style::default()
+                    .fg(theme::TEXT_BRIGHT())
+                    .bg(theme::BG_SELECTION())
+            } else {
+                Style::default().fg(theme::TEXT_DIM())
+            };
+            let meta_width = 16usize.min(width.saturating_sub(6));
+            let label_width = width.saturating_sub(meta_width + 4);
+            Line::from(vec![
+                Span::styled(format!("{marker} "), style),
+                Span::styled(
+                    pad_right(&truncate_to_width(&item.label, label_width), label_width),
+                    style,
+                ),
+                Span::styled(" ", style),
+                Span::styled(truncate_to_width(&item.meta, meta_width), meta_style),
+            ])
+        })
+        .collect();
+
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect) {
+    let line = Line::from(vec![
+        Span::styled("Enter", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" jump  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("↑↓", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" select  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("Esc", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" close", Style::default().fg(theme::TEXT_DIM())),
+    ]);
+    frame.render_widget(Paragraph::new(line), area);
+}
+
+fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {
+    let vertical = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .split(area);
+    let horizontal = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .split(vertical[0]);
+    horizontal[0]
+}
+
+fn pad_right(text: &str, width: usize) -> String {
+    let used = UnicodeWidthStr::width(text);
+    let mut out = String::with_capacity(text.len() + width.saturating_sub(used));
+    out.push_str(text);
+    out.push_str(&" ".repeat(width.saturating_sub(used)));
+    out
+}
+
+fn truncate_to_width(text: &str, width: usize) -> String {
+    if width == 0 {
+        return String::new();
+    }
+    if UnicodeWidthStr::width(text) <= width {
+        return text.to_string();
+    }
+    if width == 1 {
+        return "…".to_string();
+    }
+    let mut out = String::new();
+    let mut used = 0usize;
+    for ch in text.chars() {
+        let ch_width = UnicodeWidthChar::width(ch).unwrap_or(0);
+        if used + ch_width >= width {
+            break;
+        }
+        out.push(ch);
+        used += ch_width;
+    }
+    out.push('…');
+    out
+}

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -242,6 +242,7 @@ pub struct App {
     pub(crate) dashboard_chat_rows_cache: chat::ui::ChatRowsCache,
     pub(crate) active_room_rows_cache: chat::ui::ChatRowsCache,
     pub(crate) rooms_chat_rows_cache: chat::ui::ChatRowsCache,
+    pub(crate) room_search_modal_state: crate::app::room_search_modal::state::RoomSearchModalState,
 
     /// Which favorite room the dashboard's chat card is currently showing,
     /// when the user has 2+ favorites pinned. Clamped on read against the
@@ -729,6 +730,8 @@ impl App {
             dashboard_chat_rows_cache: chat::ui::ChatRowsCache::default(),
             active_room_rows_cache: chat::ui::ChatRowsCache::default(),
             rooms_chat_rows_cache: chat::ui::ChatRowsCache::default(),
+            room_search_modal_state:
+                crate::app::room_search_modal::state::RoomSearchModalState::default(),
             dashboard_favorite_index: 0,
             dashboard_previous_favorite_index: None,
             dashboard_g_prefix_armed: false,


### PR DESCRIPTION
## Summary
- Adds a global `Ctrl+/` room search modal so users can quickly find and jump to rooms or DMs without navigating the room list manually.

## What changed
- `Ctrl+/` now opens a centered "Jump To Room" modal from anywhere in the app.
- The modal supports filtering by room or DM name, selecting with arrow keys/page keys, and jumping with Enter.
- Help text and the chat composer placeholder now advertise the new shortcut.

## Behavior notes
- Opening room search closes other overlays/modals first.
- `Esc` closes the room search modal.
- Submitting a result switches to Chat, selects the chosen room, stops in-progress composing/processing state, and syncs the visible room.

## Feature flags
- None.

## Screenshots / Video
- UI-visible change. Screenshots or video still need to be attached before review.

## Testing
- Automated: Added/updated tests for `Ctrl+/` parsing, room search query normalization, word deletion, room/DM labels, and updated placeholder text.
- Manual: Not provided in diff context.