### PR TITLE
feat: ambient 'here Xh · ♫ Yh' row under the sidebar clock

### DIFF
--- a/late-ssh/src/app/common/sidebar.rs
+++ b/late-ssh/src/app/common/sidebar.rs
@@ -34,6 +34,9 @@ const MUSIC_QUEUE_HEIGHT: u16 = 2;
 const BONSAI_MIN_HEIGHT: u16 = 16;
 // Cat: 3 art rows + 1 footer row.
 const CAT_HEIGHT: u16 = 4;
+// Presence row: 1 line below the clock, no rule. Same drop priority as
+// the visualizer — keeps the sidebar usable on short windows.
+const PRESENCE_HEIGHT: u16 = 1;
 
 pub struct SidebarProps<'a> {
     pub game_selection: usize,
@@ -50,6 +53,10 @@ pub struct SidebarProps<'a> {
     pub connect_url: &'a str,
     pub activity: &'a VecDeque<ActivityEvent>,
     pub clock_text: &'a str,
+    /// Optional one-line ambient presence indicator rendered below the
+    /// clock when the sidebar has spare room. Typically `"here 2h 14m"` or
+    /// `"here 2h · ♫ 1h"`. `None` hides the row.
+    pub presence_text: Option<&'a str>,
     /// YouTube queue snapshot — drives the music stage's active panel and
     /// peek strip. Fed from the same watch channel as the booth modal.
     pub queue_snapshot: &'a QueueSnapshot,
@@ -108,8 +115,23 @@ fn draw_sidebar_new_shell(frame: &mut Frame, area: Rect, props: &SidebarProps<'_
             0
         };
     let show_visualizer = show_music && need_full_without_viz + cost(VISUALIZER_HEIGHT) <= h;
+    // Presence row borrows the visualizer's drop priority — kept while
+    // music+cat+bonsai have headroom for one more line, dropped first when
+    // the sidebar gets short. No rule between time and presence; they read
+    // as one stacked header.
+    let show_presence = props.presence_text.is_some()
+        && show_music
+        && need_full_without_viz
+            + if show_visualizer {
+                cost(VISUALIZER_HEIGHT)
+            } else {
+                0
+            }
+            + PRESENCE_HEIGHT
+            <= h;
 
     let fixed_without_music = TIME_HEIGHT
+        + if show_presence { PRESENCE_HEIGHT } else { 0 }
         + if show_visualizer {
             cost(VISUALIZER_HEIGHT)
         } else {
@@ -128,9 +150,12 @@ fn draw_sidebar_new_shell(frame: &mut Frame, area: Rect, props: &SidebarProps<'_
         0
     };
 
-    // Vertical real estate, top to bottom: time, [visualizer], [music],
-    // [cat], [bonsai]. A hidden section takes its rule with it.
+    // Vertical real estate, top to bottom: time, [presence], [visualizer],
+    // [music], [cat], [bonsai]. A hidden section takes its rule with it.
     let mut constraints = vec![Constraint::Length(TIME_HEIGHT)];
+    if show_presence {
+        constraints.push(Constraint::Length(PRESENCE_HEIGHT)); // presence (no rule above)
+    }
     if show_visualizer {
         constraints.push(Constraint::Length(RULE_HEIGHT)); // ── rule
         constraints.push(Constraint::Length(VISUALIZER_HEIGHT)); // visualizer
@@ -168,6 +193,13 @@ fn draw_sidebar_new_shell(frame: &mut Frame, area: Rect, props: &SidebarProps<'_
     // Time: right-aligned in the top row.
     draw_time_top(frame, inset(layout[i]), props.clock_text);
     i += 1;
+
+    if show_presence {
+        if let Some(text) = props.presence_text {
+            draw_presence_row(frame, inset(layout[i]), text);
+        }
+        i += 1;
+    }
 
     if show_visualizer {
         draw_horizontal_rule(frame, inset(layout[i]));
@@ -293,6 +325,21 @@ fn draw_time_top(frame: &mut Frame, area: Rect, clock_text: &str) {
         ));
     }
     frame.render_widget(Paragraph::new(Line::from(spans)).centered(), area);
+}
+
+/// Ambient presence row directly under the clock. Centered, dim, single
+/// line. Caller controls the text — typically `"here 2h 14m"` or
+/// `"here 2h · ♫ 1h"`. Keep this lean; busy chrome under the clock looks
+/// like noise.
+fn draw_presence_row(frame: &mut Frame, area: Rect, text: &str) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+    let line = Line::from(Span::styled(
+        text.to_string(),
+        Style::default().fg(theme::TEXT_FAINT()),
+    ));
+    frame.render_widget(Paragraph::new(line).centered(), area);
 }
 
 fn draw_horizontal_rule(frame: &mut Frame, area: Rect) {

--- a/late-ssh/src/app/common/time.rs
+++ b/late-ssh/src/app/common/time.rs
@@ -10,6 +10,36 @@ pub fn timezone_current_time(now: DateTime<Utc>, timezone: Option<&str>) -> Opti
     Some(now.with_timezone(&tz).format("%a %H:%M").to_string())
 }
 
