### PR TITLE
feat: ambient aquarium band under every screen

### DIFF
--- a/late-ssh/src/app/aquarium/mod.rs
+++ b/late-ssh/src/app/aquarium/mod.rs
@@ -1,0 +1,2 @@
+pub mod state;
+pub mod ui;

--- a/late-ssh/src/app/aquarium/state.rs
+++ b/late-ssh/src/app/aquarium/state.rs
@@ -1,0 +1,138 @@
+use ratatui::style::Color;
+use uuid::Uuid;
+
+pub const WATER_HEIGHT: u16 = 2;
+pub const POS_SCALE: i64 = 1000;
+
+const FISH_MIN: usize = 5;
+const FISH_MAX: usize = 8;
+const SPEED_MIN: i32 = 60;
+const SPEED_MAX: i32 = 200;
+
+#[derive(Clone, Copy, Debug)]
+pub enum Species {
+    Common,
+    Long,
+}
+
+#[derive(Clone, Debug)]
+pub struct Fish {
+    pub x_milli: i64,
+    pub speed_milli: i32,
+    pub species: Species,
+    pub colour: Color,
+}
+
+#[derive(Clone, Debug)]
+pub struct WaterState {
+    pub fish: Vec<Fish>,
+    pub ticks: u64,
+}
+
+impl WaterState {
+    pub fn new_for_user(user_id: Uuid) -> Self {
+        let mut rng = Xor64::from_uuid(user_id);
+        let count = FISH_MIN + (rng.next() as usize % (FISH_MAX - FISH_MIN + 1));
+        let palette: &[Color] = &[
+            Color::LightCyan,
+            Color::Yellow,
+            Color::LightMagenta,
+            Color::LightGreen,
+            Color::Cyan,
+            Color::LightYellow,
+            Color::LightRed,
+            Color::LightBlue,
+        ];
+        let mut fish = Vec::with_capacity(count);
+        for _ in 0..count {
+            let speed_mag = SPEED_MIN
+                + (rng.next() as i32).rem_euclid(SPEED_MAX - SPEED_MIN + 1);
+            let going_right = rng.next() & 1 == 0;
+            let speed_milli = if going_right { speed_mag } else { -speed_mag };
+            let x_milli = (rng.next() % 120) as i64 * POS_SCALE;
+            let species = if rng.next().is_multiple_of(4) {
+                Species::Long
+            } else {
+                Species::Common
+            };
+            let colour = palette[(rng.next() as usize) % palette.len()];
+            fish.push(Fish {
+                x_milli,
+                speed_milli,
+                species,
+                colour,
+            });
+        }
+        Self { fish, ticks: 0 }
+    }
+
+    pub fn tick(&mut self) {
+        self.ticks = self.ticks.wrapping_add(1);
+        for f in &mut self.fish {
+            f.x_milli = f.x_milli.wrapping_add(f.speed_milli as i64);
+        }
+    }
+}
+
+/// Tiny deterministic PRNG. Stable per-user without pulling SeedableRng plumbing.
+struct Xor64(u64);
+
+impl Xor64 {
+    fn from_uuid(user_id: Uuid) -> Self {
+        let bytes = user_id.as_bytes();
+        let mut seed: u64 = 0xcbf29ce484222325; // FNV offset basis as a non-zero start
+        for b in bytes {
+            seed = seed.wrapping_mul(0x100000001b3);
+            seed ^= *b as u64;
+        }
+        if seed == 0 {
+            seed = 0xdeadbeefcafebabe;
+        }
+        Self(seed)
+    }
+
+    fn next(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_per_user() {
+        let id = Uuid::from_u128(0x1234_5678_9abc_def0_1122_3344_5566_7788);
+        let a = WaterState::new_for_user(id);
+        let b = WaterState::new_for_user(id);
+        assert_eq!(a.fish.len(), b.fish.len());
+        for (fa, fb) in a.fish.iter().zip(b.fish.iter()) {
+            assert_eq!(fa.x_milli, fb.x_milli);
+            assert_eq!(fa.speed_milli, fb.speed_milli);
+        }
+    }
+
+    #[test]
+    fn different_users_get_different_shoals() {
+        let a = WaterState::new_for_user(Uuid::from_u128(1));
+        let b = WaterState::new_for_user(Uuid::from_u128(2));
+        let positions_a: Vec<_> = a.fish.iter().map(|f| (f.x_milli, f.speed_milli)).collect();
+        let positions_b: Vec<_> = b.fish.iter().map(|f| (f.x_milli, f.speed_milli)).collect();
+        assert_ne!(positions_a, positions_b);
+    }
+
+    #[test]
+    fn tick_advances_positions() {
+        let mut s = WaterState::new_for_user(Uuid::from_u128(42));
+        let before: Vec<i64> = s.fish.iter().map(|f| f.x_milli).collect();
+        s.tick();
+        let after: Vec<i64> = s.fish.iter().map(|f| f.x_milli).collect();
+        assert_ne!(before, after);
+        assert_eq!(s.ticks, 1);
+    }
+}

--- a/late-ssh/src/app/aquarium/ui.rs
+++ b/late-ssh/src/app/aquarium/ui.rs
@@ -1,0 +1,130 @@
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Color, Style},
+    text::{Line, Span},
+    widgets::{Clear, Paragraph},
+};
+
+use super::state::{POS_SCALE, Species, WaterState};
+use crate::app::common::theme;
+
+pub fn draw_water_band(frame: &mut Frame, area: Rect, state: &WaterState) {
+    if area.height < 2 || area.width < 4 {
+        return;
+    }
+    frame.render_widget(Clear, area);
+
+    let width = area.width as usize;
+
+    // Top row: gentle ripples that drift sideways with time.
+    let mut wave = String::with_capacity(width);
+    let shift = (state.ticks / 3) as usize;
+    for x in 0..width {
+        let phase = (x + shift) % 6;
+        wave.push(match phase {
+            0 => '~',
+            3 => '-',
+            _ => ' ',
+        });
+    }
+    let wave_line = Line::from(Span::styled(
+        wave,
+        Style::default().fg(theme::TEXT_FAINT()),
+    ));
+    frame.render_widget(
+        Paragraph::new(wave_line),
+        Rect::new(area.x, area.y, area.width, 1),
+    );
+
+    // Bottom row: fish swim across the full width.
+    let mut row: Vec<(char, Color)> = vec![(' ', Color::Reset); width];
+    let width_cells = width as i64;
+    if width_cells == 0 {
+        return;
+    }
+    for fish in &state.fish {
+        let going_right = fish.speed_milli >= 0;
+        let glyphs: &[char] = match (fish.species, going_right) {
+            (Species::Common, true) => &['>', '<', '>'],
+            (Species::Common, false) => &['<', '>', '<'],
+            (Species::Long, true) => &['>', '<', '(', '(', '\'', '>'],
+            (Species::Long, false) => &['<', '\'', ')', ')', '>', '<'],
+        };
+        let pos = fish.x_milli.div_euclid(POS_SCALE).rem_euclid(width_cells);
+        for (i, ch) in glyphs.iter().enumerate() {
+            let x = (pos + i as i64).rem_euclid(width_cells) as usize;
+            row[x] = (*ch, fish.colour);
+        }
+    }
+    let spans: Vec<Span> = row
+        .into_iter()
+        .map(|(ch, colour)| Span::styled(ch.to_string(), Style::default().fg(colour)))
+        .collect();
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)),
+        Rect::new(area.x, area.y + 1, area.width, 1),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+    use uuid::Uuid;
+
+    fn render(width: u16, height: u16, state: &WaterState) -> Vec<String> {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).expect("terminal");
+        terminal
+            .draw(|frame| {
+                draw_water_band(frame, Rect::new(0, 0, width, height), state);
+            })
+            .expect("draw");
+        let buffer = terminal.backend().buffer();
+        (0..height)
+            .map(|y| {
+                let mut row = String::new();
+                for x in 0..width {
+                    row.push_str(buffer[(x, y)].symbol());
+                }
+                row
+            })
+            .collect()
+    }
+
+    #[test]
+    fn band_contains_wave_and_fish_glyphs_full_width() {
+        let state = WaterState::new_for_user(Uuid::from_u128(0xa11ce));
+        let rows = render(80, 2, &state);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].chars().count(), 80);
+        assert_eq!(rows[1].chars().count(), 80);
+        assert!(rows[0].contains('~'), "wave row should contain ripples");
+        let fish_chars = ['>', '<', '(', ')', '\''];
+        assert!(
+            rows[1].chars().any(|c| fish_chars.contains(&c)),
+            "fish row should contain at least one fish glyph, got {:?}",
+            rows[1]
+        );
+    }
+
+    #[test]
+    fn fish_advance_across_the_row_between_ticks() {
+        let mut state = WaterState::new_for_user(Uuid::from_u128(0xb0b));
+        let before = render(80, 2, &state)[1].clone();
+        for _ in 0..40 {
+            state.tick();
+        }
+        let after = render(80, 2, &state)[1].clone();
+        assert_ne!(before, after, "fish positions should shift after ticking");
+    }
+
+    #[test]
+    fn band_does_not_panic_on_narrow_areas() {
+        let state = WaterState::new_for_user(Uuid::from_u128(7));
+        let _ = render(3, 2, &state); // below min width
+        let _ = render(80, 1, &state); // below min height
+    }
+}
+

