### PR TITLE
Replace cross-origin viz analyzer with synthetic browser-pair visualizer

### DIFF
--- a/late-ssh/src/api.rs
+++ b/late-ssh/src/api.rs
@@ -255,6 +255,21 @@ async fn handle_socket(mut socket: WebSocket, token: String, state: State) {
     metrics::record_ws_pair_success();
     tracing::info!(token_hint = %token_hint, "ws pair websocket established");
 
+    if send_json_ws(
+        &mut socket,
+        &crate::paired_clients::PairControlMessage::SetPlaybackSource {
+            source: audio_source,
+        },
+        &token_hint,
+        "initial playback source",
+    )
+    .await
+    .is_err()
+    {
+        release_pair_registration(&state, &token, registration_id);
+        return;
+    }
+
     match state.audio_service.initial_ws_messages().await {
         Ok(messages) => {
             for msg in messages {

--- a/late-ssh/src/app/audio/CONTEXT.md
+++ b/late-ssh/src/app/audio/CONTEXT.md
@@ -296,7 +296,7 @@ File: `late-web/src/pages/connect/page.html`. The audio source is decided in the
 - `app/tick.rs` turns `Visualizer::procedural_active` on whenever this SSH
   session has a paired browser (`paired_client_state().client_kind == Browser`).
   This is source-agnostic: Icecast and YouTube render the same procedural bars.
-- `render_inline(frame, area)` is the borderless sidebar render. Idle shows `"no audio paired"` / `"/music in chat"` / `"P install · pair"` (last only when height ≥ 5). Procedural live draws dim amber 1-cell bars with 1-cell gaps using linear resample plus tilt `(0.65 + 0.35·t)·γ^1.1`.
+- `render_inline(frame, area)` is the borderless sidebar render. Idle shows `"no audio paired"` / `"/music in chat"` / `"P install · pair"` (last only when height ≥ 5). Procedural live draws dim amber 1-cell-wide bars with 1-cell gaps at **sub-cell vertical resolution** (`▁▂▃▄▅▆▇█`, 9-step). Bar heights come from layered sines — a primary traveling wave, a faster per-band shimmer, and a slow global breath term (incommensurate frequencies so the pattern doesn't visibly repeat in a few seconds). No spectrum-style tilt is applied on the procedural path; the wave shape is decorative, not a frequency analog.
 - The old `VizFrame`/`Visualizer::update` path is still present for compatibility
   with existing payload parsing and tests, but browser web playback no longer
   drives it.

--- a/late-ssh/src/app/audio/CONTEXT.md
+++ b/late-ssh/src/app/audio/CONTEXT.md
@@ -1,9 +1,9 @@
 # late-ssh Audio Context
 
 ## Metadata
-- Domain: late.sh audio — Icecast house radio, global YouTube queue, browser/CLI source arbitration, Icecast visualizer, now-playing poller
+- Domain: late.sh audio — Icecast house radio, global YouTube queue, browser/CLI source arbitration, synthetic browser-pair visualizer, now-playing poller
 - Primary audience: LLM agents working in `late-ssh/src/app/audio` and the touchpoints it owns in `late-cli` and `late-web/src/pages/connect`
-- Last updated: 2026-05-18 (added §18 parked plan: OS audio loopback for CLI-side visualization. Premised on the embedded-webview CLI playback work — once the CLI does local audio output, tap PipeWire/WASAPI/ScreenCaptureKit, run FFT locally, produce real `VizFrame`s across YouTube + Icecast + anything. Browser Web Audio analyzer can retire when this lands. Cross-ref from §10. Sibling to §17 external-player plan but with no yt-dlp posture concerns.)
+- Last updated: 2026-05-18 (browser-pair visualizer is now synthetic-only for both Icecast and YouTube; the web page no longer creates a Web Audio analyzer or sends `viz` frames. §18 remains the parked plan for future real OS-loopback FFT.)
 - Previously: booth modal now surfaces track durations: queue list has a right-aligned `m:ss` column between title and submitter, and the Now Playing row shows the same `m:ss` next to the title. Streams render `live`; unknown durations are blank. Two submit paths diverge in metadata: booth (`booth_submit_public_task` → `submit_url` → Data API) inserts rows with title/channel/`duration_ms`/`is_stream` already populated; staff `/audio` (`submit_trusted_url_task`) inserts NULL metadata and the browser backfills `duration_ms` on first play via `record_browser_duration`. See §4 Public API + §2 booth/ui.rs note.
 - Status: Active
 - Parent context: `../../../../CONTEXT.md`
@@ -17,7 +17,7 @@ Owned by this domain:
 - Global, DB-backed YouTube queue: submission, persistence, single-playing invariant, server-driven track switching (per-browser playback timeline), fallback debounce.
 - The singleton "YouTube fallback" stream that plays when the queue is empty.
 - Audio source arbitration between paired CLI and paired browser clients on the same SSH token (`force_mute`).
-- Icecast visualizer driven by browser-side Web Audio analysis.
+- Synthetic browser-pair visualizer used for both Icecast and YouTube.
 - Now-playing poller for the Icecast track title.
 - The `/audio` and `/audio fallback` SSH chat commands (staff-only).
 
@@ -38,7 +38,7 @@ late-ssh/src/app/audio/
 ├── state.rs                # AudioState: per-session UI shim — proxies submits/votes and turns AudioEvent into Banners
 ├── client_state.rs         # ClientAudioState + ClientKind/SshMode/Platform enums (the client_state WS payload)
 ├── liquidsoap.rs           # LiquidsoapController telnet client (NOT used by AudioService — only by app/vote/svc.rs)
-├── viz.rs                  # Visualizer (Icecast bands/RMS/beat) + ratatui render_inline
+├── viz.rs                  # Visualizer (procedural bars, legacy bands/RMS/beat) + ratatui render_inline
 ├── youtube.rs              # URL parsing + optional YouTube Data API validation client
 ├── booth/
 │   ├── mod.rs
@@ -175,7 +175,7 @@ YouTube item without entering the switching/playback path.
 
 ### Client → server `WsPayload` (`api.rs:39-68`)
 - `heartbeat`
-- `viz { position_ms, bands[8], rms }` — browser-only, drives the Icecast visualizer
+- `viz { position_ms, bands[8], rms }` — legacy/compat payload; the current web page does not send it
 - `client_state { client_kind, ssh_mode, platform, capabilities, muted, volume_percent }`
 - `clipboard_image { … }`, `clipboard_image_failed { … }`
 - `player_state(PlayerStateReport)` — `{ item_id, state, offset_ms?, duration_ms?, autoplay_blocked, error? }` (`svc.rs:126-138`)
@@ -274,11 +274,12 @@ Goal: the CLI tolerates everything new the audio domain added, plays Icecast unc
 
 ## 9. Web Connect Page Integration
 
-File: `late-web/src/pages/connect/page.html`. The IFrame API and `<div id="yt-player">` are always rendered; the audio source is decided in the browser.
+File: `late-web/src/pages/connect/page.html`. The audio source is decided in the browser; the YouTube API/player is lazy-loaded only when the browser actually enters YouTube mode.
 
 - **Per-user audio source (server-authoritative).** The choice is persisted in `users.settings.audio_source` (`icecast` | `youtube`, default `icecast`). TUI `v+x` flips the value via `App::toggle_paired_playback_source`: writes to DB through `AudioService::persist_audio_source`, updates the local mirror `App::paired_browser_source`, and broadcasts `PairControlMessage::SetPlaybackSource { source }` to every paired browser. On pair-WS connect, `api.rs` sends the persisted source before the audio catch-up burst. On every browser pair-up (`api.rs` detects `previous_kind != Browser && new_kind == Browser`), the SSH session is also notified via `SessionMessage::BrowserPaired` and `App::replay_paired_browser_source` re-pushes the current value. The browser is a follower: `applyUserPlaybackSource(source)` stores `userOverrideMode` and applies. While the user is pinned to icecast, `loadYoutubeVideo` and `seekYoutube` early-return so server queue events do not flip the iframe back on (the current item is still stashed as `pendingYoutubeItem` so a toggle to youtube starts playing immediately).
-- **IFrame API load.** `<script src="https://www.youtube.com/iframe_api">` is always included. Global `window.lateYoutubeApiReady` and `onYouTubeIframeAPIReady` hooks resolve a promise that the Alpine component awaits in `init()`.
+- **IFrame API load.** The page does not include the YouTube iframe API up front. `ensureYoutubePlayer()` calls `loadYoutubeApi()` on demand, which appends `https://www.youtube.com/iframe_api`; `window.lateYoutubeApiReady` / `onYouTubeIframeAPIReady` then create the player only if `audioMode === "youtube"`.
 - **`source_changed` swap** (`applySourceMode`). Into `youtube`: pause `<audio>`, ensure player exists, kick playback of pending item. Into `icecast`: `ytPlayer.pauseVideo()`, restart `startPlayback()` for the `<audio>` if audio is enabled. The `modeChanged` guard prevents repeated `source_changed: youtube` broadcasts during queue transitions from resetting the iframe.
+- **Icecast-pinned resource behavior.** While pinned to Icecast, `load_video` only stashes `pendingYoutubeItem`; it does not create the YouTube iframe or pre-cue the video. A later source flip to YouTube starts from the pending item, and the server's 10s `load_video` heartbeat remains the safety net.
 - **`load_video` → force-switch or no-op** (`loadYoutubeVideo`). New shape: payload is `{ item_id, video_id, is_stream }` — no offset, no started_at. Same `item_id` AND iframe is already showing the right `video_id` → no-op (this is the safety-net heartbeat path; a manual pause stays paused). Otherwise → `loadVideoById({ videoId })` from 0, swap `currentYoutubeItem`. `verifyYoutubeLoad` re-checks after 1s and reloads if the video id still mismatches.
 - **No drift correction.** Each browser plays its own timeline. Slow networks just lag behind — no `seekTo` jumps. The "everyone hears the same offset" invariant is dropped on purpose.
 - **`player_state` reports** (`sendYoutubeState`). Emits `{ event: 'player_state', item_id, state, offset_ms, duration_ms, autoplay_blocked, error }` on YT state transitions (PLAYING/PAUSED/BUFFERING/ENDED). No periodic loop. Server reads `duration_ms` for backfill via `record_browser_duration`; the rest is informational.
@@ -289,15 +290,16 @@ File: `late-web/src/pages/connect/page.html`. The IFrame API and `<div id="yt-pl
 
 ## 10. Visualizer (`viz.rs`)
 
-- `Visualizer { bands[8], rms, has_viz, rms_avg, beat }` consumes `late_core::audio::VizFrame { bands[8], rms, track_pos_ms }`.
-- `update(&mut self, &VizFrame)` clamps bands, smooths `rms_avg` (0.95/0.05 EMA), decays `beat *= 0.9`, fires `beat = 1.0` when `frame.rms / rms_avg > 1.3`.
-- `tick_idle()` decays bands/RMS/beat each tick when no frames arrive (called when `has_viz == true` only).
-- `beat()` is volume-independent and drives bonsai animation.
-- `render_inline(frame, area)` is the borderless sidebar render. Idle shows `"no audio paired"` / `"/music in chat"` / `"P install · pair"` (last only when height ≥ 5). Live draws 1-cell bars with 1-cell gaps using linear resample plus tilt `(0.65 + 0.35·t)·γ^1.1`.
-
-Data flow: browser Web Audio analyzer → `WsPayload::Viz` → `api.rs:293` converts to `SessionMessage::Viz(VizFrame)` → session dispatcher → `app/tick.rs:213` feeds it through `Visualizer::update` (latest frame each tick) → `app/common/sidebar.rs:106` renders.
-
-**Icecast-only by browser constraint.** A YouTube iframe is cross-origin; the browser cannot tap its audio. When mode is YouTube, the browser stops sending `viz` frames, `has_viz` decays to false, and the sidebar reverts to the idle panel. Do not pretend YouTube has frequency analysis — if a future UI wants a "playing" indicator for YouTube, drive it procedurally and name it as such in code (e.g. `procedural_indicator_bands`, not `viz_bands`).
+- Browser-paired audio is synthetic-only for both Icecast and YouTube. The web
+  page does not create a Web Audio `AudioContext`, does not run an analyzer, and
+  does not send `viz` frames.
+- `app/tick.rs` turns `Visualizer::procedural_active` on whenever this SSH
+  session has a paired browser (`paired_client_state().client_kind == Browser`).
+  This is source-agnostic: Icecast and YouTube render the same procedural bars.
+- `render_inline(frame, area)` is the borderless sidebar render. Idle shows `"no audio paired"` / `"/music in chat"` / `"P install · pair"` (last only when height ≥ 5). Procedural live draws dim amber 1-cell bars with 1-cell gaps using linear resample plus tilt `(0.65 + 0.35·t)·γ^1.1`.
+- The old `VizFrame`/`Visualizer::update` path is still present for compatibility
+  with existing payload parsing and tests, but browser web playback no longer
+  drives it.
 
 **Future unlock: OS audio loopback.** Once the CLI hosts its own playback (embedded webview track), the cross-origin constraint disappears entirely — we capture local audio output at the OS layer (PipeWire / WASAPI / ScreenCaptureKit) and feed real `VizFrame`s through the existing pipeline for every source, including YouTube. See §18 for the parked plan. Until that lands, procedural bars are the only honest YouTube-mode indicator.
 
@@ -418,7 +420,7 @@ These are intentional non-goals. Reopen only if the constraint that put them her
 - **Ad stripping.** The iframe plays whatever YouTube serves.
 - **Lyrics, album art, fancy metadata.** Title + channel is enough.
 - **Custom genre control per submission.** Fallback uses the global vote winner like everywhere else.
-- **Real Web Audio analysis of the YouTube iframe.** Not possible — cross-origin iframe, no audio hook in the IFrame Player API. The Icecast visualizer (§10) keeps working; any future YouTube-mode visualizer must either hide, switch to a labeled "playing" indicator driven procedurally (name it honestly in code — `procedural_indicator_bands`, never `viz_bands`), or stop showing bars.
+- **Real Web Audio analysis of the YouTube iframe.** Not possible — cross-origin iframe, no audio hook in the IFrame Player API. Browser-paired audio therefore uses the same synthetic visualizer for both Icecast and YouTube (§10) until OS-loopback capture exists.
 
 ---
 
@@ -503,7 +505,7 @@ Until then, YouTube playback goes through the browser iframe path (§4-§9).
 
 ### Idea
 
-Tap the CLI's own audio output at the OS layer, run FFT locally, emit `VizFrame { bands[8], rms, track_pos_ms }` through the existing pipeline. Works uniformly for YouTube, Icecast, and anything else the user plays through `late`. The browser-side Web Audio analyzer (§10 data-flow) can retire — viz becomes CLI-owned across every source, and the pair-WS `viz` fan-in can be removed.
+Tap the CLI's own audio output at the OS layer, run FFT locally, emit `VizFrame { bands[8], rms, track_pos_ms }` through the existing pipeline. Works uniformly for YouTube, Icecast, and anything else the user plays through `late`. The current browser-pair synthetic visualizer (§10) can retire — viz becomes CLI-owned across every source, and the pair-WS `viz` fan-in can be removed.
 
 ### Per-platform capture
 
@@ -530,7 +532,8 @@ A single trait inside `late-cli/src/audio/` abstracts the platform-specific capt
 - Embedded-webview CLI playback work is on the active roadmap or already shipped.
 - We're willing to take on platform-specific audio code (the LATE bar to clear is one Linux backend).
 
-Until then, browser-pair YouTube uses procedural bars (§10) and Icecast viz continues to flow through the browser Web Audio analyzer.
+Until then, browser-paired audio uses procedural bars for both Icecast and
+YouTube (§10).
 
 ---
 

--- a/late-ssh/src/app/audio/CONTEXT.md
+++ b/late-ssh/src/app/audio/CONTEXT.md
@@ -88,7 +88,7 @@ Keep `mod.rs` declaration-only — no `pub use` re-exports.
 
 ### Constants (`svc.rs:15-21`)
 - `QUEUE_SNAPSHOT_LIMIT = 50`
-- `MAX_SUBMISSIONS_PER_WINDOW = 10` over `SUBMISSION_WINDOW = 30 minutes` — applies to un-trusted `submit_url`, which is the path reached by the Music Booth submit modal (`booth_submit_public_task`). Trusted/admin paths (`submit_trusted_url`) bypass.
+- `MAX_SUBMISSIONS_PER_WINDOW = 10` over `SUBMISSION_WINDOW = 5 minutes` — applies to un-trusted `submit_url`, which is the path reached by the Music Booth submit modal (`booth_submit_public_task`). Trusted/admin paths (`submit_trusted_url`) bypass.
 - `FALLBACK_DEBOUNCE = 10s`
 - `PLAYBACK_HEARTBEAT_INTERVAL = 10s` — periodic `LoadVideo` re-broadcast for the current item. Safety net: browsers already showing the right item no-op; stuck/disconnected/wrong-item browsers force-swap. Replaces the old `Seek`-based sync.
 - `STREAM_CAP = 1h` — hard cap on any single playing row's wall-clock lifetime.
@@ -158,7 +158,10 @@ Routed by report `state` field:
 - `control_rx` — `PairControlMessage` from `PairedClientRegistry` (mute/volume/force_mute/clipboard)
 - `audio_rx` — `AudioWsMessage` from `AudioService::subscribe_ws()`
 
-On connect, `audio_service.initial_ws_messages()` emits the catch-up burst.
+On connect, `api.rs` sends the user's persisted `set_playback_source` first, then
+`audio_service.initial_ws_messages()` emits the catch-up burst. This ordering keeps
+the browser from briefly assuming the default Icecast preference and staging a
+YouTube item without entering the switching/playback path.
 
 ### Server → client `AudioWsMessage` (tagged enum, snake_case)
 - `load_video { item_id, video_id, is_stream }` — sent on track changes AND every 10s as a heartbeat. Browsers swap when `item_id` differs from what they're playing; same-item heartbeat is a no-op.
@@ -167,6 +170,8 @@ On connect, `audio_service.initial_ws_messages()` emits the catch-up burst.
 
 ### Server → client `PairControlMessage` (`paired_clients.rs:22-30`)
 - `toggle_mute`, `volume_up`, `volume_down`, `request_clipboard_image`, `force_mute { mute }`.
+- `set_playback_source { source: "icecast" | "youtube" }` — sent immediately on
+  pair-WS connect and re-sent by the SSH session on browser-pair notification.
 
 ### Client → server `WsPayload` (`api.rs:39-68`)
 - `heartbeat`
@@ -271,7 +276,7 @@ Goal: the CLI tolerates everything new the audio domain added, plays Icecast unc
 
 File: `late-web/src/pages/connect/page.html`. The IFrame API and `<div id="yt-player">` are always rendered; the audio source is decided in the browser.
 
-- **Per-user audio source (server-authoritative).** The choice is persisted in `users.settings.audio_source` (`icecast` | `youtube`, default `icecast`). TUI `v+x` flips the value via `App::toggle_paired_playback_source`: writes to DB through `AudioService::persist_audio_source`, updates the local mirror `App::paired_browser_source`, and broadcasts `PairControlMessage::SetPlaybackSource { source }` to every paired browser. On every browser pair-up (`api.rs:298` detects `previous_kind != Browser && new_kind == Browser`), the SSH session is notified via `SessionMessage::BrowserPaired` and `App::replay_paired_browser_source` re-pushes the current value, so a refreshed page lands in the right mode. The browser is a follower: `applyUserPlaybackSource(source)` stores `userOverrideMode` and applies. While the user is pinned to icecast, `loadYoutubeVideo` and `seekYoutube` early-return so server queue events do not flip the iframe back on (the current item is still stashed as `pendingYoutubeItem` so a toggle to youtube starts playing immediately).
+- **Per-user audio source (server-authoritative).** The choice is persisted in `users.settings.audio_source` (`icecast` | `youtube`, default `icecast`). TUI `v+x` flips the value via `App::toggle_paired_playback_source`: writes to DB through `AudioService::persist_audio_source`, updates the local mirror `App::paired_browser_source`, and broadcasts `PairControlMessage::SetPlaybackSource { source }` to every paired browser. On pair-WS connect, `api.rs` sends the persisted source before the audio catch-up burst. On every browser pair-up (`api.rs` detects `previous_kind != Browser && new_kind == Browser`), the SSH session is also notified via `SessionMessage::BrowserPaired` and `App::replay_paired_browser_source` re-pushes the current value. The browser is a follower: `applyUserPlaybackSource(source)` stores `userOverrideMode` and applies. While the user is pinned to icecast, `loadYoutubeVideo` and `seekYoutube` early-return so server queue events do not flip the iframe back on (the current item is still stashed as `pendingYoutubeItem` so a toggle to youtube starts playing immediately).
 - **IFrame API load.** `<script src="https://www.youtube.com/iframe_api">` is always included. Global `window.lateYoutubeApiReady` and `onYouTubeIframeAPIReady` hooks resolve a promise that the Alpine component awaits in `init()`.
 - **`source_changed` swap** (`applySourceMode`). Into `youtube`: pause `<audio>`, ensure player exists, kick playback of pending item. Into `icecast`: `ytPlayer.pauseVideo()`, restart `startPlayback()` for the `<audio>` if audio is enabled. The `modeChanged` guard prevents repeated `source_changed: youtube` broadcasts during queue transitions from resetting the iframe.
 - **`load_video` → force-switch or no-op** (`loadYoutubeVideo`). New shape: payload is `{ item_id, video_id, is_stream }` — no offset, no started_at. Same `item_id` AND iframe is already showing the right `video_id` → no-op (this is the safety-net heartbeat path; a manual pause stays paused). Otherwise → `loadVideoById({ videoId })` from 0, swap `currentYoutubeItem`. `verifyYoutubeLoad` re-checks after 1s and reloads if the video id still mismatches.

--- a/late-ssh/src/app/audio/svc.rs
+++ b/late-ssh/src/app/audio/svc.rs
@@ -25,7 +25,7 @@ use crate::paired_clients::PairedClientRegistry;
 
 const QUEUE_SNAPSHOT_LIMIT: i64 = 50;
 const MAX_SUBMISSIONS_PER_WINDOW: i64 = 10;
-const SUBMISSION_WINDOW: chrono::Duration = chrono::Duration::minutes(30);
+const SUBMISSION_WINDOW: chrono::Duration = chrono::Duration::minutes(5);
 const FALLBACK_DEBOUNCE: Duration = Duration::from_secs(10);
 const PLAYBACK_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(10);
 const STREAM_CAP: Duration = Duration::from_secs(60 * 60);

--- a/late-ssh/src/app/audio/viz.rs
+++ b/late-ssh/src/app/audio/viz.rs
@@ -90,12 +90,26 @@ impl Visualizer {
     }
 
     fn procedural_bands(&self) -> [f32; 8] {
+        // Layered sines: a primary traveling wave, a faster shimmer offset
+        // per-band, and a slow global breath. The phases multiply (1.0, 1.7,
+        // 0.35) are deliberately incommensurate so the pattern doesn't repeat
+        // visibly inside a few seconds.
         let mut out = [0.0f32; 8];
+        let breath = 0.05 * (self.procedural_phase * 0.35).sin();
         for (i, slot) in out.iter_mut().enumerate() {
-            let phase = self.procedural_phase + (i as f32) * 0.55;
-            *slot = 0.5 + 0.25 * phase.sin();
+            let p = self.procedural_phase + (i as f32) * 0.55;
+            let primary = 0.20 * p.sin();
+            let shimmer = 0.07 * (p * 1.7 + (i as f32) * 0.31).sin();
+            *slot = (0.5 + primary + shimmer + breath).clamp(0.05, 0.95);
         }
         out
+    }
+
+    fn procedural_block(fill: f32) -> &'static str {
+        // 9-step sub-cell vertical block: ' ' through '█' in 1/8 increments.
+        const BLOCKS: [&str; 9] = [" ", "▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"];
+        let idx = (fill.clamp(0.0, 1.0) * 8.0).round() as usize;
+        BLOCKS[idx.min(8)]
     }
 
     /// Borderless visualizer for the merged shell. Renders bars only when
@@ -197,34 +211,32 @@ impl Visualizer {
         }
 
         let band_count = width.div_ceil(2).max(1);
-        let band_width = 1usize;
         let gap = 1usize;
 
+        // No tilt — the procedural pattern is decorative, not a frequency
+        // spectrum. Tilting it would lean the whole wave to one side and read
+        // as broken rather than stylized.
         let source = self.procedural_bands();
-        let mut bands = self.resample(&source, band_count);
-        let len = bands.len();
-        for (i, band) in bands.iter_mut().enumerate() {
-            *band = Self::tilt(*band, i, len);
-        }
+        let bands = self.resample(&source, band_count);
+        let style = Style::default().fg(theme::AMBER_DIM());
 
         let mut lines = Vec::with_capacity(height);
         for row in 0..height {
-            let level = height - row;
+            // Vertical cell index measured from the bottom (0 = bottom row).
+            let cell_from_bottom = (height - row - 1) as f32;
             let mut spans: Vec<Span> = Vec::with_capacity(band_count * 2);
 
             for (i, &band) in bands.iter().enumerate().take(band_count) {
-                let band = band.clamp(0.0, 1.0);
-                let bar_height = (band * height as f32).floor() as usize;
-                let bar_height = bar_height.min(height);
-                let filled = level <= bar_height;
+                let bar_height_cells = band.clamp(0.0, 1.0) * height as f32;
+                // How much of THIS cell is filled by the bar (0..1).
+                let fill = (bar_height_cells - cell_from_bottom).clamp(0.0, 1.0);
 
-                let (ch, style) = if filled {
-                    ('█', Style::default().fg(theme::AMBER_DIM()))
+                if fill <= 0.0 {
+                    spans.push(Span::raw(" "));
                 } else {
-                    (' ', Style::default())
-                };
+                    spans.push(Span::styled(Self::procedural_block(fill), style));
+                }
 
-                spans.push(Span::styled(ch.to_string().repeat(band_width), style));
                 if gap > 0 && i + 1 < band_count {
                     spans.push(Span::raw(" ".repeat(gap)));
                 }

--- a/late-ssh/src/app/audio/viz.rs
+++ b/late-ssh/src/app/audio/viz.rs
@@ -15,6 +15,12 @@ pub struct Visualizer {
     // Beat detection (volume-independent rhythm tracking)
     rms_avg: f32,
     beat: f32,
+    // Procedural indicator (YouTube source — no real frequency data, cross-origin
+    // iframe). Slow breathing sine wave. Does NOT pretend to be audio-reactive;
+    // kept visually distinct (AMBER_DIM) so a glance separates it from real bars.
+    // See CONTEXT.md §10 / §18.
+    procedural_active: bool,
+    procedural_phase: f32,
 }
 
 impl Default for Visualizer {
@@ -31,6 +37,8 @@ impl Visualizer {
             has_viz: false,
             rms_avg: 0.0,
             beat: 0.0,
+            procedural_active: false,
+            procedural_phase: 0.0,
         }
     }
 
@@ -67,12 +75,40 @@ impl Visualizer {
         self.beat = (self.beat * 0.9).max(0.0);
     }
 
+    pub fn set_procedural_active(&mut self, active: bool) {
+        self.procedural_active = active;
+    }
+
+    pub fn tick_procedural(&mut self) {
+        if !self.procedural_active {
+            return;
+        }
+        self.procedural_phase += 0.08;
+        if self.procedural_phase > std::f32::consts::TAU * 1024.0 {
+            self.procedural_phase -= std::f32::consts::TAU * 1024.0;
+        }
+    }
+
+    fn procedural_bands(&self) -> [f32; 8] {
+        let mut out = [0.0f32; 8];
+        for (i, slot) in out.iter_mut().enumerate() {
+            let phase = self.procedural_phase + (i as f32) * 0.55;
+            *slot = 0.5 + 0.25 * phase.sin();
+        }
+        out
+    }
+
     /// Borderless visualizer for the merged shell. Renders bars only when
     /// audio is paired; otherwise shows a "no audio" hint plus the `P` shortcut
     /// for the install/pair modal. No block, no title — the rail's whitespace
     /// owns the separation.
     pub fn render_inline(&self, frame: &mut Frame, area: Rect) {
         if area.height == 0 || area.width == 0 {
+            return;
+        }
+        if self.procedural_active {
+            let lines = self.build_procedural_lines(area);
+            frame.render_widget(Paragraph::new(lines), area);
             return;
         }
         if !self.has_viz {
@@ -137,6 +173,53 @@ impl Visualizer {
 
                 let (ch, style) = if filled {
                     ('█', Style::default().fg(theme::AMBER()))
+                } else {
+                    (' ', Style::default())
+                };
+
+                spans.push(Span::styled(ch.to_string().repeat(band_width), style));
+                if gap > 0 && i + 1 < band_count {
+                    spans.push(Span::raw(" ".repeat(gap)));
+                }
+            }
+
+            lines.push(Line::from(spans));
+        }
+
+        lines
+    }
+
+    fn build_procedural_lines(&self, area: Rect) -> Vec<Line<'static>> {
+        let height = area.height as usize;
+        let width = area.width as usize;
+        if height == 0 || width == 0 {
+            return Vec::new();
+        }
+
+        let band_count = width.div_ceil(2).max(1);
+        let band_width = 1usize;
+        let gap = 1usize;
+
+        let source = self.procedural_bands();
+        let mut bands = self.resample(&source, band_count);
+        let len = bands.len();
+        for (i, band) in bands.iter_mut().enumerate() {
+            *band = Self::tilt(*band, i, len);
+        }
+
+        let mut lines = Vec::with_capacity(height);
+        for row in 0..height {
+            let level = height - row;
+            let mut spans: Vec<Span> = Vec::with_capacity(band_count * 2);
+
+            for (i, &band) in bands.iter().enumerate().take(band_count) {
+                let band = band.clamp(0.0, 1.0);
+                let bar_height = (band * height as f32).floor() as usize;
+                let bar_height = bar_height.min(height);
+                let filled = level <= bar_height;
+
+                let (ch, style) = if filled {
+                    ('█', Style::default().fg(theme::AMBER_DIM()))
                 } else {
                     (' ', Style::default())
                 };
@@ -313,5 +396,96 @@ mod tests {
         viz.rms = 1.0;
         viz.tick_idle();
         assert_eq!(viz.rms, 1.0); // unchanged because has_viz is false
+    }
+
+    #[test]
+    fn tick_procedural_advances_phase_when_active() {
+        let mut viz = Visualizer::new();
+        viz.set_procedural_active(true);
+        let before = viz.procedural_phase;
+        viz.tick_procedural();
+        assert!(viz.procedural_phase > before);
+    }
+
+    #[test]
+    fn tick_procedural_no_op_when_inactive() {
+        let mut viz = Visualizer::new();
+        viz.tick_procedural();
+        assert_eq!(viz.procedural_phase, 0.0);
+    }
+
+    #[test]
+    fn procedural_bands_stay_in_range() {
+        let viz = Visualizer::new();
+        for h in viz.procedural_bands() {
+            assert!((0.0..=1.0).contains(&h));
+        }
+    }
+
+    #[test]
+    fn procedural_bands_animate_with_phase() {
+        let mut viz = Visualizer::new();
+        let first = viz.procedural_bands();
+        viz.set_procedural_active(true);
+        // Several ticks should produce a different shape.
+        for _ in 0..10 {
+            viz.tick_procedural();
+        }
+        let later = viz.procedural_bands();
+        assert!(first.iter().zip(later.iter()).any(|(a, b)| (a - b).abs() > 0.01));
+    }
+
+    #[test]
+    fn render_inline_uses_procedural_path_when_active() {
+        let width = 17;
+        let height = 6;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let mut viz = Visualizer::new();
+        viz.set_procedural_active(true);
+        // Advance once so at least one band sits above the midline.
+        viz.tick_procedural();
+
+        terminal
+            .draw(|frame| viz.render_inline(frame, Rect::new(0, 0, width, height)))
+            .expect("draw");
+
+        let buffer = terminal.backend().buffer();
+        let mut rendered = String::new();
+        for y in 0..height {
+            for x in 0..width {
+                rendered.push_str(buffer[(x, y)].symbol());
+            }
+        }
+        // Procedural path renders bars, NOT the idle "no audio paired" copy.
+        assert!(rendered.contains('█'));
+        assert!(!rendered.contains("no audio paired"));
+    }
+
+    #[test]
+    fn procedural_takes_priority_over_real_viz() {
+        // If both real viz frames AND procedural are active, procedural wins —
+        // user pinned to YouTube source should not see stale Icecast bars.
+        let width = 17;
+        let height = 4;
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        let mut viz = Visualizer::new();
+        viz.has_viz = true;
+        viz.bands = [1.0; 8];
+        viz.set_procedural_active(true);
+
+        terminal
+            .draw(|frame| viz.render_inline(frame, Rect::new(0, 0, width, height)))
+            .expect("draw");
+
+        // Procedural bars peak around 0.75; full-height column from real bands
+        // would fill every row. Top row should be empty under the procedural path.
+        let buffer = terminal.backend().buffer();
+        let mut top_row = String::new();
+        for x in 0..width {
+            top_row.push_str(buffer[(x, 0)].symbol());
+        }
+        assert!(!top_row.contains('█'));
     }
 }

--- a/late-ssh/src/app/audio/viz.rs
+++ b/late-ssh/src/app/audio/viz.rs
@@ -432,7 +432,12 @@ mod tests {
             viz.tick_procedural();
         }
         let later = viz.procedural_bands();
-        assert!(first.iter().zip(later.iter()).any(|(a, b)| (a - b).abs() > 0.01));
+        assert!(
+            first
+                .iter()
+                .zip(later.iter())
+                .any(|(a, b)| (a - b).abs() > 0.01)
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/tick.rs
+++ b/late-ssh/src/app/tick.rs
@@ -223,6 +223,18 @@ impl App {
         } else {
             self.visualizer.tick_idle();
         }
+
+        // Procedural indicator for YouTube source — real frequency analysis is
+        // impossible across the cross-origin iframe (CONTEXT.md §10). Active
+        // only when the user is pinned to YouTube AND the server has something
+        // audible (queued item or fallback); when audio_mode flips to Icecast
+        // (nothing to play), the user is hearing silence and the bars stop.
+        let procedural = self.paired_browser_source
+            == late_core::models::user::AudioSource::Youtube
+            && self.audio.queue_snapshot().audio_mode
+                == crate::app::audio::svc::AudioMode::Youtube;
+        self.visualizer.set_procedural_active(procedural);
+        self.visualizer.tick_procedural();
     }
 
     fn push_browser_frame(&mut self, frame: late_core::audio::VizFrame) {

--- a/late-ssh/src/app/tick.rs
+++ b/late-ssh/src/app/tick.rs
@@ -92,13 +92,11 @@ impl App {
             }
         }
 
-        let mut updated = false;
         for msg in messages {
             match msg {
                 SessionMessage::Heartbeat => {}
                 SessionMessage::Viz(viz) => {
                     self.push_browser_frame(viz);
-                    updated = true;
                 }
                 SessionMessage::ClipboardImage { data } => {
                     let Some(upload) = self.chat.take_pending_clipboard_image_upload() else {
@@ -113,12 +111,10 @@ impl App {
                             "Clipboard image found - uploading...",
                         ));
                     }
-                    updated = true;
                 }
                 SessionMessage::ClipboardImageFailed { message } => {
                     self.chat.clear_pending_clipboard_image_upload();
                     self.banner = Some(crate::app::common::primitives::Banner::error(&message));
-                    updated = true;
                 }
                 SessionMessage::Terminate { reason } => {
                     tracing::info!(reason, "session terminated by control message");
@@ -126,11 +122,9 @@ impl App {
                 }
                 SessionMessage::ArtboardBanChanged { banned, expires_at } => {
                     self.set_artboard_banned(banned, expires_at);
-                    updated = true;
                 }
                 SessionMessage::PermissionsChanged { permissions } => {
                     self.set_permissions(permissions);
-                    updated = true;
                 }
                 SessionMessage::RoomRemoved {
                     room_id,
@@ -142,7 +136,6 @@ impl App {
                     self.banner = Some(crate::app::common::primitives::Banner::error(&format!(
                         "{message}: #{slug}"
                     )));
-                    updated = true;
                 }
                 SessionMessage::BrowserPaired => {
                     self.replay_paired_browser_source();
@@ -216,25 +209,19 @@ impl App {
             }
         }
 
-        if updated {
-            if let Some(frame) = self.browser_viz_buffer.back().cloned() {
-                self.visualizer.update(&frame);
-            }
+        // Browser audio is synthetic-only. The web page no longer sends real
+        // frequency frames for either Icecast or YouTube, so animate whenever a
+        // browser is paired as this session's audio surface.
+        let procedural = self
+            .paired_client_state()
+            .map(|state| state.client_kind == crate::app::audio::client_state::ClientKind::Browser)
+            .unwrap_or(false);
+        self.visualizer.set_procedural_active(procedural);
+        if procedural {
+            self.visualizer.tick_procedural();
         } else {
             self.visualizer.tick_idle();
         }
-
-        // Procedural indicator for YouTube source — real frequency analysis is
-        // impossible across the cross-origin iframe (CONTEXT.md §10). Active
-        // only when the user is pinned to YouTube AND the server has something
-        // audible (queued item or fallback); when audio_mode flips to Icecast
-        // (nothing to play), the user is hearing silence and the bars stop.
-        let procedural = self.paired_browser_source
-            == late_core::models::user::AudioSource::Youtube
-            && self.audio.queue_snapshot().audio_mode
-                == crate::app::audio::svc::AudioMode::Youtube;
-        self.visualizer.set_procedural_active(procedural);
-        self.visualizer.tick_procedural();
     }
 
     fn push_browser_frame(&mut self, frame: late_core::audio::VizFrame) {

--- a/late-web/src/pages/connect/page.html
+++ b/late-web/src/pages/connect/page.html
@@ -77,19 +77,22 @@
                 console.log(`Reconnecting audio stream... (attempt ${this.audioRetries})`);
 
                 setTimeout(() => {
-                    if (this.status !== 'disconnected') {
-                        const audio = this.$refs.audio;
-                        const separator = this.audioUrl.includes('?') ? '&' : '?';
-                        audio.src = `${this.audioUrl}${separator}t=${Date.now()}`;
-                        audio.load();
-                        audio.play().then(() => {
-                            this.audioRetries = 0;
-                            this.status = 'playing';
-                        }).catch(e => {
-                            console.error("Playback restart failed:", e);
-                            this.handleAudioError();
-                        });
+                    if (this.status === 'disconnected' || this.audioMode !== 'icecast') {
+                        return;
                     }
+                    const audio = this.$refs.audio;
+                    const separator = this.audioUrl.includes('?') ? '&' : '?';
+                    audio.src = `${this.audioUrl}${separator}t=${Date.now()}`;
+                    audio.load();
+                    audio.play().then(() => {
+                        if (this.audioMode !== 'icecast') return;
+                        this.audioRetries = 0;
+                        this.status = 'playing';
+                    }).catch(e => {
+                        if (this.audioMode !== 'icecast') return;
+                        console.error("Playback restart failed:", e);
+                        this.handleAudioError();
+                    });
                 }, 2000);
             },
 
@@ -199,9 +202,11 @@
                 const separator = this.audioUrl.includes('?') ? '&' : '?';
                 audio.src = `${this.audioUrl}${separator}t=${Date.now()}`;
                 audio.play().then(() => {
+                    if (this.audioMode !== 'icecast') return;
                     this.audioRetries = 0;
                     this.status = 'playing';
                 }).catch(e => {
+                    if (this.audioMode !== 'icecast') return;
                     console.error("Playback failed:", e);
                     this.handleAudioError();
                 });
@@ -678,7 +683,7 @@
 
     <div class="space-y-3" x-cloak>
         <button @click="startPlayback"
-            x-show="status === 'ready' || status === 'disconnected' || status === 'buffering' || autoplayBlocked"
+            x-show="status !== 'playing' && (status === 'ready' || status === 'disconnected' || status === 'buffering' || autoplayBlocked)"
             :disabled="status === 'buffering' && !autoplayBlocked"
             class="w-full text-left border px-4 py-3 text-sm transition-colors duration-200" :class="(status === 'buffering' && !autoplayBlocked)
                     ? 'border-gray-800 text-gray-600 cursor-wait'

--- a/late-web/src/pages/connect/page.html
+++ b/late-web/src/pages/connect/page.html
@@ -16,14 +16,6 @@
             token: '{{ token }}',
             apiUrl: '{{ api_url }}',
             audioUrl: '{{ audio_url }}',
-            audioCtx: null,
-            analyser: null,
-            sourceNode: null,
-            freqData: null,
-            timeData: null,
-            bandBins: null,
-            vizInterval: null,
-            heartbeatInterval: null,
             ytPlayer: null,
             ytReady: false,
             pendingYoutubeItem: null,
@@ -63,7 +55,9 @@
 
                 const onYoutubeReady = () => {
                     this.ytReady = true;
-                    this.ensureYoutubePlayer();
+                    if (this.audioMode === 'youtube') {
+                        this.ensureYoutubePlayer();
+                    }
                 };
                 window.addEventListener('late-youtube-ready', onYoutubeReady);
                 if (window.lateYoutubeApiReady) {
@@ -91,9 +85,6 @@
                         audio.play().then(() => {
                             this.audioRetries = 0;
                             this.status = 'playing';
-                            if (!this.audioCtx || this.audioCtx.state !== 'running') {
-                                this.startAnalyzer();
-                            }
                         }).catch(e => {
                             console.error("Playback restart failed:", e);
                             this.handleAudioError();
@@ -204,37 +195,12 @@
                     return;
                 }
 
-                // Apple requires AudioContext creation/resume to be synchronous to user interaction
-                const AudioCtx = window.AudioContext || window.webkitAudioContext;
-                if (AudioCtx) {
-                    if (!this.audioCtx) {
-                        this.audioCtx = new AudioCtx();
-                        const audio = this.$refs.audio;
-                        this.sourceNode = this.audioCtx.createMediaElementSource(audio);
-                        this.analyser = this.audioCtx.createAnalyser();
-                        this.analyser.fftSize = 1024;
-                        this.analyser.minDecibels = -100;
-                        this.analyser.maxDecibels = -30;
-                        this.analyser.smoothingTimeConstant = 0.2;
-                        this.sourceNode.connect(this.analyser);
-                        this.analyser.connect(this.audioCtx.destination);
-
-                        this.freqData = new Uint8Array(this.analyser.frequencyBinCount);
-                        this.timeData = new Float32Array(this.analyser.fftSize);
-                        this.bandBins = this.buildLogBands(this.audioCtx.sampleRate, this.analyser.fftSize, 8);
-                    }
-                    if (this.audioCtx.state === 'suspended') {
-                        this.audioCtx.resume();
-                    }
-                }
-
                 const audio = this.$refs.audio;
                 const separator = this.audioUrl.includes('?') ? '&' : '?';
                 audio.src = `${this.audioUrl}${separator}t=${Date.now()}`;
                 audio.play().then(() => {
                     this.audioRetries = 0;
                     this.status = 'playing';
-                    this.startAnalyzer();
                 }).catch(e => {
                     console.error("Playback failed:", e);
                     this.handleAudioError();
@@ -248,20 +214,8 @@
                     audio.src = '';
                 }
 
-                if (this.vizInterval) {
-                    clearInterval(this.vizInterval);
-                    this.vizInterval = null;
-                }
-                if (this.heartbeatInterval) {
-                    clearInterval(this.heartbeatInterval);
-                    this.heartbeatInterval = null;
-                }
                 if (this.ytPlayer && this.ytPlayer.stopVideo) {
                     this.ytPlayer.stopVideo();
-                }
-
-                if (this.audioCtx && this.audioCtx.state === 'running') {
-                    this.audioCtx.suspend();
                 }
 
                 if (this.ws && this.ws.readyState === WebSocket.OPEN) {
@@ -310,113 +264,6 @@
                     muted: this.muted,
                     volume_percent: this.volumePercent,
                 }));
-            },
-
-            startAnalyzer() {
-                if (this.audioMode !== 'icecast') {
-                    return;
-                }
-                // Resume existing AudioContext if suspended
-                if (this.audioCtx) {
-                    if (this.audioCtx.state === 'suspended') {
-                        this.audioCtx.resume();
-                    }
-                    this.startVizLoop();
-                    return;
-                }
-
-                console.warn('Web Audio API not initialized or not supported; falling back to heartbeat only');
-                this.startFallbackHeartbeat();
-            },
-
-            startVizLoop() {
-                if (this.vizInterval) {
-                    return;
-                }
-                this.vizInterval = setInterval(() => {
-                    if (this.audioMode !== 'icecast' || this.status !== 'playing' || !this.ws || this.ws.readyState !== WebSocket.OPEN) {
-                        return;
-                    }
-                    const audio = this.$refs.audio;
-                    const bands = this.sampleBands();
-                    const rms = this.sampleRms();
-                    const payload = {
-                        event: 'viz',
-                        position_ms: Math.floor(audio.currentTime * 1000),
-                        bands: bands,
-                        rms: rms
-                    };
-                    this.ws.send(JSON.stringify(payload));
-                }, 100);
-            },
-
-            startFallbackHeartbeat() {
-                if (this.heartbeatInterval) {
-                    return;
-                }
-                this.heartbeatInterval = setInterval(() => {
-                    if (this.status === 'playing' && this.ws.readyState === WebSocket.OPEN) {
-                        const payload = {
-                            event: 'heartbeat',
-                            position_ms: Math.floor(this.$refs.audio.currentTime * 1000)
-                        };
-                        this.ws.send(JSON.stringify(payload));
-                    }
-                }, 1000);
-            },
-
-            buildLogBands(sampleRate, fftSize, bandCount) {
-                const nyquist = sampleRate / 2;
-                const minHz = 60.0;
-                const maxHz = Math.min(nyquist, 12000.0);
-                const logMin = Math.log(minHz);
-                const logMax = Math.log(maxHz);
-                const bins = [];
-                for (let i = 0; i < bandCount; i++) {
-                    const t0 = i / bandCount;
-                    const t1 = (i + 1) / bandCount;
-                    const f0 = Math.exp(logMin + (logMax - logMin) * t0);
-                    const f1 = Math.exp(logMin + (logMax - logMin) * t1);
-                    const b0 = Math.max(1, Math.floor((f0 / nyquist) * (fftSize / 2)));
-                    const b1 = Math.max(b0 + 1, Math.ceil((f1 / nyquist) * (fftSize / 2)));
-                    bins.push([b0, b1]);
-                }
-                return bins;
-            },
-
-            softCompress(x) {
-                const k = 2.0;
-                return (k * x) / (1.0 + k * x);
-            },
-
-            sampleBands() {
-                this.analyser.getByteFrequencyData(this.freqData);
-                const bands = [];
-                for (let i = 0; i < this.bandBins.length; i++) {
-                    const [start, end] = this.bandBins[i];
-                    let sum = 0.0;
-                    let count = 0;
-                    const max = Math.min(end, this.freqData.length);
-                    for (let j = start; j < max; j++) {
-                        sum += this.freqData[j];
-                        count += 1;
-                    }
-                    const avg = count > 0 ? sum / count : 0.0;
-                    const norm = avg / 255.0;
-                    bands.push(Math.min(1.0, this.softCompress(norm * 3.0)));
-                }
-                return bands;
-            },
-
-            sampleRms() {
-                this.analyser.getFloatTimeDomainData(this.timeData);
-                let sum = 0.0;
-                for (let i = 0; i < this.timeData.length; i++) {
-                    const v = this.timeData[i];
-                    sum += v * v;
-                }
-                const rms = Math.sqrt(sum / this.timeData.length);
-                return Math.min(1.0, this.softCompress(rms * 3.0));
             },
 
             // Apply a server-pushed user preference. The TUI's v+x keybind
@@ -490,7 +337,11 @@
             },
 
             ensureYoutubePlayer() {
-                if (this.ytPlayer || !window.YT || !window.YT.Player) {
+                if (this.ytPlayer) {
+                    return;
+                }
+                if (!window.YT || !window.YT.Player) {
+                    this.loadYoutubeApi();
                     return;
                 }
                 this.ytPlayer = new window.YT.Player('yt-player', {
@@ -506,13 +357,7 @@
                             this.ytPlayer.setVolume(this.volumePercent);
                             this.applyMuteState(this.muted);
                             if (this.pendingYoutubeItem) {
-                                // While pinned to Icecast, cue (load but don't
-                                // play). Otherwise play normally.
-                                if (this.userOverrideMode === 'icecast') {
-                                    this.ytPlayer.cueVideoById({
-                                        videoId: this.pendingYoutubeItem.videoId,
-                                    });
-                                } else {
+                                if (this.userOverrideMode !== 'icecast') {
                                     this.playYoutubeItem(this.pendingYoutubeItem);
                                 }
                             }
@@ -523,6 +368,17 @@
                 });
             },
 
+            loadYoutubeApi() {
+                if (window.lateYoutubeApiReady || window.lateYoutubeApiLoading) {
+                    return;
+                }
+                window.lateYoutubeApiLoading = true;
+                const script = document.createElement('script');
+                script.src = 'https://www.youtube.com/iframe_api';
+                script.async = true;
+                document.head.appendChild(script);
+            },
+
             loadYoutubeVideo(payload) {
                 const item = {
                     itemId: payload.item_id,
@@ -530,19 +386,8 @@
                     isStream: !!payload.is_stream,
                 };
 
-                // Pre-cue the video into the iframe even while pinned to
-                // Icecast so a later v+x flip is one `playVideo()` away.
                 if (this.userOverrideMode === 'icecast') {
                     this.pendingYoutubeItem = item;
-                    this.ensureYoutubePlayer();
-                    if (
-                        this.ytPlayer
-                        && this.ytReady
-                        && this.ytPlayer.cueVideoById
-                        && this.loadedYoutubeVideoId() !== item.videoId
-                    ) {
-                        this.ytPlayer.cueVideoById({ videoId: item.videoId });
-                    }
                     return;
                 }
                 this.audioMode = 'youtube';
@@ -586,9 +431,6 @@
                 if (switchingItems && this.ytPlayer.stopVideo) {
                     this.ytPlayer.stopVideo();
                 }
-                // If the iframe already has the same video cued (from the
-                // Icecast-pinned pre-cue path), just hit play — that path
-                // is more autoplay-friendly than a fresh loadVideoById.
                 const alreadyLoaded = !switchingItems
                     && this.loadedYoutubeVideoId() === item.videoId;
                 this.pendingYoutubeItem = null;
@@ -785,8 +627,6 @@
         }
     }
 </script>
-
-<script src="https://www.youtube.com/iframe_api"></script>
 
 <div x-data="player()" class="max-w-lg mx-auto pt-8 sm:pt-16">
 

--- a/late-web/src/pages/connect/page.html
+++ b/late-web/src/pages/connect/page.html
@@ -671,7 +671,17 @@
             },
 
             handleYoutubeStateChange(state) {
-                if (!window.YT || !this.currentYoutubeItem) {
+                if (!window.YT) {
+                    return;
+                }
+                if (!this.currentYoutubeItem && this.pendingYoutubeItem) {
+                    const loadedVideoId = this.loadedYoutubeVideoId();
+                    if (!loadedVideoId || loadedVideoId === this.pendingYoutubeItem.videoId) {
+                        this.currentYoutubeItem = this.pendingYoutubeItem;
+                        this.pendingYoutubeItem = null;
+                    }
+                }
+                if (!this.currentYoutubeItem) {
                     return;
                 }
                 if (!this.youtubePlayerMatchesCurrent()) {
@@ -679,12 +689,15 @@
                     return;
                 }
                 if (state === window.YT.PlayerState.PLAYING) {
+                    this.audioEnabled = true;
                     this.autoplayBlocked = false;
+                    this.audioMode = 'youtube';
                     this.status = 'playing';
                     if (this.unmuteOnNextPlay) {
                         this.unmuteOnNextPlay = false;
                         this.applyMuteState(this.muted);
                     }
+                    this.sendClientState();
                     this.sendYoutubeState('playing');
                 } else if (state === window.YT.PlayerState.PAUSED) {
                     this.sendYoutubeState('paused');


### PR DESCRIPTION
## Summary
The Icecast visualizer was driven by a Web Audio analyzer in the browser (`viz` frames over the pair WebSocket every 100ms), while YouTube — being a cross-origin iframe — could not produce frequency data at all. Users got "real" bars on Icecast and a dead sidebar on YouTube. This PR makes the visualizer source-agnostic by rendering procedural bars in the CLI whenever any browser is paired, and rips the entire Web Audio pipeline out of the connect page.

A handful of adjacent fixes that landed on the same branch:
- The persisted `audio_source` preference is now pushed to the browser as the **first** pair-WS message, so a fresh page no longer briefly assumes the default Icecast preference.
- The YouTube iframe API is lazy-loaded — it is no longer fetched on every page load.
- The booth submission rate limit changes from 10/30min to 10/5min.

## What changed
- `late-ssh/src/app/audio/viz.rs` — new procedural path: `procedural_active`/`procedural_phase` state, `tick_procedural`, layered-sine `procedural_bands`, and a sub-cell 9-step block renderer (`▁▂▃▄▅▆▇█`) in dim amber. The old `Visualizer::update` path remains for payload-parsing compatibility but is no longer driven by browser frames.
- `late-ssh/src/app/tick.rs` — every tick, set `procedural_active` to `paired_client_state().client_kind == Browser`. Replaces the previous "if a Viz frame arrived this tick, call `Visualizer::update`" branch.
- `late-ssh/src/api.rs` — on pair-WS connect, send `PairControlMessage::SetPlaybackSource { source }` **before** the audio catch-up burst so the browser never stages a YouTube item under the default Icecast assumption.
- `late-web/src/pages/connect/page.html` — removes ~150 lines: `AudioContext`/`AnalyserNode`/`sourceNode`/`freqData`/`timeData`/`bandBins`, `startAnalyzer`/`startVizLoop`/`startFallbackHeartbeat`/`buildLogBands`/`sampleBands`/`sampleRms`, the always-included `<script src="…/iframe_api">`, and the Icecast-pinned YouTube pre-cue path. Adds `loadYoutubeApi()` for on-demand load, and tightens reconnect/play paths to bail out if `audioMode` flipped while a promise was in flight.
- `late-ssh/src/app/audio/svc.rs` — `SUBMISSION_WINDOW`: 30m → 5m.
- Hide the `startPlayback` button when `status === 'playing'` (previously it could still render under the autoplay-blocked branch while playback was actually live).
- `handleYoutubeStateChange`: on PLAYING, also set `audioEnabled = true`, force `audioMode = 'youtube'`, and `sendClientState()` so the server sees the browser as the audio surface immediately.

## Behavior notes
- The `WsPayload::Viz` server-side handler is intentionally kept. The browser does not send those frames anymore, but removing the parsing path would break older browser sessions mid-deploy and the carrying cost is trivial.
- Procedural bars take priority over real `VizFrame` data if both are present — covered by the `procedural_takes_priority_over_real_viz` test. This matters only in transitional states.
- "OS audio loopback" (CONTEXT §18) is unchanged and still parked. Procedural bars are the honest indicator until that lands.

## Feature flags
None.

## Screenshots / Video
**Needs to be attached before review.** The visualizer is a visible behavior change in both Icecast and YouTube modes — a short recording of the sidebar in each mode would make this trivial to sign off. The bars should be dim amber, 1-cell wide with 1-cell gaps, sub-cell vertical resolution, and visibly non-repeating over several seconds (incommensurate sine phases).

## Testing
**Automated** (`late-ssh/src/app/audio/viz.rs`):
- `tick_procedural_advances_phase_when_active` / `tick_procedural_no_op_when_inactive`
- `procedural_bands_stay_in_range` (every band clamps to `[0, 1]`)
- `procedural_bands_animate_with_phase` (10 ticks produce a visibly different shape)
- `render_inline_uses_procedural_path_when_active` (renders `█`, not the "no audio paired" idle copy)
- `procedural_takes_priority_over_real_viz` (top row stays empty when procedural is active even with `bands = [1.0; 8]`)

**Manual verification needed:**
- [ ] Pair a browser in Icecast mode — sidebar shows animated procedural bars; no `viz` payloads on the WS.
- [ ] `v+x` to YouTube — sidebar keeps animating; YT iframe loads on demand (DevTools: `iframe_api` request fires only now).
- [ ] Refresh the connect page while preference is YouTube — page lands directly in YouTube mode, no flash of Icecast attempt.
- [ ] Unpair the browser — sidebar reverts to the "no audio paired" idle panel within a tick.
- [ ] Submit 11 tracks via the booth in <5 min — 11th is rate-limited; submit again 5+ min later — accepted.
- [ ] Once playing, the `startPlayback` button is no longer visible.