### PR TITLE
Feature: Add solarized classic themes (light and dark)

### DIFF
--- a/late-ssh/src/app/common/theme.rs
+++ b/late-ssh/src/app/common/theme.rs
@@ -67,6 +67,7 @@ pub enum ThemeKind {
     Cyberpunk2077 = 61,
     Monokai = 62,
     SolarizedLight = 63,
+    SolarizedDark = 64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -566,6 +567,12 @@ pub const OPTIONS: &[ThemeOption] = &[
         group: ThemeGroup::Ports,
         id: "solarized_light",
         label: "Solarized Light",
+    },
+    ThemeOption {
+        kind: ThemeKind::SolarizedDark,
+        group: ThemeGroup::Ports,
+        id: "solarized_dark",
+        label: "Solarized Dark",
     },
 ];
 
@@ -2491,6 +2498,36 @@ const PALETTE_SOLARIZED_LIGHT: Palette = Palette {
     badge_gold: Color::Rgb(181, 137, 0),
 };
 
+const PALETTE_SOLARIZED_DARK: Palette = Palette {
+    bg_canvas: Color::Rgb(0, 43, 54),
+    bg_selection: Color::Rgb(7, 54, 66),
+    bg_highlight: Color::Rgb(7, 54, 66),
+    border_dim: Color::Rgb(7, 54, 66),
+    border: Color::Rgb(88, 110, 117),
+    border_active: Color::Rgb(38, 139, 210),
+    text_faint: Color::Rgb(7, 54, 66),
+    text_dim: Color::Rgb(88, 110, 117),
+    text_muted: Color::Rgb(101, 123, 131),
+    text: Color::Rgb(131, 148, 150),
+    text_bright: Color::Rgb(147, 161, 161),
+    amber: Color::Rgb(203, 75, 22),
+    amber_dim: Color::Rgb(160, 54, 12),
+    amber_glow: Color::Rgb(224, 90, 32),
+    chat_body: Color::Rgb(131, 148, 150),
+    chat_author: Color::Rgb(38, 139, 210),
+    mention: Color::Rgb(181, 137, 0),
+    success: Color::Rgb(133, 153, 0),
+    error: Color::Rgb(220, 50, 47),
+    bot: Color::Rgb(108, 113, 196),
+    bonsai_sprout: Color::Rgb(133, 153, 0),
+    bonsai_leaf: Color::Rgb(42, 161, 152),
+    bonsai_canopy: Color::Rgb(42, 161, 152),
+    bonsai_bloom: Color::Rgb(211, 54, 130),
+    badge_bronze: Color::Rgb(203, 75, 22),
+    badge_silver: Color::Rgb(131, 148, 150),
+    badge_gold: Color::Rgb(181, 137, 0),
+};
+
 thread_local! {
     static CURRENT_THEME: Cell<ThemeKind> = const { Cell::new(ThemeKind::Contrast) };
 }
@@ -2617,6 +2654,7 @@ fn palette_for_kind(kind: ThemeKind) -> &'static Palette {
         ThemeKind::Cyberpunk2077 => &PALETTE_CYBERPUNK2077,
         ThemeKind::Late => &PALETTE_LATE,
         ThemeKind::SolarizedLight => &PALETTE_SOLARIZED_LIGHT,
+        ThemeKind::SolarizedDark => &PALETTE_SOLARIZED_DARK,
     }
 }
 

--- a/late-ssh/src/app/common/theme.rs
+++ b/late-ssh/src/app/common/theme.rs
@@ -66,6 +66,7 @@ pub enum ThemeKind {
     Winter = 60,
     Cyberpunk2077 = 61,
     Monokai = 62,
+    SolarizedLight = 63,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -559,6 +560,12 @@ pub const OPTIONS: &[ThemeOption] = &[
         group: ThemeGroup::Games,
         id: "cyberpunk2077",
         label: "Cyberpunk 2077",
+    },
+    ThemeOption {
+        kind: ThemeKind::SolarizedLight,
+        group: ThemeGroup::Ports,
+        id: "solarized_light",
+        label: "Solarized Light",
     },
 ];
 
