### PR TITLE
Add paired CLI clipboard image upload for chat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "image",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,6 +835,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1427,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1545,6 +1581,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
 name = "etcetera"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1685,6 +1727,12 @@ name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
@@ -1842,6 +1890,16 @@ dependencies = [
  "generic-array 0.14.7",
  "rustversion",
  "typenum",
+]
+
+[[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix",
+ "windows-link",
 ]
 
 [[package]]
@@ -2645,10 +2703,13 @@ name = "late-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arboard",
+ "base64 0.22.1",
  "cpal",
  "crossterm",
  "futures-util",
  "getrandom 0.4.2",
+ "image",
  "nix 0.29.0",
  "rand_core 0.6.4",
  "reqwest 0.13.2",
@@ -3313,6 +3374,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-audio-toolbox"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3361,6 +3434,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
 name = "objc2-encode"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3372,7 +3458,20 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
+ "bitflags 2.11.1",
  "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3497,6 +3596,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.45.0",
 ]
 
 [[package]]
@@ -3715,6 +3824,17 @@ checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
 dependencies = [
  "pest",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -4157,6 +4277,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2e3bf4aa9d243beeb01a7b3bc30b77cfe2c44e24ec02d751a7104a53c2c49a1"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quinn"
@@ -5735,7 +5864,7 @@ dependencies = [
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -6270,6 +6399,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6703,6 +6843,76 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustix",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "563a85523cade2429938e790815fd7319062103b9f4a2dc806e9b53b95982d8f"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.11.1",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -7332,10 +7542,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xattr"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ opentelemetry-http = "0.31.0"
 tracing-opentelemetry = "0.32.1"
 opentelemetry-appender-tracing = "0.31.1"
 askama = "0.15.1"
+arboard = { version = "3", features = ["wayland-data-control"] }
 async-stream = "0.3"
 base64 = "0.22"
 bitflags = "2"

--- a/late-cli/CONTEXT.md
+++ b/late-cli/CONTEXT.md
@@ -79,6 +79,7 @@ OpenSSH mode differs slightly: it authenticates and fetches the token first thro
 ## 3. Entry Points and Files [STABLE]
 
 - `src/main.rs` - top-level orchestration, mode split, audio/WS lifecycle
+- `src/clipboard.rs` - paired `/paste-image` clipboard read, Wayland/X clipboard backend use, PNG encoding, and local size guards
 - `src/config.rs` - flags, env vars, defaults, logging
 - `src/identity.rs` - dedicated key discovery/generation
 - `src/ssh.rs` - native SSH, OpenSSH ControlMaster mode, legacy PTY subprocess mode, token parsing, resize forwarding

--- a/late-cli/CONTEXT.md
+++ b/late-cli/CONTEXT.md
@@ -265,6 +265,7 @@ Pairing behavior:
 - The first `client_state` is sent immediately after connect, then sent again after any applied control message.
 - `/paste-image` in SSH chat depends on the paired CLI control channel. The server only sends `request_clipboard_image` after seeing `clipboard_image` in the latest paired client state, so older CLIs and browser pairs do not receive unsupported control events.
 - Linux Wayland support for `/paste-image` depends on the workspace `arboard` dependency enabling `wayland-data-control`; Hyprland uses this path. Without it, the CLI may report that the clipboard does not contain an image even when Wayland has `image/png` content.
+- Clipboard images are converted to PNG in the CLI before upload. The CLI rejects zero-size images, very large decoded RGBA buffers, and PNG payloads above the upload cap before sending them over the pair socket.
 
 ---
 

--- a/late-cli/CONTEXT.md
+++ b/late-cli/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: `late-cli` - companion CLI for late.sh
 - Primary audience: LLM agents working on the CLI, human contributors
-- Last updated: 2026-05-01
+- Last updated: 2026-05-12
 - Status: Active
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change often.
 
@@ -219,6 +219,7 @@ Client to server:
   "client_kind": "cli",
   "ssh_mode": "native",
   "platform": "linux",
+  "capabilities": ["clipboard_image"],
   "muted": false,
   "volume_percent": 30
 }
@@ -238,15 +239,32 @@ Server to client:
 { "event": "volume_down" }
 ```
 
+```json
+{ "event": "request_clipboard_image" }
+```
+
+Client to server, in response to `request_clipboard_image`:
+
+```json
+{ "event": "clipboard_image", "data_base64": "<base64 png bytes>" }
+```
+
+```json
+{ "event": "clipboard_image_failed", "message": "clipboard does not contain an image" }
+```
+
 Client state labels:
 - `ssh_mode`: `native`, `openssh`, `old`
 - `platform`: `linux`, `macos`, `windows`, `android`, or `unknown`
+- `capabilities`: optional list; current CLI advertises `clipboard_image` when it can service chat `/paste-image`.
 
 Pairing behavior:
 - The server stores one paired-client sender/state entry per token.
 - If multiple browser/CLI clients pair with the same token, latest registration owns control/state until it disconnects.
 - CLI WebSocket reconnects up to 10 consecutive failures with a 2s delay.
 - The first `client_state` is sent immediately after connect, then sent again after any applied control message.
+- `/paste-image` in SSH chat depends on the paired CLI control channel. The server only sends `request_clipboard_image` after seeing `clipboard_image` in the latest paired client state, so older CLIs and browser pairs do not receive unsupported control events.
+- Linux Wayland support for `/paste-image` depends on the workspace `arboard` dependency enabling `wayland-data-control`; Hyprland uses this path. Without it, the CLI may report that the clipboard does not contain an image even when Wayland has `image/png` content.
 
 ---
 

--- a/late-cli/Cargo.toml
+++ b/late-cli/Cargo.toml
@@ -13,6 +13,8 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
+arboard.workspace = true
+base64.workspace = true
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
@@ -22,6 +24,7 @@ cpal.workspace = true
 crossterm.workspace = true
 futures-util.workspace = true
 getrandom.workspace = true
+image.workspace = true
 rand_core.workspace = true
 reqwest = { workspace = true, features = ["blocking"] }
 ringbuf.workspace = true

--- a/late-cli/src/clipboard.rs
+++ b/late-cli/src/clipboard.rs
@@ -1,0 +1,55 @@
+use std::io::Cursor;
+
+use anyhow::{Context, Result};
+use image::{ExtendedColorType, ImageEncoder, codecs::png::PngEncoder};
+
+const IMAGE_MAX_PIXELS: usize = 25_000_000;
+const IMAGE_MAX_RGBA_BYTES: usize = 64 * 1024 * 1024;
+const IMAGE_MAX_PNG_BYTES: usize = 10 * 1024 * 1024;
+
+pub(crate) fn image_png_bytes() -> Result<Vec<u8>> {
+    let mut clipboard = arboard::Clipboard::new().context("failed to access system clipboard")?;
+    let image = clipboard
+        .get_image()
+        .context("clipboard does not contain an image; on Wayland, `wl-paste -l` should list an image MIME type like image/png")?;
+    let pixel_count = image
+        .width
+        .checked_mul(image.height)
+        .context("clipboard image dimensions overflowed")?;
+    if pixel_count == 0 {
+        anyhow::bail!("clipboard image has invalid dimensions");
+    }
+    if pixel_count > IMAGE_MAX_PIXELS {
+        anyhow::bail!("clipboard image dimensions are too large");
+    }
+
+    let expected_len = pixel_count
+        .checked_mul(4)
+        .context("clipboard image byte length overflowed")?;
+    let rgba_len = image.bytes.len();
+    if rgba_len != expected_len {
+        anyhow::bail!("clipboard image data had unexpected length");
+    }
+    if rgba_len > IMAGE_MAX_RGBA_BYTES {
+        anyhow::bail!("clipboard image dimensions are too large");
+    }
+
+    let rgba = image.bytes.into_owned();
+    let mut png = Vec::new();
+    {
+        let cursor = Cursor::new(&mut png);
+        let encoder = PngEncoder::new(cursor);
+        encoder
+            .write_image(
+                &rgba,
+                image.width as u32,
+                image.height as u32,
+                ExtendedColorType::Rgba8,
+            )
+            .context("failed to encode clipboard image as PNG")?;
+    }
+    if png.len() > IMAGE_MAX_PNG_BYTES {
+        anyhow::bail!("clipboard image is too large");
+    }
+    Ok(png)
+}

--- a/late-cli/src/main.rs
+++ b/late-cli/src/main.rs
@@ -8,6 +8,7 @@ use tokio::sync::oneshot;
 use tracing::{debug, error, info};
 
 mod audio;
+mod clipboard;
 
 mod config;
 mod identity;

--- a/late-cli/src/ws.rs
+++ b/late-cli/src/ws.rs
@@ -1,11 +1,9 @@
 use anyhow::{Context, Result};
 use base64::{Engine as _, engine::general_purpose::STANDARD};
 use futures_util::{SinkExt, StreamExt};
-use image::{ExtendedColorType, ImageEncoder, codecs::png::PngEncoder};
 use serde::Deserialize;
 use serde_json::json;
 use std::{
-    io::Cursor,
     sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
     time::Duration,
 };
@@ -13,7 +11,7 @@ use tokio::{sync::broadcast, time::interval};
 use tokio_tungstenite::{connect_async, tungstenite::Message};
 use tracing::{debug, info};
 
-use super::audio::VizSample;
+use super::{audio::VizSample, clipboard};
 
 pub(super) struct PairClientInfo {
     pub(super) ssh_mode: &'static str,
@@ -37,9 +35,6 @@ enum PairControlMessage {
 }
 
 const CLIENT_CAPABILITIES: &[&str] = &["clipboard_image"];
-const CLIPBOARD_IMAGE_MAX_PIXELS: usize = 25_000_000;
-const CLIPBOARD_IMAGE_MAX_RGBA_BYTES: usize = 64 * 1024 * 1024;
-const CLIPBOARD_IMAGE_MAX_BYTES: usize = 10 * 1024 * 1024;
 
 pub(super) async fn run_viz_ws(
     api_base_url: &str,
@@ -180,7 +175,7 @@ async fn send_clipboard_image(
         tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
     >,
 ) -> Result<()> {
-    let image_result = tokio::task::spawn_blocking(clipboard_image_png_bytes)
+    let image_result = tokio::task::spawn_blocking(clipboard::image_png_bytes)
         .await
         .map_err(|err| anyhow::anyhow!("clipboard image task failed: {err}"))?;
     let payload = match image_result {
@@ -195,53 +190,6 @@ async fn send_clipboard_image(
     };
     ws.send(Message::Text(payload.to_string().into())).await?;
     Ok(())
-}
-
-fn clipboard_image_png_bytes() -> Result<Vec<u8>> {
-    let mut clipboard = arboard::Clipboard::new().context("failed to access system clipboard")?;
-    let image = clipboard
-        .get_image()
-        .context("clipboard does not contain an image; on Wayland, `wl-paste -l` should list an image MIME type like image/png")?;
-    let pixel_count = image
-        .width
-        .checked_mul(image.height)
-        .context("clipboard image dimensions overflowed")?;
-    if pixel_count == 0 {
-        anyhow::bail!("clipboard image has invalid dimensions");
-    }
-    if pixel_count > CLIPBOARD_IMAGE_MAX_PIXELS {
-        anyhow::bail!("clipboard image dimensions are too large");
-    }
-
-    let expected_len = pixel_count
-        .checked_mul(4)
-        .context("clipboard image byte length overflowed")?;
-    let rgba_len = image.bytes.len();
-    if rgba_len != expected_len {
-        anyhow::bail!("clipboard image data had unexpected length");
-    }
-    if rgba_len > CLIPBOARD_IMAGE_MAX_RGBA_BYTES {
-        anyhow::bail!("clipboard image dimensions are too large");
-    }
-
-    let rgba = image.bytes.into_owned();
-    let mut png = Vec::new();
-    {
-        let cursor = Cursor::new(&mut png);
-        let encoder = PngEncoder::new(cursor);
-        encoder
-            .write_image(
-                &rgba,
-                image.width as u32,
-                image.height as u32,
-                ExtendedColorType::Rgba8,
-            )
-            .context("failed to encode clipboard image as PNG")?;
-    }
-    if png.len() > CLIPBOARD_IMAGE_MAX_BYTES {
-        anyhow::bail!("clipboard image is too large");
-    }
-    Ok(png)
 }
 
 fn bump_volume(volume_percent: &AtomicU8, delta: i16) -> u8 {

--- a/late-cli/src/ws.rs
+++ b/late-cli/src/ws.rs
@@ -1,8 +1,11 @@
 use anyhow::{Context, Result};
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use futures_util::{SinkExt, StreamExt};
+use image::{ExtendedColorType, ImageEncoder, codecs::png::PngEncoder};
 use serde::Deserialize;
 use serde_json::json;
 use std::{
+    io::Cursor,
     sync::atomic::{AtomicBool, AtomicU8, AtomicU64, Ordering},
     time::Duration,
 };
@@ -30,7 +33,12 @@ enum PairControlMessage {
     ToggleMute,
     VolumeUp,
     VolumeDown,
+    RequestClipboardImage,
 }
+
+const CLIENT_CAPABILITIES: &[&str] = &["clipboard_image"];
+const CLIPBOARD_IMAGE_MAX_PIXELS: usize = 25_000_000;
+const CLIPBOARD_IMAGE_MAX_BYTES: usize = 10 * 1024 * 1024;
 
 pub(super) async fn run_viz_ws(
     api_base_url: &str,
@@ -79,10 +87,17 @@ pub(super) async fn run_viz_ws(
                     break;
                 };
                 match msg? {
-                    Message::Text(text)
-                        if apply_pair_control(&text, playback.muted, playback.volume_percent)? =>
-                    {
-                        send_client_state(&mut ws, client, playback).await?;
+                    Message::Text(text) => {
+                        if handle_pair_control(
+                            &text,
+                            &mut ws,
+                            playback.muted,
+                            playback.volume_percent,
+                        )
+                        .await?
+                        {
+                            send_client_state(&mut ws, client, playback).await?;
+                        }
                     }
                     Message::Close(_) => break,
                     _ => {}
@@ -106,6 +121,7 @@ async fn send_client_state(
         "client_kind": "cli",
         "ssh_mode": client.ssh_mode,
         "platform": client.platform,
+        "capabilities": CLIENT_CAPABILITIES,
         "muted": playback.muted.load(Ordering::Relaxed),
         "volume_percent": playback.volume_percent.load(Ordering::Relaxed),
     });
@@ -113,24 +129,114 @@ async fn send_client_state(
     Ok(())
 }
 
-fn apply_pair_control(text: &str, muted: &AtomicBool, volume_percent: &AtomicU8) -> Result<bool> {
-    match serde_json::from_str::<PairControlMessage>(text)? {
+async fn handle_pair_control(
+    text: &str,
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    muted: &AtomicBool,
+    volume_percent: &AtomicU8,
+) -> Result<bool> {
+    let control = serde_json::from_str::<PairControlMessage>(text)?;
+    match control {
+        audio_control @ (PairControlMessage::ToggleMute
+        | PairControlMessage::VolumeUp
+        | PairControlMessage::VolumeDown) => {
+            apply_audio_pair_control(audio_control, muted, volume_percent);
+            Ok(true)
+        }
+        PairControlMessage::RequestClipboardImage => {
+            send_clipboard_image(ws).await?;
+            Ok(false)
+        }
+    }
+}
+
+fn apply_audio_pair_control(
+    control: PairControlMessage,
+    muted: &AtomicBool,
+    volume_percent: &AtomicU8,
+) {
+    match control {
         PairControlMessage::ToggleMute => {
             let now_muted = muted.fetch_xor(true, Ordering::Relaxed) ^ true;
             info!(muted = now_muted, "applied paired mute toggle");
-            Ok(true)
         }
         PairControlMessage::VolumeUp => {
             let new_volume = bump_volume(volume_percent, 5);
             info!(volume_percent = new_volume, "applied paired volume up");
-            Ok(true)
         }
         PairControlMessage::VolumeDown => {
             let new_volume = bump_volume(volume_percent, -5);
             info!(volume_percent = new_volume, "applied paired volume down");
-            Ok(true)
         }
+        PairControlMessage::RequestClipboardImage => {}
     }
+}
+
+async fn send_clipboard_image(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+) -> Result<()> {
+    let image_result = tokio::task::spawn_blocking(clipboard_image_png_bytes)
+        .await
+        .map_err(|err| anyhow::anyhow!("clipboard image task failed: {err}"))?;
+    let payload = match image_result {
+        Ok(bytes) => json!({
+            "event": "clipboard_image",
+            "data_base64": STANDARD.encode(bytes),
+        }),
+        Err(err) => json!({
+            "event": "clipboard_image_failed",
+            "message": err.to_string(),
+        }),
+    };
+    ws.send(Message::Text(payload.to_string().into())).await?;
+    Ok(())
+}
+
+fn clipboard_image_png_bytes() -> Result<Vec<u8>> {
+    let mut clipboard = arboard::Clipboard::new().context("failed to access system clipboard")?;
+    let image = clipboard
+        .get_image()
+        .context("clipboard does not contain an image; on Wayland, `wl-paste -l` should list an image MIME type like image/png")?;
+    let pixel_count = image
+        .width
+        .checked_mul(image.height)
+        .context("clipboard image dimensions overflowed")?;
+    if pixel_count == 0 {
+        anyhow::bail!("clipboard image has invalid dimensions");
+    }
+    if pixel_count > CLIPBOARD_IMAGE_MAX_PIXELS {
+        anyhow::bail!("clipboard image dimensions are too large");
+    }
+
+    let rgba = image.bytes.into_owned();
+    let expected_len = pixel_count
+        .checked_mul(4)
+        .context("clipboard image byte length overflowed")?;
+    if rgba.len() != expected_len {
+        anyhow::bail!("clipboard image data had unexpected length");
+    }
+
+    let mut png = Vec::new();
+    {
+        let cursor = Cursor::new(&mut png);
+        let encoder = PngEncoder::new(cursor);
+        encoder
+            .write_image(
+                &rgba,
+                image.width as u32,
+                image.height as u32,
+                ExtendedColorType::Rgba8,
+            )
+            .context("failed to encode clipboard image as PNG")?;
+    }
+    if png.len() > CLIPBOARD_IMAGE_MAX_BYTES {
+        anyhow::bail!("clipboard image is too large");
+    }
+    Ok(png)
 }
 
 fn bump_volume(volume_percent: &AtomicU8, delta: i16) -> u8 {
@@ -211,10 +317,10 @@ mod tests {
         let muted = AtomicBool::new(false);
         let volume_percent = AtomicU8::new(100);
 
-        apply_pair_control(r#"{"event":"toggle_mute"}"#, &muted, &volume_percent).unwrap();
+        apply_audio_pair_control(PairControlMessage::ToggleMute, &muted, &volume_percent);
         assert!(muted.load(Ordering::Relaxed));
 
-        apply_pair_control(r#"{"event":"toggle_mute"}"#, &muted, &volume_percent).unwrap();
+        apply_audio_pair_control(PairControlMessage::ToggleMute, &muted, &volume_percent);
         assert!(!muted.load(Ordering::Relaxed));
     }
 
@@ -223,10 +329,10 @@ mod tests {
         let muted = AtomicBool::new(false);
         let volume_percent = AtomicU8::new(50);
 
-        apply_pair_control(r#"{"event":"volume_up"}"#, &muted, &volume_percent).unwrap();
+        apply_audio_pair_control(PairControlMessage::VolumeUp, &muted, &volume_percent);
         assert_eq!(volume_percent.load(Ordering::Relaxed), 55);
 
-        apply_pair_control(r#"{"event":"volume_down"}"#, &muted, &volume_percent).unwrap();
+        apply_audio_pair_control(PairControlMessage::VolumeDown, &muted, &volume_percent);
         assert_eq!(volume_percent.load(Ordering::Relaxed), 50);
     }
 }

--- a/late-cli/src/ws.rs
+++ b/late-cli/src/ws.rs
@@ -38,6 +38,7 @@ enum PairControlMessage {
 
 const CLIENT_CAPABILITIES: &[&str] = &["clipboard_image"];
 const CLIPBOARD_IMAGE_MAX_PIXELS: usize = 25_000_000;
+const CLIPBOARD_IMAGE_MAX_RGBA_BYTES: usize = 64 * 1024 * 1024;
 const CLIPBOARD_IMAGE_MAX_BYTES: usize = 10 * 1024 * 1024;
 
 pub(super) async fn run_viz_ws(
@@ -212,14 +213,18 @@ fn clipboard_image_png_bytes() -> Result<Vec<u8>> {
         anyhow::bail!("clipboard image dimensions are too large");
     }
 
-    let rgba = image.bytes.into_owned();
     let expected_len = pixel_count
         .checked_mul(4)
         .context("clipboard image byte length overflowed")?;
-    if rgba.len() != expected_len {
+    let rgba_len = image.bytes.len();
+    if rgba_len != expected_len {
         anyhow::bail!("clipboard image data had unexpected length");
     }
+    if rgba_len > CLIPBOARD_IMAGE_MAX_RGBA_BYTES {
+        anyhow::bail!("clipboard image dimensions are too large");
+    }
 
+    let rgba = image.bytes.into_owned();
     let mut png = Vec::new();
     {
         let cursor = Cursor::new(&mut png);

--- a/late-cli/src/ws.rs
+++ b/late-cli/src/ws.rs
@@ -84,14 +84,14 @@ pub(super) async fn run_viz_ws(
                 };
                 match msg? {
                     Message::Text(text) => {
-                        if handle_pair_control(
+                        let should_send_state = handle_pair_control(
                             &text,
                             &mut ws,
                             playback.muted,
                             playback.volume_percent,
                         )
-                        .await?
-                        {
+                        .await?;
+                        if should_send_state {
                             send_client_state(&mut ws, client, playback).await?;
                         }
                     }

--- a/late-ssh/src/api.rs
+++ b/late-ssh/src/api.rs
@@ -347,6 +347,13 @@ async fn handle_socket(mut socket: WebSocket, token: String, state: State) {
 
 fn decode_clipboard_image_message(data_base64: String) -> SessionMessage {
     let max_bytes = crate::app::files::image_upload::max_upload_bytes();
+    decode_clipboard_image_message_with_max(data_base64, max_bytes)
+}
+
+fn decode_clipboard_image_message_with_max(
+    data_base64: String,
+    max_bytes: usize,
+) -> SessionMessage {
     let max_base64_len = max_bytes.saturating_mul(4).div_ceil(3).saturating_add(8);
     if data_base64.len() > max_base64_len {
         return SessionMessage::ClipboardImageFailed {
@@ -568,6 +575,58 @@ mod tests {
             "rms": 0.5
         }"#;
         assert!(serde_json::from_str::<WsPayload>(json).is_err());
+    }
+
+    #[test]
+    fn decode_clipboard_image_accepts_supported_image() {
+        let png_header = b"\x89PNG\r\n\x1a\n";
+        match decode_clipboard_image_message_with_max(STANDARD.encode(png_header), 1024) {
+            SessionMessage::ClipboardImage { data } => assert_eq!(data, png_header),
+            other => panic!("expected ClipboardImage, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_clipboard_image_rejects_oversize_payload_before_decode() {
+        match decode_clipboard_image_message_with_max("A".repeat(11), 1) {
+            SessionMessage::ClipboardImageFailed { message } => {
+                assert_eq!(message, "Clipboard image is too large");
+            }
+            other => panic!("expected ClipboardImageFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_clipboard_image_rejects_invalid_base64() {
+        match decode_clipboard_image_message_with_max("not base64!!!".to_string(), 1024) {
+            SessionMessage::ClipboardImageFailed { message } => {
+                assert_eq!(message, "Clipboard image payload was invalid");
+            }
+            other => panic!("expected ClipboardImageFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_clipboard_image_rejects_non_image_bytes() {
+        match decode_clipboard_image_message_with_max(STANDARD.encode(b"hello"), 1024) {
+            SessionMessage::ClipboardImageFailed { message } => {
+                assert_eq!(
+                    message,
+                    "Clipboard image is not a supported PNG/JPEG/GIF/WebP image"
+                );
+            }
+            other => panic!("expected ClipboardImageFailed, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn truncate_ws_error_message_defaults_and_limits_length() {
+        assert_eq!(
+            truncate_ws_error_message("  "),
+            "Clipboard image upload failed"
+        );
+        assert_eq!(truncate_ws_error_message("  no image  "), "no image");
+        assert_eq!(truncate_ws_error_message(&"x".repeat(200)).len(), 160);
     }
 
     #[test]

--- a/late-ssh/src/api.rs
+++ b/late-ssh/src/api.rs
@@ -11,6 +11,7 @@ use axum::{
     response::IntoResponse,
     routing::get,
 };
+use base64::{Engine as _, engine::general_purpose::STANDARD};
 use late_core::MutexRecover;
 use late_core::api_types::{NowPlayingResponse, StatusResponse, Track};
 use late_core::telemetry::http_telemetry_middleware;
@@ -49,9 +50,15 @@ enum WsPayload {
         ssh_mode: crate::session::ClientSshMode,
         #[serde(default)]
         platform: crate::session::ClientPlatform,
+        #[serde(default)]
+        capabilities: Vec<String>,
         muted: bool,
         volume_percent: u8,
     },
+    #[serde(rename = "clipboard_image")]
+    ClipboardImage { data_base64: String },
+    #[serde(rename = "clipboard_image_failed")]
+    ClipboardImageFailed { message: String },
 }
 
 pub async fn run_api_server(
@@ -268,6 +275,7 @@ async fn handle_socket(mut socket: WebSocket, token: String, state: State) {
                                 client_kind,
                                 ssh_mode,
                                 platform,
+                                capabilities,
                                 muted,
                                 volume_percent,
                             } => {
@@ -278,11 +286,20 @@ async fn handle_socket(mut socket: WebSocket, token: String, state: State) {
                                         client_kind,
                                         ssh_mode,
                                         platform,
+                                        capabilities,
                                         muted,
                                         volume_percent,
                                     },
                                 );
                                 continue;
+                            }
+                            WsPayload::ClipboardImage { data_base64 } => {
+                                decode_clipboard_image_message(data_base64)
+                            }
+                            WsPayload::ClipboardImageFailed { message } => {
+                                SessionMessage::ClipboardImageFailed {
+                                    message: truncate_ws_error_message(&message),
+                                }
                             }
                         };
 
@@ -326,6 +343,36 @@ async fn handle_socket(mut socket: WebSocket, token: String, state: State) {
         .paired_client_registry
         .unregister_if_match(&token, registration_id);
     tracing::info!(token_hint = %token_hint, "websocket connection closed");
+}
+
+fn decode_clipboard_image_message(data_base64: String) -> SessionMessage {
+    let max_bytes = crate::app::files::image_upload::max_upload_bytes();
+    let max_base64_len = max_bytes.saturating_mul(4).div_ceil(3).saturating_add(8);
+    if data_base64.len() > max_base64_len {
+        return SessionMessage::ClipboardImageFailed {
+            message: "Clipboard image is too large".to_string(),
+        };
+    }
+
+    match STANDARD.decode(data_base64.as_bytes()) {
+        Ok(data) if crate::app::files::image_upload::detect_image_mime(&data).is_some() => {
+            SessionMessage::ClipboardImage { data }
+        }
+        Ok(_) => SessionMessage::ClipboardImageFailed {
+            message: "Clipboard image is not a supported PNG/JPEG/GIF/WebP image".to_string(),
+        },
+        Err(_) => SessionMessage::ClipboardImageFailed {
+            message: "Clipboard image payload was invalid".to_string(),
+        },
+    }
+}
+
+fn truncate_ws_error_message(message: &str) -> String {
+    let message = message.trim();
+    if message.is_empty() {
+        return "Clipboard image upload failed".to_string();
+    }
+    message.chars().take(160).collect()
 }
 
 fn token_hint(token: &str) -> String {
@@ -423,12 +470,14 @@ mod tests {
                 client_kind,
                 ssh_mode,
                 platform,
+                capabilities,
                 muted,
                 volume_percent,
             } => {
                 assert_eq!(client_kind, crate::session::ClientKind::Cli);
                 assert_eq!(ssh_mode, crate::session::ClientSshMode::Native);
                 assert_eq!(platform, crate::session::ClientPlatform::Macos);
+                assert!(capabilities.is_empty());
                 assert!(muted);
                 assert_eq!(volume_percent, 35);
             }
@@ -452,12 +501,14 @@ mod tests {
                 client_kind,
                 ssh_mode,
                 platform,
+                capabilities,
                 muted,
                 volume_percent,
             } => {
                 assert_eq!(client_kind, crate::session::ClientKind::Cli);
                 assert_eq!(ssh_mode, crate::session::ClientSshMode::Native);
                 assert_eq!(platform, crate::session::ClientPlatform::Android);
+                assert!(capabilities.is_empty());
                 assert!(!muted);
                 assert_eq!(volume_percent, 30);
             }
@@ -481,12 +532,14 @@ mod tests {
                 client_kind,
                 ssh_mode,
                 platform,
+                capabilities,
                 muted,
                 volume_percent,
             } => {
                 assert_eq!(client_kind, crate::session::ClientKind::Cli);
                 assert_eq!(ssh_mode, crate::session::ClientSshMode::OpenSsh);
                 assert_eq!(platform, crate::session::ClientPlatform::Linux);
+                assert!(capabilities.is_empty());
                 assert!(!muted);
                 assert_eq!(volume_percent, 30);
             }

--- a/late-ssh/src/app/chat/CONTEXT.md
+++ b/late-ssh/src/app/chat/CONTEXT.md
@@ -243,7 +243,7 @@ User commands:
 - `/members` lists selected-room members.
 - `/mod` opens the moderation command modal; `/mod ...` in chat is rejected because commands run only in the modal.
 - `/music` opens music help.
-- `/paste-image` asks a paired `late` CLI with `clipboard_image` capability to read the local system clipboard image, sends it back over `/api/ws/pair`, uploads the PNG bytes through the normal image upload path, and inserts the resulting public URL into the composer.
+- `/paste-image` asks a paired `late` CLI with `clipboard_image` capability to read the local system clipboard image, sends it back over `/api/ws/pair`, uploads the PNG bytes through the normal image upload path, and inserts the resulting public URL into the composer. Pending clipboard requests time out after 15s so a dead paired client cannot wedge the command.
 - `/private #room` creates a private topic room and joins the caller.
 - `/public #room` opens or creates an opt-in public room for the caller only (`auto_join=false`).
 - `/settings` opens settings.

--- a/late-ssh/src/app/chat/CONTEXT.md
+++ b/late-ssh/src/app/chat/CONTEXT.md
@@ -243,6 +243,7 @@ User commands:
 - `/members` lists selected-room members.
 - `/mod` opens the moderation command modal; `/mod ...` in chat is rejected because commands run only in the modal.
 - `/music` opens music help.
+- `/paste-image` asks a paired `late` CLI with `clipboard_image` capability to read the local system clipboard image, sends it back over `/api/ws/pair`, uploads the PNG bytes through the normal image upload path, and inserts the resulting public URL into the composer.
 - `/private #room` creates a private topic room and joins the caller.
 - `/public #room` opens or creates an opt-in public room for the caller only (`auto_join=false`).
 - `/settings` opens settings.
@@ -297,6 +298,7 @@ Image uploads and inline rendering:
 - Pasting raw PNG/JPEG/GIF/WebP bytes into the chat composer starts an upload because there is no stable URL to preview until the bytes are hosted.
 - Pasting an image URL does not upload or rehost it. It is inserted as normal composer text; after send, inline rendering previews that URL best-effort.
 - `/upload <url>` is the explicit URL upload path: it downloads a public image URL server-side, reuploads it to configured public file storage, and inserts the resulting URL into the composer for the user to send and preview.
+- `/paste-image` is the explicit paired-CLI clipboard path. It requires an updated `late` paired client, not just browser pairing or plain `ssh`.
 - Non-admin uploads use a per-session `ChatState` cooldown. This is intentionally lightweight, not a server-side quota.
 - URL downloads for upload and inline rendering must go through `files::image_upload::download_url_bytes`: validate `http(s)`, reject localhost/private/link-local/reserved resolved IPs, pin reqwest DNS to the validated addresses, disable redirects, and stream with a hard byte cap. Do not add new ad hoc `reqwest.get(url).bytes()` paths for chat images.
 - Inline image rendering detects likely image URLs in visible room messages, fetches them through the same secure downloader, rejects oversized decoded dimensions, retries transient failures with backoff, and caches rendered terminal lines by message id. Inline previews are best-effort; failures are intentionally silent/noisy only at trace level.

--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -143,6 +143,18 @@ pub(crate) fn handle_post_submit_requests(app: &mut App) {
     if let Some(upload) = app.chat.take_requested_url_upload() {
         crate::app::input::trigger_url_image_upload(app, upload.url, upload.room_id);
     }
+    if let Some(upload) = app.chat.take_requested_clipboard_image_upload() {
+        if app.request_paired_clipboard_image_upload(upload.room_id) {
+            app.banner = Some(Banner::success(
+                "Reading image from paired CLI clipboard...",
+            ));
+        } else {
+            app.chat.clear_pending_clipboard_image_upload();
+            app.banner = Some(Banner::error(
+                "No paired CLI with clipboard image support. Update and run `late`.",
+            ));
+        }
+    }
 }
 
 pub fn handle_compose_char(app: &mut App, ch: char) {

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -45,6 +45,7 @@ const INLINE_IMAGE_MAX_WIDTH: u32 = 96;
 const INLINE_IMAGE_MAX_ROWS: u32 = 12;
 const INLINE_IMAGE_TRACKED_LIMIT: usize = 2_000;
 const INLINE_IMAGE_MAX_FAILURES: u8 = 6;
+const CLIPBOARD_IMAGE_REQUEST_TIMEOUT: Duration = Duration::from_secs(15);
 
 pub(crate) type InlineImageLines = Vec<ratatui::text::Line<'static>>;
 pub(crate) type InlineImageRenderResult = (Uuid, Result<InlineImageLines, String>);
@@ -95,6 +96,20 @@ pub(crate) struct PendingUrlUpload {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PendingClipboardImageUpload {
     pub room_id: Option<Uuid>,
+    requested_at: Instant,
+}
+
+impl PendingClipboardImageUpload {
+    fn new(room_id: Option<Uuid>) -> Self {
+        Self {
+            room_id,
+            requested_at: Instant::now(),
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        self.requested_at.elapsed() >= CLIPBOARD_IMAGE_REQUEST_TIMEOUT
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -1261,6 +1276,7 @@ impl ChatState {
             if !crate::app::files::image_upload::is_file_upload_configured() {
                 return Some(Banner::error("File uploads are disabled"));
             }
+            self.clear_expired_pending_clipboard_image_upload();
             if self.pending_clipboard_image_upload.is_some()
                 || self.requested_clipboard_image_upload.is_some()
             {
@@ -1270,7 +1286,7 @@ impl ChatState {
             }
             let room_id = self.upload_target_room_id();
             self.clear_composer_after_submit();
-            self.requested_clipboard_image_upload = Some(PendingClipboardImageUpload { room_id });
+            self.requested_clipboard_image_upload = Some(PendingClipboardImageUpload::new(room_id));
             return None;
         }
 
@@ -1601,7 +1617,7 @@ impl ChatState {
     }
 
     pub(crate) fn begin_pending_clipboard_image_upload(&mut self, room_id: Option<Uuid>) {
-        self.pending_clipboard_image_upload = Some(PendingClipboardImageUpload { room_id });
+        self.pending_clipboard_image_upload = Some(PendingClipboardImageUpload::new(room_id));
     }
 
     pub(crate) fn take_pending_clipboard_image_upload(
@@ -1612,6 +1628,25 @@ impl ChatState {
 
     pub(crate) fn clear_pending_clipboard_image_upload(&mut self) {
         self.pending_clipboard_image_upload = None;
+    }
+
+    fn clear_expired_pending_clipboard_image_upload(&mut self) -> bool {
+        if self
+            .pending_clipboard_image_upload
+            .as_ref()
+            .is_some_and(PendingClipboardImageUpload::is_expired)
+        {
+            self.pending_clipboard_image_upload = None;
+            return true;
+        }
+        false
+    }
+
+    pub(crate) fn expire_pending_clipboard_image_upload(&mut self) -> Option<Banner> {
+        if self.clear_expired_pending_clipboard_image_upload() {
+            return Some(Banner::error("Clipboard image request timed out"));
+        }
+        None
     }
 
     pub(crate) fn poll_image_upload(&mut self) -> Option<Result<String, String>> {
@@ -1742,6 +1777,7 @@ impl ChatState {
         self.drain_username_directory();
         self.drain_snapshot();
         self.drain_pinned_messages();
+        let clipboard_banner = self.expire_pending_clipboard_image_upload();
         let banner = self.drain_events();
         let moderation_banner = self.drain_moderation_events();
         let feeds_banner = self.feeds.tick();
@@ -1749,7 +1785,8 @@ impl ChatState {
         let notif_banner = self.notifications.tick();
         let showcase_banner = self.showcase.tick();
         let work_banner = self.work.tick();
-        moderation_banner
+        clipboard_banner
+            .or(moderation_banner)
             .or(banner)
             .or(feeds_banner)
             .or(news_banner)

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -41,6 +41,8 @@ const REACTION_OWNER_DISPLAY_LIMIT: usize = 4;
 const REACTION_OWNER_COLUMNS: usize = 3;
 const INLINE_IMAGE_FETCHES_PER_TICK: usize = 8;
 const INLINE_IMAGE_SCAN_LIMIT: usize = 100;
+const INLINE_IMAGE_MAX_WIDTH: u32 = 96;
+const INLINE_IMAGE_MAX_ROWS: u32 = 12;
 const INLINE_IMAGE_TRACKED_LIMIT: usize = 2_000;
 const INLINE_IMAGE_MAX_FAILURES: u8 = 6;
 
@@ -87,6 +89,11 @@ pub(crate) struct ModCommandOutput {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct PendingUrlUpload {
     pub url: String,
+    pub room_id: Option<Uuid>,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct PendingClipboardImageUpload {
     pub room_id: Option<Uuid>,
 }
 
@@ -192,6 +199,8 @@ pub struct ChatState {
     pub(crate) image_upload_pending: bool,
     pub(crate) image_upload_target_room_id: Option<Uuid>,
     pub(crate) requested_url_upload: Option<PendingUrlUpload>,
+    requested_clipboard_image_upload: Option<PendingClipboardImageUpload>,
+    pending_clipboard_image_upload: Option<PendingClipboardImageUpload>,
 
     // inline image rendering
     pub(crate) inline_image_rx:
@@ -319,6 +328,8 @@ impl ChatState {
             image_upload_pending: false,
             image_upload_target_room_id: None,
             requested_url_upload: None,
+            requested_clipboard_image_upload: None,
+            pending_clipboard_image_upload: None,
             inline_image_rx: Some(inline_image_rx),
             inline_image_tx: Some(inline_image_tx),
             inline_image_cache: HashMap::new(),
@@ -1246,6 +1257,23 @@ impl ChatState {
             return None;
         }
 
+        if body.trim() == "/paste-image" {
+            if !crate::app::files::image_upload::is_file_upload_configured() {
+                return Some(Banner::error("File uploads are disabled"));
+            }
+            if self.pending_clipboard_image_upload.is_some()
+                || self.requested_clipboard_image_upload.is_some()
+            {
+                return Some(Banner::error(
+                    "A clipboard image request is already in progress",
+                ));
+            }
+            let room_id = self.upload_target_room_id();
+            self.clear_composer_after_submit();
+            self.requested_clipboard_image_upload = Some(PendingClipboardImageUpload { room_id });
+            return None;
+        }
+
         if body.trim() == "/active" {
             self.clear_composer_after_submit();
             self.open_active_users_overlay();
@@ -1494,6 +1522,14 @@ impl ChatState {
     }
 
     pub fn start_image_upload(&mut self, bytes: Vec<u8>) -> Option<Banner> {
+        self.start_image_upload_in_room(bytes, self.upload_target_room_id())
+    }
+
+    pub(crate) fn start_image_upload_in_room(
+        &mut self,
+        bytes: Vec<u8>,
+        room_id: Option<Uuid>,
+    ) -> Option<Banner> {
         let Some(mime) = crate::app::files::image_upload::detect_image_mime(&bytes) else {
             return Some(Banner::error("Unsupported image type"));
         };
@@ -1502,7 +1538,7 @@ impl ChatState {
         }
 
         let (tx, rx) = tokio::sync::oneshot::channel();
-        if let Some(banner) = self.begin_image_upload(self.upload_target_room_id(), rx) {
+        if let Some(banner) = self.begin_image_upload(room_id, rx) {
             return Some(banner);
         }
         let mime = mime.to_string();
@@ -1556,6 +1592,26 @@ impl ChatState {
 
     pub(crate) fn take_requested_url_upload(&mut self) -> Option<PendingUrlUpload> {
         self.requested_url_upload.take()
+    }
+
+    pub(crate) fn take_requested_clipboard_image_upload(
+        &mut self,
+    ) -> Option<PendingClipboardImageUpload> {
+        self.requested_clipboard_image_upload.take()
+    }
+
+    pub(crate) fn begin_pending_clipboard_image_upload(&mut self, room_id: Option<Uuid>) {
+        self.pending_clipboard_image_upload = Some(PendingClipboardImageUpload { room_id });
+    }
+
+    pub(crate) fn take_pending_clipboard_image_upload(
+        &mut self,
+    ) -> Option<PendingClipboardImageUpload> {
+        self.pending_clipboard_image_upload.take()
+    }
+
+    pub(crate) fn clear_pending_clipboard_image_upload(&mut self) {
+        self.pending_clipboard_image_upload = None;
     }
 
     pub(crate) fn poll_image_upload(&mut self) -> Option<Result<String, String>> {
@@ -1649,11 +1705,13 @@ impl ChatState {
             if !url.is_empty() {
                 let tx_clone = tx.clone();
                 tokio::spawn(async move {
-                    // High-detail thumbnail: 96 wide, max 10 rows (20 pixels)
-                    let result =
-                        crate::app::files::inline_image::fetch_and_render_image(url, 96, 10)
-                            .await
-                            .map_err(|e| e.to_string());
+                    let result = crate::app::files::inline_image::fetch_and_render_image(
+                        url,
+                        INLINE_IMAGE_MAX_WIDTH,
+                        INLINE_IMAGE_MAX_ROWS,
+                    )
+                    .await
+                    .map_err(|e| e.to_string());
                     let _ = tx_clone.send((msg_id, result));
                 });
             }
@@ -2863,6 +2921,7 @@ const CHAT_COMMANDS: &[(&str, &str)] = &[
     ("list", "public rooms"),
     ("members", "room members"),
     ("music", "music help"),
+    ("paste-image", "upload image from CLI clipboard"),
     ("private", "new private room"),
     ("public", "open public room for everyone"),
     ("settings", "open settings"),

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -127,6 +127,7 @@ pub fn chat_help_lines() -> Vec<String> {
         "  /active            list active users",
         "  /members           list users in this room",
         "  /list              list public rooms",
+        "  /paste-image       upload image from paired CLI clipboard",
         "  /ignore [@user]    ignore a user, or list ignored users",
         "  /unignore [@user]  remove a user from your ignore list",
         "  /music             explain how music works",

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -1016,6 +1016,26 @@ impl App {
         registry.send_control(&self.session_token, PairControlMessage::VolumeDown)
     }
 
+    pub fn request_paired_clipboard_image_upload(&mut self, room_id: Option<Uuid>) -> bool {
+        let Some(registry) = &self.paired_client_registry else {
+            return false;
+        };
+        if !registry
+            .snapshot(&self.session_token)
+            .is_some_and(|state| state.supports_clipboard_image())
+        {
+            return false;
+        }
+        if registry.send_control(
+            &self.session_token,
+            PairControlMessage::RequestClipboardImage,
+        ) {
+            self.chat.begin_pending_clipboard_image_upload(room_id);
+            return true;
+        }
+        false
+    }
+
     pub fn paired_client_state(&self) -> Option<ClientAudioState> {
         self.paired_client_registry
             .as_ref()

--- a/late-ssh/src/app/tick.rs
+++ b/late-ssh/src/app/tick.rs
@@ -95,6 +95,26 @@ impl App {
                     self.push_browser_frame(viz);
                     updated = true;
                 }
+                SessionMessage::ClipboardImage { data } => {
+                    let Some(upload) = self.chat.take_pending_clipboard_image_upload() else {
+                        tracing::warn!("ignoring unsolicited paired clipboard image");
+                        continue;
+                    };
+                    if let Some(banner) = self.chat.start_image_upload_in_room(data, upload.room_id)
+                    {
+                        self.banner = Some(banner);
+                    } else {
+                        self.banner = Some(crate::app::common::primitives::Banner::success(
+                            "Clipboard image found - uploading...",
+                        ));
+                    }
+                    updated = true;
+                }
+                SessionMessage::ClipboardImageFailed { message } => {
+                    self.chat.clear_pending_clipboard_image_upload();
+                    self.banner = Some(crate::app::common::primitives::Banner::error(&message));
+                    updated = true;
+                }
                 SessionMessage::Terminate { reason } => {
                     tracing::info!(reason, "session terminated by control message");
                     self.running = false;

--- a/late-ssh/src/session.rs
+++ b/late-ssh/src/session.rs
@@ -34,6 +34,12 @@ pub struct BrowserVizFrame {
 pub enum SessionMessage {
     Heartbeat,
     Viz(BrowserVizFrame),
+    ClipboardImage {
+        data: Vec<u8>,
+    },
+    ClipboardImageFailed {
+        message: String,
+    },
     Terminate {
         reason: String,
     },
@@ -122,6 +128,8 @@ pub struct ClientAudioState {
     pub ssh_mode: ClientSshMode,
     #[serde(default)]
     pub platform: ClientPlatform,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
     pub muted: bool,
     pub volume_percent: u8,
 }
@@ -132,6 +140,7 @@ impl Default for ClientAudioState {
             client_kind: ClientKind::Unknown,
             ssh_mode: ClientSshMode::Unknown,
             platform: ClientPlatform::Unknown,
+            capabilities: Vec::new(),
             muted: false,
             volume_percent: 30,
         }
@@ -139,6 +148,14 @@ impl Default for ClientAudioState {
 }
 
 impl ClientAudioState {
+    pub fn supports_clipboard_image(&self) -> bool {
+        self.client_kind == ClientKind::Cli
+            && self
+                .capabilities
+                .iter()
+                .any(|capability| capability == "clipboard_image")
+    }
+
     fn cli_usage_labels(&self) -> Option<(&'static str, &'static str)> {
         if self.client_kind != ClientKind::Cli {
             return None;
@@ -154,6 +171,7 @@ pub enum PairControlMessage {
     ToggleMute,
     VolumeUp,
     VolumeDown,
+    RequestClipboardImage,
 }
 
 #[derive(Clone, Default)]
@@ -530,6 +548,7 @@ mod tests {
                 client_kind: ClientKind::Cli,
                 ssh_mode: ClientSshMode::Native,
                 platform: ClientPlatform::Macos,
+                capabilities: vec!["clipboard_image".to_string()],
                 muted: true,
                 volume_percent: 35,
             },
@@ -539,6 +558,7 @@ mod tests {
         assert_eq!(snapshot.client_kind, ClientKind::Cli);
         assert_eq!(snapshot.ssh_mode, ClientSshMode::Native);
         assert_eq!(snapshot.platform, ClientPlatform::Macos);
+        assert!(snapshot.supports_clipboard_image());
         assert!(snapshot.muted);
         assert_eq!(snapshot.volume_percent, 35);
     }


### PR DESCRIPTION
## Summary
- Adds a `/paste-image` chat command so SSH users can upload an image from their local system clipboard through a paired `late` CLI.
- This makes clipboard image sharing work without requiring users to save a file first, while reusing the existing image upload validation and hosting path.

## What changed
- The CLI now advertises a `clipboard_image` capability and can respond to clipboard image requests over the pairing WebSocket.
- Chat now recognizes `/paste-image`, requests the image from a capable paired CLI, uploads the returned image bytes, and reports progress or errors through banners.
- Help text, command listings, and contributor context docs now describe the new command and pairing contract.

## Behavior notes
- Requires an updated paired `late` CLI; browser pairs, plain SSH, and older CLIs do not receive unsupported clipboard requests.
- Clipboard images are encoded as PNG by the CLI, size-checked, base64-decoded server-side, and validated as supported image content before upload.
- File uploads must be configured, and only one clipboard image request can be pending at a time.
- Wayland clipboard support depends on the `arboard` `wayland-data-control` feature.

## Feature flags
- None.

## Screenshots / Video
- UI-visible terminal command/help/banner changes are included. A screenshot or short terminal recording of `/paste-image` success and unsupported-client failure should be attached before review.

## Testing
- Automated: updated existing unit coverage around paired client state parsing and capability propagation.
- Manual: verify `/paste-image` with an updated paired CLI containing an image on the clipboard, with an older/non-capable client, with an empty/non-image clipboard, and with file uploads disabled.