### PR TITLE
content: more splash tips (cat, themes, music, returning-user warmth)

### DIFF
--- a/late-ssh/assets/splash_tips/new_and_returning_users_tip_pool.json
+++ b/late-ssh/assets/splash_tips/new_and_returning_users_tip_pool.json
@@ -30,6 +30,5 @@
   "Try a different theme on screen 4 — there are loads to pick from",
   "Your bonsai grows slow and steady — water it daily for the best results",
   "The music keeps playing even when you're not chatting — pick a genre with L, A, or C",
-  "Resize your terminal and the layout reflows automatically",
-  "Press tab inside chat to cycle through @mentions and #rooms"
+  "Resize your terminal and the layout reflows automatically"
 ]

--- a/late-ssh/assets/splash_tips/new_and_returning_users_tip_pool.json
+++ b/late-ssh/assets/splash_tips/new_and_returning_users_tip_pool.json
@@ -25,5 +25,11 @@
   "Log in daily for free Late Chips, and earn more by solving daily puzzles",
   "Share a link in the news feed on screen 2",
   "Press c on the chat screen to open a paired web chat link",
-  "We suggest you to install and use Nerd Fonts for the best experience!"
+  "We suggest you to install and use Nerd Fonts for the best experience!",
+  "Press k to check in on your cat — feed, water, or play",
+  "Try a different theme on screen 4 — there are loads to pick from",
+  "Your bonsai grows slow and steady — water it daily for the best results",
+  "The music keeps playing even when you're not chatting — pick a genre with L, A, or C",
+  "Resize your terminal and the layout reflows automatically",
+  "Press tab inside chat to cycle through @mentions and #rooms"
 ]

--- a/late-ssh/assets/splash_tips/returning_users_tip_pool.json
+++ b/late-ssh/assets/splash_tips/returning_users_tip_pool.json
@@ -4,5 +4,10 @@
   "Back for more? Great!",
   "Press x to shear your bonsai's branches -- but be careful!",
   "late.sh - bring a friend next time :)",
-  "late.sh - tell a friend!"
+  "late.sh - tell a friend!",
+  "Your bonsai missed you 🌱",
+  "The cat noticed you were gone",
+  "late.sh - quietly waiting for you",
+  "The playlist kept spinning while you were away",
+  "Back again — glad you're here"
 ]


### PR DESCRIPTION
## Summary

Adds 11 new splash-screen tips across the two existing pools. No code changes — just content in the JSON files that `late-ssh/src/app/common/splash_tips.rs` already loads via `include_str!`.

**New and returning pool** (+6 utility hints, all referencing features already on main):
- Cat care with `k`
- Theme catalogue on screen 4
- Daily bonsai watering
- Music genre voting (L/A/C)
- Layout reflow on resize
- Tab autocomplete inside chat

**Returning users pool** (+5 softer lines):
- "Your bonsai missed you 🌱"
- "The cat noticed you were gone"
- "late.sh — quietly waiting for you"
- "The playlist kept spinning while you were away"
- "Back again — glad you're here"

## Test plan

- [x] `python3 -m json.tool` passes on both files
- [x] `cargo test -p late-ssh --lib splash_tips` — 3 passed
- [ ] Visual: connect a few times and confirm new tips appear in rotation

Signed-off-by: Tony Hosaroygard <tasmaniamate@gmail.com>