--- a/late-ssh/src/app/mod.rs
+++ b/late-ssh/src/app/mod.rs
@@ -1,5 +1,6 @@
 pub mod activity;
 pub mod ai;
+pub mod aquarium;
 pub mod arcade;
 pub mod artboard;
 pub mod audio;

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -180,6 +180,7 @@ struct DrawContext<'a> {
     online_count: usize,
     bonsai: &'a crate::app::bonsai::state::BonsaiState,
     cat: &'a crate::app::cat::state::CatState,
+    water: &'a crate::app::aquarium::state::WaterState,
     activity: &'a std::collections::VecDeque<crate::app::activity::event::ActivityEvent>,
     banner: Option<&'a Banner>,
     is_admin: bool,
@@ -615,6 +616,7 @@ impl App {
                         online_count,
                         bonsai: &self.bonsai_state,
                         cat: &self.cat_state,
+                        water: &self.water_state,
                         activity: &self.activity,
                         banner: banner.as_ref(),
                         is_admin: self.is_admin,
@@ -832,12 +834,25 @@ impl App {
         frame.render_widget(block, area);
         frame.render_widget(Clear, inner);
 
-        let (content_area, sidebar_area) = if ctx.show_right_sidebar {
-            let main_layout =
-                Layout::horizontal([Constraint::Fill(1), Constraint::Length(24)]).split(inner);
-            (main_layout[0], Some(main_layout[1]))
+        // Reserve a permanent water band at the bottom of every screen, full width.
+        // `main_area` is everything above the band; screen content and the right
+        // sidebar both share that reduced height.
+        let water_height = crate::app::aquarium::state::WATER_HEIGHT;
+        let (main_area, water_area) = if inner.height > water_height + 2 {
+            let split =
+                Layout::vertical([Constraint::Fill(1), Constraint::Length(water_height)])
+                    .split(inner);
+            (split[0], Some(split[1]))
         } else {
             (inner, None)
+        };
+
+        let (content_area, sidebar_area) = if ctx.show_right_sidebar {
+            let main_layout =
+                Layout::horizontal([Constraint::Fill(1), Constraint::Length(24)]).split(main_area);
+            (main_layout[0], Some(main_layout[1]))
+        } else {
+            (main_area, None)
         };
         let connect_url = ctx.connect_url;
 
@@ -936,6 +951,10 @@ impl App {
                 },
                 terminal_images,
             ),
+        }
+
+        if let Some(water_area) = water_area {
+            crate::app::aquarium::ui::draw_water_band(frame, water_area, ctx.water);
         }
 
         if let Some(sidebar_area) = sidebar_area {

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -349,6 +349,9 @@ pub struct App {
     pub(crate) cat_state: crate::app::cat::state::CatState,
     pub(crate) show_cat_modal: bool,
 
+    /// Per-user ambient aquarium band (drawn under every screen).
+    pub(crate) water_state: crate::app::aquarium::state::WaterState,
+
     /// Hub Shop
     pub(crate) shop_state: crate::app::hub::shop::state::ShopState,
 
@@ -795,6 +798,7 @@ impl App {
             bonsai_care_state,
             cat_state,
             show_cat_modal: false,
+            water_state: crate::app::aquarium::state::WaterState::new_for_user(config.user_id),
             shop_state,
             game_selection: DEFAULT_GAME_SELECTION,
             is_playing_game: false,

--- a/late-ssh/src/app/tick.rs
+++ b/late-ssh/src/app/tick.rs
@@ -484,6 +484,7 @@ impl App {
         // Bonsai passive growth
         self.bonsai_state.tick();
         self.cat_state.tick();
+        self.water_state.tick();
         if self.show_aquarium_modal {
             self.aquarium_state.tick();
         }


### PR DESCRIPTION
Before anything else — thanks Mat for the hard work on late.sh. You’ve built the community a properly cosy clubhouse, and it’s a real pleasure to contribute to it.

---

## Summary

You mentioned wanting to work out how to have the fish-tank/aquarium — floating, every screen, full width, "doesn't have to be perfect". This is a v1 take.

- Reserves a **2-row water band at the bottom of every screen**, full terminal width — drawn beneath Dashboard, Arcade, Rooms and Artboard alike.
- Top row: slowly drifting ripples (`~` / `-`).
- Bottom row: a small shoal of fish swimming across — two species (`><>` common, `><(('>` long), facing whichever way they're going.
- **Per-user**: species, colour, direction, speed and starting position are seeded deterministically from `user_id`. Each user sees their own stable aquarium across sessions, with **no new DB state** needed for v1.
- Modals still render into `inner`, so they overlay the band while open — same way toast banners already behave. The band is "under it all" positionally; modals are temporary.

If we later want the persistent customisation from the old PLAN.md `aquarium_state` shape (tank tiers, decor, owned fish species from the marketplace), that drops in on top of this without changing the renderer — just swap "seeded from user_id" for "loaded from DB".

## Scope

| | |
|---|---|
| Files | 3 new (`app/aquarium/{mod,state,ui}.rs`) + 4 touched (`app/{mod,state,tick,render}.rs`) |
| Diff | +297 / -2 |
| New deps | none |
| New DB migrations | none |

## Test plan

- [x] `cargo build -p late-ssh` clean
- [x] `cargo test -p late-ssh --lib` — 830 tests pass, including 6 new aquarium tests
- [x] `cargo clippy -p late-ssh --all-targets -- -D warnings` exits 0
- [x] Render-buffer test (`TestBackend`) confirms wave + fish glyphs actually paint across full width, and fish positions advance between ticks
- [x] Determinism test confirms same `user_id` → same shoal; different users → different shoals
- [ ] Visual smoke-test on a real terminal

## Notes

- Band height (`WATER_HEIGHT`) is a single const if you want it 1 row or 3.
- Fish glyphs are kept ASCII-only (no emoji) to avoid width-mismatch issues across terminals.
- Picks up automatically on every screen because the reservation lives in the outer `draw()` in `render.rs` — no per-screen wiring.
