### PR TITLE
feat: rotate farewell messages on disconnect

### DIFF
--- a/late-ssh/src/app/common/farewell.rs
+++ b/late-ssh/src/app/common/farewell.rs
@@ -1,0 +1,99 @@
+//! Exit-banner content shown to the user when their session ends. A small
+//! pool that's picked from at random; the original "Stay late. Code safe."
+//! stays in the rotation as a familiar default.
+
+use rand_core::{OsRng, RngCore};
+
+/// Pool of farewell messages printed on disconnect. Order is not part of any
+/// contract; `pick` always selects via modulo so reordering or extending the
+/// list is safe.
+pub const FAREWELLS: &[&str] = &[
+    "Stay late. Code safe. ✨",
+    "Sleep well. The bonsai is in good hands. 🌱",
+    "Until next time. ☕",
+    "Catch you on the next late shift.",
+    "We'll keep the lights on. 🕯",
+    "The cat says goodbye. 🐈",
+    "Take it easy out there.",
+    "Mind the witching hour.",
+    "Don't forget to drink water.",
+    "Goodnight, friend.",
+];
+
+/// Picks a farewell deterministically from `seed`. Pure — suitable for tests
+/// and any caller that wants a stable choice.
+pub fn pick(seed: u64) -> &'static str {
+    let idx = (seed as usize) % FAREWELLS.len();
+    FAREWELLS[idx]
+}
+
+/// Picks a farewell using OS entropy. Used on disconnect so each user gets a
+/// fresh line. Mirrors the entropy source used by `splash_tips::choose_splash_hint`.
+pub fn pick_random() -> &'static str {
+    pick(OsRng.next_u64())
+}
+
+/// Convenience: the same payload as `pick_random` but wrapped in `\r\n` so the
+/// SSH/web-tunnel exit handlers can hand it straight to `data` / `Message::Binary`.
+pub fn render_exit_payload() -> String {
+    format!("\r\n{}\r\n", pick_random())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn farewells_are_non_empty_and_unique() {
+        assert!(!FAREWELLS.is_empty());
+        for f in FAREWELLS {
+            assert!(!f.is_empty(), "empty farewell string");
+        }
+        let mut sorted: Vec<&&str> = FAREWELLS.iter().collect();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), FAREWELLS.len(), "duplicate farewells");
+    }
+
+    #[test]
+    fn pick_is_deterministic() {
+        for seed in 0..256u64 {
+            assert_eq!(pick(seed), pick(seed));
+        }
+    }
+
+    #[test]
+    fn pick_covers_all_indices() {
+        for (i, expected) in FAREWELLS.iter().enumerate() {
+            assert_eq!(pick(i as u64), *expected);
+        }
+    }
+
+    #[test]
+    fn pick_wraps_modulo() {
+        let n = FAREWELLS.len() as u64;
+        assert_eq!(pick(n), pick(0));
+        assert_eq!(pick(n * 7 + 3), pick(3));
+    }
+
+    #[test]
+    fn render_exit_payload_wraps_in_crlf() {
+        let payload = render_exit_payload();
+        assert!(payload.starts_with("\r\n"));
+        assert!(payload.ends_with("\r\n"));
+        // The body in between must match one of the known farewells exactly.
+        let body = payload.trim_start_matches("\r\n").trim_end_matches("\r\n");
+        assert!(
+            FAREWELLS.contains(&body),
+            "rendered body should be one of the known farewells, got: {body:?}"
+        );
+    }
+
+    #[test]
+    fn pick_random_returns_pool_member() {
+        for _ in 0..32 {
+            let chosen = pick_random();
+            assert!(FAREWELLS.contains(&chosen));
+        }
+    }
+}

--- a/late-ssh/src/app/common/mod.rs
+++ b/late-ssh/src/app/common/mod.rs
@@ -1,4 +1,5 @@
 pub mod composer;
+pub mod farewell;
 pub mod markdown;
 pub(crate) mod mentions;
 pub mod overlay;