+/// Compact duration like "2h 14m", "47m", "12s". Used by the sidebar
+/// presence row where horizontal real estate is scarce. Caps at days so
+/// long-lived sessions render "3d 4h" instead of "76h 14m".
+pub fn format_short_duration(secs: u64) -> String {
+    const MIN: u64 = 60;
+    const HOUR: u64 = 60 * MIN;
+    const DAY: u64 = 24 * HOUR;
+    if secs >= DAY {
+        let d = secs / DAY;
+        let h = (secs % DAY) / HOUR;
+        if h == 0 {
+            format!("{d}d")
+        } else {
+            format!("{d}d {h}h")
+        }
+    } else if secs >= HOUR {
+        let h = secs / HOUR;
+        let m = (secs % HOUR) / MIN;
+        if m == 0 {
+            format!("{h}h")
+        } else {
+            format!("{h}h {m}m")
+        }
+    } else if secs >= MIN {
+        format!("{}m", secs / MIN)
+    } else {
+        format!("{secs}s")
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -34,5 +64,23 @@ mod tests {
             .single()
             .unwrap();
         assert_eq!(timezone_current_time(now, Some("not/a-timezone")), None);
+    }
+
+    #[test]
+    fn format_short_duration_buckets_correctly() {
+        assert_eq!(format_short_duration(0), "0s");
+        assert_eq!(format_short_duration(47), "47s");
+        assert_eq!(format_short_duration(60), "1m");
+        assert_eq!(format_short_duration(599), "9m");
+        assert_eq!(format_short_duration(3600), "1h");
+        assert_eq!(format_short_duration(3600 + 14 * 60), "1h 14m");
+        assert_eq!(format_short_duration(2 * 3600 + 59 * 60), "2h 59m");
+    }
+
+    #[test]
+    fn format_short_duration_caps_at_days() {
+        assert_eq!(format_short_duration(24 * 3600), "1d");
+        assert_eq!(format_short_duration(24 * 3600 + 4 * 3600), "1d 4h");
+        assert_eq!(format_short_duration(3 * 24 * 3600 + 4 * 3600), "3d 4h");
     }
 }

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -64,6 +64,18 @@ fn desktop_notification_bytes(
     }
 }
 
