### PR TITLE
feat: daily care streak for cat companion

### DIFF
--- a/late-core/migrations/059_add_cat_care_streak.sql
+++ b/late-core/migrations/059_add_cat_care_streak.sql
@@ -1,0 +1,3 @@
+ALTER TABLE cat_companions
+    ADD COLUMN care_streak_days INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN care_streak_last_day DATE;

--- a/late-core/src/models/cat.rs
+++ b/late-core/src/models/cat.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use tokio_postgres::Client;
 use uuid::Uuid;
 
@@ -16,6 +16,8 @@ crate::user_scoped_model! {
         pub last_groomed: Option<DateTime<Utc>>,
         pub last_treated: Option<DateTime<Utc>>,
         pub name: Option<String>,
+        pub care_streak_days: i32,
+        pub care_streak_last_day: Option<NaiveDate>,
     }
 }
 
@@ -47,52 +49,46 @@ impl CatCompanion {
     }
 
     pub async fn touch_fed(client: &Client, user_id: Uuid) -> Result<()> {
-        client
-            .execute(
-                "UPDATE cat_companions SET last_fed = current_timestamp, updated = current_timestamp WHERE user_id = $1",
-                &[&user_id],
-            )
-            .await?;
-        Ok(())
+        Self::touch_care(client, user_id, "last_fed").await
     }
 
     pub async fn touch_watered(client: &Client, user_id: Uuid) -> Result<()> {
-        client
-            .execute(
-                "UPDATE cat_companions SET last_watered = current_timestamp, updated = current_timestamp WHERE user_id = $1",
-                &[&user_id],
-            )
-            .await?;
-        Ok(())
+        Self::touch_care(client, user_id, "last_watered").await
     }
 
     pub async fn touch_played(client: &Client, user_id: Uuid) -> Result<()> {
-        client
-            .execute(
-                "UPDATE cat_companions SET last_played = current_timestamp, updated = current_timestamp WHERE user_id = $1",
-                &[&user_id],
-            )
-            .await?;
-        Ok(())
+        Self::touch_care(client, user_id, "last_played").await
     }
 
     pub async fn touch_groomed(client: &Client, user_id: Uuid) -> Result<()> {
-        client
-            .execute(
-                "UPDATE cat_companions SET last_groomed = current_timestamp, updated = current_timestamp WHERE user_id = $1",
-                &[&user_id],
-            )
-            .await?;
-        Ok(())
+        Self::touch_care(client, user_id, "last_groomed").await
     }
 
     pub async fn touch_treated(client: &Client, user_id: Uuid) -> Result<()> {
-        client
-            .execute(
-                "UPDATE cat_companions SET last_treated = current_timestamp, updated = current_timestamp WHERE user_id = $1",
-                &[&user_id],
-            )
-            .await?;
+        Self::touch_care(client, user_id, "last_treated").await
+    }
+
+    /// Update a `last_*` care timestamp and roll the daily care streak forward.
+    /// `column` must be one of the hard-coded `last_*` names below — caller is
+    /// trusted because each `touch_*` wrapper passes a literal.
+    async fn touch_care(client: &Client, user_id: Uuid, column: &'static str) -> Result<()> {
+        debug_assert!(matches!(
+            column,
+            "last_fed" | "last_watered" | "last_played" | "last_groomed" | "last_treated"
+        ));
+        let query = format!(
+            "UPDATE cat_companions SET
+                {column} = current_timestamp,
+                care_streak_days = CASE
+                    WHEN care_streak_last_day = current_date THEN care_streak_days
+                    WHEN care_streak_last_day = current_date - 1 THEN care_streak_days + 1
+                    ELSE 1
+                END,
+                care_streak_last_day = current_date,
+                updated = current_timestamp
+             WHERE user_id = $1"
+        );
+        client.execute(&query, &[&user_id]).await?;
         Ok(())
     }
 

--- a/late-core/tests/cat.rs
+++ b/late-core/tests/cat.rs
@@ -1,3 +1,4 @@
+use chrono::Utc;
 use late_core::{models::cat::CatCompanion, test_utils::test_db};
 
 #[tokio::test]
