### PR TITLE
feat: three more small aquarium fish (anchovy / clownfish / pufferfish)

### DIFF
--- a/late-core/migrations/063_seed_more_aquarium_fish.sql
+++ b/late-core/migrations/063_seed_more_aquarium_fish.sql
@@ -1,0 +1,44 @@
+-- Three new small-tier aquarium creatures to flesh out the catalog seeded
+-- in 059_create_aquarium_shop.sql. Same payload shape (creature, size,
+-- width, height, area), same item_kind, same price tier (1000 chips).
+-- KDL art for each ships in late-ssh/assets/aquarium/creatures/ and is
+-- registered alphabetically in late-ssh/src/app/hub/aquarium/creature.rs.
+--
+-- Sort orders 3009-3011 pick up directly where the existing small block
+-- (3000-3008) left off; medium starts at 3100, large at 3200, mega at
+-- 3203 — none of those are affected.
+WITH fish_seed(sku, name, size_tier, width, height, area, price_chips, sort_order) AS (
+    VALUES
+        ('anchovy',    'Anchovy',    'small', 6, 2, 12, 1000, 3009),
+        ('clownfish',  'Clownfish',  'small', 7, 3, 21, 1000, 3010),
+        ('pufferfish', 'Pufferfish', 'small', 6, 3, 18, 1000, 3011)
+)
+INSERT INTO marketplace_items
+    (sku, item_kind, slot, name, description, price_chips, payload, active, sort_order)
+SELECT
+    'aquarium_fish_' || sku,
+    'aquarium_fish',
+    NULL,
+    name,
+    'Add one ' || size_tier || ' ' || name || ' to your aquarium.',
+    price_chips,
+    jsonb_build_object(
+        'creature', sku,
+        'size', size_tier,
+        'width', width,
+        'height', height,
+        'area', area
+    ),
+    true,
+    sort_order
+FROM fish_seed
+ON CONFLICT (sku) DO UPDATE SET
+    item_kind = EXCLUDED.item_kind,
+    slot = EXCLUDED.slot,
+    name = EXCLUDED.name,
+    description = EXCLUDED.description,
+    price_chips = EXCLUDED.price_chips,
+    payload = EXCLUDED.payload,
+    active = EXCLUDED.active,
+    sort_order = EXCLUDED.sort_order,
+    updated = current_timestamp;

