### PR TITLE
fix: nix syntax error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ target/
 tmp/
 node_modules
 .env
+.envrc
 .env.local
 .claude
 .codex

--- a/default.nix
+++ b/default.nix
@@ -100,7 +100,7 @@ in
           --prefix GST_PLUGIN_SYSTEM_PATH_1_0 : "${gstreamerPluginPath}" \
           --prefix GIO_EXTRA_MODULES : "${glib-networking}/lib/gio/modules"
       fi
-    ];
+    '';
 
     # Integration tests require a live postgres; skip by default.
     doCheck = false;


### PR DESCRIPTION
also adds .envrc to the gitignore (used by me to automatically use direnv on cd)