### PR TITLE
Replace `ForceMute` with a per-source playback gate

### DIFF
--- a/late-cli/src/audio/mod.rs
+++ b/late-cli/src/audio/mod.rs
@@ -28,6 +28,12 @@ pub(super) struct AudioRuntime {
     pub(super) stop: Arc<AtomicBool>,
     pub(super) muted: Arc<AtomicBool>,
     pub(super) volume_percent: Arc<AtomicU8>,
+    /// True when the user's audio_source preference is Icecast and the CLI
+    /// should actually emit samples. False when the user picked YouTube — the
+    /// CLI can't decode YouTube, so we silence the output without touching the
+    /// user-controlled `muted` flag. Driven by `SetPlaybackSource` over the
+    /// pair WS.
+    pub(super) source_is_icecast: Arc<AtomicBool>,
     pub(super) enabled: bool,
 }
 
@@ -93,6 +99,10 @@ impl AudioRuntime {
         let stop = Arc::new(AtomicBool::new(false));
         let muted = Arc::new(AtomicBool::new(false));
         let volume_percent = Arc::new(AtomicU8::new(30));
+        // Default to Icecast (play). The server's pair-WS connect always
+        // sends SetPlaybackSource right after register, which flips this if
+        // the user's persisted preference is Youtube.
+        let source_is_icecast = Arc::new(AtomicBool::new(true));
         let (analyzer_tx, _) = broadcast::channel(32);
         let (ready_tx, ready_rx) = mpsc::sync_channel(1);
 
@@ -103,6 +113,7 @@ impl AudioRuntime {
             Arc::clone(&played_samples),
             Arc::clone(&muted),
             Arc::clone(&volume_percent),
+            Arc::clone(&source_is_icecast),
             profile,
         )?;
         let output_sample_rate = stream.sample_rate;
@@ -137,6 +148,7 @@ impl AudioRuntime {
             stop,
             muted,
             volume_percent,
+            source_is_icecast,
             enabled: true,
         })
     }
@@ -151,6 +163,7 @@ impl AudioRuntime {
             stop: Arc::new(AtomicBool::new(false)),
             muted: Arc::new(AtomicBool::new(false)),
             volume_percent: Arc::new(AtomicU8::new(0)),
+            source_is_icecast: Arc::new(AtomicBool::new(true)),
             enabled: false,
         }
     }