@@ -74,4 +75,96 @@ async fn touch_actions_record_independent_timestamps() {
     assert!(cat.last_played.is_some());
     assert!(cat.last_groomed.is_some());
     assert!(cat.last_treated.is_some());
+}
+
+#[tokio::test]
+async fn new_companion_starts_with_zero_streak() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let user = late_core::test_utils::create_test_user(&test_db.db, "cat-streak-zero").await;
+
+    let cat = CatCompanion::ensure(&client, user.id)
+        .await
+        .expect("ensure");
+
+    assert_eq!(cat.care_streak_days, 0);
+    assert_eq!(cat.care_streak_last_day, None);
+}
+
+#[tokio::test]
+async fn first_care_action_sets_streak_to_one() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let user = late_core::test_utils::create_test_user(&test_db.db, "cat-streak-first").await;
+
+    CatCompanion::ensure(&client, user.id).await.expect("ensure");
+    CatCompanion::touch_fed(&client, user.id).await.expect("fed");
+
+    let cat = CatCompanion::ensure(&client, user.id).await.expect("reload");
+    assert_eq!(cat.care_streak_days, 1);
+    assert_eq!(cat.care_streak_last_day, Some(Utc::now().date_naive()));
+}
+
+#[tokio::test]
+async fn multiple_care_actions_same_day_keep_streak_at_one() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let user = late_core::test_utils::create_test_user(&test_db.db, "cat-streak-same-day").await;
+
+    CatCompanion::ensure(&client, user.id).await.expect("ensure");
+    CatCompanion::touch_fed(&client, user.id).await.expect("fed");
+    CatCompanion::touch_watered(&client, user.id).await.expect("watered");
+    CatCompanion::touch_played(&client, user.id).await.expect("played");
+
+    let cat = CatCompanion::ensure(&client, user.id).await.expect("reload");
+    assert_eq!(
+        cat.care_streak_days, 1,
+        "the streak counts days, not actions — same-day care must not advance it"
+    );
+}
+
+#[tokio::test]
+async fn care_after_yesterday_extends_streak() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let user = late_core::test_utils::create_test_user(&test_db.db, "cat-streak-extend").await;
+
+    CatCompanion::ensure(&client, user.id).await.expect("ensure");
+    client
+        .execute(
+            "UPDATE cat_companions SET care_streak_days = 4, care_streak_last_day = current_date - 1 WHERE user_id = $1",
+            &[&user.id],
+        )
+        .await
+        .expect("seed streak at 4 ending yesterday");
+
+    CatCompanion::touch_fed(&client, user.id).await.expect("fed today");
+
+    let cat = CatCompanion::ensure(&client, user.id).await.expect("reload");
+    assert_eq!(cat.care_streak_days, 5);
+    assert_eq!(cat.care_streak_last_day, Some(Utc::now().date_naive()));
+}
+
+#[tokio::test]
+async fn care_after_a_gap_resets_streak_to_one() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+    let user = late_core::test_utils::create_test_user(&test_db.db, "cat-streak-reset").await;
+
+    CatCompanion::ensure(&client, user.id).await.expect("ensure");
+    client
+        .execute(
+            "UPDATE cat_companions SET care_streak_days = 12, care_streak_last_day = current_date - 3 WHERE user_id = $1",
+            &[&user.id],
+        )
+        .await
+        .expect("seed lapsed streak");
+
+    CatCompanion::touch_fed(&client, user.id).await.expect("fed today");
+
+    let cat = CatCompanion::ensure(&client, user.id).await.expect("reload");
+    assert_eq!(
+        cat.care_streak_days, 1,
+        "a multi-day gap breaks the streak and restarts the counter"
+    );
 }