@@ -2454,6 +2461,36 @@ const PALETTE_MONOKAI: Palette = Palette {
     badge_gold: Color::Rgb(255, 216, 102),
 };
 
+const PALETTE_SOLARIZED_LIGHT: Palette = Palette {
+    bg_canvas: Color::Rgb(253, 246, 227),
+    bg_selection: Color::Rgb(238, 232, 213),
+    bg_highlight: Color::Rgb(238, 232, 213),
+    border_dim: Color::Rgb(147, 161, 161),
+    border: Color::Rgb(131, 148, 150),
+    border_active: Color::Rgb(38, 139, 210),
+    text_faint: Color::Rgb(147, 161, 161),
+    text_dim: Color::Rgb(131, 148, 150),
+    text_muted: Color::Rgb(101, 123, 131),
+    text: Color::Rgb(101, 123, 131),
+    text_bright: Color::Rgb(88, 110, 117),
+    amber: Color::Rgb(203, 75, 22),
+    amber_dim: Color::Rgb(160, 54, 12),
+    amber_glow: Color::Rgb(224, 90, 32),
+    chat_body: Color::Rgb(101, 123, 131),
+    chat_author: Color::Rgb(38, 139, 210),
+    mention: Color::Rgb(181, 137, 0),
+    success: Color::Rgb(133, 153, 0),
+    error: Color::Rgb(220, 50, 47),
+    bot: Color::Rgb(108, 113, 196),
+    bonsai_sprout: Color::Rgb(133, 153, 0),
+    bonsai_leaf: Color::Rgb(42, 161, 152),
+    bonsai_canopy: Color::Rgb(42, 161, 152),
+    bonsai_bloom: Color::Rgb(211, 54, 130),
+    badge_bronze: Color::Rgb(203, 75, 22),
+    badge_silver: Color::Rgb(131, 148, 150),
+    badge_gold: Color::Rgb(181, 137, 0),
+};
+
 thread_local! {
     static CURRENT_THEME: Cell<ThemeKind> = const { Cell::new(ThemeKind::Contrast) };
 }
@@ -2579,6 +2616,7 @@ fn palette_for_kind(kind: ThemeKind) -> &'static Palette {
         ThemeKind::Winter => &PALETTE_WINTER,
         ThemeKind::Cyberpunk2077 => &PALETTE_CYBERPUNK2077,
         ThemeKind::Late => &PALETTE_LATE,
+        ThemeKind::SolarizedLight => &PALETTE_SOLARIZED_LIGHT,
     }
 }
 


### PR DESCRIPTION
## Themes

Ports:
- Solarized Light
- Solarized Dark

## Screenshorts

### Solarized Light

| profile/settings | dashboard/sidebar | chat | games |
|------------------|-------------------|------|-------|
| <img width="1465" height="881" alt="image" src="https://github.com/user-attachments/assets/f66e03b6-dfc6-4906-95a2-21fe7f3b015e" /> | <img width="1470" height="880" alt="image" src="https://github.com/user-attachments/assets/e5b84e7f-d5b7-46df-bcac-2d3da3c472b4" /> | <img width="1468" height="882" alt="image" src="https://github.com/user-attachments/assets/842ff6e8-9f16-4ccb-bc02-c438ffa90e8e" /> | <img width="1470" height="883" alt="image" src="https://github.com/user-attachments/assets/5d70cec8-1b31-4de4-9330-c02ab3677364" /> |

### Solarized Dark

| profile/settings | dashboard/sidebar | chat | games |
|------------------|-------------------|------|-------|
| <img width="1470" height="882" alt="image" src="https://github.com/user-attachments/assets/687eb471-de40-47f1-9bc4-85f39e79b643" /> | <img width="1470" height="879" alt="image" src="https://github.com/user-attachments/assets/3e9d7c5c-26bd-495f-8d97-8d24b4c9ffc9" /> | <img width="1470" height="879" alt="image" src="https://github.com/user-attachments/assets/c1d2220f-1d8c-4233-8192-8bd0b0ac4d63" /> |  <img width="1468" height="881" alt="image" src="https://github.com/user-attachments/assets/455eafa5-c89b-4443-9e6d-73e3843ba3eb" /> |