### PR TITLE
content: more jabs in graybeard's rotation

### DIFF
--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -130,6 +130,12 @@ const GRAYBEARD_PERSONA: &str = "You are a burned-out senior developer, deeply n
     rust rewrites of coreutils, everything-in-rust, 'blazingly fast' as branding, \
     zig, go generics arriving a decade late, \
     LLM autocomplete, vibe coding, copilot, cursor, juniors who cannot write a for loop without autocomplete, \
+    vector databases for problems sqlite handled, RAG as if grep did not exist, MCP servers for shell commands wearing a tie, agents that are loops with a vibe, prompt engineering as a job title, \
+    prisma, drizzle, an ORM rewritten every two years to dodge the same n plus one, supabase as your auth and your db and your hosting and your bedtime story, \
+    clerk, auth0, kinde, workos, paying a vendor for three lines of session middleware, \
+    zod, valibot, typebox, schema validation duplicated in five places for the same form, \
+    poetry, uv, pdm, hatch, rye, the python packaging carousel, \
+    honeycomb, sentry, lightstep, three SaaS bills to find a null pointer, \
     microservices, serverless, the cloud, vercel pricing, aws billing, datadog charges, \
     jira, scrum, standups, planning poker, OKRs, retros, \
     SPAs for static sites, hash routing, SEO tax on JS-heavy pages, \


### PR DESCRIPTION
Thanks Mat — content-only follow-up. Quick top-up of graybeard's modern-tech jab list so he repeats himself less.

---

## Summary

Six new comma-grouped lines inside `GRAYBEARD_PERSONA`, slotted right after the existing LLM autocomplete line so the AI thread expands naturally:

| Category | Why it fills a gap |
|---|---|
| AI infra | List only had \`copilot, cursor, vibe coding\` — nothing on vector DBs, RAG, MCP, agents, prompt engineering as a profession |
| ORM / db-tool churn | Whole category absent — frontend churn is well covered, the data layer was not |
| Auth-as-a-service | Absent (clerk, auth0, kinde, workos) |
| Schema validation sprawl | Absent (zod, valibot, typebox) |
| Python packaging carousel | Absent — list was very JS-leaning (poetry, uv, pdm, hatch, rye) |
| Observability SaaS | \`datadog\` mentioned once under cloud billing; honeycomb / sentry / lightstep deserved their own line |

## Why

Graybeard's prompt already tells him to *"rotate jabs at modern tech … widely, picking a fresh angle each time"*, and explicitly *"do not repeat catchphrases"*. With the 60-second mention cooldown and how often he gets pulled into chat, the rotation pool was the limiting factor.

Followed the rules in the persona blurb to the letter:

- Weary, tooling-targeted (never the human)
- No slurs, threats, identity attacks
- Same comma-separated category-line format as the surrounding list
- New material — not paraphrases of existing lines

## Scope

| | |
|---|---|
| Files | \`late-ssh/src/app/ai/ghost.rs\` (+6 / -0) |
| Diff | +6 / -0 |
| Migrations | none |
| New deps | none |
| Behavior changes | none — string-literal extension only |

## Test plan

Nothing to test — this is a prompt-string extension inside a \`const &str\`. No code paths touched, no branches, no new functions. The only "verification" is reading the diff to confirm the new lines stay on-brand.