--- a/late-ssh/src/app/cat/modal_ui.rs
+++ b/late-ssh/src/app/cat/modal_ui.rs
@@ -175,7 +175,7 @@ fn draw_mood_line(frame: &mut Frame, area: Rect, state: &CatState, mood: CatMood
                 .add_modifier(Modifier::BOLD),
         ))
     } else {
-        Line::from(vec![
+        let mut spans = vec![
             Span::styled(
                 mood.label(),
                 Style::default()
@@ -184,7 +184,16 @@ fn draw_mood_line(frame: &mut Frame, area: Rect, state: &CatState, mood: CatMood
             ),
             dot(),
             Span::styled(mood_message(mood), Style::default().fg(theme::TEXT_DIM())),
-        ])
+        ];
+        let streak = state.care_streak();
+        if streak >= 2 {
+            spans.push(dot());
+            spans.push(Span::styled(
+                format!("{streak}-day streak"),
+                Style::default().fg(theme::AMBER_DIM()),
+            ));
+        }
+        Line::from(spans)
     };
     frame.render_widget(Paragraph::new(line.centered()), area);
 }

--- a/late-ssh/src/app/cat/state.rs
+++ b/late-ssh/src/app/cat/state.rs
@@ -206,6 +206,9 @@ pub struct CatState {
     /// User-set pet name. `None` until set via the `/petname` chat command.
     pub name: Option<String>,
 
+    care_streak_days: i32,
+    care_streak_last_day: Option<NaiveDate>,
+
     pub action_feedback: Option<&'static str>,
     feedback_ticks: usize,
     animation_ticks: usize,
@@ -223,11 +226,36 @@ impl CatState {
             last_watered: companion.last_watered,
             last_played: companion.last_played,
             name: companion.name,
+            care_streak_days: companion.care_streak_days,
+            care_streak_last_day: companion.care_streak_last_day,
             action_feedback: None,
             feedback_ticks: 0,
             animation_ticks: 0,
             play: None,
         }
+    }
+
+    /// Days the user has cared for the cat in a row, counting today. Returns 0
+    /// when the streak has lapsed (last care day older than yesterday) so a
+    /// stale value never lingers in the UI.
+    pub fn care_streak(&self) -> i32 {
+        display_streak(
+            self.care_streak_last_day,
+            self.care_streak_days,
+            Utc::now().date_naive(),
+        )
+    }
+
+    /// Mirror the SQL streak update locally so the modal reflects the new
+    /// count immediately, before the background `touch_*` task lands.
+    fn bump_streak_today(&mut self) {
+        let today = Utc::now().date_naive();
+        self.care_streak_days = match self.care_streak_last_day {
+            Some(day) if day == today => self.care_streak_days,
+            Some(day) if day == today.pred_opt().unwrap_or(today) => self.care_streak_days + 1,
+            _ => 1,
+        };
+        self.care_streak_last_day = Some(today);
     }
 
     /// Set (or clear with `None`) the user-set pet name and persist it.
@@ -271,6 +299,7 @@ impl CatState {
     pub fn feed(&mut self) {
         self.play = None;
         self.last_fed = Some(Utc::now());
+        self.bump_streak_today();
         self.action_feedback = Some("fed!");
         self.feedback_ticks = FEEDBACK_TICKS;
         self.svc.feed_task(self.user_id);
@@ -279,6 +308,7 @@ impl CatState {
     pub fn water(&mut self) {
         self.play = None;
         self.last_watered = Some(Utc::now());
+        self.bump_streak_today();
         self.action_feedback = Some("watered!");
         self.feedback_ticks = FEEDBACK_TICKS;
         self.svc.water_task(self.user_id);
@@ -341,10 +371,26 @@ impl CatState {
     fn complete_play(&mut self) {
         self.play = None;
         self.last_played = Some(Utc::now());
+        self.bump_streak_today();
         self.action_feedback = Some("played!");
         self.feedback_ticks = FEEDBACK_TICKS;
         self.svc.play_task(self.user_id);
     }
+}
+
+/// Pure streak resolver: returns `streak_days` while the streak is alive
+/// (last care day is today or yesterday); returns 0 once it has lapsed.
+fn display_streak(last_day: Option<NaiveDate>, streak_days: i32, today: NaiveDate) -> i32 {
+    let Some(last) = last_day else {
+        return 0;
+    };
+    if last == today {
+        return streak_days;
+    }
+    if Some(last) == today.pred_opt() {
+        return streak_days;
+    }
+    0
 }
 
 fn step_toward(current: i16, target: i16, step: i16) -> i16 {
@@ -478,5 +524,31 @@ mod tests {
 
         assert_eq!(play.pounces, 1);
         assert_eq!(play.run_energy, 50 - PLAY_POUNCE_PENALTY);
+    }
+
+    #[test]
+    fn display_streak_shows_streak_when_cared_for_today() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        assert_eq!(display_streak(Some(today), 7, today), 7);
+    }
+
+    #[test]
+    fn display_streak_keeps_streak_when_yesterday_was_last_care() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        let yesterday = NaiveDate::from_ymd_opt(2026, 5, 25).unwrap();
+        assert_eq!(display_streak(Some(yesterday), 3, today), 3);
+    }
+
+    #[test]
+    fn display_streak_lapses_when_older_than_yesterday() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        let two_days_ago = NaiveDate::from_ymd_opt(2026, 5, 24).unwrap();
+        assert_eq!(display_streak(Some(two_days_ago), 9, today), 0);
+    }
+
+    #[test]
+    fn display_streak_zero_when_no_care_recorded() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 26).unwrap();
+        assert_eq!(display_streak(None, 0, today), 0);
     }
 }


