### PR TITLE
make mod command surface nicer

### DIFF
--- a/late-core/src/models/artboard.rs
+++ b/late-core/src/models/artboard.rs
@@ -85,6 +85,29 @@ impl Snapshot {
             .collect())
     }
 
+    pub async fn list_archive_summaries(
+        client: &Client,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<SnapshotSummary>> {
+        let rows = client
+            .query(
+                "SELECT board_key, updated FROM artboard_snapshots
+                 WHERE board_key LIKE 'daily:%' OR board_key LIKE 'monthly:%'
+                 ORDER BY board_key DESC, created DESC
+                 LIMIT $1 OFFSET $2",
+                &[&limit, &offset],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| SnapshotSummary {
+                board_key: row.get("board_key"),
+                updated: row.get("updated"),
+            })
+            .collect())
+    }
+
     pub async fn delete_by_board_key(client: &Client, board_key: &str) -> Result<u64> {
         let count = client
             .execute(

--- a/late-core/src/models/artboard_ban.rs
+++ b/late-core/src/models/artboard_ban.rs
@@ -83,6 +83,14 @@ impl ArtboardBan {
         client: &Client,
         limit: i64,
     ) -> Result<Vec<ArtboardBanListItem>> {
+        Self::active_with_usernames_page(client, limit, 0).await
+    }
+
+    pub async fn active_with_usernames_page(
+        client: &Client,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ArtboardBanListItem>> {
         let rows = client
             .query(
                 "SELECT ab.*, target.username AS target_username, actor.username AS actor_username
@@ -91,8 +99,8 @@ impl ArtboardBan {
                  LEFT JOIN users actor ON actor.id = ab.actor_user_id
                  WHERE ab.expires_at IS NULL OR ab.expires_at > current_timestamp
                  ORDER BY ab.created DESC
-                 LIMIT $1",
-                &[&limit],
+                 LIMIT $1 OFFSET $2",
+                &[&limit, &offset],
             )
             .await?;
         Ok(rows

--- a/late-core/src/models/moderation_audit_log.rs
+++ b/late-core/src/models/moderation_audit_log.rs
@@ -27,6 +27,14 @@ impl ModerationAuditLog {
         client: &tokio_postgres::Client,
         limit: i64,
     ) -> Result<Vec<ModerationAuditLogListItem>> {
+        Self::recent_with_usernames_page(client, limit, 0).await
+    }
+
+    pub async fn recent_with_usernames_page(
+        client: &tokio_postgres::Client,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ModerationAuditLogListItem>> {
         let rows = client
             .query(
                 "SELECT mal.*, actor.username AS actor_username, target.username AS target_username
@@ -35,8 +43,8 @@ impl ModerationAuditLog {
                  LEFT JOIN users target
                    ON target.id = mal.target_id AND mal.target_kind = 'user'
                  ORDER BY mal.created DESC
-                 LIMIT $1",
-                &[&limit],
+                 LIMIT $1 OFFSET $2",
+                &[&limit, &offset],
             )
             .await?;
         Ok(rows

--- a/late-core/src/models/room_ban.rs
+++ b/late-core/src/models/room_ban.rs
@@ -75,6 +75,14 @@ impl RoomBan {
         client: &Client,
         limit: i64,
     ) -> Result<Vec<RoomBanListItem>> {
+        Self::active_with_usernames_page(client, limit, 0).await
+    }
+
+    pub async fn active_with_usernames_page(
+        client: &Client,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<RoomBanListItem>> {
         let rows = client
             .query(
                 "SELECT rb.*, room.slug AS room_slug,
@@ -86,8 +94,8 @@ impl RoomBan {
                  LEFT JOIN users actor ON actor.id = rb.actor_user_id
                  WHERE rb.expires_at IS NULL OR rb.expires_at > current_timestamp
                  ORDER BY rb.created DESC
-                 LIMIT $1",
-                &[&limit],
+                 LIMIT $1 OFFSET $2",
+                &[&limit, &offset],
             )
             .await?;
         Ok(rows.into_iter().map(Self::list_item_from_row).collect())
@@ -97,6 +105,15 @@ impl RoomBan {
         client: &Client,
         room_id: Uuid,
         limit: i64,
+    ) -> Result<Vec<RoomBanListItem>> {
+        Self::active_for_room_with_usernames_page(client, room_id, limit, 0).await
+    }
+
+    pub async fn active_for_room_with_usernames_page(
+        client: &Client,
+        room_id: Uuid,
+        limit: i64,
+        offset: i64,
     ) -> Result<Vec<RoomBanListItem>> {
         let rows = client
             .query(
@@ -110,8 +127,8 @@ impl RoomBan {
                  WHERE rb.room_id = $1
                    AND (rb.expires_at IS NULL OR rb.expires_at > current_timestamp)
                  ORDER BY rb.created DESC
-                 LIMIT $2",
-                &[&room_id, &limit],
+                 LIMIT $2 OFFSET $3",
+                &[&room_id, &limit, &offset],
             )
             .await?;
         Ok(rows.into_iter().map(Self::list_item_from_row).collect())

--- a/late-core/src/models/server_ban.rs
+++ b/late-core/src/models/server_ban.rs
@@ -109,6 +109,14 @@ impl ServerBan {
         client: &Client,
         limit: i64,
     ) -> Result<Vec<ServerBanListItem>> {
+        Self::active_with_usernames_page(client, limit, 0).await
+    }
+
+    pub async fn active_with_usernames_page(
+        client: &Client,
+        limit: i64,
+        offset: i64,
+    ) -> Result<Vec<ServerBanListItem>> {
         let rows = client
             .query(
                 "SELECT sb.*, target.username AS target_username, actor.username AS actor_username
@@ -117,8 +125,8 @@ impl ServerBan {
                  LEFT JOIN users actor ON actor.id = sb.actor_user_id
                  WHERE sb.expires_at IS NULL OR sb.expires_at > current_timestamp
                  ORDER BY sb.created DESC
-                 LIMIT $1",
-                &[&limit],
+                 LIMIT $1 OFFSET $2",
+                &[&limit, &offset],
             )
             .await?;
         Ok(rows

--- a/late-ssh/src/app/chat/CONTEXT.md
+++ b/late-ssh/src/app/chat/CONTEXT.md
@@ -251,22 +251,18 @@ Admin commands:
 - `/fill-room #room` bulk-adds all users to an existing public room and flips `auto_join=true`; private rooms cannot be filled.
 
 Moderation modal commands:
-- `help [command]`
-- `user @name`
-- `bans [server|artboard|room #slug] [limit]`
-- `audit [limit]`
-- `room kick #slug @name [reason...]`
-- `room ban #slug @name [duration] [reason...]`
-- `room unban #slug @name`
-- `server kick @name [reason...]`
-- `server ban @name [duration] [reason...]`
-- `server unban @name`
-- `artboard ban @name [duration] [reason...]`
-- `artboard unban @name`
-- `grant mod @name`
-- `revoke mod @name`
+- `rename-room <#oldname> <#newname>`
+- `rename-user <@oldname> <@newname>`
+- `view <@user|#room|bans|audit|artboard|help> [pagenumber]`
+- `artboard restore [YYYY-MM-DD] [reason...]`
+- `kick <server|#room> @name [reason...]`
+- `ban <server|#room|artboard> @name [duration] [reason...]`
+- `unban <server|#room|artboard> @name [reason...]`
+- `admin`
+- `admin grant mod @name`
+- `admin revoke mod @name`
 
-Moderation list limits default to 25 and cap at 100. Durations use positive `s/m/h/d` suffixes.
+Moderation list pages show 15 rows. Durations use positive `s/m/h/d` suffixes.
 
 Reply mode:
 - Captures `ReplyTarget { message_id, author, preview }`.

--- a/late-ssh/src/app/mod_modal/input.rs
+++ b/late-ssh/src/app/mod_modal/input.rs
@@ -198,9 +198,9 @@ mod tests {
 
         paste_into_command_input(
             &mut state,
-            b"\x1b[200~server ban @alice\r\npolicy\x00\x7f\x1b[201~",
+            b"\x1b[200~ban server @alice\r\npolicy\x00\x7f\x1b[201~",
         );
 
-        assert_eq!(state.command_text(), "server ban @alice policy");
+        assert_eq!(state.command_text(), "ban server @alice policy");
     }
 }

--- a/late-ssh/src/app/mod_modal/state.rs
+++ b/late-ssh/src/app/mod_modal/state.rs
@@ -5,6 +5,7 @@ use uuid::Uuid;
 
 use crate::app::chat::state::{MentionAutocomplete, MentionMatch};
 use crate::app::common::composer;
+use crate::moderation::command::mod_help_lines;
 
 const MAX_LOG_LINES: usize = 1000;
 const COMMAND_SEPARATOR: &str = "───────────";
@@ -15,6 +16,7 @@ pub struct ModModalState {
     scroll: usize,
     screen_start: usize,
     mention_ac: MentionAutocomplete,
+    has_opened: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -40,17 +42,20 @@ impl ModModalState {
             scroll: 0,
             screen_start: 0,
             mention_ac: MentionAutocomplete::default(),
+            has_opened: false,
         }
     }
 
     pub fn open(&mut self, can_moderate: bool) {
         composer::set_themed_textarea_cursor_visible(&mut self.command_input, true);
-        if self.log.is_empty() {
-            if can_moderate {
-                self.append_info("type help for commands");
-            } else {
-                self.append_error("access denied: moderator or admin only");
-            }
+        if self.has_opened {
+            return;
+        }
+        self.has_opened = true;
+        if can_moderate {
+            self.append_help();
+        } else {
+            self.append_error("access denied: moderator or admin only");
         }
     }
 
@@ -192,6 +197,12 @@ impl ModModalState {
         self.push_log(line.into(), ModLogKind::Error);
     }
 
+    fn append_help(&mut self) {
+        for line in mod_help_lines(None) {
+            self.append_info(line);
+        }
+    }
+
     pub fn append_result(&mut self, success: bool, lines: Vec<String>) {
         let kind = if success {
             ModLogKind::Success
@@ -262,6 +273,44 @@ mod tests {
     }
 
     #[test]
+    fn first_moderator_open_displays_command_help_once() {
+        let mut state = ModModalState::new();
+
+        state.open(true);
+
+        assert!(
+            state
+                .log()
+                .iter()
+                .any(|line| line.text == "rename-room <#oldname> <#newname>"),
+            "first open should display command help: {:?}",
+            state.log()
+        );
+        let first_len = state.log().len();
+
+        state.open(true);
+
+        assert_eq!(
+            state.log().len(),
+            first_len,
+            "subsequent opens should not replay help"
+        );
+    }
+
+    #[test]
+    fn first_non_moderator_open_displays_access_denied() {
+        let mut state = ModModalState::new();
+
+        state.open(false);
+
+        assert_eq!(state.log().len(), 1);
+        assert_eq!(
+            state.log().front().unwrap().text,
+            "access denied: moderator or admin only"
+        );
+    }
+
+    #[test]
     fn command_input_adds_separator_between_runs() {
         let mut state = ModModalState::new();
 
@@ -280,7 +329,7 @@ mod tests {
     #[test]
     fn autocomplete_query_detects_at_prefixed_current_token() {
         let mut state = ModModalState::new();
-        state.command_input.insert_str("server ban @ali");
+        state.command_input.insert_str("ban server @ali");
 
         assert_eq!(
             state.autocomplete_query(),
@@ -291,18 +340,18 @@ mod tests {
     #[test]
     fn autocomplete_query_detects_hash_prefixed_current_token() {
         let mut state = ModModalState::new();
-        state.command_input.insert_str("room ban #rust");
+        state.command_input.insert_str("ban #rust");
 
         assert_eq!(
             state.autocomplete_query(),
-            Some((9, '#', "rust".to_string()))
+            Some((4, '#', "rust".to_string()))
         );
     }
 
     #[test]
     fn autocomplete_query_ignores_at_without_word_boundary() {
         let mut state = ModModalState::new();
-        state.command_input.insert_str("server ban nope@ali");
+        state.command_input.insert_str("ban server nope@ali");
 
         assert_eq!(state.autocomplete_query(), None);
     }
@@ -310,7 +359,7 @@ mod tests {
     #[test]
     fn autocomplete_confirm_replaces_query_with_selected_username() {
         let mut state = ModModalState::new();
-        state.command_input.insert_str("server ban @ali");
+        state.command_input.insert_str("ban server @ali");
         state.update_autocomplete_matches(
             11,
             "ali".to_string(),
@@ -324,7 +373,7 @@ mod tests {
 
         state.ac_confirm();
 
-        assert_eq!(state.command_text(), "server ban @alice");
+        assert_eq!(state.command_text(), "ban server @alice");
         assert!(!state.is_autocomplete_active());
     }
 }

--- a/late-ssh/src/moderation/command.rs
+++ b/late-ssh/src/moderation/command.rs
@@ -8,12 +8,18 @@ pub(crate) enum ModCommand {
     User {
         username: String,
     },
+    RoomInfo {
+        slug: String,
+    },
     Bans {
         scope: BanListScope,
-        limit: i64,
+        page: i64,
     },
     Audit {
-        limit: i64,
+        page: i64,
+    },
+    ArtboardSnapshots {
+        page: i64,
     },
     RenameRoom {
         slug: String,
@@ -168,19 +174,59 @@ pub(crate) fn parse_mod_command(input: &str) -> Result<ModCommand> {
         "help" => Ok(ModCommand::Help {
             topic: nonempty(rest.join(" ")),
         }),
-        "user" => Ok(ModCommand::User {
-            username: required_username(rest.first().copied(), "usage: user @name")?,
-        }),
-        "bans" => parse_bans_mod_command(&rest),
-        "audit" => parse_audit_mod_command(&rest),
+        "view" => parse_view_mod_command(&rest),
         "rename-room" => parse_rename_room_mod_command(&rest),
         "rename-user" => parse_rename_user_mod_command(&rest),
-        "room" => parse_room_mod_command(&rest),
-        "server" => parse_server_mod_command(&rest),
+        "kick" => parse_kick_mod_command(&rest),
+        "ban" => parse_ban_mod_command(&rest),
+        "unban" => parse_unban_mod_command(&rest),
         "artboard" => parse_artboard_mod_command(&rest),
-        "grant" => parse_role_mod_command(RoleAction::GrantMod, &rest),
-        "revoke" => parse_role_mod_command(RoleAction::RevokeMod, &rest),
+        "admin" => parse_admin_mod_command(&rest),
         _ => anyhow::bail!("unknown mod command: {head}"),
+    }
+}
+
+fn parse_view_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    const USAGE: &str = "usage: view <@user|#room|bans|audit|artboard|help> [pagenumber]";
+    let Some(target) = parts.first().copied() else {
+        anyhow::bail!(USAGE);
+    };
+    match target {
+        "help" => {
+            if parts.len() > 1 {
+                anyhow::bail!(USAGE);
+            }
+            Ok(ModCommand::Help {
+                topic: Some("view".to_string()),
+            })
+        }
+        "bans" => parse_bans_mod_command(&parts[1..]),
+        "audit" => parse_audit_mod_command(&parts[1..]),
+        "artboard" => {
+            if parts.len() > 2 {
+                anyhow::bail!("usage: view artboard [pagenumber]");
+            }
+            Ok(ModCommand::ArtboardSnapshots {
+                page: optional_page(parts.get(1).copied())?,
+            })
+        }
+        _ if target.starts_with('@') => {
+            if parts.len() > 1 {
+                anyhow::bail!("usage: view @name");
+            }
+            Ok(ModCommand::User {
+                username: required_username(Some(target), "usage: view @name")?,
+            })
+        }
+        _ if target.starts_with('#') => {
+            if parts.len() > 1 {
+                anyhow::bail!("usage: view #roomname");
+            }
+            Ok(ModCommand::RoomInfo {
+                slug: required_room_target(target, "usage: view #roomname")?,
+            })
+        }
+        _ => anyhow::bail!(USAGE),
     }
 }
 
@@ -188,51 +234,48 @@ fn parse_bans_mod_command(parts: &[&str]) -> Result<ModCommand> {
     let Some(first) = parts.first().copied() else {
         return Ok(ModCommand::Bans {
             scope: BanListScope::All,
-            limit: DEFAULT_LIST_LIMIT,
+            page: DEFAULT_PAGE,
         });
     };
 
-    if let Some(limit) = parse_limit(first)? {
+    if let Some(page) = parse_page(first)? {
         if parts.len() > 1 {
-            anyhow::bail!("usage: bans [server|artboard|room #roomname] [limit]");
+            anyhow::bail!("usage: view bans [server|artboard|#roomname] [pagenumber]");
         }
         return Ok(ModCommand::Bans {
             scope: BanListScope::All,
-            limit,
+            page,
         });
     }
 
     match first {
         "server" => {
             if parts.len() > 2 {
-                anyhow::bail!("usage: bans server [limit]");
+                anyhow::bail!("usage: view bans server [pagenumber]");
             }
             Ok(ModCommand::Bans {
                 scope: BanListScope::Server,
-                limit: optional_limit(parts.get(1).copied())?,
+                page: optional_page(parts.get(1).copied())?,
             })
         }
         "artboard" => {
             if parts.len() > 2 {
-                anyhow::bail!("usage: bans artboard [limit]");
+                anyhow::bail!("usage: view bans artboard [pagenumber]");
             }
             Ok(ModCommand::Bans {
                 scope: BanListScope::Artboard,
-                limit: optional_limit(parts.get(1).copied())?,
+                page: optional_page(parts.get(1).copied())?,
             })
         }
-        "room" => {
-            if parts.len() > 3 {
-                anyhow::bail!("usage: bans room #roomname [limit]");
+        _ if first.starts_with('#') => {
+            if parts.len() > 2 {
+                anyhow::bail!("usage: view bans #roomname [pagenumber]");
             }
             Ok(ModCommand::Bans {
                 scope: BanListScope::Room {
-                    slug: required_slug(
-                        parts.get(1).copied(),
-                        "usage: bans room #roomname [limit]",
-                    )?,
+                    slug: required_room_target(first, "usage: view bans #roomname [pagenumber]")?,
                 },
-                limit: optional_limit(parts.get(2).copied())?,
+                page: optional_page(parts.get(1).copied())?,
             })
         }
         _ => anyhow::bail!("unknown bans scope: {first}"),
@@ -241,113 +284,140 @@ fn parse_bans_mod_command(parts: &[&str]) -> Result<ModCommand> {
 
 fn parse_audit_mod_command(parts: &[&str]) -> Result<ModCommand> {
     if parts.len() > 1 {
-        anyhow::bail!("usage: audit [limit]");
+        anyhow::bail!("usage: view audit [pagenumber]");
     }
     Ok(ModCommand::Audit {
-        limit: optional_limit(parts.first().copied())?,
+        page: optional_page(parts.first().copied())?,
     })
 }
 
 fn parse_rename_room_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    const USAGE: &str = "usage: rename-room #oldname #newname";
     if parts.len() != 2 {
-        anyhow::bail!("usage: rename-room #old #new");
+        anyhow::bail!(USAGE);
     }
     Ok(ModCommand::RenameRoom {
-        slug: required_slug(parts.first().copied(), "usage: rename-room #old #new")?,
-        new_slug: required_slug(parts.get(1).copied(), "usage: rename-room #old #new")?,
+        slug: required_slug(parts.first().copied(), USAGE)?,
+        new_slug: required_slug(parts.get(1).copied(), USAGE)?,
     })
 }
 
 fn parse_rename_user_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    const USAGE: &str = "usage: rename-user @oldname @newname";
     if parts.len() != 2 {
-        anyhow::bail!("usage: rename-user @old @new");
+        anyhow::bail!(USAGE);
     }
     Ok(ModCommand::RenameUser {
-        username: required_username(parts.first().copied(), "usage: rename-user @old @new")?,
-        new_username: required_username(parts.get(1).copied(), "usage: rename-user @old @new")?,
+        username: required_username(parts.first().copied(), USAGE)?,
+        new_username: required_username(parts.get(1).copied(), USAGE)?,
     })
 }
 
-fn parse_room_mod_command(parts: &[&str]) -> Result<ModCommand> {
-    let Some(first) = parts.first().copied() else {
-        anyhow::bail!("usage: room #roomname | room <action> ...");
+fn parse_kick_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    const USAGE: &str = "usage: kick <server|#roomname> @name [reason...]";
+    let Some(target) = parts.first().copied() else {
+        anyhow::bail!(USAGE);
     };
-    match first {
-        "kick" | "ban" | "unban" => {
-            let action = match first {
-                "kick" => RoomModAction::Kick,
-                "ban" => RoomModAction::Ban,
-                "unban" => RoomModAction::Unban,
-                _ => unreachable!(),
-            };
-            let slug = required_slug(parts.get(1).copied(), "usage: room kick #roomname @name")?;
-            let username =
-                required_username(parts.get(2).copied(), "usage: room kick #roomname @name")?;
-            let (duration, reason_start) = if matches!(action, RoomModAction::Ban) {
-                parse_optional_duration(parts.get(3).copied(), 3)?
-            } else {
-                (None, 3)
-            };
-            Ok(ModCommand::RoomAction {
-                action,
-                slug,
-                username,
-                duration,
-                reason: parts.get(reason_start..).unwrap_or_default().join(" "),
-            })
-        }
-        _ => anyhow::bail!("unknown room action: {first}"),
+    let username = required_username(parts.get(1).copied(), USAGE)?;
+    let reason = parts.get(2..).unwrap_or_default().join(" ");
+    if target == "server" {
+        return Ok(ModCommand::ServerUser {
+            action: ServerUserAction::Kick,
+            username,
+            duration: None,
+            reason,
+        });
+    }
+    if target.starts_with('#') {
+        return Ok(ModCommand::RoomAction {
+            action: RoomModAction::Kick,
+            slug: required_room_target(target, USAGE)?,
+            username,
+            duration: None,
+            reason,
+        });
+    }
+    anyhow::bail!(USAGE)
+}
+
+fn parse_ban_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    const USAGE: &str = "usage: ban <server|#roomname|artboard> @name [duration] [reason...]";
+    let Some(target) = parts.first().copied() else {
+        anyhow::bail!(USAGE);
+    };
+    let username = required_username(parts.get(1).copied(), USAGE)?;
+    let (duration, reason_start) = parse_optional_duration(parts.get(2).copied(), 2)?;
+    let reason = parts.get(reason_start..).unwrap_or_default().join(" ");
+    match target {
+        "server" => Ok(ModCommand::ServerUser {
+            action: ServerUserAction::Ban,
+            username,
+            duration,
+            reason,
+        }),
+        "artboard" => Ok(ModCommand::Artboard {
+            action: ArtboardAction::Ban,
+            username,
+            duration,
+            reason,
+        }),
+        _ if target.starts_with('#') => Ok(ModCommand::RoomAction {
+            action: RoomModAction::Ban,
+            slug: required_room_target(target, USAGE)?,
+            username,
+            duration,
+            reason,
+        }),
+        _ => anyhow::bail!(USAGE),
     }
 }
 
-fn parse_server_mod_command(parts: &[&str]) -> Result<ModCommand> {
-    let Some(first) = parts.first().copied() else {
-        anyhow::bail!("usage: server <kick|ban|unban> @name");
+fn parse_unban_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    const USAGE: &str = "usage: unban <server|#roomname|artboard> @name [reason...]";
+    let Some(target) = parts.first().copied() else {
+        anyhow::bail!(USAGE);
     };
-    let action = match first {
-        "kick" => ServerUserAction::Kick,
-        "ban" => ServerUserAction::Ban,
-        "unban" => ServerUserAction::Unban,
-        _ => anyhow::bail!("unknown server action: {first}"),
-    };
-    let username = required_username(parts.get(1).copied(), "usage: server <action> @name")?;
-    let (duration, reason_start) = if matches!(action, ServerUserAction::Ban) {
-        parse_optional_duration(parts.get(2).copied(), 2)?
-    } else {
-        (None, 2)
-    };
-    Ok(ModCommand::ServerUser {
-        action,
-        username,
-        duration,
-        reason: parts.get(reason_start..).unwrap_or_default().join(" "),
-    })
+    let username = required_username(parts.get(1).copied(), USAGE)?;
+    let reason = parts.get(2..).unwrap_or_default().join(" ");
+    match target {
+        "server" => Ok(ModCommand::ServerUser {
+            action: ServerUserAction::Unban,
+            username,
+            duration: None,
+            reason,
+        }),
+        "artboard" => Ok(ModCommand::Artboard {
+            action: ArtboardAction::Unban,
+            username,
+            duration: None,
+            reason,
+        }),
+        _ if target.starts_with('#') => Ok(ModCommand::RoomAction {
+            action: RoomModAction::Unban,
+            slug: required_room_target(target, USAGE)?,
+            username,
+            duration: None,
+            reason,
+        }),
+        _ => anyhow::bail!(USAGE),
+    }
 }
 
 fn parse_artboard_mod_command(parts: &[&str]) -> Result<ModCommand> {
     let Some(first) = parts.first().copied() else {
-        anyhow::bail!("usage: artboard <ban|unban|restore> ...");
+        anyhow::bail!("usage: artboard restore [YYYY-MM-DD] [reason...]");
     };
     if first == "restore" {
         return parse_artboard_restore_mod_command(&parts[1..]);
     }
-    let action = match first {
-        "ban" => ArtboardAction::Ban,
-        "unban" => ArtboardAction::Unban,
-        _ => anyhow::bail!("unknown artboard action: {first}"),
-    };
-    let username = required_username(parts.get(1).copied(), "usage: artboard <action> @name")?;
-    let (duration, reason_start) = if matches!(action, ArtboardAction::Ban) {
-        parse_optional_duration(parts.get(2).copied(), 2)?
-    } else {
-        (None, 2)
-    };
-    Ok(ModCommand::Artboard {
-        action,
-        username,
-        duration,
-        reason: parts.get(reason_start..).unwrap_or_default().join(" "),
-    })
+    anyhow::bail!("usage: artboard restore [YYYY-MM-DD] [reason...]")
+}
+
+fn required_room_target(value: &str, usage: &str) -> Result<String> {
+    if !value.starts_with('#') {
+        anyhow::bail!(usage.to_string());
+    }
+    required_slug(Some(value), usage)
 }
 
 fn parse_artboard_restore_mod_command(parts: &[&str]) -> Result<ModCommand> {
@@ -359,15 +429,25 @@ fn parse_artboard_restore_mod_command(parts: &[&str]) -> Result<ModCommand> {
         None => (None, 0),
     };
     let reason = parts.get(reason_start..).unwrap_or_default().join(" ");
-    if reason.trim().is_empty() {
-        anyhow::bail!("usage: artboard restore [YYYY-MM-DD] <reason...>");
-    }
     Ok(ModCommand::ArtboardRestore { date, reason })
+}
+
+fn parse_admin_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    let Some(action) = parts.first().copied() else {
+        return Ok(ModCommand::Help {
+            topic: Some("admin".to_string()),
+        });
+    };
+    match action {
+        "grant" => parse_role_mod_command(RoleAction::GrantMod, &parts[1..]),
+        "revoke" => parse_role_mod_command(RoleAction::RevokeMod, &parts[1..]),
+        _ => anyhow::bail!("unknown admin command: {action}"),
+    }
 }
 
 fn parse_role_mod_command(mod_action: RoleAction, parts: &[&str]) -> Result<ModCommand> {
     let Some(role) = parts.first().copied() else {
-        anyhow::bail!("usage: grant mod @name | revoke mod @name");
+        anyhow::bail!("usage: admin grant mod @name | admin revoke mod @name");
     };
     let action = match role {
         "mod" | "moderator" => mod_action,
@@ -376,7 +456,7 @@ fn parse_role_mod_command(mod_action: RoleAction, parts: &[&str]) -> Result<ModC
     };
     Ok(ModCommand::Role {
         action,
-        username: required_username(parts.get(1).copied(), "usage: grant mod @name")?,
+        username: required_username(parts.get(1).copied(), "usage: admin grant mod @name")?,
     })
 }
 
@@ -421,24 +501,25 @@ fn parse_mod_duration(value: &str) -> Result<Option<chrono::Duration>> {
     Ok(Some(duration))
 }
 
-const DEFAULT_LIST_LIMIT: i64 = 25;
-const MAX_LIST_LIMIT: i64 = 100;
+pub(crate) const LIST_PAGE_SIZE: i64 = 15;
+const DEFAULT_PAGE: i64 = 1;
+const MAX_PAGE: i64 = 1000;
 
-fn optional_limit(value: Option<&str>) -> Result<i64> {
+fn optional_page(value: Option<&str>) -> Result<i64> {
     let Some(value) = value else {
-        return Ok(DEFAULT_LIST_LIMIT);
+        return Ok(DEFAULT_PAGE);
     };
-    parse_limit(value)?.ok_or_else(|| anyhow::anyhow!("limit must be a positive number"))
+    parse_page(value)?.ok_or_else(|| anyhow::anyhow!("page number must be a positive number"))
 }
 
-fn parse_limit(value: &str) -> Result<Option<i64>> {
-    let Ok(limit) = value.parse::<i64>() else {
+fn parse_page(value: &str) -> Result<Option<i64>> {
+    let Ok(page) = value.parse::<i64>() else {
         return Ok(None);
     };
-    if limit <= 0 {
-        anyhow::bail!("limit must be positive");
+    if page <= 0 {
+        anyhow::bail!("page number must be positive");
     }
-    Ok(Some(limit.min(MAX_LIST_LIMIT)))
+    Ok(Some(page.min(MAX_PAGE)))
 }
 
 fn nonempty(value: String) -> Option<String> {
@@ -513,153 +594,168 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
         .filter(|topic| !topic.is_empty())
     else {
         return help_lines(&[
-            "help [command]",
-            "user @name",
-            "bans [server|artboard|room #roomname] [limit]",
-            "audit [limit]",
-            "rename-room #old #new",
-            "rename-user @old @new",
-            "room kick #roomname @name [reason...]",
-            "room ban #roomname @name [duration] [reason...]",
-            "room unban #roomname @name",
-            "server kick @name [reason...]",
-            "server ban @name [duration] [reason...]",
-            "server unban @name",
-            "artboard ban @name [duration] [reason...]",
-            "artboard unban @name",
+            "--- general ---",
+            "rename-room <#oldname> <#newname>",
+            "rename-user <@oldname> <@newname>",
+            "view   <@user|#room|bans|audit|artboard|help> [pagenumber]",
             "artboard restore [YYYY-MM-DD] [reason...]",
-            "grant mod @name",
-            "revoke mod @name",
             "",
-            "Username arguments prefer @name; bare name is also accepted.",
-            "Use help <command> for details, e.g. help room ban.",
+            "--- bans, etc. ---",
+            "kick   <server|#room> @name [reason...]",
+            "ban    <server|#room|artboard> @name [duration] [reason...]",
+            "unban  <server|#room|artboard> @name [reason...]",
+            "",
+            "--- help & admin ---",
+            "admin           - show admin commands",
+            "admin <command> - run admin commands",
+            "help <command>  - get help with command",
         ]);
     };
 
     let lines: &[&str] = match topic.as_str() {
         "help" => &[
-            "help [command]",
+            "help <command>",
             "Shows the command list or focused help for one command.",
-            "command: optional command/subcommand, e.g. user, room ban, server ban.",
+            "command: e.g. rename-room, view, ban, artboard restore, admin grant mod.",
         ],
-        "user" => &[
-            "user @name",
-            "Shows one user's id, roles, timestamps, and active server/artboard ban flags.",
-            "@name: username; bare name is also accepted.",
+        "rename" => &[
+            "rename-room <#oldname> <#newname>",
+            "rename-user <@oldname> <@newname>",
+            "Renames rooms or users.",
+            "Subtopics: help rename-room, help rename-user.",
         ],
-        "bans" => &[
-            "bans [server|artboard|room #roomname] [limit]",
-            "Lists current active bans. Without a scope, shows server, artboard, and room bans.",
-            "limit: optional positive number; capped at 100; default 25.",
-        ],
-        "bans server" => &[
-            "bans server [limit]",
-            "Lists active server bans with actor, expiry, and reason.",
-        ],
-        "bans artboard" => &[
-            "bans artboard [limit]",
-            "Lists active artboard bans with actor, expiry, and reason.",
-        ],
-        "bans room" => &[
-            "bans room #roomname [limit]",
-            "Lists active bans for one room, e.g. #general.",
-        ],
-        "audit" => &[
-            "audit [limit]",
-            "Lists recent moderation audit log entries.",
-            "limit: optional positive number; capped at 100; default 25.",
-        ],
-        "rename-room" => &[
-            "rename-room #old #new",
+        "rename-room" | "rename room" => &[
+            "rename-room #oldname #newname",
             "Renames a non-DM room, e.g. #old-room to #new-room.",
             "Moderator or admin only. #general is reserved and cannot be renamed.",
         ],
-        "rename-user" => &[
-            "rename-user @old @new",
+        "rename-user" | "rename user" => &[
+            "rename-user @oldname @newname",
             "Renames a user account.",
-            "@old: existing username; bare old is also accepted.",
-            "@new: desired username; bare new is also accepted and sanitized with normal username rules.",
+            "@oldname: existing username; bare oldname is also accepted.",
+            "@newname: desired username; bare newname is also accepted and sanitized with normal username rules.",
             "Moderator or admin only. Writes a moderation audit entry.",
         ],
-        "room" => &[
-            "room <kick|ban|unban> #roomname @name",
-            "Subcommands: room kick, room ban, room unban.",
+        "view" => &[
+            "view <@user|#room|bans|audit|artboard|help> [pagenumber]",
+            "Views moderation data.",
+            "Subtopics: help view user, help view room, help view bans, help view audit, help view artboard.",
         ],
-        "room kick" => &[
-            "room kick #roomname @name [reason...]",
-            "Removes a user from a room without creating a ban.",
-            "#roomname: room name, e.g. #general. @name: username; bare name is also accepted. reason: optional audit text.",
+        "view user" => &[
+            "view @name",
+            "Shows one user's id, roles, timestamps, and active server/artboard ban flags.",
+            "@name: username; bare name is also accepted.",
         ],
-        "room ban" => &[
-            "room ban #roomname @name [duration] [reason...]",
-            "Bans a user from a room and removes their membership.",
-            "#roomname: room name, e.g. #general. @name: username; bare name is also accepted.",
+        "view room" => &[
+            "view #roomname",
+            "Shows room id, type, visibility, flags, and member count.",
+        ],
+        "view bans" => &[
+            "view bans [server|artboard|#roomname] [pagenumber]",
+            "Lists current active bans. Without a scope, shows server, artboard, and room bans.",
+            "pagenumber: optional positive page number; 15 rows per page.",
+        ],
+        "view bans server" => &[
+            "view bans server [pagenumber]",
+            "Lists active server bans with actor, expiry, and reason.",
+        ],
+        "view bans artboard" => &[
+            "view bans artboard [pagenumber]",
+            "Lists active artboard bans with actor, expiry, and reason.",
+        ],
+        "view bans room" => &[
+            "view bans #roomname [pagenumber]",
+            "Lists active bans for one room, e.g. #general.",
+        ],
+        "view audit" => &[
+            "view audit [pagenumber]",
+            "Lists recent moderation audit log entries.",
+            "pagenumber: optional positive page number; 15 rows per page.",
+        ],
+        "view artboard" => &[
+            "view artboard [pagenumber]",
+            "Lists daily and monthly Artboard snapshots.",
+            "pagenumber: optional positive page number; 15 rows per page.",
+        ],
+        "kick" => &[
+            "kick <server|#room> @name [reason...]",
+            "Terminates active sessions for server, or removes a user from a room.",
+            "#roomname is required for room operations, e.g. #general.",
+            "@name: username; bare name is also accepted. reason: optional audit text.",
+            "Subtopics: help kick server, help kick room.",
+        ],
+        "kick server" => &[
+            "kick server @name [reason...]",
+            "Terminates active sessions for one user.",
+        ],
+        "kick room" => &[
+            "kick #roomname @name [reason...]",
+            "Removes one user from one room.",
+        ],
+        "ban" => &[
+            "ban <server|#room|artboard> @name [duration] [reason...]",
+            "Creates a server, artboard, or room ban. Room bans also remove membership.",
+            "#roomname is required for room operations, e.g. #general.",
+            "@name: username; bare name is also accepted.",
             "duration: optional positive number plus s/m/h/d, e.g. 30m or 7d; omit for permanent.",
             "reason: optional audit text after duration.",
+            "Subtopics: help ban server, help ban room, help ban artboard.",
         ],
-        "room unban" => &[
-            "room unban #roomname @name",
-            "Removes an active room ban for a user.",
-            "#roomname: room name, e.g. #general. @name: username; bare name is also accepted.",
+        "ban server" => &[
+            "ban server @name [duration] [reason...]",
+            "Creates a server ban and terminates active sessions.",
         ],
-        "server" => &[
-            "server <kick|ban|unban> @name",
-            "Applies server-wide session removal or bans.",
-            "Subcommands: server kick, server ban, server unban.",
+        "ban room" => &[
+            "ban #roomname @name [duration] [reason...]",
+            "Creates a room ban and removes membership.",
         ],
-        "server kick" => &[
-            "server kick @name [reason...]",
-            "Terminates a user's active sessions without creating a ban.",
+        "ban artboard" => &[
+            "ban artboard @name [duration] [reason...]",
+            "Creates an Artboard editing ban.",
+        ],
+        "unban" => &[
+            "unban <server|#room|artboard> @name [reason...]",
+            "Removes active server, artboard, or room bans for a user.",
+            "#roomname is required for room operations, e.g. #general.",
             "@name: username; bare name is also accepted. reason: optional audit text.",
+            "Subtopics: help unban server, help unban room, help unban artboard.",
         ],
-        "server ban" => &[
-            "server ban @name [duration] [reason...]",
-            "Creates a server user ban and terminates active sessions.",
-            "@name: username; bare name is also accepted.",
-            "duration: optional positive number plus s/m/h/d, e.g. 2h or 7d; omit for permanent.",
-            "reason: optional audit text after duration.",
+        "unban server" => &[
+            "unban server @name [reason...]",
+            "Removes active server bans for one user.",
         ],
-        "server unban" => &[
-            "server unban @name",
-            "Removes active server bans for that user.",
-            "@name: username; bare name is also accepted.",
+        "unban room" => &[
+            "unban #roomname @name [reason...]",
+            "Removes active room bans for one user in one room.",
+        ],
+        "unban artboard" => &[
+            "unban artboard @name [reason...]",
+            "Removes active Artboard editing bans for one user.",
         ],
         "artboard" => &[
-            "artboard <ban|unban|restore> ...",
-            "Controls artboard access and snapshots.",
-            "Subcommands: artboard ban, artboard unban, artboard restore.",
-        ],
-        "artboard ban" => &[
-            "artboard ban @name [duration] [reason...]",
-            "Bans a user from the artboard.",
-            "@name: username; bare name is also accepted.",
-            "duration: optional positive number plus s/m/h/d; omit for permanent.",
-            "reason: optional audit text after duration.",
-        ],
-        "artboard unban" => &[
-            "artboard unban @name",
-            "Removes an artboard ban for a user.",
-            "@name: username; bare name is also accepted.",
+            "artboard restore [YYYY-MM-DD] [reason...]",
+            "Restores Artboard snapshots.",
+            "Subtopics: help artboard restore.",
         ],
         "artboard restore" => &[
-            "artboard restore [YYYY-MM-DD] <reason...>",
+            "artboard restore [YYYY-MM-DD] [reason...]",
             "Restores live Artboard from a daily UTC snapshot.",
             "date: optional daily snapshot date; defaults to previous UTC day.",
-            "reason: required audit text.",
+            "reason: optional audit text.",
             "Moderator or admin only. Writes a moderation audit entry and backs up the previous main row.",
         ],
-        "grant" => &[
-            "grant mod @name",
-            "Grants a role to a user.",
-            "@name: username; bare name is also accepted.",
+        "admin" => &[
+            "admin <grant|revoke> mod @name",
+            "Admin-only role commands.",
+            "Subcommands: admin grant mod, admin revoke mod.",
         ],
-        "grant mod" => &[
-            "grant mod @name",
+        "admin grant" | "admin grant mod" => &[
+            "admin grant mod @name",
             "Grants moderator role to a user.",
             "@name: username; bare name is also accepted.",
         ],
-        "revoke" | "revoke mod" => &[
-            "revoke mod @name",
+        "admin revoke" | "admin revoke mod" => &[
+            "admin revoke mod @name",
             "Revokes moderator role from a user.",
             "@name: username; bare name is also accepted.",
         ],
@@ -705,15 +801,21 @@ mod tests {
             ModCommand::Help { topic: None }
         );
         assert_eq!(
-            parse_mod_command("help server ban").unwrap(),
+            parse_mod_command("help ban server").unwrap(),
             ModCommand::Help {
-                topic: Some("server ban".to_string())
+                topic: Some("ban server".to_string())
             }
         );
         assert_eq!(
-            parse_mod_command("help room ban").unwrap(),
+            parse_mod_command("help ban room").unwrap(),
             ModCommand::Help {
-                topic: Some("room ban".to_string())
+                topic: Some("ban room".to_string())
+            }
+        );
+        assert_eq!(
+            parse_mod_command("admin").unwrap(),
+            ModCommand::Help {
+                topic: Some("admin".to_string())
             }
         );
         assert!(parse_mod_command("/moderator help").is_err());
@@ -721,48 +823,54 @@ mod tests {
 
     #[test]
     fn command_help_explains_audit_arguments() {
-        let lines = mod_help_lines(Some("audit"));
+        let lines = mod_help_lines(Some("view audit"));
 
         assert!(
-            lines.iter().any(|line| line == "audit [limit]"),
+            lines.iter().any(|line| line == "view audit [pagenumber]"),
             "audit help should be available: {lines:?}"
         );
         assert!(
-            lines.iter().any(|line| line.contains("capped at 100")),
-            "audit help should explain limit bounds: {lines:?}"
+            lines.iter().any(|line| line.contains("15 rows per page")),
+            "audit help should explain page size: {lines:?}"
         );
     }
 
     #[test]
-    fn command_help_explains_server_ban_arguments() {
-        let lines = mod_help_lines(Some("server ban"));
+    fn command_help_explains_ban_arguments() {
+        let lines = mod_help_lines(Some("ban"));
 
         assert!(
             lines
                 .iter()
-                .any(|line| line == "server ban @name [duration] [reason...]")
+                .any(|line| line == "ban <server|#room|artboard> @name [duration] [reason...]")
         );
         assert!(
             lines.iter().any(|line| line.contains("s/m/h/d")),
-            "server ban help should explain duration syntax: {lines:?}"
+            "ban help should explain duration syntax: {lines:?}"
         );
     }
 
     #[test]
-    fn command_help_prefers_at_prefixed_usernames() {
+    fn command_help_uses_limited_grouped_surface() {
         let lines = mod_help_lines(None);
 
         assert!(
             lines
                 .iter()
-                .any(|line| line == "Username arguments prefer @name; bare name is also accepted."),
-            "top-level help should explain username convention: {lines:?}"
+                .any(|line| line == "rename-room <#oldname> <#newname>"),
+            "top-level help should show rename-room command: {lines:?}"
         );
         assert!(
             lines
                 .iter()
-                .any(|line| line == "server ban @name [duration] [reason...]"),
-            "top-level help should show @name in username-taking commands: {lines:?}"
+                .any(|line| line == "rename-user <@oldname> <@newname>"),
+            "top-level help should show rename-user command: {lines:?}"
+        );
+        assert!(
+            lines
+                .iter()
+                .any(|line| line == "ban    <server|#room|artboard> @name [duration] [reason...]"),
+            "top-level help should show verb-primary ban form: {lines:?}"
         );
     }
 
@@ -770,8 +878,8 @@ mod tests {
     fn command_help_uses_roomname_examples_instead_of_slug_jargon() {
         let lines = [
             mod_help_lines(None),
-            mod_help_lines(Some("room ban")),
-            mod_help_lines(Some("bans room")),
+            mod_help_lines(Some("ban room")),
+            mod_help_lines(Some("view bans room")),
         ]
         .concat();
 
@@ -801,7 +909,7 @@ mod tests {
     #[test]
     fn parses_room_ban_with_duration_and_reason() {
         assert_eq!(
-            parse_mod_command("room ban #lobby @alice 7d cleanup").unwrap(),
+            parse_mod_command("ban #lobby @alice 7d cleanup").unwrap(),
             ModCommand::RoomAction {
                 action: RoomModAction::Ban,
                 slug: "lobby".to_string(),
@@ -815,18 +923,18 @@ mod tests {
     #[test]
     fn parses_at_prefixed_usernames_for_all_username_commands() {
         let cases = [
-            ("user @alice", "alice"),
+            ("view @alice", "alice"),
             ("rename-user @alice @bob", "alice"),
-            ("room kick #lobby @alice reason", "alice"),
-            ("room ban #lobby @alice 7d cleanup", "alice"),
-            ("room unban #lobby @alice", "alice"),
-            ("server kick @alice reason", "alice"),
-            ("server ban @alice policy", "alice"),
-            ("server unban @alice", "alice"),
-            ("artboard ban @alice policy", "alice"),
-            ("artboard unban @alice", "alice"),
-            ("grant mod @alice", "alice"),
-            ("revoke mod @alice", "alice"),
+            ("kick #lobby @alice reason", "alice"),
+            ("ban #lobby @alice 7d cleanup", "alice"),
+            ("unban #lobby @alice", "alice"),
+            ("kick server @alice reason", "alice"),
+            ("ban server @alice policy", "alice"),
+            ("unban server @alice", "alice"),
+            ("ban artboard @alice policy", "alice"),
+            ("unban artboard @alice", "alice"),
+            ("admin grant mod @alice", "alice"),
+            ("admin revoke mod @alice", "alice"),
         ];
 
         for (input, expected_username) in cases {
@@ -849,7 +957,7 @@ mod tests {
     #[test]
     fn parses_bare_usernames_for_mod_commands() {
         assert_eq!(
-            parse_mod_command("server ban alice policy").unwrap(),
+            parse_mod_command("ban server alice policy").unwrap(),
             ModCommand::ServerUser {
                 action: ServerUserAction::Ban,
                 username: "alice".to_string(),
@@ -877,6 +985,7 @@ mod tests {
         );
         assert!(parse_mod_command("rename-room #old").is_err());
         assert!(parse_mod_command("rename-room #old #new extra").is_err());
+        assert!(parse_mod_command("rename room #old #new").is_err());
     }
 
     #[test]
@@ -890,12 +999,13 @@ mod tests {
         );
         assert!(parse_mod_command("rename-user @old").is_err());
         assert!(parse_mod_command("rename-user @old @new extra").is_err());
+        assert!(parse_mod_command("rename user @old @new").is_err());
     }
 
     #[test]
     fn parses_server_permanent_ban_without_duration() {
         assert_eq!(
-            parse_mod_command("server ban @alice policy").unwrap(),
+            parse_mod_command("ban server @alice policy").unwrap(),
             ModCommand::ServerUser {
                 action: ServerUserAction::Ban,
                 username: "alice".to_string(),
@@ -908,7 +1018,7 @@ mod tests {
     #[test]
     fn parses_reason_that_looks_like_duration_suffix() {
         assert_eq!(
-            parse_mod_command("server ban @alice spam wave").unwrap(),
+            parse_mod_command("ban server @alice spam wave").unwrap(),
             ModCommand::ServerUser {
                 action: ServerUserAction::Ban,
                 username: "alice".to_string(),
@@ -921,7 +1031,7 @@ mod tests {
     #[test]
     fn parses_server_kick() {
         assert_eq!(
-            parse_mod_command("server kick @alice go outside").unwrap(),
+            parse_mod_command("kick server @alice go outside").unwrap(),
             ModCommand::ServerUser {
                 action: ServerUserAction::Kick,
                 username: "alice".to_string(),
@@ -929,50 +1039,50 @@ mod tests {
                 reason: "go outside".to_string(),
             }
         );
-        assert!(parse_mod_command("server disconnect @alice").is_err());
+        assert!(parse_mod_command("disconnect server @alice").is_err());
     }
 
     #[test]
     fn parses_ban_listing_commands() {
         assert_eq!(
-            parse_mod_command("bans").unwrap(),
+            parse_mod_command("view bans").unwrap(),
             ModCommand::Bans {
                 scope: BanListScope::All,
-                limit: DEFAULT_LIST_LIMIT,
+                page: DEFAULT_PAGE,
             }
         );
         assert_eq!(
-            parse_mod_command("bans room #lobby 200").unwrap(),
+            parse_mod_command("view bans #lobby 200").unwrap(),
             ModCommand::Bans {
                 scope: BanListScope::Room {
                     slug: "lobby".to_string()
                 },
-                limit: MAX_LIST_LIMIT,
+                page: 200,
             }
         );
         assert_eq!(
-            parse_mod_command("bans server 3").unwrap(),
+            parse_mod_command("view bans server 3").unwrap(),
             ModCommand::Bans {
                 scope: BanListScope::Server,
-                limit: 3,
+                page: 3,
             }
         );
-        assert!(parse_mod_command("bans topic").is_err());
+        assert!(parse_mod_command("view bans topic").is_err());
+        assert!(parse_mod_command("bans").is_err());
     }
 
     #[test]
     fn parses_audit_listing_commands() {
         assert_eq!(
-            parse_mod_command("audit").unwrap(),
-            ModCommand::Audit {
-                limit: DEFAULT_LIST_LIMIT,
-            }
+            parse_mod_command("view audit").unwrap(),
+            ModCommand::Audit { page: DEFAULT_PAGE }
         );
         assert_eq!(
-            parse_mod_command("audit 5").unwrap(),
-            ModCommand::Audit { limit: 5 }
+            parse_mod_command("view audit 5").unwrap(),
+            ModCommand::Audit { page: 5 }
         );
-        assert!(parse_mod_command("audit nope").is_err());
+        assert!(parse_mod_command("view audit nope").is_err());
+        assert!(parse_mod_command("audit").is_err());
     }
 
     #[test]
@@ -991,8 +1101,20 @@ mod tests {
                 reason: "rollback latest".to_string(),
             }
         );
-        assert!(parse_mod_command("artboard restore").is_err());
-        assert!(parse_mod_command("artboard restore 2026-05-06").is_err());
+        assert_eq!(
+            parse_mod_command("artboard restore").unwrap(),
+            ModCommand::ArtboardRestore {
+                date: None,
+                reason: String::new(),
+            }
+        );
+        assert_eq!(
+            parse_mod_command("artboard restore 2026-05-06").unwrap(),
+            ModCommand::ArtboardRestore {
+                date: Some(chrono::NaiveDate::from_ymd_opt(2026, 5, 6).unwrap()),
+                reason: String::new(),
+            }
+        );
     }
 
     #[test]
@@ -1010,8 +1132,10 @@ mod tests {
             | ModCommand::Artboard { username, .. }
             | ModCommand::Role { username, .. } => username,
             ModCommand::Help { .. }
+            | ModCommand::RoomInfo { .. }
             | ModCommand::Bans { .. }
             | ModCommand::Audit { .. }
+            | ModCommand::ArtboardSnapshots { .. }
             | ModCommand::RenameRoom { .. }
             | ModCommand::ArtboardRestore { .. } => {
                 panic!("command does not have a primary username: {command:?}")

--- a/late-ssh/src/moderation/service.rs
+++ b/late-ssh/src/moderation/service.rs
@@ -4,7 +4,7 @@ use dartboard_core::Canvas;
 use late_core::{
     db::Db,
     models::{
-        artboard::Snapshot as ArtboardSnapshot,
+        artboard::{Snapshot as ArtboardSnapshot, SnapshotSummary as ArtboardSnapshotSummary},
         artboard_ban::{ArtboardBan, ArtboardBanListItem},
         chat_room::ChatRoom,
         chat_room_member::ChatRoomMember,
@@ -24,8 +24,8 @@ use crate::app::artboard::provenance::{ArtboardProvenance, SharedArtboardProvena
 use crate::authz::{Caps, Permissions, Tier};
 use crate::dartboard;
 use crate::moderation::command::{
-    ArtboardAction, BanListScope, ModCommand, RoleAction, RoomModAction, ServerUserAction,
-    mod_help_lines, normalize_mod_slug, parse_mod_command, strip_user_prefix,
+    ArtboardAction, BanListScope, LIST_PAGE_SIZE, ModCommand, RoleAction, RoomModAction,
+    ServerUserAction, mod_help_lines, normalize_mod_slug, parse_mod_command, strip_user_prefix,
 };
 use crate::moderation::event::ModerationEvent;
 use crate::moderation::session_effects::ModerationSessionEffects;
@@ -113,8 +113,12 @@ impl ModerationService {
         match command {
             ModCommand::Help { topic } => Ok(mod_help_lines(topic.as_deref())),
             ModCommand::User { username } => self.user_detail(permissions, &username).await,
-            ModCommand::Bans { scope, limit } => self.list_bans(permissions, scope, limit).await,
-            ModCommand::Audit { limit } => self.list_audit(permissions, limit).await,
+            ModCommand::RoomInfo { slug } => self.room_detail(permissions, &slug).await,
+            ModCommand::Bans { scope, page } => self.list_bans(permissions, scope, page).await,
+            ModCommand::Audit { page } => self.list_audit(permissions, page).await,
+            ModCommand::ArtboardSnapshots { page } => {
+                self.list_artboard_snapshots(permissions, page).await
+            }
             ModCommand::RenameRoom { slug, new_slug } => {
                 self.rename_room(actor_user_id, permissions, &slug, &new_slug)
                     .await
@@ -207,23 +211,53 @@ impl ModerationService {
         ])
     }
 
+    async fn room_detail(&self, permissions: Permissions, slug: &str) -> Result<Vec<String>> {
+        ensure_mod_surface(permissions)?;
+        let client = self.db.get().await?;
+        let room = find_room_by_mod_slug(&client, slug).await?;
+        let member_count: i64 = client
+            .query_one(
+                "SELECT COUNT(*)::bigint FROM chat_room_members WHERE room_id = $1",
+                &[&room.id],
+            )
+            .await?
+            .get(0);
+        let room_slug = room.slug.clone().unwrap_or_else(|| room.kind.clone());
+        Ok(vec![
+            format!("#{room_slug}"),
+            format!("id: {}", room.id),
+            format!("kind: {}", room.kind),
+            format!("visibility: {}", room.visibility),
+            format!("auto_join: {}", room.auto_join),
+            format!("permanent: {}", room.permanent),
+            format!("members: {member_count}"),
+        ])
+    }
+
     async fn list_bans(
         &self,
         permissions: Permissions,
         scope: BanListScope,
-        limit: i64,
+        page: i64,
     ) -> Result<Vec<String>> {
         ensure_mod_surface(permissions)?;
         let client = self.db.get().await?;
+        let offset = page_offset(page);
         match scope {
             BanListScope::All => {
-                let server = ServerBan::active_with_usernames(&client, limit).await?;
-                let artboard = ArtboardBan::active_with_usernames(&client, limit).await?;
-                let room = RoomBan::active_with_usernames(&client, limit).await?;
+                let server =
+                    ServerBan::active_with_usernames_page(&client, LIST_PAGE_SIZE, offset).await?;
+                let artboard =
+                    ArtboardBan::active_with_usernames_page(&client, LIST_PAGE_SIZE, offset)
+                        .await?;
+                let room =
+                    RoomBan::active_with_usernames_page(&client, LIST_PAGE_SIZE, offset).await?;
                 if server.is_empty() && artboard.is_empty() && room.is_empty() {
                     return Ok(vec!["no active bans".to_string()]);
                 }
-                let mut lines = vec![format!("active bans (limit {limit} per section)")];
+                let mut lines = vec![format!(
+                    "active bans (page {page}, {LIST_PAGE_SIZE} per section)"
+                )];
                 append_section(
                     &mut lines,
                     "server bans",
@@ -248,17 +282,20 @@ impl ModerationService {
                 Ok(lines)
             }
             BanListScope::Server => {
-                let items = ServerBan::active_with_usernames(&client, limit).await?;
+                let items =
+                    ServerBan::active_with_usernames_page(&client, LIST_PAGE_SIZE, offset).await?;
                 Ok(single_section(
-                    "active server bans",
+                    &format!("active server bans (page {page})"),
                     "no active server bans",
                     items.iter().map(format_server_ban_item).collect(),
                 ))
             }
             BanListScope::Artboard => {
-                let items = ArtboardBan::active_with_usernames(&client, limit).await?;
+                let items =
+                    ArtboardBan::active_with_usernames_page(&client, LIST_PAGE_SIZE, offset)
+                        .await?;
                 Ok(single_section(
-                    "active artboard bans",
+                    &format!("active artboard bans (page {page})"),
                     "no active artboard bans",
                     items.iter().map(format_artboard_ban_item).collect(),
                 ))
@@ -266,10 +303,15 @@ impl ModerationService {
             BanListScope::Room { slug } => {
                 let room = find_room_by_mod_slug(&client, &slug).await?;
                 let room_slug = room.slug.clone().unwrap_or_else(|| room.kind.clone());
-                let items =
-                    RoomBan::active_for_room_with_usernames(&client, room.id, limit).await?;
+                let items = RoomBan::active_for_room_with_usernames_page(
+                    &client,
+                    room.id,
+                    LIST_PAGE_SIZE,
+                    offset,
+                )
+                .await?;
                 Ok(single_section(
-                    &format!("active room bans for #{room_slug}"),
+                    &format!("active room bans for #{room_slug} (page {page})"),
                     &format!("no active room bans for #{room_slug}"),
                     items.iter().map(format_room_ban_item).collect(),
                 ))
@@ -277,15 +319,42 @@ impl ModerationService {
         }
     }
 
-    async fn list_audit(&self, permissions: Permissions, limit: i64) -> Result<Vec<String>> {
+    async fn list_audit(&self, permissions: Permissions, page: i64) -> Result<Vec<String>> {
         ensure_has(permissions, Caps::VIEW_STAFF_INFO)?;
         let client = self.db.get().await?;
-        let items = ModerationAuditLog::recent_with_usernames(&client, limit).await?;
+        let items = ModerationAuditLog::recent_with_usernames_page(
+            &client,
+            LIST_PAGE_SIZE,
+            page_offset(page),
+        )
+        .await?;
         if items.is_empty() {
             return Ok(vec!["no audit log entries".to_string()]);
         }
-        let mut lines = vec![format!("recent audit log entries (limit {limit})")];
+        let mut lines = vec![format!(
+            "recent audit log entries (page {page}, {LIST_PAGE_SIZE} per page)"
+        )];
         lines.extend(items.iter().map(format_audit_log_item));
+        Ok(lines)
+    }
+
+    async fn list_artboard_snapshots(
+        &self,
+        permissions: Permissions,
+        page: i64,
+    ) -> Result<Vec<String>> {
+        ensure_mod_surface(permissions)?;
+        let client = self.db.get().await?;
+        let items =
+            ArtboardSnapshot::list_archive_summaries(&client, LIST_PAGE_SIZE, page_offset(page))
+                .await?;
+        if items.is_empty() {
+            return Ok(vec!["no artboard snapshots".to_string()]);
+        }
+        let mut lines = vec![format!(
+            "artboard snapshots (page {page}, {LIST_PAGE_SIZE} per page)"
+        )];
+        lines.extend(items.iter().map(format_artboard_snapshot_summary));
         Ok(lines)
     }
 
@@ -974,6 +1043,21 @@ fn format_audit_log_item(item: &ModerationAuditLogListItem) -> String {
     )
 }
 
+fn format_artboard_snapshot_summary(item: &ArtboardSnapshotSummary) -> String {
+    let kind = if item.board_key.starts_with("monthly:") {
+        "monthly"
+    } else if item.board_key.starts_with("daily:") {
+        "daily"
+    } else {
+        "snapshot"
+    };
+    format!(
+        "- {kind} {} updated: {}",
+        item.board_key,
+        item.updated.format("%Y-%m-%d %H:%M UTC")
+    )
+}
+
 fn format_expires_at(expires_at: Option<chrono::DateTime<Utc>>) -> String {
     expires_at
         .map(|expires_at| expires_at.format("%Y-%m-%d %H:%M UTC").to_string())
@@ -1001,6 +1085,10 @@ fn previous_utc_day() -> NaiveDate {
 
 fn daily_artboard_key(date: NaiveDate) -> String {
     format!("daily:{date}")
+}
+
+fn page_offset(page: i64) -> i64 {
+    (page.saturating_sub(1)) * LIST_PAGE_SIZE
 }
 
 fn is_unique_violation(error: &anyhow::Error) -> bool {

--- a/late-ssh/src/paired_clients.rs
+++ b/late-ssh/src/paired_clients.rs
@@ -324,10 +324,7 @@ impl PairedClientRegistry {
         let Some(tx) = tx else {
             return false;
         };
-        if tx
-            .send(PairControlMessage::RequestClipboardImage)
-            .is_err()
-        {
+        if tx.send(PairControlMessage::RequestClipboardImage).is_err() {
             tracing::warn!(
                 token_hint = %token_hint(token),
                 "failed to send paired clipboard image request"

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -1540,7 +1540,7 @@ async fn mod_room_ban_command_bans_kicks_and_audits() {
         actor.id,
         Permissions::new(false, true),
         request_id,
-        "room ban #mod-ban-room @mod_ban_target 1h test cleanup".to_string(),
+        "ban #mod-ban-room @mod_ban_target 1h test cleanup".to_string(),
     );
 
     let event = timeout(Duration::from_secs(2), events.recv())
@@ -1820,7 +1820,7 @@ async fn mod_server_kick_command_terminates_active_sessions_and_audits() {
         actor.id,
         Permissions::new(false, true),
         request_id,
-        "server kick @server_kick_target cool off".to_string(),
+        "kick server @server_kick_target cool off".to_string(),
     );
 
     let event = timeout(Duration::from_secs(2), events.recv())
@@ -1902,7 +1902,7 @@ async fn mod_server_ban_command_bans_and_terminates_active_sessions() {
         actor.id,
         Permissions::new(false, true),
         request_id,
-        "server ban @server_ban_target 1h test ban".to_string(),
+        "ban server @server_ban_target 1h test ban".to_string(),
     );
 
     let event = timeout(Duration::from_secs(2), events.recv())
@@ -2019,7 +2019,7 @@ async fn mod_artboard_ban_command_notifies_active_sessions() {
         actor.id,
         Permissions::new(false, true),
         request_id,
-        "artboard ban @artboard_ban_target 1h paint cooldown".to_string(),
+        "ban artboard @artboard_ban_target 1h paint cooldown".to_string(),
     );
 
     let event = timeout(Duration::from_secs(2), events.recv())
@@ -2235,9 +2235,9 @@ async fn mod_bans_command_lists_active_bans() {
         .expect("create room");
 
     for command in [
-        "server ban @list_server_target 1h server reason",
-        "artboard ban @list_artboard_target 1h art reason",
-        "room ban #list-bans-room @list_room_target 1h room reason",
+        "ban server @list_server_target 1h server reason",
+        "ban artboard @list_artboard_target 1h art reason",
+        "ban #list-bans-room @list_room_target 1h room reason",
     ] {
         service.run_mod_command_task(
             actor.id,
@@ -2260,7 +2260,7 @@ async fn mod_bans_command_lists_active_bans() {
         actor.id,
         Permissions::new(false, true),
         request_id,
-        "bans 10".to_string(),
+        "view bans".to_string(),
     );
 
     let event = timeout(Duration::from_secs(2), events.recv())
@@ -2329,7 +2329,7 @@ async fn mod_audit_command_lists_recent_audit_entries() {
         actor.id,
         Permissions::new(false, true),
         Uuid::now_v7(),
-        "server kick @list_audit_target audit reason".to_string(),
+        "kick server @list_audit_target audit reason".to_string(),
     );
     let event = timeout(Duration::from_secs(2), events.recv())
         .await
@@ -2345,7 +2345,7 @@ async fn mod_audit_command_lists_recent_audit_entries() {
         actor.id,
         Permissions::new(false, true),
         request_id,
-        "audit 5".to_string(),
+        "view audit".to_string(),
     );
 
     let event = timeout(Duration::from_secs(2), events.recv())
@@ -2364,7 +2364,7 @@ async fn mod_audit_command_lists_recent_audit_entries() {
             assert!(
                 lines
                     .iter()
-                    .any(|line| line == "recent audit log entries (limit 5)")
+                    .any(|line| line == "recent audit log entries (page 1, 15 per page)")
             );
             assert!(lines.iter().any(|line| line.contains("@list_audit_actor")
                 && line.contains("server_kick")
@@ -2420,7 +2420,7 @@ async fn mod_room_ban_command_notifies_target_sessions_to_drop_room() {
         actor.id,
         Permissions::new(false, true),
         request_id,
-        "room ban #room-notify @room_notify_target 1h test".to_string(),
+        "ban #room-notify @room_notify_target 1h test".to_string(),
     );
 
     let event = timeout(Duration::from_secs(2), events.recv())
@@ -2488,7 +2488,7 @@ async fn grant_mod_command_updates_active_session_permissions() {
         actor.id,
         Permissions::new(true, false),
         request_id,
-        "grant mod @grant_mod_target".to_string(),
+        "admin grant mod @grant_mod_target".to_string(),
     );
 
     let event = timeout(Duration::from_secs(2), events.recv())


### PR DESCRIPTION
new
```
--- general ---
rename-room <#oldname> <#newname>
rename-user <@oldname> <@newname>
view <@user|#room|bans|audit|artboard|help> [pagenumber]

--- bans, etc. ---
kick   <server|#room> @name [reason...]
ban    <server|#room|artboard> @name [duration] [reason...]
unban  <server|#room|artboard> @name [reason...]
artboard restore <YYYY-MM-DD> [reason...]

--- help & admin ---
admin [command] - show/run admin commands
help  <command> - get help with command
```

old
```
help [command]                                                  
user @name                                                      
bans [server|artboard|room #roomname] [limit]                   
audit [limit]                                                   
rename-room #old #new                                           
rename-user @old @new                                           
room kick #roomname @name [reason...]                           
room ban #roomname @name [duration] [reason...]                 
room unban #roomname @name                                      
server kick @name [reason...]                                   
server ban @name [duration] [reason...]                         
server unban @name                                              
artboard ban @name [duration] [reason...]                       
artboard unban @name                                            
artboard restore [YYYY-MM-DD] [reason...]                       
grant mod @name                                                 
revoke mod @name                                                
                                                                
Username arguments prefer @name; bare name is also accepted.    
Use help <command> for details, e.g. help room ban.             
```