+/// Build the dim "ambient presence" line shown under the sidebar clock:
+/// `here 2h 14m` always, `here 2h · ♫ 1h` once a browser/CLI is paired up
+/// for audio. `music_secs` is `None` whenever pairing is absent.
+fn build_presence_text(session_secs: u64, music_secs: Option<u64>) -> String {
+    use crate::app::common::time::format_short_duration;
+    let here = format_short_duration(session_secs);
+    match music_secs {
+        Some(secs) => format!("here {here}  ·  ♫ {}", format_short_duration(secs)),
+        None => format!("here {here}"),
+    }
+}
+
 fn sidebar_enabled(show_settings: bool, draft_enabled: bool, profile_enabled: bool) -> bool {
     if show_settings {
         draft_enabled
@@ -169,6 +181,7 @@ struct DrawContext<'a> {
     paired_client: Option<&'a ClientAudioState>,
     vote_view: crate::app::vote::ui::VoteCardView<'a>,
     sidebar_clock: &'a str,
+    presence_text: &'a str,
     online_count: usize,
     bonsai: &'a crate::app::bonsai::state::BonsaiState,
     cat: &'a crate::app::cat::state::CatState,
@@ -309,11 +322,23 @@ impl App {
             .as_mut()
             .and_then(|rx| rx.borrow_and_update().clone());
         let paired_client = self.paired_client_state();
+        // Track when a paired audio client first appears so the sidebar can
+        // show "♫ since" — drop the marker if pairing goes away so a fresh
+        // pair starts a new timer rather than resuming the old one.
+        match (paired_client.is_some(), self.audio_paired_at) {
+            (true, None) => self.audio_paired_at = Some(std::time::Instant::now()),
+            (false, Some(_)) => self.audio_paired_at = None,
+            _ => {}
+        }
         let vote_snapshot = self.vote.snapshot();
         let vote_my_vote = self.vote.my_vote();
         let vote_ends_in = vote_snapshot.remaining_until_switch();
         let banner = self.active_banner().cloned();
         let sidebar_clock = sidebar_clock_text(self.profile_state.profile().timezone.as_deref());
+        let presence_text = build_presence_text(
+            self.session_started_at.elapsed().as_secs(),
+            self.audio_paired_at.map(|t| t.elapsed().as_secs()),
+        );
         let visualizer = &self.visualizer;
         self.chat
             .request_image_modal_terminal_image(self.terminal_image_protocol);
@@ -611,6 +636,7 @@ impl App {
                             ends_in: vote_ends_in,
                         },
                         sidebar_clock: &sidebar_clock,
+                        presence_text: &presence_text,
                         online_count,
                         bonsai: &self.bonsai_state,
                         cat: &self.cat_state,
@@ -978,6 +1004,7 @@ impl App {
                     connect_url,
                     activity: ctx.activity,
                     clock_text: ctx.sidebar_clock,
+                    presence_text: Some(ctx.presence_text),
                     queue_snapshot: &ctx.booth_snapshot,
                     youtube_source_count: ctx.youtube_source_count,
                     icecast_source_count: ctx.icecast_source_count,

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -291,6 +291,17 @@ pub struct App {
     pub(super) viz_frame_buffer: VecDeque<VizFrame>,
     pub(super) last_viz_frame_at: Option<Instant>,
 
+    /// Wall-clock start of this SSH session. Drives the "here Xh" portion
+    /// of the sidebar presence row. Set once in `App::new` and never
+    /// rewritten — reconnects spawn a fresh `App`, so the timer naturally
+    /// resets per session.
+    pub(super) session_started_at: Instant,
+    /// First instant we observed a paired audio client. `None` until a
+    /// browser or `late` CLI has registered against this session's token,
+    /// flipped back to `None` when pairing drops. Drives the "♫ Yh"
+    /// portion of the sidebar presence row.
+    pub(super) audio_paired_at: Option<Instant>,
+
     /// Session / connection
     pub(super) connect_url: String,
     pub(super) session_registry: Option<SessionRegistry>,
@@ -745,6 +756,8 @@ impl App {
             visualizer: Visualizer::new(),
             viz_frame_buffer: VecDeque::new(),
             last_viz_frame_at: None,
+            session_started_at: Instant::now(),
+            audio_paired_at: None,
             connect_url: format!("{}/{}", config.web_url, config.session_token),
             session_registry: config.session_registry,
             paired_client_registry: config.paired_client_registry,


### PR DESCRIPTION
Thanks Mat — picking up another item from CONTEXT.md §7 \"ambient presence\" (listed there alongside quiet hours / typing indicator). Tiny diff, same \"feels alive per LOC\" lane.

---

## Summary

Adds one dim line directly under the sidebar clock that reads:

- \`here 2h 14m\` as soon as you arrive.
- \`here 2h 14m  ·  ♫ 1h\` once a browser/CLI is paired up for audio.

Glanceable session ambience, no settings to toggle, no DB or service.

- \`format_short_duration\` in \`app/common/time.rs\` picks the unit: \`47s\` / \`14m\` / \`2h\` / \`2h 14m\` / \`1d 4h\`. Caps at days so multi-day SSH sessions don't render \`76h 14m\`.
- New \`session_started_at: Instant\` on \`App\` (set in \`App::new\`) and \`audio_paired_at: Option<Instant>\` (set/cleared in \`App::render\` based on \`paired_client_state()\`).
- The presence row borrows the visualizer's drop priority — kept while music + cat + bonsai still have headroom for one more line, dropped first on tight sidebars. No rule between the clock and presence; they read as one stacked header.
- \`audio_paired_at\` flips back to \`None\` when pairing drops, so a fresh browser pair-up restarts the music timer rather than resuming the old one. Session timer never resets within a session — reconnects spawn a new \`App\`.

## Scope

| | |
|---|---|
| Files | 4 touched (\`app/state.rs\`, \`app/render.rs\`, \`app/common/{sidebar,time}.rs\`) |
| Diff | +137 / −2 |
| New deps | none |
| New DB migrations | none |

## Test plan

- [x] \`cargo check -p late-ssh --tests\` clean
- [x] \`cargo fmt --all -- --check\` clean on touched files
- [x] New unit tests for \`format_short_duration\` covering all five buckets (seconds, minutes, hours, hours+minutes, days+hours)
- [ ] Sidebar shows \`here Xs/Xm/Xh\` under the clock; updates as the session ages
- [ ] Pair audio via browser or CLI — \`· ♫ Xs\` segment appears
- [ ] Disconnect audio — music tail disappears, here-timer keeps counting
- [ ] Reconnect audio — music timer starts from zero, not the previous value
- [ ] Shrink the SSH window vertically — presence row drops with the visualizer; clock + music/cat/bonsai survive