--- a/late-cli/src/audio/output.rs
+++ b/late-cli/src/audio/output.rs
@@ -36,6 +36,7 @@ pub(super) struct BuiltOutputStream {
     pub(super) sample_rate: u32,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(super) fn build_output_stream(
     spec: AudioSpec,
     queue: PlaybackQueueReader,

--- a/late-cli/src/audio/output.rs
+++ b/late-cli/src/audio/output.rs
@@ -24,6 +24,10 @@ struct PlaybackOutputState {
     source_channels: usize,
     muted: Arc<AtomicBool>,
     volume_percent: Arc<AtomicU8>,
+    /// When false, the user has selected a non-Icecast source (today: only
+    /// YouTube). The CLI can't decode it, so we emit silence regardless of
+    /// `muted`. Driven by `SetPlaybackSource` over the pair WS.
+    source_is_icecast: Arc<AtomicBool>,
     source_frame: Vec<f32>,
 }
 
@@ -39,6 +43,7 @@ pub(super) fn build_output_stream(
     played_samples: Arc<AtomicU64>,
     muted: Arc<AtomicBool>,
     volume_percent: Arc<AtomicU8>,
+    source_is_icecast: Arc<AtomicBool>,
     profile: AudioBackendProfile,
 ) -> Result<BuiltOutputStream> {
     let host = cpal::default_host();
@@ -68,6 +73,7 @@ pub(super) fn build_output_stream(
         source_channels: spec.channels,
         muted,
         volume_percent,
+        source_is_icecast,
         source_frame: vec![0.0; spec.channels],
     };
 
@@ -163,7 +169,11 @@ fn write_output_data<T>(output: &mut [T], channels: usize, state: &mut PlaybackO
 where
     T: cpal::SizedSample + cpal::FromSample<f32>,
 {
-    let muted = state.muted.load(Ordering::Relaxed);
+    // `muted` is the user's intent (`m` keybind). `source_is_icecast` is the
+    // structural gate: a Youtube preference means the CLI has nothing real to
+    // play, so we emit silence even if the user toggled unmuted.
+    let muted =
+        state.muted.load(Ordering::Relaxed) || !state.source_is_icecast.load(Ordering::Relaxed);
     let linear = state.volume_percent.load(Ordering::Relaxed) as f32 / 100.0;
     let volume = linear * linear;
     let source_channels = state.source_channels;

--- a/late-cli/src/main.rs
+++ b/late-cli/src/main.rs
@@ -147,6 +147,7 @@ fn spawn_ws_pairing(
     let played_samples = Arc::clone(&audio.played_samples);
     let muted = Arc::clone(&audio.muted);
     let volume_percent = Arc::clone(&audio.volume_percent);
+    let source_is_icecast = Arc::clone(&audio.source_is_icecast);
     // Copy scalar state before spawning so the task does not capture the
     // borrowed AudioRuntime reference.
     let sample_rate = audio.sample_rate;
@@ -158,6 +159,7 @@ fn spawn_ws_pairing(
             sample_rate,
             muted: &muted,
             volume_percent: &volume_percent,
+            source_is_icecast: &source_is_icecast,
         };
         let mut retries = 0;
         const MAX_RETRIES: usize = 10;

--- a/late-cli/src/ws.rs
+++ b/late-cli/src/ws.rs
@@ -23,6 +23,7 @@ pub(super) struct PlaybackState<'a> {
     pub(super) sample_rate: u32,
     pub(super) muted: &'a AtomicBool,
     pub(super) volume_percent: &'a AtomicU8,
+    pub(super) source_is_icecast: &'a AtomicBool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -32,7 +33,14 @@ enum PairControlMessage {
     VolumeUp,
     VolumeDown,
     RequestClipboardImage,
-    ForceMute { mute: bool },
+    SetPlaybackSource { source: PairAudioSource },
+}
+
+#[derive(Debug, Deserialize, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+enum PairAudioSource {
+    Icecast,
+    Youtube,
 }
 
 #[cfg(any(target_os = "linux", target_os = "macos", target_os = "windows"))]
@@ -94,6 +102,7 @@ pub(super) async fn run_viz_ws(
                             &mut ws,
                             playback.muted,
                             playback.volume_percent,
+                            playback.source_is_icecast,
                         )
                         .await?;
                         if should_send_state {
@@ -137,6 +146,7 @@ async fn handle_pair_control(
     >,
     muted: &AtomicBool,
     volume_percent: &AtomicU8,
+    source_is_icecast: &AtomicBool,
 ) -> Result<bool> {
     let control = match serde_json::from_str::<PairControlMessage>(text) {
         Ok(control) => control,
@@ -152,21 +162,21 @@ async fn handle_pair_control(
             apply_audio_pair_control(audio_control, muted, volume_percent);
             Ok(true)
         }
-        PairControlMessage::ForceMute { mute } => {
-            apply_force_mute(muted, mute);
-            Ok(true)
+        PairControlMessage::SetPlaybackSource { source } => {
+            let is_icecast = matches!(source, PairAudioSource::Icecast);
+            let previous = source_is_icecast.swap(is_icecast, Ordering::Relaxed);
+            if previous != is_icecast {
+                info!(
+                    source = ?source,
+                    "applied playback source change"
+                );
+            }
+            Ok(false)
         }
         PairControlMessage::RequestClipboardImage => {
             send_clipboard_image(ws).await?;
             Ok(false)
         }
-    }
-}
-
-fn apply_force_mute(muted: &AtomicBool, mute: bool) {
-    let previous = muted.swap(mute, Ordering::Relaxed);
-    if previous != mute {
-        info!(muted = mute, "applied server-forced mute");
     }
 }
 
@@ -188,7 +198,8 @@ fn apply_audio_pair_control(
             let new_volume = bump_volume(volume_percent, -5);
             info!(volume_percent = new_volume, "applied paired volume down");
         }
-        PairControlMessage::ForceMute { .. } | PairControlMessage::RequestClipboardImage => {}
+        PairControlMessage::SetPlaybackSource { .. }
+        | PairControlMessage::RequestClipboardImage => {}
     }
 }
 

--- a/late-ssh/src/api.rs
+++ b/late-ssh/src/api.rs
@@ -259,6 +259,7 @@ async fn handle_socket(mut socket: WebSocket, token: String, state: State) {
         &mut socket,
         &crate::paired_clients::PairControlMessage::SetPlaybackSource {
             source: audio_source,
+            web_icecast_enabled: state.paired_client_registry.web_icecast_enabled(&token),
         },
         &token_hint,
         "initial playback source",
@@ -347,14 +348,22 @@ async fn handle_socket(mut socket: WebSocket, token: String, state: State) {
                                         volume_percent,
                                     },
                                 );
-                                if let Some(update) = result
-                                    && update.new_kind == ClientKind::Browser
-                                    && update.previous_kind != ClientKind::Browser
-                                {
-                                    state
-                                        .session_registry
-                                        .send_message(&token, SessionMessage::BrowserPaired)
-                                        .await;
+                                if let Some(update) = result {
+                                    if (update.previous_kind == ClientKind::Cli)
+                                        != (update.new_kind == ClientKind::Cli)
+                                    {
+                                        state
+                                            .paired_client_registry
+                                            .broadcast_playback_source_for_token(&token);
+                                    }
+                                    if update.new_kind == ClientKind::Browser
+                                        && update.previous_kind != ClientKind::Browser
+                                    {
+                                        state
+                                            .session_registry
+                                            .send_message(&token, SessionMessage::BrowserPaired)
+                                            .await;
+                                    }
                                 }
                                 continue;
                             }
@@ -422,13 +431,16 @@ async fn handle_socket(mut socket: WebSocket, token: String, state: State) {
     tracing::info!(token_hint = %token_hint, "websocket connection closed");
 }
 
-/// Drop a paired-client registration. The registry atomically relaxes any
-/// server-imposed CLI mute when this removal leaves the token with zero
-/// browsers, so callers don't need to manage that follow-up themselves.
+/// Drop a paired-client registration and refresh the remaining clients'
+/// playback-source view, because CLI presence controls whether the browser may
+/// play Icecast.
 fn release_pair_registration(state: &State, token: &str, registration_id: u64) {
     state
         .paired_client_registry
         .unregister_if_match(token, registration_id);
+    state
+        .paired_client_registry
+        .broadcast_playback_source_for_token(token);
     state.audio_service.reevaluate_skip_threshold_task();
 }
 

--- a/late-ssh/src/app/audio/CONTEXT.md
+++ b/late-ssh/src/app/audio/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: late.sh audio — Icecast house radio, global YouTube queue, browser/CLI source arbitration, synthetic browser-pair visualizer, now-playing poller
 - Primary audience: LLM agents working in `late-ssh/src/app/audio` and the touchpoints it owns in `late-cli` and `late-web/src/pages/connect`
-- Last updated: 2026-05-18 (browser-pair visualizer is now synthetic-only for both Icecast and YouTube; the web page no longer creates a Web Audio analyzer or sends `viz` frames. §18 remains the parked plan for future real OS-loopback FFT.)
+- Last updated: 2026-05-19 (source arbitration simplified: no `ForceMute`; CLI gates Icecast on `set_playback_source`, and browsers only play web Icecast when no CLI is paired. Browser-pair visualizer remains synthetic-only for both Icecast and YouTube.)
 - Previously: booth modal now surfaces track durations: queue list has a right-aligned `m:ss` column between title and submitter, and the Now Playing row shows the same `m:ss` next to the title. Streams render `live`; unknown durations are blank. Two submit paths diverge in metadata: booth (`booth_submit_public_task` → `submit_url` → Data API) inserts rows with title/channel/`duration_ms`/`is_stream` already populated; staff `/audio` (`submit_trusted_url_task`) inserts NULL metadata and the browser backfills `duration_ms` on first play via `record_browser_duration`. See §4 Public API + §2 booth/ui.rs note.
 - Status: Active
 - Parent context: `../../../../CONTEXT.md`
@@ -16,7 +16,7 @@ Owned by this domain:
 - Always-on Icecast house radio playback (the `<audio>` and CLI symphonia path).
 - Global, DB-backed YouTube queue: submission, persistence, single-playing invariant, server-driven track switching (per-browser playback timeline), fallback debounce.
 - The singleton "YouTube fallback" stream that plays when the queue is empty.
-- Audio source arbitration between paired CLI and paired browser clients on the same SSH token (`force_mute`).
+- Audio source arbitration between paired CLI and paired browser clients on the same SSH token (`set_playback_source` + browser Icecast gate).
 - Synthetic browser-pair visualizer used for both Icecast and YouTube.
 - Now-playing poller for the Icecast track title.
 - The `/audio` and `/audio fallback` SSH chat commands (staff-only).
@@ -57,10 +57,10 @@ Cross-crate touchpoints:
   `048_create_media_sources.sql`,
   `049_create_media_queue_votes.sql`.
 - `late-core/src/audio.rs` — `VizFrame { bands[8], rms, track_pos_ms }` shared between server and CLI.
-- `late-ssh/src/paired_clients.rs` — `PairedClientRegistry`, `PairControlMessage::ForceMute`, mute-priority policy.
+- `late-ssh/src/paired_clients.rs` — `PairedClientRegistry`, `PairControlMessage::SetPlaybackSource`, source/surface policy.
 - `late-ssh/src/api.rs` — `/api/ws/pair` multiplexes `AudioWsMessage` + `PairControlMessage`; `/api/now-playing`.
 - `late-ssh/src/app/chat/{state,input}.rs` — `/audio` and `/audio fallback` chat commands.
-- `late-cli/src/ws.rs`, `late-cli/src/main.rs`, `late-cli/src/audio/output.rs` — CLI tolerates unknown audio events, applies `force_mute` to the shared mute atomic.
+- `late-cli/src/ws.rs`, `late-cli/src/main.rs`, `late-cli/src/audio/output.rs` — CLI tolerates unknown audio events and gates Icecast output on `set_playback_source` without changing the user mute flag.
 - `late-web/src/pages/connect/page.html` + `connect/mod.rs` — browser IFrame player, force-switch on heartbeat, per-user v+x source toggle.
 
 ---
@@ -155,7 +155,7 @@ Routed by report `state` field:
 
 `api.rs` `handle_socket` (`api.rs:231-382`) drives three sources per connection with `tokio::select!`:
 - inbound `socket.recv()` — client → server
-- `control_rx` — `PairControlMessage` from `PairedClientRegistry` (mute/volume/force_mute/clipboard)
+- `control_rx` — `PairControlMessage` from `PairedClientRegistry` (mute/volume/source/clipboard)
 - `audio_rx` — `AudioWsMessage` from `AudioService::subscribe_ws()`
 
 On connect, `api.rs` sends the user's persisted `set_playback_source` first, then
@@ -169,9 +169,8 @@ YouTube item without entering the switching/playback path.
 - `queue_update { current, queue, sequence }`
 
 ### Server → client `PairControlMessage` (`paired_clients.rs:22-30`)
-- `toggle_mute`, `volume_up`, `volume_down`, `request_clipboard_image`, `force_mute { mute }`.
-- `set_playback_source { source: "icecast" | "youtube" }` — sent immediately on
-  pair-WS connect and re-sent by the SSH session on browser-pair notification.
+- `toggle_mute`, `volume_up`, `volume_down`, `request_clipboard_image`.
+- `set_playback_source { source: "icecast" | "youtube", web_icecast_enabled: bool }` — sent immediately on pair-WS connect, after persisted `v+x` source changes, and when CLI presence changes. CLI ignores `web_icecast_enabled`; browsers use it to avoid double Icecast when a CLI is paired.
 
 ### Client → server `WsPayload` (`api.rs:39-68`)
 - `heartbeat`
@@ -184,27 +183,25 @@ There is **one global broadcast**, no room scoping. Every paired browser on ever
 
 ---
 
-## 6. Source Arbitration and `force_mute`
+## 6. Source Arbitration (single audible surface)
 
-Policy lives entirely in `late-ssh/src/paired_clients.rs`. The audio domain does not own the registry; it only consumes the resulting per-token mute state via the browser's `client_state` reports.
+Policy lives in `late-ssh/src/paired_clients.rs` plus the browser/CLI followers. There is no `ForceMute` control message anymore; the server broadcasts `set_playback_source { source, web_icecast_enabled }` and clients gate themselves.
 
-Rule: **if any browser is paired on a token, every CLI on that token is force-muted.** The browser is the audio surface when present; the CLI is the audio surface only when alone.
+Rule: **Icecast belongs to the CLI when a CLI is paired; YouTube belongs to the browser.** When a CLI and browser are both paired and the user flips from YouTube back to Icecast, the browser pauses/silences YouTube and does **not** start its own Icecast `<audio>` element, preventing doubled radio streams.
 
-| CLI paired | Browser paired | Browser hears        | CLI behavior                          |
-|------------|----------------|----------------------|---------------------------------------|
-| yes        | no             | n/a                  | plays Icecast normally                |
-| yes        | yes            | Icecast or YouTube   | force-muted via `ForceMute { true }`  |
-| no         | yes            | Icecast or YouTube   | n/a                                   |
-| no         | no             | silent               | n/a                                   |
+| CLI paired | Browser paired | Source  | Audible surface                                      |
+|------------|----------------|---------|------------------------------------------------------|
+| yes        | no             | Icecast | CLI                                                  |
+| yes        | no             | YouTube | silent (CLI cannot decode YouTube)                   |
+| yes        | yes            | Icecast | CLI; browser web-Icecast disabled                    |
+| yes        | yes            | YouTube | browser iframe; CLI source gate emits silence        |
+| no         | yes            | Icecast | browser `<audio>` (`web_icecast_enabled = true`)     |
+| no         | yes            | YouTube | browser iframe                                       |
 
-Triggers (`paired_clients.rs:217-297`, `:88-150`):
-- Browser appears on a token, or CLI joins a token already holding a browser → broadcast `ForceMute { mute: true }` to every CLI sender on that token.
-- Last browser on a token disconnects → broadcast `ForceMute { mute: false }`.
-- The CLI's `!new_muted` guard preserves a user-initiated *unmute* across WS reconnect — the server does not re-impose mute on a still-paired browser if the user has manually opted into double audio.
-
-Both decisions run under the same `PairedClientRegistry` lock to close the TOCTOU window where a new browser could register between removal and sender collection.
-
-CLI side: `late-cli/src/ws.rs:155-171` swaps the shared mute atomic — `Arc::clone(&audio.muted)` (`late-cli/src/main.rs:148`) — the same atomic used by the local mute keybind (`late-cli/src/audio/output.rs:166-193`). After applying it, the CLI re-sends `client_state` so the server sees the new `muted` value.
+Mechanics:
+- `PairControlMessage::SetPlaybackSource { source, web_icecast_enabled }` is sent on pair-WS connect, on persisted `v+x` source changes, and when CLI presence changes for a token.
+- CLI stores `source_is_icecast`; output emits silence when `source != Icecast` without touching the user `muted` flag.
+- Browser stores `webIcecastEnabled`; `source=Icecast && webIcecastEnabled=false` pauses YouTube and stops the web Icecast element. If the CLI disconnects, the server replays the same source with `web_icecast_enabled=true` so a browser-only token can resume web Icecast.
 
 ### Skip-vote eligibility — only YouTube listeners
 
@@ -263,12 +260,12 @@ The unrelated bare `/music` command (`state.rs:1325`) opens a help topic, not a 
 
 ## 8. CLI Integration
 
-Goal: the CLI tolerates everything new the audio domain added, plays Icecast unchanged, and obeys server force-mute.
+Goal: the CLI tolerates everything new the audio domain added, plays Icecast when selected, and stays silent when the user selects YouTube.
 
 - **Unknown audio events ignored** (`late-cli/src/ws.rs`). Inbound text is parsed only as `PairControlMessage`. `load_video`, `source_changed`, `queue_update` fail to deserialize, the CLI logs `warn!("ignoring unsupported pair websocket event")`, and the select loop continues. **The CLI does not disconnect on audio events.** Note: each playing track now also produces a 10s `load_video` heartbeat — the CLI log noise budget should account for that.
-- **`force_mute` applied to shared atomic** (`late-cli/src/ws.rs:155-171` → `apply_force_mute` → `muted.swap(mute, Relaxed)`). Same atomic as the local mute keybind, so the server's force-mute and the user's manual mute coexist on one piece of state. After applying, CLI re-sends `client_state` so the server observes the new value.
+- **Source gate, not forced mute.** `set_playback_source` updates `source_is_icecast`; `late-cli/src/audio/output.rs` emits silence when it is false. The user-controlled `muted` atomic remains only the local mute keybind / paired mute control.
 - **No YouTube decoding in the CLI.** The CLI never receives audio frames for YouTube — only metadata it ignores. Icecast path: `late-cli/src/audio/decoder_thread.rs` runs a symphonia HTTP stream decoder with 2s reconnect retry.
-- **CLI identifies itself.** First `client_state` emitted by `late-cli/src/ws.rs:113-131` carries `"client_kind": "cli"`. That tag is what lets the registry decide who to force-mute.
+- **CLI identifies itself.** First `client_state` emitted by `late-cli/src/ws.rs:113-131` carries `"client_kind": "cli"`. That tag lets the registry disable browser Icecast for the token.
 
 ---
 
@@ -276,9 +273,9 @@ Goal: the CLI tolerates everything new the audio domain added, plays Icecast unc
 
 File: `late-web/src/pages/connect/page.html`. The audio source is decided in the browser; the YouTube API/player is lazy-loaded only when the browser actually enters YouTube mode.
 
-- **Per-user audio source (server-authoritative).** The choice is persisted in `users.settings.audio_source` (`icecast` | `youtube`, default `icecast`). TUI `v+x` flips the value via `App::toggle_paired_playback_source`: writes to DB through `AudioService::persist_audio_source`, updates the local mirror `App::paired_browser_source`, and broadcasts `PairControlMessage::SetPlaybackSource { source }` to every paired browser. On pair-WS connect, `api.rs` sends the persisted source before the audio catch-up burst. On every browser pair-up (`api.rs` detects `previous_kind != Browser && new_kind == Browser`), the SSH session is also notified via `SessionMessage::BrowserPaired` and `App::replay_paired_browser_source` re-pushes the current value. The browser is a follower: `applyUserPlaybackSource(source)` stores `userOverrideMode` and applies. While the user is pinned to icecast, `loadYoutubeVideo` and `seekYoutube` early-return so server queue events do not flip the iframe back on (the current item is still stashed as `pendingYoutubeItem` so a toggle to youtube starts playing immediately).
+- **Per-user audio source (server-authoritative).** The choice is persisted in `users.settings.audio_source` (`icecast` | `youtube`, default `icecast`). TUI `v+x` flips the value via `App::toggle_paired_playback_source`: writes to DB through `AudioService::persist_audio_source`, updates the local mirror `App::paired_browser_source`, and broadcasts `PairControlMessage::SetPlaybackSource { source, web_icecast_enabled }` to paired clients. On pair-WS connect, `api.rs` sends the persisted source before the audio catch-up burst. On browser pair-up the SSH session also replays the value; on CLI presence changes `api.rs` replays it for the token so browsers know whether web Icecast is allowed. The browser is a follower: `applyUserPlaybackSource(source, web_icecast_enabled)` stores `userOverrideMode` and applies. While the user is pinned to icecast, `loadYoutubeVideo` early-returns so server queue events do not flip the iframe back on (the current item is still stashed as `pendingYoutubeItem` so a toggle to youtube starts playing immediately).
 - **IFrame API load.** The page does not include the YouTube iframe API up front. `ensureYoutubePlayer()` calls `loadYoutubeApi()` on demand, which appends `https://www.youtube.com/iframe_api`; `window.lateYoutubeApiReady` / `onYouTubeIframeAPIReady` then create the player only if `audioMode === "youtube"`.
-- **`source_changed` swap** (`applySourceMode`). Into `youtube`: pause `<audio>`, ensure player exists, kick playback of pending item. Into `icecast`: `ytPlayer.pauseVideo()`, restart `startPlayback()` for the `<audio>` if audio is enabled. The `modeChanged` guard prevents repeated `source_changed: youtube` broadcasts during queue transitions from resetting the iframe.
+- **`source_changed` / `set_playback_source` swap** (`applySourceMode`). Into `youtube`: stop `<audio>`, ensure player exists, kick playback of pending item. Into `icecast`: `ytPlayer.pauseVideo()`; restart the web `<audio>` only when `webIcecastEnabled` is true. With a CLI paired, `webIcecastEnabled=false`, so the browser goes quiet and the CLI is the only Icecast surface. The `modeChanged` guard prevents repeated `source_changed: youtube` broadcasts during queue transitions from resetting the iframe.
 - **Icecast-pinned resource behavior.** While pinned to Icecast, `load_video` only stashes `pendingYoutubeItem`; it does not create the YouTube iframe or pre-cue the video. A later source flip to YouTube starts from the pending item, and the server's 10s `load_video` heartbeat remains the safety net.
 - **`load_video` → force-switch or no-op** (`loadYoutubeVideo`). New shape: payload is `{ item_id, video_id, is_stream }` — no offset, no started_at. Same `item_id` AND iframe is already showing the right `video_id` → no-op (this is the safety-net heartbeat path; a manual pause stays paused). Otherwise → `loadVideoById({ videoId })` from 0, swap `currentYoutubeItem`. `verifyYoutubeLoad` re-checks after 1s and reloads if the video id still mismatches.
 - **No drift correction.** Each browser plays its own timeline. Slow networks just lag behind — no `seekTo` jumps. The "everyone hears the same offset" invariant is dropped on purpose.
@@ -400,7 +397,7 @@ Model helpers (`late-core/src/models/media_queue_item.rs`, `media_source.rs`):
 ## 14. Known Gaps and Things to Watch
 
 - **`GET /api/queue` is intentionally not exposed.** `AudioService::snapshot()` and `QueueSnapshot` exist for in-process use only. The TUI booth modal reads the snapshot from `AudioState::queue_snapshot()` (a `watch::Receiver<QueueSnapshot>` populated by `publish_queue_update_with_guard`); browsers receive state via the `initial_ws_messages` catch-up burst and live `queue_update` events. An external route would only matter for non-paired observers, which we do not have today.
-- **Booth modal renders from `watch::Receiver<QueueSnapshot>`.** `AudioService` keeps a `snapshot_tx` watch sender alongside the broadcast channels; every `publish_queue_update_with_guard` pushes a snapshot into it, and `AudioState::queue_snapshot()` borrows the current value. Skip progress (`votes/threshold`) is folded into the snapshot before it ships.
+- **Booth modal renders from `watch::Receiver<QueueSnapshot>`.** `AudioService` keeps a `snapshot_tx` watch sender alongside the broadcast channels; every `publish_queue_update_with_guard` uses `send_replace` to store the latest snapshot even when zero receivers are alive (startup often publishes before any SSH booth exists), and `AudioState::queue_snapshot()` borrows the current value. Skip progress (`votes/threshold`) is folded into the snapshot before it ships.
 - **`liquidsoap.rs` lives here but is only used by `app/vote/svc.rs`.** AudioService does *not* drive Liquidsoap. Treat `AudioMode::Icecast` as a hint to the browser/CLI, not a Liquidsoap state change.
 - **`/music` ≠ `/audio`.** `/music` is a help-topic command. `/audio` (and `/audio fallback`) are the submit commands. Don't conflate.
 - **No `GET /api/queue` HTTP route.** Submit and visibility for end users happen through the SSH booth modal (submit + queue list) and the staff `/audio` chat command. Non-paired observers have no way to see the queue today.

--- a/late-ssh/src/app/audio/svc.rs
+++ b/late-ssh/src/app/audio/svc.rs
@@ -1122,7 +1122,12 @@ impl AudioService {
         state.sequence = state.sequence.saturating_add(1);
         let mut snapshot = self.load_snapshot(state.mode).await?;
         snapshot.skip_progress = self.compute_skip_progress(state, snapshot.current.as_ref());
-        let _ = self.snapshot_tx.send(snapshot.clone());
+        // `send` fails without active receivers and would leave the watch at
+        // its constructor's empty value. Startup often publishes before any
+        // SSH session has opened the booth, so replace the retained value even
+        // when receiver_count == 0; later subscribers then see the real DB
+        // queue immediately after a restart.
+        self.snapshot_tx.send_replace(snapshot.clone());
         let _ = self.ws_tx.send(AudioWsMessage::QueueUpdate {
             current: snapshot.current,
             queue: snapshot.queue,

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -920,24 +920,26 @@ impl App {
         );
     }
 
-    pub fn toggle_paired_playback_source(
-        &mut self,
-    ) -> Option<late_core::models::user::AudioSource> {
+    /// Flip the per-user audio source preference. Persisted server-side and
+    /// pushed to any paired browser; the CLI mute follows from the source via
+    /// `set_audio_source`. Works whether a browser is paired or not — the
+    /// preference is meaningful even with only a CLI, because Youtube means
+    /// "mute the CLI" and Icecast means "let the CLI play."
+    pub fn toggle_paired_playback_source(&mut self) -> late_core::models::user::AudioSource {
         use late_core::models::user::AudioSource;
-        let registry = self.paired_client_registry.as_ref()?;
         let next = match self.paired_browser_source {
             AudioSource::Icecast => AudioSource::Youtube,
             AudioSource::Youtube => AudioSource::Icecast,
         };
-        if !registry.send_control_to_browsers(
-            &self.session_token,
-            PairControlMessage::SetPlaybackSource { source: next },
-        ) {
-            return None;
+        if let Some(registry) = self.paired_client_registry.as_ref() {
+            registry.send_control_to_browsers(
+                &self.session_token,
+                PairControlMessage::SetPlaybackSource { source: next },
+            );
         }
         self.paired_browser_source = next;
         self.audio.persist_audio_source(next);
-        Some(next)
+        next
     }
 
     pub fn request_paired_clipboard_image_upload(&mut self, room_id: Option<Uuid>) -> bool {

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -920,23 +920,17 @@ impl App {
         );
     }
 
-    /// Flip the per-user audio source preference. Persisted server-side and
-    /// pushed to any paired browser; the CLI mute follows from the source via
-    /// `set_audio_source`. Works whether a browser is paired or not — the
-    /// preference is meaningful even with only a CLI, because Youtube means
-    /// "mute the CLI" and Icecast means "let the CLI play."
+    /// Flip the per-user audio source preference. Persisted server-side; the
+    /// `persist_audio_source` task then pushes `SetPlaybackSource` to every
+    /// paired entry (CLI and browser) for this user. Works whether a browser
+    /// is paired or not — the preference is meaningful even with only a CLI,
+    /// because the CLI gates its Icecast decoder on the received source.
     pub fn toggle_paired_playback_source(&mut self) -> late_core::models::user::AudioSource {
         use late_core::models::user::AudioSource;
         let next = match self.paired_browser_source {
             AudioSource::Icecast => AudioSource::Youtube,
             AudioSource::Youtube => AudioSource::Icecast,
         };
-        if let Some(registry) = self.paired_client_registry.as_ref() {
-            registry.send_control_to_browsers(
-                &self.session_token,
-                PairControlMessage::SetPlaybackSource { source: next },
-            );
-        }
         self.paired_browser_source = next;
         self.audio.persist_audio_source(next);
         next

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -907,7 +907,9 @@ impl App {
     }
 
     /// Push the currently-stored audio source to all paired browsers. Called
-    /// when a browser registers so a fresh page reflects the persisted choice.
+    /// when a browser registers so a fresh page reflects the persisted choice
+    /// plus whether the browser is allowed to play Icecast (only when no CLI
+    /// is paired).
     pub fn replay_paired_browser_source(&self) {
         let Some(registry) = self.paired_client_registry.as_ref() else {
             return;
@@ -916,6 +918,7 @@ impl App {
             &self.session_token,
             PairControlMessage::SetPlaybackSource {
                 source: self.paired_browser_source,
+                web_icecast_enabled: registry.web_icecast_enabled(&self.session_token),
             },
         );
     }

--- a/late-ssh/src/app/vote/input.rs
+++ b/late-ssh/src/app/vote/input.rs
@@ -37,17 +37,11 @@ pub fn handle_vote_suffix(app: &mut App, byte: u8) -> bool {
         }
         b'x' | b'X' => {
             use late_core::models::user::AudioSource;
-            match app.toggle_paired_playback_source() {
-                Some(AudioSource::Youtube) => {
-                    app.banner = Some(Banner::success("Paired browser audio: YouTube"));
-                }
-                Some(AudioSource::Icecast) => {
-                    app.banner = Some(Banner::success("Paired browser audio: Icecast"));
-                }
-                None => {
-                    app.banner = Some(Banner::error("No paired browser"));
-                }
-            }
+            let banner = match app.toggle_paired_playback_source() {
+                AudioSource::Youtube => "Audio source: YouTube",
+                AudioSource::Icecast => "Audio source: Icecast",
+            };
+            app.banner = Some(Banner::success(banner));
             true
         }
         // b'z' | b'Z' => {

--- a/late-ssh/src/paired_clients.rs
+++ b/late-ssh/src/paired_clients.rs
@@ -16,10 +16,12 @@ use crate::metrics;
 
 // Multiplexed outbound channel to every paired client (browser + CLI) for a
 // given SSH session token. Carries audio control (mute/volume/force-mute) and
-// clipboard fan-out. The registry owns the "browser is the audio-output
-// priority" policy: when a browser appears on a token, every CLI on that
-// token is force-muted; when the last browser leaves, the CLI mute is
-// relaxed.
+// clipboard fan-out. Mute policy is source-driven, not pair-driven: a CLI
+// entry is force-muted iff its user's audio_source is Youtube. The CLI can
+// only play Icecast, so a Youtube preference means the CLI must be silent.
+// Browser presence does not enter the decision — `update_state_and_enforce_
+// mute_policy` applies it when the CLI first reports state, and `set_audio_
+// source` re-applies it on v+x flips.
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(tag = "event", rename_all = "snake_case")]
@@ -56,16 +58,9 @@ struct PairControlEntry {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct UnregisterResult {
-    pub removed_kind: ClientKind,
-    pub browsers_remaining: usize,
-}
-
-#[derive(Debug, Clone, Copy)]
 pub struct UpdateStateResult {
     pub previous_kind: ClientKind,
     pub new_kind: ClientKind,
-    pub browsers_total: usize,
 }
 
 impl PairedClientRegistry {
@@ -100,73 +95,33 @@ impl PairedClientRegistry {
         registration_id
     }
 
-    /// Remove the matching entry and, if doing so leaves the token with zero
-    /// browsers after removing a browser, atomically relaxes the server-imposed
-    /// CLI mute on the same token. Holding a single lock across removal and
-    /// CLI-sender collection closes the race where a new browser could register
-    /// between the two steps and have its ForceMute clobbered by a stale unmute.
-    pub fn unregister_if_match(
-        &self,
-        token: &str,
-        registration_id: u64,
-    ) -> Option<UnregisterResult> {
-        let (result, cli_senders_to_unmute) = {
-            let mut clients = self.clients.lock_recover();
-            let entries = clients.get_mut(token)?;
-            let position = entries
-                .iter()
-                .position(|entry| entry.registration_id == registration_id)?;
-            let removed = entries.remove(position);
-            if let Some((ssh_mode, platform)) = removed.state.cli_usage_labels() {
-                metrics::add_cli_pair_active(-1, ssh_mode, platform);
-            }
-            let removed_kind = removed.state.client_kind;
-            let browsers_remaining = entries
-                .iter()
-                .filter(|entry| entry.state.client_kind == ClientKind::Browser)
-                .count();
-            let cli_senders = if removed_kind == ClientKind::Browser && browsers_remaining == 0 {
-                entries
-                    .iter()
-                    .filter(|entry| entry.state.client_kind == ClientKind::Cli)
-                    .map(|entry| entry.tx.clone())
-                    .collect::<Vec<_>>()
-            } else {
-                Vec::new()
-            };
-            tracing::info!(
-                token_hint = %token_hint(token),
-                registration_id,
-                ?removed_kind,
-                browsers_remaining,
-                relax_cli_mute = !cli_senders.is_empty(),
-                "unregistered paired client session"
-            );
-            if entries.is_empty() {
-                clients.remove(token);
-            }
-            (
-                UnregisterResult {
-                    removed_kind,
-                    browsers_remaining,
-                },
-                cli_senders,
-            )
+    /// Remove the matching entry. Mute policy is source-driven, so disconnect
+    /// doesn't change another entry's mute state — that only moves on
+    /// `set_audio_source`.
+    pub fn unregister_if_match(&self, token: &str, registration_id: u64) {
+        let mut clients = self.clients.lock_recover();
+        let Some(entries) = clients.get_mut(token) else {
+            return;
         };
-
-        for tx in cli_senders_to_unmute {
-            if tx
-                .send(PairControlMessage::ForceMute { mute: false })
-                .is_err()
-            {
-                tracing::warn!(
-                    token_hint = %token_hint(token),
-                    "failed to relax CLI mute after browser disconnect"
-                );
-            }
+        let Some(position) = entries
+            .iter()
+            .position(|entry| entry.registration_id == registration_id)
+        else {
+            return;
+        };
+        let removed = entries.remove(position);
+        if let Some((ssh_mode, platform)) = removed.state.cli_usage_labels() {
+            metrics::add_cli_pair_active(-1, ssh_mode, platform);
         }
-
-        Some(result)
+        tracing::info!(
+            token_hint = %token_hint(token),
+            registration_id,
+            removed_kind = ?removed.state.client_kind,
+            "unregistered paired client session"
+        );
+        if entries.is_empty() {
+            clients.remove(token);
+        }
     }
 
     /// Broadcast a control message to every paired client of `token`. Returns
@@ -221,27 +176,24 @@ impl PairedClientRegistry {
     }
 
     /// Apply a state update for a single entry and atomically enforce the
-    /// browser-priority mute policy under the same lock. Returns the update
-    /// outcome for callers that need it; the policy side-effects (ForceMute to
-    /// every CLI on the token) are dispatched after the lock is released.
+    /// source-driven mute policy. Returns the update outcome for callers that
+    /// need it; the force-mute side-effect is dispatched after the lock is
+    /// released.
     ///
-    /// Policy:
-    /// - A browser just appeared on this token (transition into Browser kind) —
-    ///   every CLI on the token gets ForceMute { mute: true }.
-    /// - A CLI just identified itself with a browser already paired AND the CLI
-    ///   does not already report `muted == true` — same. The `muted` guard
-    ///   stops a WS reconnect from overriding a state the CLI is already in
-    ///   (e.g. user-initiated local mute).
-    ///
-    /// Holding the lock across the decision closes the same TOCTOU window that
-    /// `unregister_if_match` closes on the disconnect side.
+    /// Policy: any CLI state update where `audio_source == Youtube` and the
+    /// CLI reports `muted == false` re-imposes `ForceMute { mute: true }`.
+    /// The CLI can only decode Icecast, so a Youtube preference means the CLI
+    /// must stay silent — unmute attempts via `m` are intentionally
+    /// short-circuited (the user sees a brief flicker, then mute is back).
+    /// Source flips are handled in `set_audio_source`; browser state updates
+    /// are recorded but never trigger a mute.
     pub fn update_state_and_enforce_mute_policy(
         &self,
         token: &str,
         registration_id: u64,
         new_state: ClientAudioState,
     ) -> Option<UpdateStateResult> {
-        let (result, cli_senders_to_mute) = {
+        let (result, mute_target) = {
             let mut clients = self.clients.lock_recover();
             let entries = clients.get_mut(token)?;
             let entry = entries
@@ -270,48 +222,40 @@ impl PairedClientRegistry {
 
             let new_kind = new_state.client_kind;
             let new_muted = new_state.muted;
-            entry.state = new_state;
-
-            let browsers_total = entries
-                .iter()
-                .filter(|entry| entry.state.client_kind == ClientKind::Browser)
-                .count();
-
-            let browser_just_appeared =
-                new_kind == ClientKind::Browser && previous_kind != ClientKind::Browser;
-            let cli_joined_with_browser =
-                new_kind == ClientKind::Cli && browsers_total > 0 && !new_muted;
-
-            let cli_senders = if browser_just_appeared || cli_joined_with_browser {
-                entries
-                    .iter()
-                    .filter(|entry| entry.state.client_kind == ClientKind::Cli)
-                    .map(|entry| entry.tx.clone())
-                    .collect::<Vec<_>>()
+            let entry_audio_source = entry.audio_source;
+            // CLI on Youtube source must stay silent. If the CLI reports
+            // unmuted, slap the mute back. The loop is intentional: it makes
+            // `m` a no-op on Youtube so the user is funneled toward v+x
+            // instead of getting Icecast through a CLI they thought was on
+            // Youtube.
+            let mute_target = if new_kind == ClientKind::Cli
+                && entry_audio_source == AudioSource::Youtube
+                && !new_muted
+            {
+                Some(entry.tx.clone())
             } else {
-                Vec::new()
+                None
             };
+            entry.state = new_state;
 
             (
                 UpdateStateResult {
                     previous_kind,
                     new_kind,
-                    browsers_total,
                 },
-                cli_senders,
+                mute_target,
             )
         };
 
-        for tx in cli_senders_to_mute {
-            if tx
+        if let Some(tx) = mute_target
+            && tx
                 .send(PairControlMessage::ForceMute { mute: true })
                 .is_err()
-            {
-                tracing::warn!(
-                    token_hint = %token_hint(token),
-                    "failed to enforce CLI force-mute"
-                );
-            }
+        {
+            tracing::warn!(
+                token_hint = %token_hint(token),
+                "failed to enforce CLI force-mute"
+            );
         }
 
         Some(result)
@@ -358,36 +302,6 @@ impl PairedClientRegistry {
             return false;
         }
         true
-    }
-
-    /// Total number of paired client entries across all tokens. Used as the
-    /// denominator for skip-vote threshold calculations.
-    pub fn total_pairings(&self) -> usize {
-        let clients = self.clients.lock_recover();
-        clients.values().map(|entries| entries.len()).sum()
-    }
-
-    pub fn has_browser(&self, token: &str) -> bool {
-        let clients = self.clients.lock_recover();
-        clients
-            .get(token)
-            .map(|entries| {
-                entries
-                    .iter()
-                    .any(|entry| entry.state.client_kind == ClientKind::Browser)
-            })
-            .unwrap_or(false)
-    }
-
-    /// True when at least one paired entry (CLI or browser) exists for `token`.
-    /// Used to gate listener-only actions (e.g. booth skip-vote) on actual
-    /// pairing, so an SSH-only user can't influence what paired listeners hear.
-    pub fn is_paired(&self, token: &str) -> bool {
-        let clients = self.clients.lock_recover();
-        clients
-            .get(token)
-            .map(|entries| !entries.is_empty())
-            .unwrap_or(false)
     }
 
     /// True when at least one paired browser on `token` is currently pinned to
@@ -442,19 +356,34 @@ impl PairedClientRegistry {
     /// Returns true when at least one entry's value transitioned away from
     /// `Youtube` — caller uses this to drop the user's pending skip-vote.
     pub fn set_audio_source(&self, user_id: Uuid, source: AudioSource) -> bool {
-        let mut clients = self.clients.lock_recover();
+        let mute = source == AudioSource::Youtube;
         let mut left_youtube = false;
-        for entries in clients.values_mut() {
-            for entry in entries.iter_mut() {
-                if entry.user_id != user_id {
-                    continue;
+        let mut cli_senders = Vec::new();
+        {
+            let mut clients = self.clients.lock_recover();
+            for entries in clients.values_mut() {
+                for entry in entries.iter_mut() {
+                    if entry.user_id != user_id {
+                        continue;
+                    }
+                    if entry.audio_source == AudioSource::Youtube && source != AudioSource::Youtube
+                    {
+                        left_youtube = true;
+                    }
+                    entry.audio_source = source;
+                    if entry.state.client_kind == ClientKind::Cli {
+                        cli_senders.push(entry.tx.clone());
+                    }
                 }
-                if entry.audio_source == AudioSource::Youtube && source != AudioSource::Youtube {
-                    left_youtube = true;
-                }
-                entry.audio_source = source;
             }
         }
+
+        for tx in cli_senders {
+            if tx.send(PairControlMessage::ForceMute { mute }).is_err() {
+                tracing::warn!("failed to update CLI force-mute after audio source change");
+            }
+        }
+
         left_youtube
     }
 }
@@ -589,10 +518,6 @@ mod tests {
             },
         );
 
-        // Drain the force-mute the browser pairing triggers on the CLI so
-        // the next assertion sees only the clipboard request.
-        let _ = cli_rx.try_recv();
-
         assert!(registry.request_clipboard_image("tok1"));
         assert_eq!(
             cli_rx.try_recv().unwrap(),
@@ -626,5 +551,148 @@ mod tests {
 
         assert!(!registry.request_clipboard_image("tok1"));
         assert!(browser_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn cli_with_youtube_source_is_muted_on_first_state_update() {
+        let registry = PairedClientRegistry::new();
+        let user_id = Uuid::now_v7();
+
+        let (cli_tx, mut cli_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::Youtube);
+        registry.update_state_and_enforce_mute_policy(
+            "tok1",
+            cli_id,
+            ClientAudioState {
+                client_kind: ClientKind::Cli,
+                ssh_mode: ClientSshMode::Native,
+                platform: ClientPlatform::Linux,
+                capabilities: Vec::new(),
+                muted: false,
+                volume_percent: 30,
+            },
+        );
+
+        assert_eq!(
+            cli_rx.try_recv().unwrap(),
+            PairControlMessage::ForceMute { mute: true }
+        );
+    }
+
+    #[test]
+    fn cli_with_icecast_source_is_not_muted() {
+        let registry = PairedClientRegistry::new();
+        let user_id = Uuid::now_v7();
+
+        let (cli_tx, mut cli_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::Icecast);
+        registry.update_state_and_enforce_mute_policy(
+            "tok1",
+            cli_id,
+            ClientAudioState {
+                client_kind: ClientKind::Cli,
+                ssh_mode: ClientSshMode::Native,
+                platform: ClientPlatform::Linux,
+                capabilities: Vec::new(),
+                muted: false,
+                volume_percent: 30,
+            },
+        );
+
+        assert!(cli_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn cli_manual_unmute_is_preserved_on_subsequent_state_updates() {
+        let registry = PairedClientRegistry::new();
+        let user_id = Uuid::now_v7();
+
+        let (cli_tx, mut cli_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::Youtube);
+        // First state update: Unknown -> Cli with Youtube source -> server
+        // sends the initial ForceMute{true}.
+        registry.update_state_and_enforce_mute_policy(
+            "tok1",
+            cli_id,
+            ClientAudioState {
+                client_kind: ClientKind::Cli,
+                ssh_mode: ClientSshMode::Native,
+                platform: ClientPlatform::Linux,
+                capabilities: Vec::new(),
+                muted: false,
+                volume_percent: 30,
+            },
+        );
+        assert_eq!(
+            cli_rx.try_recv().unwrap(),
+            PairControlMessage::ForceMute { mute: true }
+        );
+
+        // CLI acknowledges by re-reporting muted=true. Server must NOT
+        // re-fire ForceMute on this subsequent update.
+        registry.update_state_and_enforce_mute_policy(
+            "tok1",
+            cli_id,
+            ClientAudioState {
+                client_kind: ClientKind::Cli,
+                ssh_mode: ClientSshMode::Native,
+                platform: ClientPlatform::Linux,
+                capabilities: Vec::new(),
+                muted: true,
+                volume_percent: 30,
+            },
+        );
+        assert!(cli_rx.try_recv().is_err());
+
+        // User presses `m` to unmute -> CLI reports muted=false. Server must
+        // NOT re-impose mute; otherwise the user can never escape the silence.
+        registry.update_state_and_enforce_mute_policy(
+            "tok1",
+            cli_id,
+            ClientAudioState {
+                client_kind: ClientKind::Cli,
+                ssh_mode: ClientSshMode::Native,
+                platform: ClientPlatform::Linux,
+                capabilities: Vec::new(),
+                muted: false,
+                volume_percent: 30,
+            },
+        );
+        assert!(cli_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn set_audio_source_toggles_cli_force_mute() {
+        let registry = PairedClientRegistry::new();
+        let user_id = Uuid::now_v7();
+
+        let (cli_tx, mut cli_rx) = tokio::sync::mpsc::unbounded_channel();
+        let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::Icecast);
+        registry.update_state_and_enforce_mute_policy(
+            "tok1",
+            cli_id,
+            ClientAudioState {
+                client_kind: ClientKind::Cli,
+                ssh_mode: ClientSshMode::Native,
+                platform: ClientPlatform::Linux,
+                capabilities: Vec::new(),
+                muted: false,
+                volume_percent: 30,
+            },
+        );
+        // No mute on the Icecast-source CLI registration.
+        assert!(cli_rx.try_recv().is_err());
+
+        assert!(!registry.set_audio_source(user_id, AudioSource::Youtube));
+        assert_eq!(
+            cli_rx.try_recv().unwrap(),
+            PairControlMessage::ForceMute { mute: true }
+        );
+
+        assert!(registry.set_audio_source(user_id, AudioSource::Icecast));
+        assert_eq!(
+            cli_rx.try_recv().unwrap(),
+            PairControlMessage::ForceMute { mute: false }
+        );
     }
 }

--- a/late-ssh/src/paired_clients.rs
+++ b/late-ssh/src/paired_clients.rs
@@ -30,12 +30,11 @@ pub enum PairControlMessage {
     VolumeUp,
     VolumeDown,
     RequestClipboardImage,
-    ForceMute {
-        mute: bool,
-    },
-    /// Per-user setting: tell the paired browser which audio source to use.
-    /// Server is the source of truth (persisted in `users.settings.audio_source`)
-    /// so the browser does not toggle locally; it applies whatever it receives.
+    /// Per-user setting: tell paired clients which audio source the user wants
+    /// to hear. Server is the source of truth (persisted in
+    /// `users.settings.audio_source`). Browsers swap their playback element;
+    /// CLIs gate their Icecast decoder on this — `youtube` means silence
+    /// because the CLI can only play Icecast.
     SetPlaybackSource {
         source: AudioSource,
     },
@@ -175,90 +174,49 @@ impl PairedClientRegistry {
         delivered
     }
 
-    /// Apply a state update for a single entry and atomically enforce the
-    /// source-driven mute policy. Returns the update outcome for callers that
-    /// need it; the force-mute side-effect is dispatched after the lock is
-    /// released.
-    ///
-    /// Policy: any CLI state update where `audio_source == Youtube` and the
-    /// CLI reports `muted == false` re-imposes `ForceMute { mute: true }`.
-    /// The CLI can only decode Icecast, so a Youtube preference means the CLI
-    /// must stay silent — unmute attempts via `m` are intentionally
-    /// short-circuited (the user sees a brief flicker, then mute is back).
-    /// Source flips are handled in `set_audio_source`; browser state updates
-    /// are recorded but never trigger a mute.
+    /// Record a state update for an entry and return the kind transition for
+    /// the caller. Pure state bookkeeping — playback gating lives on the
+    /// client side (CLI gates on `audio_source`, browser swaps its player on
+    /// `SetPlaybackSource`).
     pub fn update_state_and_enforce_mute_policy(
         &self,
         token: &str,
         registration_id: u64,
         new_state: ClientAudioState,
     ) -> Option<UpdateStateResult> {
-        let (result, mute_target) = {
-            let mut clients = self.clients.lock_recover();
-            let entries = clients.get_mut(token)?;
-            let entry = entries
-                .iter_mut()
-                .find(|entry| entry.registration_id == registration_id)?;
+        let mut clients = self.clients.lock_recover();
+        let entries = clients.get_mut(token)?;
+        let entry = entries
+            .iter_mut()
+            .find(|entry| entry.registration_id == registration_id)?;
 
-            let previous_kind = entry.state.client_kind;
-            let previous_labels = entry.state.cli_usage_labels();
-            let new_labels = new_state.cli_usage_labels();
+        let previous_kind = entry.state.client_kind;
+        let previous_labels = entry.state.cli_usage_labels();
+        let new_labels = new_state.cli_usage_labels();
 
-            if previous_labels != new_labels {
-                if let Some((ssh_mode, platform)) = previous_labels {
-                    metrics::add_cli_pair_active(-1, ssh_mode, platform);
-                }
-                if let Some((ssh_mode, platform)) = new_labels {
-                    metrics::add_cli_pair_active(1, ssh_mode, platform);
-                }
+        if previous_labels != new_labels {
+            if let Some((ssh_mode, platform)) = previous_labels {
+                metrics::add_cli_pair_active(-1, ssh_mode, platform);
             }
-
-            if !entry.usage_total_recorded
-                && let Some((ssh_mode, platform)) = new_labels
-            {
-                metrics::record_cli_pair_usage(ssh_mode, platform);
-                entry.usage_total_recorded = true;
+            if let Some((ssh_mode, platform)) = new_labels {
+                metrics::add_cli_pair_active(1, ssh_mode, platform);
             }
-
-            let new_kind = new_state.client_kind;
-            let new_muted = new_state.muted;
-            let entry_audio_source = entry.audio_source;
-            // CLI on Youtube source must stay silent. If the CLI reports
-            // unmuted, slap the mute back. The loop is intentional: it makes
-            // `m` a no-op on Youtube so the user is funneled toward v+x
-            // instead of getting Icecast through a CLI they thought was on
-            // Youtube.
-            let mute_target = if new_kind == ClientKind::Cli
-                && entry_audio_source == AudioSource::Youtube
-                && !new_muted
-            {
-                Some(entry.tx.clone())
-            } else {
-                None
-            };
-            entry.state = new_state;
-
-            (
-                UpdateStateResult {
-                    previous_kind,
-                    new_kind,
-                },
-                mute_target,
-            )
-        };
-
-        if let Some(tx) = mute_target
-            && tx
-                .send(PairControlMessage::ForceMute { mute: true })
-                .is_err()
-        {
-            tracing::warn!(
-                token_hint = %token_hint(token),
-                "failed to enforce CLI force-mute"
-            );
         }
 
-        Some(result)
+        if !entry.usage_total_recorded
+            && let Some((ssh_mode, platform)) = new_labels
+        {
+            metrics::record_cli_pair_usage(ssh_mode, platform);
+            entry.usage_total_recorded = true;
+        }
+
+        let new_kind = new_state.client_kind;
+        entry.state = new_state;
+
+        Some(UpdateStateResult {
+            previous_kind,
+            new_kind,
+        })
     }
 
     /// Snapshot the state of the most recently registered entry, preferring a
@@ -353,12 +311,15 @@ impl PairedClientRegistry {
     }
 
     /// Update the cached `audio_source` for every entry owned by `user_id`.
-    /// Returns true when at least one entry's value transitioned away from
-    /// `Youtube` — caller uses this to drop the user's pending skip-vote.
+    /// Update every entry for `user_id` to the new audio source and push
+    /// `SetPlaybackSource { source }` to each (CLI and browser alike). The
+    /// CLI uses it to gate its Icecast decoder; the browser uses it to swap
+    /// playback element. Returns true when at least one entry's value
+    /// transitioned away from `Youtube` — caller uses this to drop the
+    /// user's pending skip-vote.
     pub fn set_audio_source(&self, user_id: Uuid, source: AudioSource) -> bool {
-        let mute = source == AudioSource::Youtube;
         let mut left_youtube = false;
-        let mut cli_senders = Vec::new();
+        let mut targets = Vec::new();
         {
             let mut clients = self.clients.lock_recover();
             for entries in clients.values_mut() {
@@ -371,16 +332,17 @@ impl PairedClientRegistry {
                         left_youtube = true;
                     }
                     entry.audio_source = source;
-                    if entry.state.client_kind == ClientKind::Cli {
-                        cli_senders.push(entry.tx.clone());
-                    }
+                    targets.push(entry.tx.clone());
                 }
             }
         }
 
-        for tx in cli_senders {
-            if tx.send(PairControlMessage::ForceMute { mute }).is_err() {
-                tracing::warn!("failed to update CLI force-mute after audio source change");
+        for tx in targets {
+            if tx
+                .send(PairControlMessage::SetPlaybackSource { source })
+                .is_err()
+            {
+                tracing::warn!("failed to push SetPlaybackSource after audio source change");
             }
         }
 
@@ -554,7 +516,11 @@ mod tests {
     }
 
     #[test]
-    fn cli_with_youtube_source_is_muted_on_first_state_update() {
+    fn state_update_never_sends_pair_control_message() {
+        // CLI playback gating now lives on the CLI side (it reads
+        // SetPlaybackSource and silences the Icecast decoder when source !=
+        // Icecast). The server's state-update path is pure bookkeeping and
+        // must not push anything back at the client.
         let registry = PairedClientRegistry::new();
         let user_id = Uuid::now_v7();
 
@@ -572,15 +538,11 @@ mod tests {
                 volume_percent: 30,
             },
         );
-
-        assert_eq!(
-            cli_rx.try_recv().unwrap(),
-            PairControlMessage::ForceMute { mute: true }
-        );
+        assert!(cli_rx.try_recv().is_err());
     }
 
     #[test]
-    fn cli_with_icecast_source_is_not_muted() {
+    fn set_audio_source_pushes_playback_source_to_every_entry() {
         let registry = PairedClientRegistry::new();
         let user_id = Uuid::now_v7();
 
@@ -598,101 +560,52 @@ mod tests {
                 volume_percent: 30,
             },
         );
-
-        assert!(cli_rx.try_recv().is_err());
-    }
-
-    #[test]
-    fn cli_manual_unmute_is_preserved_on_subsequent_state_updates() {
-        let registry = PairedClientRegistry::new();
-        let user_id = Uuid::now_v7();
-
-        let (cli_tx, mut cli_rx) = tokio::sync::mpsc::unbounded_channel();
-        let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::Youtube);
-        // First state update: Unknown -> Cli with Youtube source -> server
-        // sends the initial ForceMute{true}.
+        let (browser_tx, mut browser_rx) = tokio::sync::mpsc::unbounded_channel();
+        let browser_id = registry.register(
+            "tok1".to_string(),
+            browser_tx,
+            user_id,
+            AudioSource::Icecast,
+        );
         registry.update_state_and_enforce_mute_policy(
             "tok1",
-            cli_id,
+            browser_id,
             ClientAudioState {
-                client_kind: ClientKind::Cli,
-                ssh_mode: ClientSshMode::Native,
-                platform: ClientPlatform::Linux,
+                client_kind: ClientKind::Browser,
+                ssh_mode: ClientSshMode::Unknown,
+                platform: ClientPlatform::Unknown,
                 capabilities: Vec::new(),
                 muted: false,
                 volume_percent: 30,
             },
         );
-        assert_eq!(
-            cli_rx.try_recv().unwrap(),
-            PairControlMessage::ForceMute { mute: true }
-        );
-
-        // CLI acknowledges by re-reporting muted=true. Server must NOT
-        // re-fire ForceMute on this subsequent update.
-        registry.update_state_and_enforce_mute_policy(
-            "tok1",
-            cli_id,
-            ClientAudioState {
-                client_kind: ClientKind::Cli,
-                ssh_mode: ClientSshMode::Native,
-                platform: ClientPlatform::Linux,
-                capabilities: Vec::new(),
-                muted: true,
-                volume_percent: 30,
-            },
-        );
-        assert!(cli_rx.try_recv().is_err());
-
-        // User presses `m` to unmute -> CLI reports muted=false. Server must
-        // NOT re-impose mute; otherwise the user can never escape the silence.
-        registry.update_state_and_enforce_mute_policy(
-            "tok1",
-            cli_id,
-            ClientAudioState {
-                client_kind: ClientKind::Cli,
-                ssh_mode: ClientSshMode::Native,
-                platform: ClientPlatform::Linux,
-                capabilities: Vec::new(),
-                muted: false,
-                volume_percent: 30,
-            },
-        );
-        assert!(cli_rx.try_recv().is_err());
-    }
-
-    #[test]
-    fn set_audio_source_toggles_cli_force_mute() {
-        let registry = PairedClientRegistry::new();
-        let user_id = Uuid::now_v7();
-
-        let (cli_tx, mut cli_rx) = tokio::sync::mpsc::unbounded_channel();
-        let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::Icecast);
-        registry.update_state_and_enforce_mute_policy(
-            "tok1",
-            cli_id,
-            ClientAudioState {
-                client_kind: ClientKind::Cli,
-                ssh_mode: ClientSshMode::Native,
-                platform: ClientPlatform::Linux,
-                capabilities: Vec::new(),
-                muted: false,
-                volume_percent: 30,
-            },
-        );
-        // No mute on the Icecast-source CLI registration.
-        assert!(cli_rx.try_recv().is_err());
 
         assert!(!registry.set_audio_source(user_id, AudioSource::Youtube));
         assert_eq!(
             cli_rx.try_recv().unwrap(),
-            PairControlMessage::ForceMute { mute: true }
+            PairControlMessage::SetPlaybackSource {
+                source: AudioSource::Youtube
+            }
+        );
+        assert_eq!(
+            browser_rx.try_recv().unwrap(),
+            PairControlMessage::SetPlaybackSource {
+                source: AudioSource::Youtube
+            }
         );
 
         assert!(registry.set_audio_source(user_id, AudioSource::Icecast));
         assert_eq!(
             cli_rx.try_recv().unwrap(),
-            PairControlMessage::ForceMute { mute: false }
+            PairControlMessage::SetPlaybackSource {
+                source: AudioSource::Icecast
+            }
+        );
+        assert_eq!(
+            browser_rx.try_recv().unwrap(),
+            PairControlMessage::SetPlaybackSource {
+                source: AudioSource::Icecast
+            }
         );
     }
 }

--- a/late-ssh/src/paired_clients.rs
+++ b/late-ssh/src/paired_clients.rs
@@ -15,13 +15,15 @@ use crate::app::audio::client_state::{ClientAudioState, ClientKind};
 use crate::metrics;
 
 // Multiplexed outbound channel to every paired client (browser + CLI) for a
-// given SSH session token. Carries audio control (mute/volume/force-mute) and
-// clipboard fan-out. Mute policy is source-driven, not pair-driven: a CLI
-// entry is force-muted iff its user's audio_source is Youtube. The CLI can
-// only play Icecast, so a Youtube preference means the CLI must be silent.
-// Browser presence does not enter the decision — `update_state_and_enforce_
-// mute_policy` applies it when the CLI first reports state, and `set_audio_
-// source` re-applies it on v+x flips.
+// given SSH session token. Carries audio control (mute/volume/source) and
+// clipboard fan-out.
+//
+// Audio surface policy is intentionally small:
+// - CLI plays Icecast only when the user's source is Icecast.
+// - Browser plays YouTube when the user's source is YouTube.
+// - Browser plays Icecast only when no CLI is paired for the token; otherwise
+//   switching back to Icecast just pauses the web YouTube player so the CLI is
+//   the single Icecast surface.
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 #[serde(tag = "event", rename_all = "snake_case")]
@@ -37,6 +39,10 @@ pub enum PairControlMessage {
     /// because the CLI can only play Icecast.
     SetPlaybackSource {
         source: AudioSource,
+        /// Whether the browser should use its `<audio>` Icecast element when
+        /// `source == Icecast`. False when a CLI is paired, because the CLI is
+        /// then the single Icecast surface. CLI clients ignore this field.
+        web_icecast_enabled: bool,
     },
 }
 
@@ -94,9 +100,9 @@ impl PairedClientRegistry {
         registration_id
     }
 
-    /// Remove the matching entry. Mute policy is source-driven, so disconnect
-    /// doesn't change another entry's mute state — that only moves on
-    /// `set_audio_source`.
+    /// Remove the matching entry. The API disconnect path replays playback
+    /// source afterward so remaining browsers can react to CLI presence
+    /// changes.
     pub fn unregister_if_match(&self, token: &str, registration_id: u64) {
         let mut clients = self.clients.lock_recover();
         let Some(entries) = clients.get_mut(token) else {
@@ -130,13 +136,65 @@ impl PairedClientRegistry {
     }
 
     /// Send a control message only to browser entries on `token`. Used for
-    /// browser-only signals like `TogglePlaybackSource`.
+    /// browser-only signals.
     pub fn send_control_to_browsers(&self, token: &str, msg: PairControlMessage) -> bool {
         self.send_control_filter(token, msg, |kind| kind == ClientKind::Browser) > 0
     }
 
+    /// True when the browser should be allowed to play the Icecast `<audio>`
+    /// element for this token. A paired CLI owns Icecast, so the browser must
+    /// stay silent on Icecast to avoid doubled streams.
+    pub fn web_icecast_enabled(&self, token: &str) -> bool {
+        let clients = self.clients.lock_recover();
+        !clients
+            .get(token)
+            .map(|entries| {
+                entries
+                    .iter()
+                    .any(|entry| entry.state.client_kind == ClientKind::Cli)
+            })
+            .unwrap_or(false)
+    }
+
+    /// Re-send each paired entry's cached playback source for `token`, with a
+    /// fresh browser Icecast allowance derived from current CLI presence.
+    pub fn broadcast_playback_source_for_token(&self, token: &str) -> bool {
+        let targets: Vec<_> = {
+            let clients = self.clients.lock_recover();
+            let Some(entries) = clients.get(token) else {
+                return false;
+            };
+            let web_icecast_enabled = !entries
+                .iter()
+                .any(|entry| entry.state.client_kind == ClientKind::Cli);
+            entries
+                .iter()
+                .map(|entry| (entry.tx.clone(), entry.audio_source, web_icecast_enabled))
+                .collect()
+        };
+
+        let mut delivered = 0;
+        for (tx, source, web_icecast_enabled) in targets {
+            if tx
+                .send(PairControlMessage::SetPlaybackSource {
+                    source,
+                    web_icecast_enabled,
+                })
+                .is_ok()
+            {
+                delivered += 1;
+            } else {
+                tracing::warn!(
+                    token_hint = %token_hint(token),
+                    "failed to replay paired playback source"
+                );
+            }
+        }
+        delivered > 0
+    }
+
     /// Send a control message to paired entries whose `client_kind` matches the
-    /// predicate. Used to target CLI-only force-mute or browser-only controls.
+    /// predicate. Used to target browser-only controls.
     /// Returns the number of entries that accepted the message.
     fn send_control_filter<F>(&self, token: &str, msg: PairControlMessage, mut matches: F) -> usize
     where
@@ -310,12 +368,12 @@ impl PairedClientRegistry {
             .sum()
     }
 
-    /// Update the cached `audio_source` for every entry owned by `user_id`.
     /// Update every entry for `user_id` to the new audio source and push
-    /// `SetPlaybackSource { source }` to each (CLI and browser alike). The
-    /// CLI uses it to gate its Icecast decoder; the browser uses it to swap
-    /// playback element. Returns true when at least one entry's value
-    /// transitioned away from `Youtube` — caller uses this to drop the
+    /// `SetPlaybackSource` to each (CLI and browser alike). The CLI uses it to
+    /// gate its Icecast decoder; the browser uses it to swap playback element.
+    /// Browser Icecast is disabled whenever a CLI is present on the token, so
+    /// Icecast has only one surface. Returns true when at least one entry's
+    /// value transitioned away from `Youtube` — caller uses this to drop the
     /// user's pending skip-vote.
     pub fn set_audio_source(&self, user_id: Uuid, source: AudioSource) -> bool {
         let mut left_youtube = false;
@@ -323,6 +381,9 @@ impl PairedClientRegistry {
         {
             let mut clients = self.clients.lock_recover();
             for entries in clients.values_mut() {
+                let web_icecast_enabled = !entries
+                    .iter()
+                    .any(|entry| entry.state.client_kind == ClientKind::Cli);
                 for entry in entries.iter_mut() {
                     if entry.user_id != user_id {
                         continue;
@@ -332,14 +393,17 @@ impl PairedClientRegistry {
                         left_youtube = true;
                     }
                     entry.audio_source = source;
-                    targets.push(entry.tx.clone());
+                    targets.push((entry.tx.clone(), web_icecast_enabled));
                 }
             }
         }
 
-        for tx in targets {
+        for (tx, web_icecast_enabled) in targets {
             if tx
-                .send(PairControlMessage::SetPlaybackSource { source })
+                .send(PairControlMessage::SetPlaybackSource {
+                    source,
+                    web_icecast_enabled,
+                })
                 .is_err()
             {
                 tracing::warn!("failed to push SetPlaybackSource after audio source change");
@@ -584,13 +648,15 @@ mod tests {
         assert_eq!(
             cli_rx.try_recv().unwrap(),
             PairControlMessage::SetPlaybackSource {
-                source: AudioSource::Youtube
+                source: AudioSource::Youtube,
+                web_icecast_enabled: false,
             }
         );
         assert_eq!(
             browser_rx.try_recv().unwrap(),
             PairControlMessage::SetPlaybackSource {
-                source: AudioSource::Youtube
+                source: AudioSource::Youtube,
+                web_icecast_enabled: false,
             }
         );
 
@@ -598,13 +664,50 @@ mod tests {
         assert_eq!(
             cli_rx.try_recv().unwrap(),
             PairControlMessage::SetPlaybackSource {
-                source: AudioSource::Icecast
+                source: AudioSource::Icecast,
+                web_icecast_enabled: false,
             }
         );
         assert_eq!(
             browser_rx.try_recv().unwrap(),
             PairControlMessage::SetPlaybackSource {
-                source: AudioSource::Icecast
+                source: AudioSource::Icecast,
+                web_icecast_enabled: false,
+            }
+        );
+    }
+
+    #[test]
+    fn browser_only_token_can_play_web_icecast() {
+        let registry = PairedClientRegistry::new();
+        let user_id = Uuid::now_v7();
+
+        let (browser_tx, mut browser_rx) = tokio::sync::mpsc::unbounded_channel();
+        let browser_id = registry.register(
+            "tok1".to_string(),
+            browser_tx,
+            user_id,
+            AudioSource::Youtube,
+        );
+        registry.update_state_and_enforce_mute_policy(
+            "tok1",
+            browser_id,
+            ClientAudioState {
+                client_kind: ClientKind::Browser,
+                ssh_mode: ClientSshMode::Unknown,
+                platform: ClientPlatform::Unknown,
+                capabilities: Vec::new(),
+                muted: false,
+                volume_percent: 30,
+            },
+        );
+
+        assert!(registry.set_audio_source(user_id, AudioSource::Icecast));
+        assert_eq!(
+            browser_rx.try_recv().unwrap(),
+            PairControlMessage::SetPlaybackSource {
+                source: AudioSource::Icecast,
+                web_icecast_enabled: true,
             }
         );
     }

--- a/late-ssh/src/session.rs
+++ b/late-ssh/src/session.rs
@@ -8,7 +8,7 @@ use crate::authz::Permissions;
 
 // WebSocket → SSH session routing for browser-sent visualization data and
 // other inbound SSH-side effects. The matching outbound channel (mute,
-// volume, clipboard request, force-mute) lives in `paired_clients.rs`.
+// volume, clipboard request, source selection) lives in `paired_clients.rs`.
 //
 // Flow:
 //   Browser (WS) sends Heartbeat + Viz frames

--- a/late-web/src/pages/connect/page.html
+++ b/late-web/src/pages/connect/page.html
@@ -30,6 +30,7 @@
             audioRetries: 0,
             userOverrideMode: 'icecast',
             serverAudioMode: 'icecast',
+            webIcecastEnabled: true,
             unmuteOnNextPlay: false,
 
             init() {
@@ -38,13 +39,13 @@
                 this.$refs.audio.muted = this.muted;
 
                 this.$refs.audio.addEventListener('error', (e) => {
-                    if (this.status === 'disconnected') return;
+                    if (this.status === 'disconnected' || !this.webIcecastEnabled) return;
                     console.error('Audio stream error', e);
                     this.handleAudioError();
                 });
 
                 this.$refs.audio.addEventListener('ended', () => {
-                    if (this.status === 'disconnected') return;
+                    if (this.status === 'disconnected' || !this.webIcecastEnabled) return;
                     console.warn('Audio stream ended unexpectedly');
                     this.handleAudioError();
                 });
@@ -66,6 +67,9 @@
             },
 
             handleAudioError() {
+                if (this.audioMode !== 'icecast' || !this.webIcecastEnabled) {
+                    return;
+                }
                 this.audioRetries++;
                 if (this.audioRetries > 10) {
                     console.error('Audio stream failed 10 times consecutively, giving up.');
@@ -77,7 +81,7 @@
                 console.log(`Reconnecting audio stream... (attempt ${this.audioRetries})`);
 
                 setTimeout(() => {
-                    if (this.status === 'disconnected' || this.audioMode !== 'icecast') {
+                    if (this.status === 'disconnected' || this.audioMode !== 'icecast' || !this.webIcecastEnabled) {
                         return;
                     }
                     const audio = this.$refs.audio;
@@ -85,11 +89,11 @@
                     audio.src = `${this.audioUrl}${separator}t=${Date.now()}`;
                     audio.load();
                     audio.play().then(() => {
-                        if (this.audioMode !== 'icecast') return;
+                        if (this.audioMode !== 'icecast' || !this.webIcecastEnabled) return;
                         this.audioRetries = 0;
                         this.status = 'playing';
                     }).catch(e => {
-                        if (this.audioMode !== 'icecast') return;
+                        if (this.audioMode !== 'icecast' || !this.webIcecastEnabled) return;
                         console.error("Playback restart failed:", e);
                         this.handleAudioError();
                     });
@@ -148,7 +152,7 @@
                         case 'queue_update':
                             break;
                         case 'set_playback_source':
-                            this.applyUserPlaybackSource(payload.source);
+                            this.applyUserPlaybackSource(payload.source, payload.web_icecast_enabled);
                             break;
                     }
                 };
@@ -198,15 +202,21 @@
                     return;
                 }
 
+                if (!this.webIcecastEnabled) {
+                    this.stopIcecastAudio();
+                    this.status = 'ready';
+                    return;
+                }
+
                 const audio = this.$refs.audio;
                 const separator = this.audioUrl.includes('?') ? '&' : '?';
                 audio.src = `${this.audioUrl}${separator}t=${Date.now()}`;
                 audio.play().then(() => {
-                    if (this.audioMode !== 'icecast') return;
+                    if (this.audioMode !== 'icecast' || !this.webIcecastEnabled) return;
                     this.audioRetries = 0;
                     this.status = 'playing';
                 }).catch(e => {
-                    if (this.audioMode !== 'icecast') return;
+                    if (this.audioMode !== 'icecast' || !this.webIcecastEnabled) return;
                     console.error("Playback failed:", e);
                     this.handleAudioError();
                 });
@@ -228,6 +238,14 @@
                 }
 
                 this.status = 'disconnected';
+            },
+
+            stopIcecastAudio() {
+                const audio = this.$refs.audio;
+                if (!audio) return;
+                audio.pause();
+                audio.removeAttribute('src');
+                audio.load();
             },
 
             toggleLocalMute() {
@@ -274,13 +292,22 @@
             // Apply a server-pushed user preference. The TUI's v+x keybind
             // flips the value in the DB and broadcasts `set_playback_source`;
             // we just apply whatever the server tells us, no local toggling.
-            applyUserPlaybackSource(source) {
+            applyUserPlaybackSource(source, webIcecastEnabled = null) {
                 if (source !== 'icecast' && source !== 'youtube') {
                     return;
                 }
+                const previousWebIcecastEnabled = this.webIcecastEnabled;
+                if (typeof webIcecastEnabled === 'boolean') {
+                    this.webIcecastEnabled = webIcecastEnabled;
+                }
                 this.userOverrideMode = source;
-                if (this.audioMode !== source) {
+
+                const webIcecastPolicyChanged = previousWebIcecastEnabled !== this.webIcecastEnabled;
+                if (this.audioMode !== source || (source === 'icecast' && webIcecastPolicyChanged)) {
                     this.applySourceMode(source);
+                } else if (source === 'icecast' && !this.webIcecastEnabled) {
+                    this.stopIcecastAudio();
+                    this.status = 'ready';
                 }
             },
 
@@ -311,8 +338,7 @@
                         // (queue transitions) must not reset status — the iframe
                         // is already showing/playing and we want loadYoutubeVideo
                         // to take it from there.
-                        const audio = this.$refs.audio;
-                        audio.pause();
+                        this.stopIcecastAudio();
                         this.status = this.audioEnabled ? 'buffering' : 'ready';
                     }
                     this.ensureYoutubePlayer();
@@ -332,7 +358,12 @@
                     if (this.ytPlayer && this.ytPlayer.pauseVideo) {
                         this.ytPlayer.pauseVideo();
                     }
-                    if (this.audioEnabled || this.status === 'playing' || this.status === 'buffering') {
+                    this.autoplayBlocked = false;
+                    this.unmuteOnNextPlay = false;
+                    if (!this.webIcecastEnabled) {
+                        this.stopIcecastAudio();
+                        this.status = 'ready';
+                    } else if (this.audioEnabled || this.status === 'playing' || this.status === 'buffering') {
                         this.startPlayback();
                     } else {
                         this.status = 'ready';
@@ -429,6 +460,10 @@
             },
 
             playYoutubeItem(item) {
+                if (this.userOverrideMode === 'icecast') {
+                    this.pendingYoutubeItem = item;
+                    return;
+                }
                 if (!this.ytPlayer || !this.ytReady || !this.ytPlayer.loadVideoById) {
                     return;
                 }
@@ -454,6 +489,9 @@
 
             detectAutoplayBlocked(item) {
                 const flagBlocked = () => {
+                    if (this.userOverrideMode === 'icecast') {
+                        return;
+                    }
                     if (!this.isSameYoutubeItem(this.currentYoutubeItem, item)) {
                         return;
                     }
@@ -473,6 +511,9 @@
                 };
 
                 const tryMutedRecovery = () => {
+                    if (this.userOverrideMode === 'icecast') {
+                        return;
+                    }
                     if (!this.isSameYoutubeItem(this.currentYoutubeItem, item)) {
                         return;
                     }
@@ -490,6 +531,9 @@
                     // If even muted autoplay doesn't get us to PLAYING within
                     // 1.5s, fall back to the [ tap to play ] flow.
                     window.setTimeout(() => {
+                        if (this.userOverrideMode === 'icecast') {
+                            return;
+                        }
                         if (!this.isSameYoutubeItem(this.currentYoutubeItem, item)) {
                             return;
                         }
@@ -507,6 +551,9 @@
                 // attempt the muted-autoplay recovery before resorting to the
                 // tap-to-play button.
                 window.setTimeout(() => {
+                    if (this.userOverrideMode === 'icecast') {
+                        return;
+                    }
                     if (!this.ytPlayer || !this.ytPlayer.getPlayerState || !window.YT) {
                         return;
                     }
@@ -533,6 +580,17 @@
                 }
                 if (!this.youtubePlayerMatchesCurrent()) {
                     this.reloadCurrentYoutubeItem();
+                    return;
+                }
+                if (this.userOverrideMode === 'icecast') {
+                    if ((state === window.YT.PlayerState.PLAYING || state === window.YT.PlayerState.BUFFERING)
+                        && this.ytPlayer && this.ytPlayer.pauseVideo
+                    ) {
+                        this.ytPlayer.pauseVideo();
+                    }
+                    if (!this.webIcecastEnabled) {
+                        this.status = 'ready';
+                    }
                     return;
                 }
                 if (state === window.YT.PlayerState.PLAYING) {
@@ -574,6 +632,9 @@
             },
 
             reloadCurrentYoutubeItem() {
+                if (this.userOverrideMode === 'icecast') {
+                    return;
+                }
                 if (!this.currentYoutubeItem || !this.ytPlayer || !this.ytPlayer.loadVideoById) {
                     return;
                 }
@@ -591,6 +652,9 @@
 
             verifyYoutubeLoad(item) {
                 window.setTimeout(() => {
+                    if (this.userOverrideMode === 'icecast') {
+                        return;
+                    }
                     if (!this.isSameYoutubeItem(this.currentYoutubeItem, item)) {
                         return;
                     }
@@ -683,7 +747,7 @@
 
     <div class="space-y-3" x-cloak>
         <button @click="startPlayback"
-            x-show="status !== 'playing' && (status === 'ready' || status === 'disconnected' || status === 'buffering' || autoplayBlocked)"
+            x-show="!(audioMode === 'icecast' && !webIcecastEnabled) && status !== 'playing' && (status === 'ready' || status === 'disconnected' || status === 'buffering' || autoplayBlocked)"
             :disabled="status === 'buffering' && !autoplayBlocked"
             class="w-full text-left border px-4 py-3 text-sm transition-colors duration-200" :class="(status === 'buffering' && !autoplayBlocked)
                     ? 'border-gray-800 text-gray-600 cursor-wait'


### PR DESCRIPTION
## Summary
- Source arbitration between a paired CLI and a paired browser previously relied on the server force-muting the CLI whenever a browser appeared. That trampled the user's `m` keybind and made `v+x` (the audio-source toggle) silently no-op when no browser was paired.
- This PR removes `ForceMute` entirely. The server instead broadcasts the user's persisted audio source plus a `web_icecast_enabled` flag, and each client gates its own playback. CLI mute stays purely user-controlled; `v+x` now works whether the user has a browser, a CLI, or both.

## What changed
- **TUI `v+x` works without a paired browser.** `App::toggle_paired_playback_source` no longer requires a browser sender — it persists the preference and the registry pushes `SetPlaybackSource` to every paired entry. The banner now always reflects the new source instead of falling through to "No paired browser".
- **CLI gates Icecast on the received source, not on a server-imposed mute.** A new `source_is_icecast` atomic feeds the output thread; YouTube source → emit silence (the CLI can't decode YouTube), Icecast source → play. The user's `muted` atomic is again *only* the local mute keybind / paired mute control.
- **Browser learns whether it's allowed to play web Icecast.** New `web_icecast_enabled` field on `SetPlaybackSource`: when a CLI is paired on the same token, web Icecast is disabled so the CLI is the single Icecast surface and we don't double up the radio. When the CLI disconnects, the server replays the source with `web_icecast_enabled = true` so a browser-only token resumes web Icecast automatically.
- **`paired_clients.rs` shrinks.** Drops `ForceMute`, `UnregisterResult`, `has_browser`, `is_paired`, `total_pairings`, and the TOCTOU-sensitive mute fan-out under the registry lock. `set_audio_source` now also pushes `SetPlaybackSource` to every affected entry. New `web_icecast_enabled(token)` and `broadcast_playback_source_for_token(token)` helpers; the latter is called on pair-WS connect, on CLI kind transitions, and on disconnect.
- **Booth queue snapshot survives startup.** `AudioService::publish_queue_update_with_guard` switches from `send` to `send_replace` on the `watch::Sender<QueueSnapshot>`, so a snapshot published before any SSH booth subscribes is still visible to later subscribers (previously they saw the constructor's empty value until the next publish).
- Browser page (`page.html`) honors `webIcecastEnabled` across `applySourceMode`, `startPlayback`, `handleAudioError`, the YT state-change handler, autoplay-block detection, and the tap-to-play button visibility. `playYoutubeItem` / `reloadCurrentYoutubeItem` early-return when the user is pinned to Icecast so server queue events don't resurrect the iframe.
- `late-ssh/src/app/audio/CONTEXT.md` rewritten to describe the new source-gate policy and the audible-surface matrix.

## Behavior notes
- **CLI + browser, source = Icecast:** CLI plays, browser `<audio>` is silenced (`web_icecast_enabled = false`).
- **CLI + browser, source = YouTube:** Browser iframe plays, CLI emits silence (it can't decode YouTube).
- **Browser only:** Plays whichever source is selected; web Icecast is re-enabled automatically when the CLI disconnects.
- **CLI only, source = YouTube:** Silent. The preference is still meaningful — flipping back to Icecast over `v+x` resumes audio without needing a paired browser.
- The user's `m` keybind / paired toggle-mute is never overridden by the server anymore, including across WS reconnect.

## Feature flags
- None.

## Screenshots / Video
- No UI-visible layout changes; the only user-facing surface is the `v+x` banner text, which is now unconditional ("Audio source: YouTube" / "Audio source: Icecast"). No screenshots attached.

## Testing
- Updated `paired_clients` tests:
  - `state_update_never_sends_pair_control_message` — registry state updates no longer fan out control messages.
  - `set_audio_source_pushes_playback_source_to_every_entry` — flipping the user preference pushes `SetPlaybackSource` to both CLI and browser, with `web_icecast_enabled = false` while a CLI is paired.
  - `browser_only_token_can_play_web_icecast` — a browser-only token receives `web_icecast_enabled = true`.
- Manual verification:
  - Paired CLI only: `v+x` flips between Icecast (audible) and YouTube (silent), `m` mute toggles independently.
  - Paired CLI + browser: source toggle correctly produces a single audible surface; switching back to Icecast pauses the browser `<audio>` instead of doubling the radio.
  - Browser only: `v+x` flips between Icecast `<audio>` and YouTube iframe; reconnecting after the CLI drops re-enables web Icecast without needing a manual reload.
  - SSH booth opened immediately after server restart shows the current queue snapshot instead of an empty list.