### PR DESCRIPTION
Thanks Mat — small follow-up in the same lane as #240, same "feels more alive per LOC" lever on the cat.

---

## Summary

Single per-user care streak: any care action (feed, water, play, groom, treat) keeps the streak alive once per day. Surfaced on the cat modal mood line when the streak reaches 2+ days:

```
content  .  mostly cared for  .  7-day streak
```

That's the entire user-visible change.

## Why

Cheap "perceived-change-per-LOC" extension on top of #205. Honours the **"neither pet ever dies"** rule: a lapsed streak silently sits at 0 — no shaming banner, no neglect downgrade, just stops counting until the next care day brings it back to 1.

Daily granularity (not per-action) is intentional — you can't grind the counter by spamming feed/water/play in the same session.

## Scope

| | |
|---|---|
| Files | `late-core/migrations/059_add_cat_care_streak.sql` (+3), `late-core/src/models/cat.rs` (+29 / -37 — five `touch_*` methods consolidated through a shared `touch_care` helper), `late-core/tests/cat.rs` (+93), `late-ssh/src/app/cat/state.rs` (+72), `late-ssh/src/app/cat/modal_ui.rs` (+13) |
| Diff | +210 / -37 |
| Migrations | `059_add_cat_care_streak.sql` — adds `care_streak_days INTEGER NOT NULL DEFAULT 0` + `care_streak_last_day DATE` to `cat_companions` |
| New deps | none |

Streak math lives in SQL on each `touch_care` update so concurrent care actions can't race the counter:

```sql
care_streak_days = CASE
  WHEN care_streak_last_day = current_date     THEN care_streak_days
  WHEN care_streak_last_day = current_date - 1 THEN care_streak_days + 1
  ELSE 1
END
```

`CatState::bump_streak_today` mirrors the same logic locally so the modal reflects the new count immediately, before the spawned `feed_task` / `water_task` / `play_task` lands. `CatState::care_streak()` returns 0 once the streak has lapsed (last care day older than yesterday) so a stale "42-day streak" never lingers in the UI.

## Test plan

Pure-logic unit tests inline (per CONTRIBUTING):

- `display_streak_shows_streak_when_cared_for_today`
- `display_streak_keeps_streak_when_yesterday_was_last_care`
- `display_streak_lapses_when_older_than_yesterday`
- `display_streak_zero_when_no_care_recorded`

Integration tests in `late-core/tests/cat.rs` against a testcontainers Postgres:

- `new_companion_starts_with_zero_streak`
- `first_care_action_sets_streak_to_one`
- `multiple_care_actions_same_day_keep_streak_at_one`
- `care_after_yesterday_extends_streak`
- `care_after_a_gap_resets_streak_to_one`