--- a/late-ssh/assets/aquarium/creatures/anchovy.kdl
+++ b/late-ssh/assets/aquarium/creatures/anchovy.kdl
@@ -1,0 +1,16 @@
+name "anchovy"
+title "a slim sleek fish"
+description "long thin body with a forked tail; swims in schools"
+sauce author=hardlygospel date=20260527 license=CCBYSA4.0
+
+count 3
+
+left ###"""
+  __
+<'-.-=
+"""###
+
+right ###"""
+  __
+=-.-'>
+"""###

--- a/late-ssh/assets/aquarium/creatures/clownfish.kdl
+++ b/late-ssh/assets/aquarium/creatures/clownfish.kdl
@@ -1,0 +1,18 @@
+name "clownfish"
+title "a banded clownfish"
+description "rounded body with vertical bands and a chunky tail"
+sauce author=hardlygospel date=20260527 license=CCBYSA4.0
+
+count 2
+
+left ###"""
+  __
+<(|=|)
+  ''
+"""###
+
+right ###"""
+  __
+ (|=|)>
+  ''
+"""###

--- a/late-ssh/assets/aquarium/creatures/pufferfish.kdl
+++ b/late-ssh/assets/aquarium/creatures/pufferfish.kdl
@@ -1,0 +1,18 @@
+name "pufferfish"
+title "a small spiky pufferfish"
+description "round body with bristled spines top and bottom and a tiny tail"
+sauce author=hardlygospel date=20260527 license=CCBYSA4.0
+
+count 1
+
+left ###"""
+  ^^^
+ (o )<
+  vvv
+"""###
+
+right ###"""
+  ^^^
+ >( o)
+  vvv
+"""###

--- a/late-ssh/src/app/hub/aquarium/creature.rs
+++ b/late-ssh/src/app/hub/aquarium/creature.rs
@@ -44,6 +44,10 @@ const DEFAULT_KINDOM_SOURCES: &[EmbeddedKdl] = &[
 
 const DEFAULT_CREATURE_SOURCES: &[EmbeddedKdl] = &[
     EmbeddedKdl {
+        path: "art/creatures/anchovy.kdl",
+        source: include_str!("../../../../assets/aquarium/creatures/anchovy.kdl"),
+    },
+    EmbeddedKdl {
         path: "art/creatures/bee.kdl",
         source: include_str!("../../../../assets/aquarium/creatures/bee.kdl"),
     },
@@ -62,6 +66,10 @@ const DEFAULT_CREATURE_SOURCES: &[EmbeddedKdl] = &[
     EmbeddedKdl {
         path: "art/creatures/bumble.kdl",
         source: include_str!("../../../../assets/aquarium/creatures/bumble.kdl"),
+    },
+    EmbeddedKdl {
+        path: "art/creatures/clownfish.kdl",
+        source: include_str!("../../../../assets/aquarium/creatures/clownfish.kdl"),
     },
     EmbeddedKdl {
         path: "art/creatures/diamondfish.kdl",
@@ -86,6 +94,10 @@ const DEFAULT_CREATURE_SOURCES: &[EmbeddedKdl] = &[
     EmbeddedKdl {
         path: "art/creatures/oldskool.kdl",
         source: include_str!("../../../../assets/aquarium/creatures/oldskool.kdl"),
+    },
+    EmbeddedKdl {
+        path: "art/creatures/pufferfish.kdl",
+        source: include_str!("../../../../assets/aquarium/creatures/pufferfish.kdl"),
     },
     EmbeddedKdl {
         path: "art/creatures/rugbert.kdl",
@@ -1424,4 +1436,31 @@ fn optional_probability_prop(node: &kdl::KdlNode, name: &str) -> Result<Option<f
 
 fn clamp_velocity(value: i128) -> i16 {
     value.clamp(-1, 1) as i16
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn all_embedded_creatures_parse() {
+        // Tripwire: any new `.kdl` added to DEFAULT_CREATURE_SOURCES must
+        // parse cleanly. Catches typos in tag names, heredoc fences, or
+        // missing required fields before they hit a live aquarium.
+        let creatures =
+            load_default_creatures().expect("embedded creature kdl files must all parse");
+        assert!(
+            !creatures.is_empty(),
+            "expected at least one default creature"
+        );
+
+        let names: std::collections::HashSet<String> =
+            creatures.iter().map(|c| c.name.clone()).collect();
+        for required in ["anchovy", "clownfish", "pufferfish"] {
+            assert!(
+                names.contains(required),
+                "new creature `{required}` missing from default sources"
+            );
+        }
+    }
 }


### PR DESCRIPTION
Thanks Mat — third \"more shop items\" PR, this one in the aquarium catalog you rolled out in #258. Tried to match the existing fish aesthetic (simple ASCII line art, CC-BY-SA, left/right frames, 2-3 rows) — happy to redo the art if any of them feel off.

---

## Summary

Three new small-tier creatures at 1000 chips each, slotting into the existing aquarium catalog. Each ships a KDL art file and a marketplace row.

| sku | size | dim | count | art |
|---|---|---|---|---|
| anchovy | 6x2 (12) | small | 3 | slim sleek schooler |
| clownfish | 7x3 (21) | small | 2 | banded body, chunky tail |
| pufferfish | 6x3 (18) | small | 1 | round with bristled spines |

- KDL files under \`late-ssh/assets/aquarium/creatures/\` follow the existing author/license shape (CC-BY-SA 4.0). Registered alphabetically in \`DEFAULT_CREATURE_SOURCES\`.
- Migration 063 picks up where the existing small block (3000-3008) left off at sort_order 3009-3011. Medium starts at 3100 and large at 3200, so the new rows don't shift anything. \`ON CONFLICT DO UPDATE\` keeps it idempotent.
- New inline test \`all_embedded_creatures_parse\` loads every embedded KDL through \`load_default_creatures\` and asserts the three new creatures are present — tripwire for typos in heredoc fences or required fields.

## Scope

| | |
|---|---|
| Files | 1 migration + 3 new KDL + 1 touched (\`creature.rs\` for source registration + test) |
| Diff | +135 / 0 |
| New deps | none |

## Test plan

- [x] \`cargo check -p late-ssh --tests\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] New \`all_embedded_creatures_parse\` test asserts the three new KDLs parse and load
- [ ] Apply migration; visit Hub Shop → Aquarium tab; see Anchovy/Clownfish/Pufferfish listed
- [ ] Buy each, drop into the aquarium tray, confirm they animate and turn left/right
- [ ] Re-run migration; rows update in place

## Notes

The fish art aims for the same simple-ASCII style as the existing set (bee, finnegan, diamondfish, tiger, etc.) — if any of the three doesn't fit the aesthetic, I'm happy to redo the art or drop it. Easy enough to ship 2 of 3 if one's the odd one out.