### PR TITLE
mod command "artboard curate" allows preserving nice artboards

### DIFF
--- a/late-core/src/models/artboard.rs
+++ b/late-core/src/models/artboard.rs
@@ -93,7 +93,9 @@ impl Snapshot {
         let rows = client
             .query(
                 "SELECT board_key, updated FROM artboard_snapshots
-                 WHERE board_key LIKE 'daily:%' OR board_key LIKE 'monthly:%'
+                 WHERE board_key LIKE 'daily:%'
+                    OR board_key LIKE 'monthly:%'
+                    OR board_key LIKE 'curated:%'
                  ORDER BY board_key DESC, created DESC
                  LIMIT $1 OFFSET $2",
                 &[&limit, &offset],
@@ -137,6 +139,25 @@ impl Snapshot {
             )
             .await?;
         Ok(count)
+    }
+
+    pub async fn copy_board_key_if_absent(
+        client: &impl GenericClient,
+        source_key: &str,
+        target_key: &str,
+    ) -> Result<Option<Self>> {
+        let row = client
+            .query_opt(
+                "INSERT INTO artboard_snapshots (board_key, canvas, provenance)
+                 SELECT $1, canvas, provenance
+                 FROM artboard_snapshots
+                 WHERE board_key = $2
+                 ON CONFLICT (board_key) DO NOTHING
+                 RETURNING *",
+                &[&target_key, &source_key],
+            )
+            .await?;
+        Ok(row.map(Self::from))
     }
 
     pub async fn upsert(

--- a/late-core/tests/artboard_snapshot.rs
+++ b/late-core/tests/artboard_snapshot.rs
@@ -97,6 +97,17 @@ async fn artboard_snapshot_prefix_listing_and_delete_by_board_key_work() {
     Snapshot::upsert(&client, "monthly:2026-04", canvas, provenance)
         .await
         .expect("insert monthly snapshot");
+    let copied =
+        Snapshot::copy_board_key_if_absent(&client, "daily:2026-04-22", "curated:2026-04-22")
+            .await
+            .expect("copy curated snapshot")
+            .expect("curated snapshot copied");
+    assert_eq!(copied.board_key, "curated:2026-04-22");
+    let duplicate =
+        Snapshot::copy_board_key_if_absent(&client, "daily:2026-04-22", "curated:2026-04-22")
+            .await
+            .expect("copy duplicate curated snapshot");
+    assert!(duplicate.is_none());
 
     let daily = Snapshot::list_by_board_key_prefix(&client, "daily:")
         .await
@@ -106,6 +117,15 @@ async fn artboard_snapshot_prefix_listing_and_delete_by_board_key_work() {
         .map(|snapshot| snapshot.board_key.as_str())
         .collect();
     assert_eq!(keys, vec!["daily:2026-04-22", "daily:2026-04-21"]);
+
+    let archives = Snapshot::list_archive_summaries(&client, 10, 0)
+        .await
+        .expect("list archive snapshots");
+    let archive_keys: Vec<_> = archives
+        .iter()
+        .map(|snapshot| snapshot.board_key.as_str())
+        .collect();
+    assert!(archive_keys.contains(&"curated:2026-04-22"));
 
     let deleted = Snapshot::delete_by_board_key(&client, "daily:2026-04-21")
         .await

--- a/late-ssh/src/app/artboard/state.rs
+++ b/late-ssh/src/app/artboard/state.rs
@@ -1049,14 +1049,32 @@ impl State {
 
     fn ensure_snapshot_browser_selection_visible(&mut self) {
         let visible = self.snapshot_browser.visible_height.get().max(1);
-        if self.snapshot_browser.selected_index < self.snapshot_browser.scroll_offset {
-            self.snapshot_browser.scroll_offset = self.snapshot_browser.selected_index;
-        } else if self.snapshot_browser.selected_index
-            >= self.snapshot_browser.scroll_offset + visible
-        {
-            self.snapshot_browser.scroll_offset =
-                self.snapshot_browser.selected_index + 1 - visible;
+        let selected_row = self.snapshot_browser_selected_display_index();
+        if selected_row < self.snapshot_browser.scroll_offset {
+            self.snapshot_browser.scroll_offset = selected_row;
+        } else if selected_row >= self.snapshot_browser.scroll_offset + visible {
+            self.snapshot_browser.scroll_offset = selected_row + 1 - visible;
         }
+    }
+
+    fn snapshot_browser_selected_display_index(&self) -> usize {
+        if self.snapshot_browser.selected_index == 0 {
+            return 0;
+        }
+        let selected_item_idx = self.snapshot_browser.selected_index - 1;
+        let mut display_idx = 1;
+        let mut current_kind = None;
+        for (idx, item) in self.snapshot_browser.items.iter().enumerate() {
+            if current_kind != Some(item.kind) {
+                display_idx += 1;
+                current_kind = Some(item.kind);
+            }
+            if idx == selected_item_idx {
+                return display_idx;
+            }
+            display_idx += 1;
+        }
+        display_idx
     }
 
     fn activate_archive_snapshot(&mut self, item: ArtboardArchiveSnapshot) {

--- a/late-ssh/src/app/artboard/svc.rs
+++ b/late-ssh/src/app/artboard/svc.rs
@@ -150,9 +150,9 @@ async fn list_archive_snapshots(db: &Db) -> anyhow::Result<Vec<ArtboardArchiveSn
         .context("failed to get db client for artboard snapshot list")?;
     let mut snapshots = Vec::new();
     for (prefix, kind) in [
-        ("curated:", ArtboardSnapshotKind::Curated),
         ("daily:", ArtboardSnapshotKind::Daily),
         ("monthly:", ArtboardSnapshotKind::Monthly),
+        ("curated:", ArtboardSnapshotKind::Curated),
     ] {
         let rows = Snapshot::list_by_board_key_prefix(&client, prefix)
             .await

--- a/late-ssh/src/app/artboard/svc.rs
+++ b/late-ssh/src/app/artboard/svc.rs
@@ -55,6 +55,7 @@ pub enum DartboardEvent {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum ArtboardSnapshotKind {
+    Curated,
     Daily,
     Monthly,
 }
@@ -62,6 +63,7 @@ pub enum ArtboardSnapshotKind {
 impl ArtboardSnapshotKind {
     pub fn label(self) -> &'static str {
         match self {
+            Self::Curated => "curated",
             Self::Daily => "daily",
             Self::Monthly => "monthly",
         }
@@ -148,6 +150,7 @@ async fn list_archive_snapshots(db: &Db) -> anyhow::Result<Vec<ArtboardArchiveSn
         .context("failed to get db client for artboard snapshot list")?;
     let mut snapshots = Vec::new();
     for (prefix, kind) in [
+        ("curated:", ArtboardSnapshotKind::Curated),
         ("daily:", ArtboardSnapshotKind::Daily),
         ("monthly:", ArtboardSnapshotKind::Monthly),
     ] {

--- a/late-ssh/src/app/artboard/ui.rs
+++ b/late-ssh/src/app/artboard/ui.rs
@@ -14,6 +14,7 @@ use crate::app::common::theme;
 
 use super::data::lines_for;
 use super::state::{BrushMode, HelpTab, PAINT_PALETTE, PRIMARY_SWATCH_IDX, State};
+use super::svc::ArtboardSnapshotKind;
 
 const INFO_WIDTH: u16 = 21;
 const SWATCH_BOX_WIDTH: u16 = 8;
@@ -1079,32 +1080,11 @@ fn snapshot_browser_lines(
     visible_height: usize,
     width: usize,
 ) -> Vec<Line<'static>> {
-    let total = state.snapshot_browser_items().len() + 1;
+    let all_lines = snapshot_browser_all_lines(state, width);
+    let total = all_lines.len();
     let start = state.snapshot_browser_scroll_offset().min(total);
     let end = (start + visible_height).min(total);
-    let mut lines = Vec::new();
-
-    for option_idx in start..end {
-        let selected = option_idx == state.snapshot_browser_selected_index();
-        if option_idx == 0 {
-            lines.push(snapshot_browser_row(
-                selected,
-                "live",
-                "Current artboard",
-                "editable after closing",
-                width,
-            ));
-            continue;
-        }
-        let snapshot = &state.snapshot_browser_items()[option_idx - 1];
-        lines.push(snapshot_browser_row(
-            selected,
-            snapshot.kind.label(),
-            &snapshot.label,
-            &snapshot.board_key,
-            width,
-        ));
-    }
+    let mut lines = all_lines[start..end].to_vec();
 
     if state.snapshot_browser_loading() {
         lines.push(Line::from(Span::styled(
@@ -1116,14 +1096,48 @@ fn snapshot_browser_lines(
             format!("  {error}"),
             Style::default().fg(theme::AMBER_DIM()),
         )));
-    } else if total == 1 {
+    } else if state.snapshot_browser_items().is_empty() {
         lines.push(Line::from(Span::styled(
-            "  no daily or monthly snapshots yet",
+            "  no curated, daily, or monthly snapshots yet",
             Style::default().fg(theme::TEXT_DIM()),
         )));
     }
 
     lines
+}
+
+fn snapshot_browser_all_lines(state: &State, width: usize) -> Vec<Line<'static>> {
+    let mut lines = vec![snapshot_browser_row(
+        state.snapshot_browser_selected_index() == 0,
+        "live",
+        "Current artboard",
+        "editable after closing",
+        width,
+    )];
+    let mut current_kind = None;
+    for (idx, snapshot) in state.snapshot_browser_items().iter().enumerate() {
+        if current_kind != Some(snapshot.kind) {
+            lines.push(snapshot_browser_section(snapshot.kind));
+            current_kind = Some(snapshot.kind);
+        }
+        lines.push(snapshot_browser_row(
+            state.snapshot_browser_selected_index() == idx + 1,
+            snapshot.kind.label(),
+            &snapshot.label,
+            &snapshot.board_key,
+            width,
+        ));
+    }
+    lines
+}
+
+fn snapshot_browser_section(kind: ArtboardSnapshotKind) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("  {}", kind.label()),
+        Style::default()
+            .fg(theme::TEXT_DIM())
+            .add_modifier(Modifier::BOLD),
+    ))
 }
 
 fn snapshot_browser_row(

--- a/late-ssh/src/app/pinstar/state.rs
+++ b/late-ssh/src/app/pinstar/state.rs
@@ -1036,11 +1036,11 @@ impl PinstarState {
     }
 
     pub fn toggle_editor(&mut self) {
-        if self.floating_editor.is_some() {
+        if let Some(editor) = self.floating_editor.as_ref() {
             if let Some(node_id) = self.selected_node_id.clone()
                 && self.check_mutation_permission()
             {
-                let text = self.floating_editor.as_ref().unwrap().lines().join("\n");
+                let text = editor.lines().join("\n");
                 for node in &mut self.data.nodes {
                     if node.id() == node_id {
                         if matches!(node, CanvasNode::Group(_)) {
@@ -1619,14 +1619,18 @@ impl PinstarState {
 
         let (ax, ay) = if is_horiz {
             if dx > 0.0 { (fx + fw, scy) } else { (fx, scy) }
+        } else if dy > 0.0 {
+            (scx, fy + fh)
         } else {
-            if dy > 0.0 { (scx, fy + fh) } else { (scx, fy) }
+            (scx, fy)
         };
 
         let (bx, by) = if is_horiz {
             if dx > 0.0 { (tx, tcy) } else { (tx + tw, tcy) }
+        } else if dy > 0.0 {
+            (tcx, ty)
         } else {
-            if dy > 0.0 { (tcx, ty) } else { (tcx, ty + th) }
+            (tcx, ty + th)
         };
 
         let use_orthogonal = self.orthogonal_connections;

--- a/late-ssh/src/app/pinstar/ui.rs
+++ b/late-ssh/src/app/pinstar/ui.rs
@@ -322,14 +322,18 @@ pub fn draw_pinstar_view(
 
             let (ax, ay) = if is_horizontal_exit {
                 if dx > 0.0 { (fx + fw, scy) } else { (fx, scy) }
+            } else if dy > 0.0 {
+                (scx, fy + fh)
             } else {
-                if dy > 0.0 { (scx, fy + fh) } else { (scx, fy) }
+                (scx, fy)
             };
 
             let (bx, by) = if is_horizontal_exit {
                 if dx > 0.0 { (tx, tcy) } else { (tx + tw, tcy) }
+            } else if dy > 0.0 {
+                (tcx, ty)
             } else {
-                if dy > 0.0 { (tcx, ty) } else { (tcx, ty + th) }
+                (tcx, ty + th)
             };
 
             let mut sfx = ((ax - state.viewport_x) * state.zoom)
@@ -348,12 +352,10 @@ pub fn draw_pinstar_view(
                 } else {
                     stx -= 1.0; // Target entering from right
                 }
+            } else if dy > 0.0 {
+                sfy -= 1.0; // Source exiting from bottom
             } else {
-                if dy > 0.0 {
-                    sfy -= 1.0; // Source exiting from bottom
-                } else {
-                    sty -= 1.0; // Target entering from bottom
-                }
+                sty -= 1.0; // Target entering from bottom
             }
 
             let edge_color = if state.selected_edge_id.as_ref() == Some(&edge.id) {
@@ -469,14 +471,12 @@ pub fn draw_pinstar_view(
                             draw_corner(buf, mid_x, sy, '\u{2518}'); // ┘
                             draw_corner(buf, mid_x, ey, '\u{250C}'); // ┌
                         }
-                    } else {
-                        if ey > sy {
-                            draw_corner(buf, mid_x, sy, '\u{250C}'); // ┌
-                            draw_corner(buf, mid_x, ey, '\u{2518}'); // ┘
-                        } else if sy > ey {
-                            draw_corner(buf, mid_x, sy, '\u{2514}'); // └
-                            draw_corner(buf, mid_x, ey, '\u{2510}'); // ┐
-                        }
+                    } else if ey > sy {
+                        draw_corner(buf, mid_x, sy, '\u{250C}'); // ┌
+                        draw_corner(buf, mid_x, ey, '\u{2518}'); // ┘
+                    } else if sy > ey {
+                        draw_corner(buf, mid_x, sy, '\u{2514}'); // └
+                        draw_corner(buf, mid_x, ey, '\u{2510}'); // ┐
                     }
 
                     let (arrow_c, arrow_col, arrow_row) = if ex > sx {
@@ -499,14 +499,12 @@ pub fn draw_pinstar_view(
                             draw_corner(buf, sx, mid_y, '\u{2518}'); // ┘
                             draw_corner(buf, ex, mid_y, '\u{250C}'); // ┌
                         }
-                    } else {
-                        if ex > sx {
-                            draw_corner(buf, sx, mid_y, '\u{250C}'); // ┌
-                            draw_corner(buf, ex, mid_y, '\u{2518}'); // ┘
-                        } else if sx > ex {
-                            draw_corner(buf, sx, mid_y, '\u{2510}'); // ┐
-                            draw_corner(buf, ex, mid_y, '\u{2514}'); // └
-                        }
+                    } else if ex > sx {
+                        draw_corner(buf, sx, mid_y, '\u{250C}'); // ┌
+                        draw_corner(buf, ex, mid_y, '\u{2518}'); // ┘
+                    } else if sx > ex {
+                        draw_corner(buf, sx, mid_y, '\u{2510}'); // ┐
+                        draw_corner(buf, ex, mid_y, '\u{2514}'); // └
                     }
 
                     let (arrow_c, arrow_col, arrow_row) = if ey > sy {

--- a/late-ssh/src/moderation/command.rs
+++ b/late-ssh/src/moderation/command.rs
@@ -53,7 +53,7 @@ pub(crate) enum ModCommand {
         reason: String,
     },
     ArtboardCurate {
-        date: Option<chrono::NaiveDate>,
+        source: ArtboardCurateSource,
         reason: String,
     },
     Audio {
@@ -131,6 +131,12 @@ impl ServerUserAction {
 pub enum ArtboardAction {
     Ban,
     Unban,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ArtboardCurateSource {
+    Live,
+    Daily(chrono::NaiveDate),
 }
 
 impl ArtboardAction {
@@ -459,12 +465,12 @@ fn parse_unban_mod_command(parts: &[&str]) -> Result<ModCommand> {
 
 fn parse_artboard_mod_command(parts: &[&str]) -> Result<ModCommand> {
     let Some(first) = parts.first().copied() else {
-        anyhow::bail!("usage: artboard <restore|curate> [YYYY-MM-DD] [reason...]");
+        anyhow::bail!("usage: artboard <restore|curate> ...");
     };
     match first {
         "restore" => parse_artboard_restore_mod_command(&parts[1..]),
         "curate" => parse_artboard_curate_mod_command(&parts[1..]),
-        _ => anyhow::bail!("usage: artboard <restore|curate> [YYYY-MM-DD] [reason...]"),
+        _ => anyhow::bail!("usage: artboard <restore|curate> ..."),
     }
 }
 
@@ -488,15 +494,20 @@ fn parse_artboard_restore_mod_command(parts: &[&str]) -> Result<ModCommand> {
 }
 
 fn parse_artboard_curate_mod_command(parts: &[&str]) -> Result<ModCommand> {
-    let (date, reason_start) = match parts.first().copied() {
-        Some(value) => match chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d") {
-            Ok(date) => (Some(date), 1),
-            Err(_) => (None, 0),
-        },
-        None => (None, 0),
+    const USAGE: &str = "usage: artboard curate <live|YYYY-MM-DD> [reason...]";
+    let Some(source) = parts.first().copied() else {
+        anyhow::bail!(USAGE);
     };
-    let reason = parts.get(reason_start..).unwrap_or_default().join(" ");
-    Ok(ModCommand::ArtboardCurate { date, reason })
+    let source = if source == "live" {
+        ArtboardCurateSource::Live
+    } else {
+        ArtboardCurateSource::Daily(
+            chrono::NaiveDate::parse_from_str(source, "%Y-%m-%d")
+                .map_err(|_| anyhow::anyhow!(USAGE))?,
+        )
+    };
+    let reason = parts.get(1..).unwrap_or_default().join(" ");
+    Ok(ModCommand::ArtboardCurate { source, reason })
 }
 
 fn parse_admin_mod_command(parts: &[&str]) -> Result<ModCommand> {
@@ -666,7 +677,7 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "rename-user <@oldname> <@newname>",
             "view   <@user|#room|bans|audit|artboard|help> [pagenumber]",
             "artboard restore [YYYY-MM-DD] [reason...]",
-            "artboard curate [YYYY-MM-DD] [reason...]",
+            "artboard curate <live|YYYY-MM-DD> [reason...]",
             "",
             "--- bans, etc. ---",
             "kick   <server|#room> @name [reason...]",
@@ -814,8 +825,8 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
         ],
         "artboard" => &[
             "artboard restore [YYYY-MM-DD] [reason...]",
-            "artboard curate [YYYY-MM-DD] [reason...]",
-            "Restores Artboard snapshots.",
+            "artboard curate <live|YYYY-MM-DD> [reason...]",
+            "Restores live Artboard from daily snapshots, or copies live/daily snapshots into curated history.",
             "Subtopics: help artboard restore, help artboard curate.",
         ],
         "artboard restore" => &[
@@ -826,9 +837,9 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "Moderator or admin only. Writes a moderation audit entry and backs up the previous main row.",
         ],
         "artboard curate" => &[
-            "artboard curate [YYYY-MM-DD] [reason...]",
-            "Copies a daily UTC snapshot to a curated snapshot key.",
-            "date: optional daily snapshot date; defaults to previous UTC day.",
+            "artboard curate <live|YYYY-MM-DD> [reason...]",
+            "Copies live Artboard or a daily UTC snapshot to a curated snapshot key.",
+            "live: copies the current main row. YYYY-MM-DD: copies daily snapshot for that UTC date.",
             "reason: optional audit text.",
             "Moderator or admin only. Writes a moderation audit entry.",
         ],
@@ -1207,17 +1218,21 @@ mod tests {
         assert_eq!(
             parse_mod_command("artboard curate 2026-05-06 preserve").unwrap(),
             ModCommand::ArtboardCurate {
-                date: Some(chrono::NaiveDate::from_ymd_opt(2026, 5, 6).unwrap()),
+                source: ArtboardCurateSource::Daily(
+                    chrono::NaiveDate::from_ymd_opt(2026, 5, 6).unwrap()
+                ),
                 reason: "preserve".to_string(),
             }
         );
         assert_eq!(
-            parse_mod_command("artboard curate preserve latest").unwrap(),
+            parse_mod_command("artboard curate live preserve latest").unwrap(),
             ModCommand::ArtboardCurate {
-                date: None,
+                source: ArtboardCurateSource::Live,
                 reason: "preserve latest".to_string(),
             }
         );
+        assert!(parse_mod_command("artboard curate").is_err());
+        assert!(parse_mod_command("artboard curate preserve latest").is_err());
     }
 
     #[test]

--- a/late-ssh/src/moderation/command.rs
+++ b/late-ssh/src/moderation/command.rs
@@ -52,6 +52,10 @@ pub(crate) enum ModCommand {
         date: Option<chrono::NaiveDate>,
         reason: String,
     },
+    ArtboardCurate {
+        date: Option<chrono::NaiveDate>,
+        reason: String,
+    },
     Audio {
         action: AudioAction,
         username: String,
@@ -455,12 +459,13 @@ fn parse_unban_mod_command(parts: &[&str]) -> Result<ModCommand> {
 
 fn parse_artboard_mod_command(parts: &[&str]) -> Result<ModCommand> {
     let Some(first) = parts.first().copied() else {
-        anyhow::bail!("usage: artboard restore [YYYY-MM-DD] [reason...]");
+        anyhow::bail!("usage: artboard <restore|curate> [YYYY-MM-DD] [reason...]");
     };
-    if first == "restore" {
-        return parse_artboard_restore_mod_command(&parts[1..]);
+    match first {
+        "restore" => parse_artboard_restore_mod_command(&parts[1..]),
+        "curate" => parse_artboard_curate_mod_command(&parts[1..]),
+        _ => anyhow::bail!("usage: artboard <restore|curate> [YYYY-MM-DD] [reason...]"),
     }
-    anyhow::bail!("usage: artboard restore [YYYY-MM-DD] [reason...]")
 }
 
 fn required_room_target(value: &str, usage: &str) -> Result<String> {
@@ -480,6 +485,18 @@ fn parse_artboard_restore_mod_command(parts: &[&str]) -> Result<ModCommand> {
     };
     let reason = parts.get(reason_start..).unwrap_or_default().join(" ");
     Ok(ModCommand::ArtboardRestore { date, reason })
+}
+
+fn parse_artboard_curate_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    let (date, reason_start) = match parts.first().copied() {
+        Some(value) => match chrono::NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+            Ok(date) => (Some(date), 1),
+            Err(_) => (None, 0),
+        },
+        None => (None, 0),
+    };
+    let reason = parts.get(reason_start..).unwrap_or_default().join(" ");
+    Ok(ModCommand::ArtboardCurate { date, reason })
 }
 
 fn parse_admin_mod_command(parts: &[&str]) -> Result<ModCommand> {
@@ -649,6 +666,7 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "rename-user <@oldname> <@newname>",
             "view   <@user|#room|bans|audit|artboard|help> [pagenumber]",
             "artboard restore [YYYY-MM-DD] [reason...]",
+            "artboard curate [YYYY-MM-DD] [reason...]",
             "",
             "--- bans, etc. ---",
             "kick   <server|#room> @name [reason...]",
@@ -728,7 +746,7 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
         ],
         "view artboard" => &[
             "view artboard [pagenumber]",
-            "Lists daily and monthly Artboard snapshots.",
+            "Lists daily, monthly, and curated Artboard snapshots.",
             "pagenumber: optional positive page number; 15 rows per page.",
         ],
         "kick" => &[
@@ -796,8 +814,9 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
         ],
         "artboard" => &[
             "artboard restore [YYYY-MM-DD] [reason...]",
+            "artboard curate [YYYY-MM-DD] [reason...]",
             "Restores Artboard snapshots.",
-            "Subtopics: help artboard restore.",
+            "Subtopics: help artboard restore, help artboard curate.",
         ],
         "artboard restore" => &[
             "artboard restore [YYYY-MM-DD] [reason...]",
@@ -805,6 +824,13 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "date: optional daily snapshot date; defaults to previous UTC day.",
             "reason: optional audit text.",
             "Moderator or admin only. Writes a moderation audit entry and backs up the previous main row.",
+        ],
+        "artboard curate" => &[
+            "artboard curate [YYYY-MM-DD] [reason...]",
+            "Copies a daily UTC snapshot to a curated snapshot key.",
+            "date: optional daily snapshot date; defaults to previous UTC day.",
+            "reason: optional audit text.",
+            "Moderator or admin only. Writes a moderation audit entry.",
         ],
         "admin" => &[
             "admin <grant|revoke> mod @name",
@@ -1178,6 +1204,20 @@ mod tests {
                 reason: String::new(),
             }
         );
+        assert_eq!(
+            parse_mod_command("artboard curate 2026-05-06 preserve").unwrap(),
+            ModCommand::ArtboardCurate {
+                date: Some(chrono::NaiveDate::from_ymd_opt(2026, 5, 6).unwrap()),
+                reason: "preserve".to_string(),
+            }
+        );
+        assert_eq!(
+            parse_mod_command("artboard curate preserve latest").unwrap(),
+            ModCommand::ArtboardCurate {
+                date: None,
+                reason: "preserve latest".to_string(),
+            }
+        );
     }
 
     #[test]
@@ -1201,7 +1241,8 @@ mod tests {
             | ModCommand::Audit { .. }
             | ModCommand::ArtboardSnapshots { .. }
             | ModCommand::RenameRoom { .. }
-            | ModCommand::ArtboardRestore { .. } => {
+            | ModCommand::ArtboardRestore { .. }
+            | ModCommand::ArtboardCurate { .. } => {
                 panic!("command does not have a primary username: {command:?}")
             }
         }

--- a/late-ssh/src/moderation/service.rs
+++ b/late-ssh/src/moderation/service.rs
@@ -25,9 +25,9 @@ use crate::app::artboard::provenance::{ArtboardProvenance, SharedArtboardProvena
 use crate::authz::{Caps, Permissions, Tier};
 use crate::dartboard;
 use crate::moderation::command::{
-    ArtboardAction, AudioAction, BanListScope, LIST_PAGE_SIZE, ModCommand, RoleAction,
-    RoomModAction, ServerUserAction, mod_help_lines, normalize_mod_slug, parse_mod_command,
-    strip_user_prefix,
+    ArtboardAction, ArtboardCurateSource, AudioAction, BanListScope, LIST_PAGE_SIZE, ModCommand,
+    RoleAction, RoomModAction, ServerUserAction, mod_help_lines, normalize_mod_slug,
+    parse_mod_command, strip_user_prefix,
 };
 use crate::moderation::event::ModerationEvent;
 use crate::moderation::session_effects::ModerationSessionEffects;
@@ -188,8 +188,8 @@ impl ModerationService {
                 self.artboard_restore(actor_user_id, permissions, date, reason)
                     .await
             }
-            ModCommand::ArtboardCurate { date, reason } => {
-                self.artboard_curate(actor_user_id, permissions, date, reason)
+            ModCommand::ArtboardCurate { source, reason } => {
+                self.artboard_curate(actor_user_id, permissions, source, reason)
                     .await
             }
             ModCommand::Audio {
@@ -896,12 +896,24 @@ impl ModerationService {
         &self,
         actor_user_id: Uuid,
         permissions: Permissions,
-        date: Option<NaiveDate>,
+        source: ArtboardCurateSource,
         reason: String,
     ) -> Result<Vec<String>> {
         ensure_has(permissions, Caps::RESTORE_ARTBOARD)?;
-        let date = date.unwrap_or_else(previous_utc_day);
-        let source_key = daily_artboard_key(date);
+        let (source_key, target_date) = match source {
+            ArtboardCurateSource::Live => {
+                let (server, shared_provenance) = self
+                    .infra
+                    .artboard_handles()
+                    .ok_or_else(|| anyhow::anyhow!("artboard live curation is unavailable"))?;
+                dartboard::flush_server_snapshot(&self.db, server, shared_provenance).await?;
+                (
+                    ArtboardSnapshot::MAIN_BOARD_KEY.to_string(),
+                    Utc::now().date_naive(),
+                )
+            }
+            ArtboardCurateSource::Daily(date) => (daily_artboard_key(date), date),
+        };
 
         let mut client = self.db.get().await?;
         ArtboardSnapshot::find_by_board_key(&client, &source_key)
@@ -911,7 +923,7 @@ impl ModerationService {
         let tx = client.transaction().await?;
         let mut curated = None;
         for suffix in 0..=999 {
-            let target_key = curated_artboard_key(date, suffix);
+            let target_key = curated_artboard_key(target_date, suffix);
             if let Some(snapshot) =
                 ArtboardSnapshot::copy_board_key_if_absent(&tx, &source_key, &target_key).await?
             {

--- a/late-ssh/src/moderation/service.rs
+++ b/late-ssh/src/moderation/service.rs
@@ -188,6 +188,10 @@ impl ModerationService {
                 self.artboard_restore(actor_user_id, permissions, date, reason)
                     .await
             }
+            ModCommand::ArtboardCurate { date, reason } => {
+                self.artboard_curate(actor_user_id, permissions, date, reason)
+                    .await
+            }
             ModCommand::Audio {
                 action,
                 username,
@@ -888,6 +892,56 @@ impl ModerationService {
         Ok(lines)
     }
 
+    async fn artboard_curate(
+        &self,
+        actor_user_id: Uuid,
+        permissions: Permissions,
+        date: Option<NaiveDate>,
+        reason: String,
+    ) -> Result<Vec<String>> {
+        ensure_has(permissions, Caps::RESTORE_ARTBOARD)?;
+        let date = date.unwrap_or_else(previous_utc_day);
+        let source_key = daily_artboard_key(date);
+
+        let mut client = self.db.get().await?;
+        ArtboardSnapshot::find_by_board_key(&client, &source_key)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("artboard snapshot not found: {source_key}"))?;
+
+        let tx = client.transaction().await?;
+        let mut curated = None;
+        for suffix in 0..=999 {
+            let target_key = curated_artboard_key(date, suffix);
+            if let Some(snapshot) =
+                ArtboardSnapshot::copy_board_key_if_absent(&tx, &source_key, &target_key).await?
+            {
+                curated = Some(snapshot);
+                break;
+            }
+        }
+        let curated = curated
+            .ok_or_else(|| anyhow::anyhow!("no available curated artboard key for {source_key}"))?;
+        let target_key = curated.board_key.clone();
+        ModerationAuditLog::record(
+            &tx,
+            actor_user_id,
+            "artboard_curate",
+            "artboard",
+            None,
+            json!({
+                "source_key": source_key.clone(),
+                "target_key": target_key.clone(),
+                "reason": reason,
+            }),
+        )
+        .await?;
+        tx.commit().await?;
+
+        Ok(vec![format!(
+            "curated artboard snapshot {target_key} from {source_key}"
+        )])
+    }
+
     async fn role(
         &self,
         actor_user_id: Uuid,
@@ -1149,7 +1203,9 @@ fn format_audit_log_item(item: &ModerationAuditLogListItem) -> String {
 }
 
 fn format_artboard_snapshot_summary(item: &ArtboardSnapshotSummary) -> String {
-    let kind = if item.board_key.starts_with("monthly:") {
+    let kind = if item.board_key.starts_with("curated:") {
+        "curated"
+    } else if item.board_key.starts_with("monthly:") {
         "monthly"
     } else if item.board_key.starts_with("daily:") {
         "daily"
@@ -1190,6 +1246,14 @@ fn previous_utc_day() -> NaiveDate {
 
 fn daily_artboard_key(date: NaiveDate) -> String {
     format!("daily:{date}")
+}
+
+fn curated_artboard_key(date: NaiveDate, suffix: usize) -> String {
+    if suffix == 0 {
+        format!("curated:{date}")
+    } else {
+        format!("curated:{date}-{}", suffix + 1)
+    }
 }
 
 fn page_offset(page: i64) -> i64 {

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use dartboard_core::{Canvas, CanvasOp, Pos, RgbColor};
 use late_core::models::{
     artboard::Snapshot as ArtboardSnapshot,
@@ -2401,6 +2402,111 @@ async fn mod_artboard_curate_command_copies_daily_snapshot_and_disambiguates_key
             && entry.metadata["source_key"] == "daily:2026-05-06"
             && entry.metadata["target_key"] == "curated:2026-05-06-2"
             && entry.metadata["reason"] == "preserve"
+    }));
+}
+
+#[tokio::test]
+async fn mod_artboard_curate_live_copies_main_snapshot() {
+    let test_db = new_test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let actor = create_test_user(&test_db.db, "artboard_curate_live_actor").await;
+
+    let mut stale_canvas = Canvas::with_size(dartboard::CANVAS_WIDTH, dartboard::CANVAS_HEIGHT);
+    let _ = stale_canvas.put_glyph(Pos { x: 0, y: 0 }, 'S');
+    let mut stale_provenance = ArtboardProvenance::default();
+    stale_provenance.set_username(Pos { x: 0, y: 0 }, "stale_owner");
+    ArtboardSnapshot::upsert(
+        &client,
+        ArtboardSnapshot::MAIN_BOARD_KEY,
+        serde_json::to_value(&stale_canvas).expect("serialize stale canvas"),
+        serde_json::to_value(&stale_provenance).expect("serialize stale provenance"),
+    )
+    .await
+    .expect("insert stale live snapshot");
+
+    let mut server_canvas = Canvas::with_size(dartboard::CANVAS_WIDTH, dartboard::CANVAS_HEIGHT);
+    let _ = server_canvas.put_glyph(Pos { x: 0, y: 0 }, 'L');
+    let mut server_provenance = ArtboardProvenance::default();
+    server_provenance.set_username(Pos { x: 0, y: 0 }, "live_owner");
+    let shared_provenance = server_provenance.shared();
+    let server = dartboard::spawn_persistent_server_with_interval(
+        test_db.db.clone(),
+        Some(server_canvas),
+        shared_provenance.clone(),
+        Duration::from_secs(60 * 60),
+    );
+
+    let service = ChatService::new(
+        test_db.db.clone(),
+        NotificationService::new(test_db.db.clone()),
+    )
+    .with_moderation_infra(
+        ModerationInfra::default().with_artboard_handles(server.clone(), shared_provenance),
+    );
+    let mut events = service.subscribe_events();
+
+    let request_id = Uuid::now_v7();
+    service.run_mod_command_task(
+        actor.id,
+        Permissions::new(false, true),
+        request_id,
+        "artboard curate live preserve live".to_string(),
+    );
+
+    let event = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("event timeout")
+        .expect("event");
+    match event {
+        ChatEvent::ModCommandOutput {
+            request_id: got_request,
+            lines,
+            success,
+            ..
+        } => {
+            assert_eq!(got_request, request_id);
+            assert!(success, "unexpected mod command failure: {lines:?}");
+            assert!(
+                lines.first().is_some_and(|line| line
+                    .starts_with("curated artboard snapshot curated:")
+                    && line.ends_with(" from main")),
+                "unexpected output: {lines:?}"
+            );
+        }
+        other => panic!("expected ModCommandOutput, got {other:?}"),
+    }
+
+    let curated = ArtboardSnapshot::list_by_board_key_prefix(&client, "curated:")
+        .await
+        .expect("list curated snapshots");
+    assert_eq!(curated.len(), 1);
+    let today = Utc::now().date_naive().to_string();
+    assert!(
+        curated[0]
+            .board_key
+            .starts_with(&format!("curated:{today}")),
+        "unexpected curated key: {}",
+        curated[0].board_key
+    );
+    let curated_canvas: Canvas =
+        serde_json::from_value(curated[0].canvas.clone()).expect("decode curated canvas");
+    assert_eq!(curated_canvas.get(Pos { x: 0, y: 0 }), 'L');
+
+    let main = ArtboardSnapshot::find_by_board_key(&client, ArtboardSnapshot::MAIN_BOARD_KEY)
+        .await
+        .expect("load main")
+        .expect("main exists");
+    let main_canvas: Canvas = serde_json::from_value(main.canvas).expect("decode main canvas");
+    assert_eq!(main_canvas.get(Pos { x: 0, y: 0 }), 'L');
+
+    let audit = ModerationAuditLog::all(&client).await.expect("audit log");
+    assert!(audit.iter().any(|entry| {
+        entry.actor_user_id == actor.id
+            && entry.action == "artboard_curate"
+            && entry.target_kind == "artboard"
+            && entry.metadata["source_key"] == ArtboardSnapshot::MAIN_BOARD_KEY
+            && entry.metadata["target_key"] == curated[0].board_key
+            && entry.metadata["reason"] == "preserve live"
     }));
 }
 

--- a/late-ssh/tests/chat/svc.rs
+++ b/late-ssh/tests/chat/svc.rs
@@ -2316,6 +2316,95 @@ async fn mod_artboard_restore_command_restores_daily_snapshot_and_audits() {
 }
 
 #[tokio::test]
+async fn mod_artboard_curate_command_copies_daily_snapshot_and_disambiguates_keys() {
+    let test_db = new_test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let actor = create_test_user(&test_db.db, "artboard_curate_actor").await;
+
+    let mut daily_canvas = Canvas::with_size(dartboard::CANVAS_WIDTH, dartboard::CANVAS_HEIGHT);
+    let _ = daily_canvas.put_glyph(Pos { x: 0, y: 0 }, 'C');
+    let mut daily_provenance = ArtboardProvenance::default();
+    daily_provenance.set_username(Pos { x: 0, y: 0 }, "curator");
+    ArtboardSnapshot::upsert(
+        &client,
+        "daily:2026-05-06",
+        serde_json::to_value(&daily_canvas).expect("serialize daily canvas"),
+        serde_json::to_value(&daily_provenance).expect("serialize daily provenance"),
+    )
+    .await
+    .expect("insert daily snapshot");
+    ArtboardSnapshot::upsert(
+        &client,
+        "curated:2026-05-06",
+        serde_json::to_value(Canvas::with_size(
+            dartboard::CANVAS_WIDTH,
+            dartboard::CANVAS_HEIGHT,
+        ))
+        .expect("serialize existing curated canvas"),
+        serde_json::to_value(ArtboardProvenance::default())
+            .expect("serialize existing curated provenance"),
+    )
+    .await
+    .expect("insert existing curated snapshot");
+
+    let service = ChatService::new(
+        test_db.db.clone(),
+        NotificationService::new(test_db.db.clone()),
+    );
+    let mut events = service.subscribe_events();
+
+    let request_id = Uuid::now_v7();
+    service.run_mod_command_task(
+        actor.id,
+        Permissions::new(false, true),
+        request_id,
+        "artboard curate 2026-05-06 preserve".to_string(),
+    );
+
+    let event = timeout(Duration::from_secs(2), events.recv())
+        .await
+        .expect("event timeout")
+        .expect("event");
+    match event {
+        ChatEvent::ModCommandOutput {
+            request_id: got_request,
+            lines,
+            success,
+            ..
+        } => {
+            assert_eq!(got_request, request_id);
+            assert!(success, "unexpected mod command failure: {lines:?}");
+            assert_eq!(
+                lines,
+                vec![
+                    "curated artboard snapshot curated:2026-05-06-2 from daily:2026-05-06"
+                        .to_string()
+                ]
+            );
+        }
+        other => panic!("expected ModCommandOutput, got {other:?}"),
+    }
+
+    let curated = ArtboardSnapshot::find_by_board_key(&client, "curated:2026-05-06-2")
+        .await
+        .expect("load curated snapshot")
+        .expect("curated snapshot exists");
+    let curated_canvas: Canvas =
+        serde_json::from_value(curated.canvas).expect("decode curated canvas");
+    assert_eq!(curated_canvas.get(Pos { x: 0, y: 0 }), 'C');
+
+    let audit = ModerationAuditLog::all(&client).await.expect("audit log");
+    assert!(audit.iter().any(|entry| {
+        entry.actor_user_id == actor.id
+            && entry.action == "artboard_curate"
+            && entry.target_kind == "artboard"
+            && entry.metadata["source_key"] == "daily:2026-05-06"
+            && entry.metadata["target_key"] == "curated:2026-05-06-2"
+            && entry.metadata["reason"] == "preserve"
+    }));
+}
+
+#[tokio::test]
 async fn mod_bans_command_lists_active_bans() {
     let test_db = new_test_db().await;
     let client = test_db.db.get().await.expect("db client");

--- a/late-web/src/pages/gallery/mod.rs
+++ b/late-web/src/pages/gallery/mod.rs
@@ -100,9 +100,9 @@ async fn handler(
     let default_key = live
         .as_ref()
         .map(|snapshot| snapshot.board_key.clone())
-        .or_else(|| curated.first().map(|snapshot| snapshot.board_key.clone()))
         .or_else(|| daily.first().map(|snapshot| snapshot.board_key.clone()))
-        .or_else(|| monthly.first().map(|snapshot| snapshot.board_key.clone()));
+        .or_else(|| monthly.first().map(|snapshot| snapshot.board_key.clone()))
+        .or_else(|| curated.first().map(|snapshot| snapshot.board_key.clone()));
     let selected_key = requested_key.or(default_key);
     let selected = match selected_key.as_deref() {
         Some(key) => Snapshot::find_by_board_key(&client, key)

--- a/late-web/src/pages/gallery/mod.rs
+++ b/late-web/src/pages/gallery/mod.rs
@@ -16,6 +16,7 @@ use crate::{AppState, error::AppError, metrics};
 
 const DAILY_PREFIX: &str = "daily:";
 const MONTHLY_PREFIX: &str = "monthly:";
+const CURATED_PREFIX: &str = "curated:";
 
 pub fn router() -> Router<AppState> {
     Router::new().route("/gallery", get(handler))
@@ -30,9 +31,11 @@ struct GalleryQuery {
 #[template(path = "pages/gallery/page.html")]
 struct Page {
     live_items: Vec<SnapshotNavItem>,
+    curated_items: Vec<SnapshotNavItem>,
     daily_items: Vec<SnapshotNavItem>,
     monthly_items: Vec<SnapshotNavItem>,
     show_live_empty: bool,
+    show_curated_empty: bool,
     show_daily_empty: bool,
     show_monthly_empty: bool,
     has_selected: bool,
@@ -83,6 +86,9 @@ async fn handler(
     let live = Snapshot::find_summary_by_board_key(&client, Snapshot::MAIN_BOARD_KEY)
         .await
         .context("failed to load live artboard snapshot")?;
+    let curated = Snapshot::list_summaries_by_board_key_prefix(&client, CURATED_PREFIX)
+        .await
+        .context("failed to load curated artboard snapshots")?;
     let daily = Snapshot::list_summaries_by_board_key_prefix(&client, DAILY_PREFIX)
         .await
         .context("failed to load daily artboard snapshots")?;
@@ -94,6 +100,7 @@ async fn handler(
     let default_key = live
         .as_ref()
         .map(|snapshot| snapshot.board_key.clone())
+        .or_else(|| curated.first().map(|snapshot| snapshot.board_key.clone()))
         .or_else(|| daily.first().map(|snapshot| snapshot.board_key.clone()))
         .or_else(|| monthly.first().map(|snapshot| snapshot.board_key.clone()));
     let selected_key = requested_key.or(default_key);
@@ -108,6 +115,10 @@ async fn handler(
         .iter()
         .map(|snapshot| nav_item(snapshot, selected_key.as_deref()))
         .collect();
+    let curated_items: Vec<SnapshotNavItem> = curated
+        .iter()
+        .map(|snapshot| nav_item(snapshot, selected_key.as_deref()))
+        .collect();
     let daily_items: Vec<SnapshotNavItem> = daily
         .iter()
         .map(|snapshot| nav_item(snapshot, selected_key.as_deref()))
@@ -118,13 +129,16 @@ async fn handler(
         .collect();
 
     let show_live_empty = live_items.is_empty();
+    let show_curated_empty = curated_items.is_empty();
     let show_daily_empty = daily_items.is_empty();
     let show_monthly_empty = monthly_items.is_empty();
     let mut page = Page {
         live_items,
+        curated_items,
         daily_items,
         monthly_items,
         show_live_empty,
+        show_curated_empty,
         show_daily_empty,
         show_monthly_empty,
         has_selected: false,
@@ -248,6 +262,9 @@ fn snapshot_title(key: &str) -> String {
         _ if key.starts_with(MONTHLY_PREFIX) => {
             format!("Monthly {}", key.trim_start_matches(MONTHLY_PREFIX))
         }
+        _ if key.starts_with(CURATED_PREFIX) => {
+            format!("Curated {}", key.trim_start_matches(CURATED_PREFIX))
+        }
         _ => key.to_string(),
     }
 }
@@ -257,6 +274,7 @@ fn snapshot_label(key: &str) -> String {
         Snapshot::MAIN_BOARD_KEY => "Live".to_string(),
         _ if key.starts_with(DAILY_PREFIX) => key.trim_start_matches(DAILY_PREFIX).to_string(),
         _ if key.starts_with(MONTHLY_PREFIX) => key.trim_start_matches(MONTHLY_PREFIX).to_string(),
+        _ if key.starts_with(CURATED_PREFIX) => key.trim_start_matches(CURATED_PREFIX).to_string(),
         _ => key.to_string(),
     }
 }
@@ -272,6 +290,8 @@ mod tests {
     #[test]
     fn snapshot_labels_are_human_readable() {
         assert_eq!(snapshot_label("main"), "Live");
+        assert_eq!(snapshot_label("curated:2026-04-24"), "2026-04-24");
+        assert_eq!(snapshot_label("curated:2026-04-24-2"), "2026-04-24-2");
         assert_eq!(snapshot_label("daily:2026-04-24"), "2026-04-24");
         assert_eq!(snapshot_label("monthly:2026-04"), "2026-04");
     }
@@ -279,6 +299,7 @@ mod tests {
     #[test]
     fn snapshot_titles_include_kind() {
         assert_eq!(snapshot_title("main"), "Live / latest saved");
+        assert_eq!(snapshot_title("curated:2026-04-24"), "Curated 2026-04-24");
         assert_eq!(snapshot_title("daily:2026-04-24"), "Daily 2026-04-24");
         assert_eq!(snapshot_title("monthly:2026-04"), "Monthly 2026-04");
     }

--- a/late-web/src/pages/gallery/page.html
+++ b/late-web/src/pages/gallery/page.html
@@ -311,19 +311,6 @@
                 </section>
 
                 <section>
-                    <h2>Curated</h2>
-                    {% if show_curated_empty %}
-                    <div class="snap-empty">none yet</div>
-                    {% endif %}
-                    {% for item in curated_items %}
-                    <a class="snap-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
-                        {{ item.label }}
-                        <span class="snap-meta">{{ item.meta }}</span>
-                    </a>
-                    {% endfor %}
-                </section>
-
-                <section>
                     <h2>Daily</h2>
                     {% if show_daily_empty %}
                     <div class="snap-empty">none yet</div>
@@ -342,6 +329,19 @@
                     <div class="snap-empty">none yet</div>
                     {% endif %}
                     {% for item in monthly_items %}
+                    <a class="snap-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
+                        {{ item.label }}
+                        <span class="snap-meta">{{ item.meta }}</span>
+                    </a>
+                    {% endfor %}
+                </section>
+
+                <section>
+                    <h2>Curated</h2>
+                    {% if show_curated_empty %}
+                    <div class="snap-empty">none yet</div>
+                    {% endif %}
+                    {% for item in curated_items %}
                     <a class="snap-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
                         {{ item.label }}
                         <span class="snap-meta">{{ item.meta }}</span>

--- a/late-web/src/pages/gallery/page.html
+++ b/late-web/src/pages/gallery/page.html
@@ -311,6 +311,19 @@
                 </section>
 
                 <section>
+                    <h2>Curated</h2>
+                    {% if show_curated_empty %}
+                    <div class="snap-empty">none yet</div>
+                    {% endif %}
+                    {% for item in curated_items %}
+                    <a class="snap-link {% if item.active %}active{% endif %}" href="/gallery?key={{ item.key }}">
+                        {{ item.label }}
+                        <span class="snap-meta">{{ item.meta }}</span>
+                    </a>
+                    {% endfor %}
+                </section>
+
+                <section>
                     <h2>Daily</h2>
                     {% if show_daily_empty %}
                     <div class="snap-empty">none yet</div>


### PR DESCRIPTION
new mod command `artboard curate <live|YYYY-MM-DD>` allows mods to preserve nice artboard states for reminiscence, nostalgia, or just nice art

one nice thing about it: allows preservation of pre-"vandal" artboards without having to undo the "vandalism"