--- a/late-ssh/src/ssh.rs
+++ b/late-ssh/src/ssh.rs
@@ -39,7 +39,6 @@ const PROXY_HEADER_TIMEOUT: Duration = Duration::from_millis(250);
 const CLI_MODE_ENV: &str = "LATE_CLI_MODE";
 const CLI_TOKEN_PREFIX: &str = "LATE_SESSION_TOKEN=";
 const CLI_TOKEN_REQUEST: &str = "late-cli-token-v1";
-const EXIT_MESSAGE: &str = "\r\nStay late. Code safe. ✨\r\n";
 const INPUT_QUEUE_CAP: usize = 256;
 
 /// World tick advances animations, game clocks, splash timer, visualizer
@@ -1328,7 +1327,10 @@ async fn clean_disconnect(handle: &russh::server::Handle, channel_id: ChannelId)
     let _ = timeout(Duration::from_millis(50), handle.data(channel_id, exit)).await;
     let _ = timeout(
         Duration::from_millis(50),
-        handle.data(channel_id, EXIT_MESSAGE.as_bytes().to_vec()),
+        handle.data(
+            channel_id,
+            crate::app::common::farewell::render_exit_payload().into_bytes(),
+        ),
     )
     .await;
     let _ = handle.eof(channel_id).await;

--- a/late-ssh/src/web_tunnel.rs
+++ b/late-ssh/src/web_tunnel.rs
@@ -41,8 +41,6 @@ const INPUT_QUEUE_CAP: usize = 256;
 const WS_OUT_BUFFER: usize = 8;
 const WORLD_TICK_INTERVAL: Duration = Duration::from_millis(66);
 const MIN_RENDER_GAP: Duration = Duration::from_millis(15);
-const EXIT_MESSAGE: &str = "\r\nStay late. Code safe. ✨\r\n";
-
 static FRAME_DROP_COUNT: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Deserialize)]
@@ -522,7 +520,11 @@ async fn clean_disconnect(out_tx: &mpsc::Sender<Message>) {
         .send(Message::Binary(App::leave_alt_screen().into()))
         .await;
     let _ = out_tx
-        .send(Message::Binary(EXIT_MESSAGE.as_bytes().to_vec().into()))
+        .send(Message::Binary(
+            crate::app::common::farewell::render_exit_payload()
+                .into_bytes()
+                .into(),
+        ))
         .await;
     let _ = out_tx.send(Message::Close(None)).await;
 }


### PR DESCRIPTION
## Summary

Replaces the single hardcoded \"Stay late. Code safe. ✨\" exit string with a small pool picked from at random on each disconnect. Same warmth, a bit more variety. The original line stays in the rotation as a familiar default.

Companion piece to #221 (welcome banner on the way in) — this one's on the way out.

## What's in it

- **New module `late-ssh::app::common::farewell`**: 10-line pool, pure `pick(seed)`, runtime `pick_random()` (via `OsRng`, same entropy source `splash_tips` uses), `render_exit_payload()` which wraps the choice in `\r\n` for the SSH/web-tunnel `data` calls.
- **SSH (`late-ssh/src/ssh.rs`)** and **web-tunnel (`late-ssh/src/web_tunnel.rs`)** exit handlers both call `render_exit_payload()`, so the two paths stay in sync without duplicating the string.
- Removed the two `const EXIT_MESSAGE: &str = ...` declarations.

## Pool

> Stay late. Code safe. ✨
> Sleep well. The bonsai is in good hands. 🌱
> Until next time. ☕
> Catch you on the next late shift.
> We'll keep the lights on. 🕯
> The cat says goodbye. 🐈
> Take it easy out there.
> Mind the witching hour.
> Don't forget to drink water.
> Goodnight, friend.

Easy to add or swap any of these — the pool is just a `&[&str]` and `pick` is modular.

## Test plan

- [x] \`cargo fmt --check\`
- [x] \`cargo clippy -p late-ssh --all-targets -- -D warnings\`
- [x] \`cargo test -p late-ssh --lib farewell\` — 6 passed
- [ ] Manual: SSH in and \`exit\` a few times; confirm different lines appear

Signed-off-by: Tony Hosaroygard <tasmaniamate@gmail.com>