### PR TITLE
Improve Rooms selection, Chess mouse input, and Aquarium shop previews

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -61,7 +61,7 @@ Routing rules for future LLM agents:
 The system is a Rust workspace with four crates (`late-cli`, `late-core`, `late-ssh`, `late-web`) backed by PostgreSQL, Icecast audio streaming, and Liquidsoap playlist management.
 
 - **Primary entry points:** SSH server (russh on port 2222), HTTP API (axum on port 4000), Web server (axum on port 3000)
-- **Main responsibilities:** Multi-screen TUI over SSH (Home/Dashboard, The Arcade, Rooms, Artboard), public web frontend, genre voting, paired browser/CLI audio control plus visualizer, real-time chat and chat-adjacent surfaces inside Home, private per-user RSS/Atom inboxes that can be shared into News, link/YouTube sharing with AI summaries/ASCII thumbnails, Arcade games, persistent game-backed Rooms, a shared multi-user ASCII Artboard, a global Hub domain for leaderboard/dailies/shop/events surfaces, a Shop-unlocked ambient Aquarium tray toggled with `Ctrl+Q`, and one structured global Activity stream for user actions. Detailed CLI behavior lives in `late-cli/CONTEXT.md`; detailed Web behavior lives in `late-web/CONTEXT.md`; detailed Arcade behavior lives in `late-ssh/src/app/arcade/CONTEXT.md`; detailed Rooms/Blackjack behavior lives in `late-ssh/src/app/rooms/CONTEXT.md`; detailed Chat behavior lives in `late-ssh/src/app/chat/CONTEXT.md`; detailed Artboard/dartboard behavior lives in `late-ssh/src/app/artboard/CONTEXT.md`. Configurable Home layout surfaces: the global right sidebar (time, visualizer, hot rooms, bonsai, and unlockable cat companion) with on/off/custom per-screen visibility, the Home room-list rail, and lounge top boxes (always on for #general/lounge, optional on other Home rooms); `v` then `v` cycles persisted combinations of those panels. `c` opens the cat care modal after Cat Companion is unlocked; locked users use `Ctrl+G` to visit Hub Shop. Global `q` opens quit confirm; pressing `q` again exits and `Esc` dismisses it.
+- **Main responsibilities:** Multi-screen TUI over SSH (Home/Dashboard, The Arcade, Rooms, Artboard), public web frontend, genre voting, paired browser/CLI audio control plus visualizer, real-time chat and chat-adjacent surfaces inside Home, private per-user RSS/Atom inboxes that can be shared into News, link/YouTube sharing with AI summaries/ASCII thumbnails, Arcade games, persistent game-backed Rooms, a shared multi-user ASCII Artboard, a global Hub domain for leaderboard/dailies/shop/events surfaces, a Shop-unlocked ambient Aquarium tray toggled with `Ctrl+Q`, and one structured global Activity stream for user actions. The complete local context routing map is in `Context Directory (Read-First Routing)` above. Configurable Home layout surfaces: the global right sidebar (time, visualizer, hot rooms, bonsai, and unlockable cat companion) with on/off/custom per-screen visibility, the Home room-list rail, and lounge top boxes (always on for #general/lounge, optional on other Home rooms); `v` then `v` cycles persisted combinations of those panels. `c` opens the cat care modal after Cat Companion is unlocked; locked users use `Ctrl+G` to visit Hub Shop. Global `q` opens quit confirm; pressing `q` again exits and `Esc` dismisses it.
 - **Highest-risk areas:** SSH render loop backpressure, connection limiting, chat sync consistency, paired-client WS routing/state drift
 
 ---
@@ -436,7 +436,7 @@ Local playlist files retain full annotated metadata including duration (when pre
 
 ### 2.8 Arcade Runtime Notes
 
-The Arcade source domain is `late-ssh/src/app/arcade`. It owns single-player terminal games, daily puzzle state, high scores, the Arcade lobby, shared card/chip helpers, and leaderboard surfaces. Detailed file maps, per-game controls, persistence rules, nonogram asset generation, and test guidance live in `late-ssh/src/app/arcade/CONTEXT.md`.
+The Arcade source domain is `late-ssh/src/app/arcade`. It owns single-player terminal games, daily puzzle state, high scores, and the Arcade lobby. Shared card/chip primitives live in `late-ssh/src/app/games`; Hub owns cross-product leaderboard surfaces. Detailed Arcade file maps, per-game controls, persistence rules, nonogram asset generation, and test guidance live in `late-ssh/src/app/arcade/CONTEXT.md`.
 
 ### 2.9 Local CLI
 
@@ -451,7 +451,7 @@ Root-level contracts:
 
 ### 2.10 Artboard (Shared ASCII Canvas) [STABLE]
 
-The Artboard is a shared, persistent, multiplayer ASCII canvas on its own top-level screen (`5`, or cycle with `Tab` / `Shift+Tab`). User-facing docs say `Artboard`; code and upstream crates still use `dartboard` heavily, so search both terms.
+The Artboard is a shared, persistent, multiplayer ASCII canvas on its own top-level screen (`4`, or cycle with `Tab` / `Shift+Tab`). User-facing docs say `Artboard`; code and upstream crates still use `dartboard` heavily, so search both terms.
 
 Detailed Artboard/dartboard behavior lives in `late-ssh/src/app/artboard/CONTEXT.md`, including lifecycle, `late-ssh/src/dartboard.rs` persistence, provenance, keybindings, archive snapshots, tests, and fragile invariants.
 
@@ -493,12 +493,15 @@ late-sh/
 │   │   ├── state.rs            # Shared app state, activity, presence
 │   │   └── app/
 │   │       ├── ai/             # AI services: bot/graybeard + summarization
+│   │       ├── arcade/         # Arcade hub + single-player game subdomains; see app/arcade/CONTEXT.md
 │   │       ├── artboard/       # Shared ASCII Artboard; see app/artboard/CONTEXT.md
+│   │       ├── audio/          # Audio/YouTube queue/source arbitration; see app/audio/CONTEXT.md
 │   │       ├── bonsai/         # Persistent bonsai tree state, service, and UI
 │   │       ├── cat/            # Persistent cat companion state, service, and UI
 │   │       ├── chat/           # Chat implementation; see app/chat/CONTEXT.md
 │   │       ├── dashboard/      # Landing screen layout + shortcuts
-│   │       ├── arcade/         # Arcade hub, leaderboards, shared card/chip helpers, and game subdomains
+│   │       ├── games/          # Shared cards/chips primitives; see app/games/CONTEXT.md
+│   │       ├── hub/            # Leaderboard, Dailies, Shop, Events, Guide; see app/hub/CONTEXT.md
 │   │       ├── icon_picker/    # Ctrl+] emoji + nerd font overlay (chat composer only)
 │   │       ├── profile/        # Username/profile settings and stats
 │   │       ├── rooms/          # Persistent game-room directory; see app/rooms/CONTEXT.md

--- a/late-ssh/src/app/hub/CONTEXT.md
+++ b/late-ssh/src/app/hub/CONTEXT.md
@@ -52,7 +52,7 @@ If another tab is added, update `HubTab::ALL`, `HubTab::label`, `input.rs`, `ui.
 
 ## Aquarium
 
-Aquarium is a Shop unlock, not an admin/mod preview. The Aquarium feature costs 10,000 chips and unlocks the Aquarium Shop category fish catalog. `Ctrl+Q` toggles the owned user's full-width bottom tray across screens; locked users are sent to Hub Shop with a banner.
+Aquarium is a Shop unlock, not an admin/mod preview. The Aquarium feature costs 10,000 chips and unlocks Aquarium ownership/use. The Aquarium Shop category is browseable before unlock so users can preview fish, but fish purchases and active-count changes are blocked until the Aquarium feature is owned. `Ctrl+Q` toggles the owned user's full-width bottom tray across screens; locked users are sent to Hub Shop with a banner.
 
 The runtime is ambient-only for now:
 - Fish ownership and active counts persist through `marketplace_items` / `user_purchases`.

--- a/late-ssh/src/app/hub/shop/state.rs
+++ b/late-ssh/src/app/hub/shop/state.rs
@@ -93,16 +93,7 @@ impl ShopState {
         self.snapshot
             .items
             .iter()
-            .filter(|item| {
-                if !category.matches_item(item) {
-                    return false;
-                }
-                if item.is_aquarium_fish() {
-                    self.snapshot.entitlements.has_aquarium()
-                } else {
-                    true
-                }
-            })
+            .filter(|item| category.matches_item(item))
             .collect()
     }
 
@@ -161,6 +152,9 @@ impl ShopState {
     pub fn activate_selected(&mut self) -> Option<Banner> {
         let item = self.selected_item()?.clone();
         if item.is_aquarium_fish() {
+            if !self.snapshot.entitlements.has_aquarium() {
+                return Some(Banner::error("Unlock Aquarium before buying fish"));
+            }
             self.service.purchase_item_task(self.user_id, item.sku);
             return Some(Banner::success(&format!("Buying {}", item.name)));
         }
@@ -187,6 +181,9 @@ impl ShopState {
         let item = self.selected_item()?.clone();
         if !item.is_aquarium_fish() {
             return None;
+        }
+        if !self.snapshot.entitlements.has_aquarium() {
+            return Some(Banner::error("Unlock Aquarium before managing fish"));
         }
         self.service
             .adjust_aquarium_fish_task(self.user_id, item.sku, delta);

--- a/late-ssh/src/app/hub/shop/ui.rs
+++ b/late-ssh/src/app/hub/shop/ui.rs
@@ -58,7 +58,12 @@ fn draw_body(frame: &mut Frame, area: Rect, state: &ShopState) {
     let columns =
         Layout::horizontal([Constraint::Percentage(45), Constraint::Percentage(55)]).split(area);
     draw_item_list(frame, columns[0], state);
-    draw_item_detail(frame, columns[1], state.selected_item());
+    draw_item_detail(
+        frame,
+        columns[1],
+        state.selected_item(),
+        state.entitlements().has_aquarium(),
+    );
 }
 
 fn draw_item_list(frame: &mut Frame, area: Rect, state: &ShopState) {
@@ -150,13 +155,20 @@ fn visible_window_start(selected_index: usize, item_count: usize, height: usize)
         .min(item_count.saturating_sub(height))
 }
 
-fn draw_item_detail(frame: &mut Frame, area: Rect, item: Option<&ShopCatalogItem>) {
+fn draw_item_detail(
+    frame: &mut Frame,
+    area: Rect,
+    item: Option<&ShopCatalogItem>,
+    has_aquarium: bool,
+) {
     let Some(item) = item else {
         return;
     };
 
     let action = if item.equipped {
         "displaying"
+    } else if item.is_aquarium_fish() && !has_aquarium {
+        "needs aquarium"
     } else if item.is_aquarium_fish() {
         "buy fish"
     } else if item.owned && item.slot.is_some() {
@@ -173,6 +185,10 @@ fn draw_item_detail(frame: &mut Frame, area: Rect, item: Option<&ShopCatalogItem
     let status = if item.owned {
         Style::default()
             .fg(theme::SUCCESS())
+            .add_modifier(Modifier::BOLD)
+    } else if item.is_aquarium_fish() && !has_aquarium {
+        Style::default()
+            .fg(theme::TEXT_DIM())
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(theme::AMBER())
@@ -210,6 +226,17 @@ fn draw_item_detail(frame: &mut Frame, area: Rect, item: Option<&ShopCatalogItem
         ]));
     }
     if item.is_aquarium_fish() {
+        if !has_aquarium {
+            lines.push(Line::from(vec![
+                Span::raw("  unlock "),
+                Span::styled(
+                    "Aquarium first",
+                    Style::default()
+                        .fg(theme::AMBER())
+                        .add_modifier(Modifier::BOLD),
+                ),
+            ]));
+        }
         if let Some(size) = &item.aquarium_size {
             lines.push(Line::from(vec![
                 Span::raw("  size   "),
@@ -328,8 +355,11 @@ fn truncate_display_width(value: &str, max_width: usize) -> String {
 
 fn draw_footer(frame: &mut Frame, area: Rect, state: &ShopState) {
     let selected = state.selected_item();
+    let has_aquarium = state.entitlements().has_aquarium();
     let enter_label = if selected.is_some_and(|item| item.equipped) {
         "clear"
+    } else if selected.is_some_and(|item| item.is_aquarium_fish() && !has_aquarium) {
+        "needs aquarium"
     } else if selected.is_some_and(|item| item.is_aquarium_fish()) {
         "buy one"
     } else if selected.is_some_and(|item| item.owned && item.slot.is_some()) {
@@ -350,7 +380,7 @@ fn draw_footer(frame: &mut Frame, area: Rect, state: &ShopState) {
         Span::styled("Enter", key),
         Span::styled(format!(" {enter_label}"), text),
     ];
-    if selected.is_some_and(|item| item.is_aquarium_fish()) {
+    if selected.is_some_and(|item| item.is_aquarium_fish() && has_aquarium) {
         spans.extend([Span::styled("  +/-", key), Span::styled(" active", text)]);
     }
     if state.selected_category() == ShopCategory::Aquarium {

--- a/late-ssh/src/app/rooms/CONTEXT.md
+++ b/late-ssh/src/app/rooms/CONTEXT.md
@@ -65,6 +65,7 @@
 - `rooms_selected_index` counts only visible real rooms.
 - `state.rs::visible_real_rooms_count` and `input.rs::visible_real_count`/`visible_real_room_at` intentionally duplicate the same filter/search predicate. Change them together.
 - Wide directory layout starts at `WIDE_LIST_MIN_WIDTH = 96` and renders a columned table with dynamic breathing room plus a `Creator` column. Narrow layout renders two-line cards and includes the creator in the metadata line.
+- The selected room must be obvious at a glance: wide and narrow directory rows use an amber-selected full-row highlight, not just a leading marker.
 - Directory handlers support `j/k` and up/down arrows to navigate, `h/l` and left/right arrows to filter, `/` to search, `n` to create, `d` to delete, and `Enter` to enter. The rendered footer is role-aware: `n` always shows, `d` shows only for admins, and `Esc` shows only for admins/mods.
 - In the idle directory, `Tab`, `Shift+Tab`, and number keys remain global screen navigation, not Rooms filter shortcuts. The create modal consumes `Tab`/`BackTab` for field focus, and active-room input is intercepted before global screen switching.
 - Directory `Esc` peels state in this order: create form -> active search -> search query -> non-All filter -> active room/list exit. Active rooms bypass that directory escape path: `Esc` first clears embedded chat selection when present, then routes to the game and may leave the room.
@@ -169,7 +170,7 @@
 - Chess sit, leave, ready/start, resign, and accepted move actions touch the persistent `game_rooms.updated` timestamp. That keeps active daily boards alive while letting abandoned pre-game seats or empty boards be closed by the generic 24h room cleanup.
 - Time controls are preset-only and intentionally generous: blitz is `5+3`, rapid is `15+10`, and daily is `1d/move`. Room settings store only `blitz`, `rapid`, or `daily`; old seven-preset IDs fall back to rapid. Countdown clocks debit elapsed time idempotently as clock state is settled and add increment after a legal move. Daily clocks use a per-move deadline instead of a banked player clock.
 - When a new game starts after a finished round, the service swaps the two seated players so colours alternate. A decisive Chess win (checkmate, timeout, or resignation) credits the winner 500 chips when the user is outside the 60-minute DB-backed Chess payout cooldown; drawn games do not award chips.
-- Input is cursor-first. Seated players move the local cursor with `w/a/s/d` or arrows, press `Space`/`Enter` to select a piece and then a destination, and promotion defaults to queen. `r` resigns an active game; `l` leaves only before/after a game.
+- Input is cursor-first. Seated players move the local cursor with `w/a/s/d` or arrows, click a board square, or press `Space`/`Enter` to select a piece and then a destination; promotion defaults to queen. `r` resigns an active game; `l` leaves only before/after a game.
 - Checkmate, timeout, and resignation publish `ActivityGame::Chess` win events with detail `checkmate`, `timeout`, or `resignation`. Draws do not publish win activity.
 
 ## Tron Runtime

--- a/late-ssh/src/app/rooms/backend.rs
+++ b/late-ssh/src/app/rooms/backend.rs
@@ -3,7 +3,7 @@ use serde_json::Value;
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
-use crate::app::input::ParsedInput;
+use crate::app::input::{MouseEvent, ParsedInput};
 use crate::usernames::UsernameLookup;
 
 use super::svc::{GameKind, RoomListItem};
@@ -74,6 +74,9 @@ pub trait ActiveRoomBackend: Send {
     fn touch_activity(&self);
     fn handle_key(&mut self, byte: u8) -> InputAction;
     fn handle_arrow(&mut self, _key: u8) -> bool {
+        false
+    }
+    fn handle_mouse(&mut self, _mouse: MouseEvent, _area: Rect) -> bool {
         false
     }
     fn preferred_game_height(&self, area: Rect) -> u16;

--- a/late-ssh/src/app/rooms/chess/input.rs
+++ b/late-ssh/src/app/rooms/chess/input.rs
@@ -1,4 +1,9 @@
-use crate::app::rooms::{backend::InputAction, chess::state::State};
+use ratatui::layout::Rect;
+
+use crate::app::{
+    input::{MouseButton, MouseEvent, MouseEventKind},
+    rooms::{backend::InputAction, chess::state::State},
+};
 
 pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
     let seated = state.seat_index().is_some();
@@ -57,4 +62,20 @@ pub fn handle_arrow(state: &mut State, key: u8) -> bool {
         _ => return false,
     }
     true
+}
+
+pub fn handle_mouse(state: &mut State, mouse: MouseEvent, area: Rect) -> bool {
+    if mouse.kind != MouseEventKind::Down || mouse.button != Some(MouseButton::Left) {
+        return false;
+    }
+    let Some(x) = mouse.x.checked_sub(1) else {
+        return false;
+    };
+    let Some(y) = mouse.y.checked_sub(1) else {
+        return false;
+    };
+    let Some(square) = crate::app::rooms::chess::ui::board_square_at(area, state, x, y) else {
+        return false;
+    };
+    state.click_square(square)
 }

--- a/late-ssh/src/app/rooms/chess/manager.rs
+++ b/late-ssh/src/app/rooms/chess/manager.rs
@@ -157,6 +157,14 @@ impl ActiveRoomBackend for State {
         crate::app::rooms::chess::input::handle_arrow(self, key)
     }
 
+    fn handle_mouse(
+        &mut self,
+        mouse: crate::app::input::MouseEvent,
+        area: ratatui::layout::Rect,
+    ) -> bool {
+        crate::app::rooms::chess::input::handle_mouse(self, mouse, area)
+    }
+
     fn preferred_game_height(&self, area: ratatui::layout::Rect) -> u16 {
         crate::app::rooms::chess::ui::preferred_height(area)
     }

--- a/late-ssh/src/app/rooms/chess/state.rs
+++ b/late-ssh/src/app/rooms/chess/state.rs
@@ -211,6 +211,18 @@ impl State {
         }
     }
 
+    pub fn click_square(&mut self, index: usize) -> bool {
+        if index >= 64 {
+            return false;
+        }
+        self.cursor = index;
+        if self.user_color().is_none() {
+            return true;
+        }
+        self.select_or_move();
+        true
+    }
+
     pub fn move_cursor(&mut self, dx: isize, dy: isize) {
         let (dx, dy) = match self.orienting_color() {
             ChessColor::White => (dx, dy),

--- a/late-ssh/src/app/rooms/chess/ui.rs
+++ b/late-ssh/src/app/rooms/chess/ui.rs
@@ -137,6 +137,89 @@ fn centered_x(rect: Rect, width: u16) -> Rect {
     }
 }
 
+pub(crate) fn board_square_at(area: Rect, state: &State, x: u16, y: u16) -> Option<usize> {
+    board_square_at_for_orientation(area, state.orienting_color(), x, y)
+}
+
+fn board_square_at_for_orientation(
+    area: Rect,
+    orientation: ChessColor,
+    x: u16,
+    y: u16,
+) -> Option<usize> {
+    let (board_area, tier) = board_geometry(area)?;
+    if x < board_area.x || x >= board_area.right() || y < board_area.y || y >= board_area.bottom() {
+        return None;
+    }
+
+    let local_x = x - board_area.x;
+    let local_y = y - board_area.y;
+    if local_y == 0 || local_y >= 1 + tier.ch as u16 * 8 {
+        return None;
+    }
+    let cell_x = local_x.checked_sub(tier.gutter as u16)?;
+    if cell_x >= tier.cw as u16 * 8 {
+        return None;
+    }
+
+    let display_col = (cell_x / tier.cw as u16) as usize;
+    let display_row = ((local_y - 1) / tier.ch as u16) as usize;
+    let rank = match orientation {
+        ChessColor::White => 7usize.saturating_sub(display_row),
+        ChessColor::Black => display_row,
+    };
+    let file = match orientation {
+        ChessColor::White => display_col,
+        ChessColor::Black => 7usize.saturating_sub(display_col),
+    };
+    Some(rank * 8 + file)
+}
+
+fn board_geometry(area: Rect) -> Option<(Rect, Tier)> {
+    if area.height < 10 || area.width < 30 {
+        return None;
+    }
+
+    let show_sidebar = area.width >= INFO_SIDEBAR_MIN_WIDTH;
+    let content = if show_sidebar {
+        Layout::horizontal([Constraint::Fill(1), Constraint::Length(INFO_SIDEBAR_WIDTH)])
+            .split(area)[0]
+    } else {
+        area
+    };
+    let rows = if show_sidebar {
+        Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(6),
+            Constraint::Length(1),
+        ])
+        .split(content)
+    } else {
+        Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(6),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .split(content)
+    };
+    let board_region = rows[2];
+    let tier = pick_tier(board_region.width as usize, board_region.height as usize);
+    let board_w = (tier.board_w() as u16).min(board_region.width);
+    let board_h = (tier.board_h() as u16).min(board_region.height);
+    Some((
+        Rect {
+            x: board_region.x + board_region.width.saturating_sub(board_w) / 2,
+            y: board_region.y + board_region.height.saturating_sub(board_h) / 2,
+            width: board_w,
+            height: board_h,
+        },
+        tier,
+    ))
+}
+
 // ── Entry point ────────────────────────────────────────────────
 
 pub fn draw_game(frame: &mut Frame, area: Rect, state: &State, usernames: &UsernameLookup<'_>) {
@@ -790,6 +873,7 @@ fn info_lines(
         Line::raw(""),
         key_hint("arrows/wasd", "move cursor"),
         key_hint("Space/Enter", "select / move"),
+        key_hint("click", "select / move"),
         key_hint("n", "ready / start"),
         key_hint("l", "stand up"),
         key_hint("r", "resign active"),
@@ -974,6 +1058,47 @@ mod tests {
         assert_eq!(material_advantage(&snapshot), 4);
         assert_eq!(captured_pieces(&snapshot, ChessColor::White).len(), 2);
         assert!(captured_pieces(&snapshot, ChessColor::Black).is_empty());
+    }
+
+    #[test]
+    fn board_square_hit_test_maps_orientation() {
+        let area = Rect::new(10, 5, 80, 32);
+        let (board, tier) = board_geometry(area).expect("board should fit");
+
+        let top_left_x = board.x + tier.gutter as u16;
+        let top_left_y = board.y + 1;
+        assert_eq!(
+            board_square_at_for_orientation(area, ChessColor::White, top_left_x, top_left_y),
+            Some(56)
+        );
+        assert_eq!(
+            board_square_at_for_orientation(area, ChessColor::Black, top_left_x, top_left_y),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn board_square_hit_test_ignores_labels_and_gutters() {
+        let area = Rect::new(0, 0, 80, 32);
+        let (board, tier) = board_geometry(area).expect("board should fit");
+
+        assert_eq!(
+            board_square_at_for_orientation(area, ChessColor::White, board.x, board.y),
+            None
+        );
+        assert_eq!(
+            board_square_at_for_orientation(area, ChessColor::White, board.x, board.y + 1),
+            None
+        );
+        assert_eq!(
+            board_square_at_for_orientation(
+                area,
+                ChessColor::White,
+                board.x + tier.gutter as u16,
+                board.bottom() - 1
+            ),
+            None
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/rooms/chess/ui.rs
+++ b/late-ssh/src/app/rooms/chess/ui.rs
@@ -154,7 +154,7 @@ fn board_square_at_for_orientation(
 
     let local_x = x - board_area.x;
     let local_y = y - board_area.y;
-    if local_y == 0 || local_y >= 1 + tier.ch as u16 * 8 {
+    if local_y == 0 || local_y > tier.ch as u16 * 8 {
         return None;
     }
     let cell_x = local_x.checked_sub(tier.gutter as u16)?;

--- a/late-ssh/src/app/rooms/input.rs
+++ b/late-ssh/src/app/rooms/input.rs
@@ -1,13 +1,17 @@
 use crate::app::state::DashboardGameToggleTarget;
 use crate::app::{
     common::primitives::Banner,
-    input::{MouseEventKind, ParsedInput, sanitize_paste_markers},
+    input::{MouseButton, MouseEvent, MouseEventKind, ParsedInput, sanitize_paste_markers},
     rooms::{
         backend::{CreateModalAction, CreateRoomFlow, InputAction},
         filter::RoomsFilter,
         svc::GameKind,
     },
     state::App,
+};
+use ratatui::{
+    layout::{Constraint, Layout, Rect},
+    widgets::{Block, Borders},
 };
 
 const SEARCH_QUERY_MAX_LEN: usize = 32;
@@ -29,6 +33,9 @@ pub(crate) fn handle_event(app: &mut App, event: &ParsedInput) -> bool {
             ParsedInput::Mouse(mouse) => match mouse.kind {
                 MouseEventKind::ScrollUp => return handle_active_room_scroll(app, 1),
                 MouseEventKind::ScrollDown => return handle_active_room_scroll(app, -1),
+                MouseEventKind::Down if mouse.button == Some(MouseButton::Left) => {
+                    return handle_active_room_mouse(app, *mouse);
+                }
                 _ => {}
             },
             _ => {}
@@ -536,6 +543,21 @@ fn handle_active_room_arrow(app: &mut App, key: u8) -> bool {
     crate::app::chat::input::handle_message_arrow_in_room(app, chat_room_id, key)
 }
 
+fn handle_active_room_mouse(app: &mut App, mouse: MouseEvent) -> bool {
+    let content_area = rooms_content_area(app);
+    let Some(active_room_game) = app.active_room_game.as_ref() else {
+        return false;
+    };
+    let game_area = crate::app::rooms::ui::active_room_game_area(&**active_room_game, content_area);
+    if !rect_contains_mouse(game_area, mouse) {
+        return false;
+    }
+    touch_active_room_activity(app);
+    app.active_room_game
+        .as_mut()
+        .is_some_and(|game| game.handle_mouse(mouse, game_area))
+}
+
 fn handle_active_room_scroll(app: &mut App, delta: isize) -> bool {
     let Some(room) = app.rooms_active_room.as_ref() else {
         return false;
@@ -544,6 +566,36 @@ fn handle_active_room_scroll(app: &mut App, delta: isize) -> bool {
     touch_active_room_activity(app);
     crate::app::chat::input::handle_scroll_in_room(app, chat_room_id, delta);
     true
+}
+
+fn rooms_content_area(app: &App) -> Rect {
+    let area = Rect::new(0, 0, app.size.0, app.size.1);
+    let mut inner = Block::default().borders(Borders::ALL).inner(area);
+    if app.show_aquarium_tray && app.shop_state.entitlements().has_aquarium() {
+        let tray = crate::app::hub::aquarium::ui::bottom_tray_area(inner);
+        inner.height = inner.height.saturating_sub(tray.height);
+    }
+
+    let profile = app.profile_state.profile();
+    if crate::app::render::resolve_right_sidebar_enabled(
+        profile.right_sidebar_mode,
+        &profile.right_sidebar_screens,
+        app.screen,
+    ) {
+        Layout::horizontal([Constraint::Fill(1), Constraint::Length(24)]).split(inner)[0]
+    } else {
+        inner
+    }
+}
+
+fn rect_contains_mouse(area: Rect, mouse: MouseEvent) -> bool {
+    let Some(x) = mouse.x.checked_sub(1) else {
+        return false;
+    };
+    let Some(y) = mouse.y.checked_sub(1) else {
+        return false;
+    };
+    x >= area.x && x < area.right() && y >= area.y && y < area.bottom()
 }
 
 fn touch_active_room_activity(app: &mut App) {

--- a/late-ssh/src/app/rooms/ui.rs
+++ b/late-ssh/src/app/rooms/ui.rs
@@ -338,7 +338,7 @@ fn draw_room_list_wide(frame: &mut Frame, area: Rect, view: &RoomsPageView<'_>, 
     for (real_index, row) in rows.iter().take(visible).enumerate() {
         let Row::Real(room) = row;
         let selected = real_index == view.selected_index;
-        lines.push(real_row_wide(room, selected, view, cols));
+        lines.push(real_row_wide(room, selected, view, cols, area.width));
     }
 
     frame.render_widget(Paragraph::new(lines), area);
@@ -405,11 +405,17 @@ fn divider_line(width: u16) -> Line<'static> {
     ))
 }
 
+fn row_background_style(bg: Option<ratatui::style::Color>) -> Style {
+    bg.map(|color| Style::default().bg(color))
+        .unwrap_or_default()
+}
+
 fn real_row_wide(
     room: &RoomListItem,
     selected: bool,
     view: &RoomsPageView<'_>,
     cols: WideColumns,
+    width: u16,
 ) -> Line<'static> {
     let meta = view.room_game_registry.directory_meta(room);
     let (status_text, status_color) = real_status(&room.status);
@@ -424,19 +430,47 @@ fn real_row_wide(
     };
     let name_style = if selected {
         Style::default()
-            .fg(theme::TEXT_BRIGHT())
+            .fg(theme::AMBER_GLOW())
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(theme::TEXT())
     };
-    let dim = Style::default().fg(theme::TEXT_DIM());
+    let dim = if selected {
+        Style::default().fg(theme::TEXT_BRIGHT())
+    } else {
+        Style::default().fg(theme::TEXT_DIM())
+    };
+    let game_style = if selected {
+        Style::default()
+            .fg(theme::AMBER())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::AMBER())
+    };
+    let status_style = if selected {
+        Style::default()
+            .fg(theme::AMBER_GLOW())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(status_color)
+    };
+    let row_bg = selected.then(theme::BG_HIGHLIGHT);
+    let row_len = 2
+        + cols.name
+        + cols.game
+        + cols.creator
+        + cols.seats
+        + cols.pace
+        + cols.stakes
+        + status_text.chars().count();
+    let trailing = " ".repeat((width as usize).saturating_sub(row_len));
 
     Line::from(vec![
         Span::styled(if selected { "▸ " } else { "  " }, pointer_style),
         Span::styled(pad_col(&room.display_name, cols.name), name_style),
         Span::styled(
             pad_col(view.room_game_registry.label(room.game_kind), cols.game),
-            Style::default().fg(theme::AMBER()),
+            game_style,
         ),
         Span::styled(pad_col(&creator, cols.creator), dim),
         Span::styled(
@@ -445,8 +479,10 @@ fn real_row_wide(
         ),
         Span::styled(pad_col(&meta.pace, cols.pace), dim),
         Span::styled(pad_col(&meta.stakes, cols.stakes), dim),
-        Span::styled(status_text, Style::default().fg(status_color)),
+        Span::styled(status_text, status_style),
+        Span::styled(trailing, dim),
     ])
+    .patch_style(row_background_style(row_bg))
 }
 
 fn draw_room_list_narrow(
@@ -473,7 +509,7 @@ fn draw_room_list_narrow(
         }
         let Row::Real(room) = row;
         let selected = real_index == view.selected_index;
-        let (a, b) = real_card_narrow(room, selected, view);
+        let (a, b) = real_card_narrow(room, selected, view, area.width);
         lines.push(a);
         lines.push(b);
     }
@@ -485,6 +521,7 @@ fn real_card_narrow<'a>(
     room: &'a RoomListItem,
     selected: bool,
     view: &RoomsPageView<'_>,
+    width: u16,
 ) -> (Line<'a>, Line<'a>) {
     let meta = view.room_game_registry.directory_meta(room);
     let (status_text, status_color) = real_status(&room.status);
@@ -492,41 +529,79 @@ fn real_card_narrow<'a>(
     let pointer = if selected { "▸ " } else { "  " };
     let name_style = if selected {
         Style::default()
-            .fg(theme::TEXT_BRIGHT())
+            .fg(theme::AMBER_GLOW())
             .add_modifier(Modifier::BOLD)
     } else {
         Style::default().fg(theme::TEXT())
     };
+    let row_bg = selected.then(theme::BG_HIGHLIGHT);
+    let marker_style = if selected {
+        Style::default()
+            .fg(theme::AMBER_GLOW())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default()
+            .fg(theme::AMBER())
+            .add_modifier(Modifier::BOLD)
+    };
+    let game_style = if selected {
+        Style::default()
+            .fg(theme::AMBER())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::AMBER())
+    };
+    let body_style = if selected {
+        Style::default().fg(theme::TEXT_BRIGHT())
+    } else {
+        Style::default().fg(theme::TEXT_DIM())
+    };
+    let status_style = if selected {
+        Style::default()
+            .fg(theme::AMBER_GLOW())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(status_color)
+    };
+    let head_len = 2
+        + room.display_name.chars().count()
+        + 2
+        + view
+            .room_game_registry
+            .label(room.game_kind)
+            .chars()
+            .count();
+    let body_text = format!(
+        "by {} · {} seats · {} · {}",
+        creator,
+        seats_label(room, meta.seats, view),
+        meta.pace,
+        meta.stakes
+    );
+    let body_len = 4 + body_text.chars().count() + 3 + status_text.chars().count();
 
     let head = Line::from(vec![
-        Span::styled(
-            pointer,
-            Style::default()
-                .fg(theme::AMBER())
-                .add_modifier(Modifier::BOLD),
-        ),
+        Span::styled(pointer, marker_style),
         Span::styled(room.display_name.clone(), name_style),
         Span::raw("  "),
+        Span::styled(view.room_game_registry.label(room.game_kind), game_style),
         Span::styled(
-            view.room_game_registry.label(room.game_kind),
-            Style::default().fg(theme::AMBER()),
+            " ".repeat((width as usize).saturating_sub(head_len)),
+            body_style,
         ),
-    ]);
+    ])
+    .patch_style(row_background_style(row_bg));
     let body = Line::from(vec![
         Span::raw("    "),
-        Span::styled(
-            format!(
-                "by {} · {} seats · {} · {}",
-                creator,
-                seats_label(room, meta.seats, view),
-                meta.pace,
-                meta.stakes
-            ),
-            Style::default().fg(theme::TEXT_DIM()),
-        ),
+        Span::styled(body_text, body_style),
         Span::raw("   "),
-        Span::styled(status_text, Style::default().fg(status_color)),
-    ]);
+        Span::styled(status_text, status_style),
+        Span::styled(
+            " ".repeat((width as usize).saturating_sub(body_len)),
+            body_style,
+        ),
+    ])
+    .patch_style(row_background_style(row_bg));
     (head, body)
 }
 
@@ -651,9 +726,9 @@ fn draw_active_room(
     active_room_chat: Option<EmbeddedRoomChatView<'_>>,
     terminal_images: &mut TerminalImageFrame,
 ) {
-    let game_height = preferred_game_height(active_room_game, area);
+    let game_area = active_room_game_area(active_room_game, area);
     let layout = Layout::vertical([
-        Constraint::Length(game_height),
+        Constraint::Length(game_area.height),
         Constraint::Length(1),
         Constraint::Min(5),
     ])
@@ -663,6 +738,16 @@ fn draw_active_room(
     draw_active_room_spacer(frame, layout[1]);
     if let Some(chat) = active_room_chat {
         crate::app::chat::ui::draw_embedded_room_chat(frame, layout[2], chat, terminal_images);
+    }
+}
+
+pub(crate) fn active_room_game_area(active_room_game: &dyn ActiveRoomBackend, area: Rect) -> Rect {
+    let game_height = preferred_game_height(active_room_game, area);
+    Rect {
+        x: area.x,
+        y: area.y,
+        width: area.width,
+        height: game_height,
     }
 }
 


### PR DESCRIPTION
## Summary
- Makes Rooms easier to use by adding full-row selected highlights, clickable Chess board squares, and browseable Aquarium fish previews before unlock.

## Changes
- Rooms directory rows now highlight the full selected row in both wide and narrow layouts.
- Active Chess rooms now accept left-click board input for selecting and moving pieces, with hit testing that respects board orientation.
- Aquarium fish remain visible in the Shop before Aquarium ownership, but buying fish and changing active counts are blocked until the Aquarium is unlocked.
- Context docs were updated for routing, Arcade/Hub ownership, Artboard shortcut, Aquarium behavior, Rooms highlighting, and Chess click input.

## Behavior notes
- Locked Aquarium users can preview fish catalog items, but actions show an unlock-first error instead of purchasing or managing fish.
- Chess mouse handling only applies inside the active room game area and ignores labels, gutters, and non-left-click mouse events.

## Feature flags
- None

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Added unit coverage for Chess board-square hit testing and orientation mapping. Test run not included in the diff context.
- Manual: Not run; no manual verification details were included in the diff context.