### PR TITLE
Add SSH account linking

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -571,7 +571,7 @@ late-sh/
 
 ### 4.2 Auth and scope model
 
-- **Identity:** SSH key fingerprint → `users` table (`User::find_by_fingerprint`)
+- **Identity:** First unknown SSH key creates a user instantly. `user_ssh_keys` maps many fingerprints to one user. Settings > Account supports destructive account linking by moving the losing account's SSH keys to the chosen main account; no user data is merged.
 - **Open access:** `LATE_SSH_OPEN=true` enables auth, but only public-key auth is accepted; password and keyboard-interactive are always rejected
 - **User scoping:** Votes are scoped to `user_id` (FK to `users.id`)
 - **Chat scoping:** Rooms visible via membership (`ChatRoom::list_for_user`, `ChatRoomMember`)
@@ -585,6 +585,8 @@ late-sh/
 | Entity | Table | Key constraints |
 |--------|-------|----------------|
 | User | `users` | `fingerprint` UNIQUE; `is_admin` and `is_moderator` role flags; `username` trimmed length 1-32, case-insensitive UNIQUE via `idx_users_username_lower`, format `^[A-Za-z0-9._-]+$` and no `@` (canonical public handle); `settings` JSONB holds `ignored_user_ids: [uuid]` (keyed by id, not username, so renames don't drop ignores), `theme_id` (string), `enable_background_color` (bool), `show_right_sidebar` (bool, default-on when absent), `show_room_list_sidebar` (bool, default-on when absent), `favorite_room_ids: [uuid]` (ordered room pins toggled from Home with `f`, not edited in Settings), `show_dashboard_header` (bool, default-on when absent; controls top boxes on non-general Home rooms only; #general/lounge always shows them), `notify_kinds: [text]` (desktop-notification opt-ins: `dms`, `mentions`, `game_events`), `notify_cooldown_mins` (int >= 0; 0 = no throttle) |
+| UserSshKey | `user_ssh_keys` | `fingerprint` UNIQUE; many SSH key fingerprints may point to one `users.id`; account linking moves rows from the abandoned user to the kept user before deleting the abandoned user |
+| AccountLinkCode | `account_link_codes` | Short post-login link codes, `code` UNIQUE, per-user expiry and `consumed_at`; used only from Settings > Account between already-created accounts |
 | Vote | `votes` | `user_id` UNIQUE (one vote per user per round) |
 | ChatRoom | `chat_rooms` | `kind` IN (general, language, dm, topic), complex constraints |
 | ChatRoomMember | `chat_room_members` | PK `(room_id, user_id)`, `last_read_at` |
@@ -842,8 +844,10 @@ let client = db.get().await?;
 db.migrate().await?;
 
 // === User identity ===
-let user = User::find_by_fingerprint(&client, &fingerprint).await?;
-user.update_last_seen(&client).await?;
+if let Some(mut user) = User::find_by_fingerprint(&client, &fingerprint).await? {
+    User::ensure_ssh_key(&client, user.id, &fingerprint).await?;
+    user.update_last_seen(&client).await?;
+}
 
 // === Vote ===
 Vote::upsert(&client, user_id, "lofi").await?;

--- a/late-core/migrations/061_create_user_ssh_keys_and_account_links.sql
+++ b/late-core/migrations/061_create_user_ssh_keys_and_account_links.sql
@@ -1,0 +1,30 @@
+CREATE TABLE user_ssh_keys (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    last_seen TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    fingerprint TEXT NOT NULL UNIQUE,
+    label TEXT
+);
+
+CREATE INDEX idx_user_ssh_keys_user_id ON user_ssh_keys(user_id);
+CREATE INDEX idx_user_ssh_keys_fingerprint ON user_ssh_keys(fingerprint);
+
+INSERT INTO user_ssh_keys (user_id, fingerprint, created, updated, last_seen)
+SELECT id, fingerprint, created, updated, last_seen
+FROM users
+ON CONFLICT (fingerprint) DO NOTHING;
+
+CREATE TABLE account_link_codes (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    code TEXT NOT NULL UNIQUE,
+    expires_at TIMESTAMPTZ NOT NULL,
+    consumed_at TIMESTAMPTZ
+);
+
+CREATE INDEX idx_account_link_codes_user_id ON account_link_codes(user_id);
+CREATE INDEX idx_account_link_codes_code ON account_link_codes(code);

--- a/late-core/src/models/account_link.rs
+++ b/late-core/src/models/account_link.rs
@@ -1,0 +1,216 @@
+use anyhow::{Result, bail};
+use chrono::{DateTime, Duration, Utc};
+use deadpool_postgres::GenericClient;
+use tokio_postgres::Client;
+use uuid::Uuid;
+
+#[derive(Clone, Debug)]
+pub struct AccountLinkPeer {
+    pub user_id: Uuid,
+    pub username: String,
+    pub created: DateTime<Utc>,
+}
+
+#[derive(Clone, Debug)]
+pub struct AccountLinkResult {
+    pub kept_user_id: Uuid,
+    pub kept_username: String,
+    pub abandoned_user_id: Uuid,
+    pub abandoned_username: String,
+}
+
+pub async fn create_code(client: &Client, user_id: Uuid) -> Result<(String, DateTime<Utc>)> {
+    let expires_at = Utc::now() + Duration::minutes(10);
+    client
+        .execute(
+            "UPDATE account_link_codes
+             SET consumed_at = current_timestamp, updated = current_timestamp
+             WHERE user_id = $1 AND consumed_at IS NULL",
+            &[&user_id],
+        )
+        .await?;
+
+    for _ in 0..8 {
+        let code = generate_code();
+        let row = client
+            .query_opt(
+                "INSERT INTO account_link_codes (user_id, code, expires_at)
+                 VALUES ($1, $2, $3)
+                 ON CONFLICT (code) DO NOTHING
+                 RETURNING code",
+                &[&user_id, &code, &expires_at],
+            )
+            .await?;
+        if row.is_some() {
+            return Ok((code, expires_at));
+        }
+    }
+
+    bail!("could not allocate account link code")
+}
+
+pub async fn peer_for_code(
+    client: &Client,
+    current_user_id: Uuid,
+    code: &str,
+) -> Result<AccountLinkPeer> {
+    let code = normalize_code(code);
+    if code.is_empty() {
+        bail!("enter a link code");
+    }
+
+    let row = client
+        .query_opt(
+            "SELECT u.id, u.username, u.created
+             FROM account_link_codes c
+             JOIN users u ON u.id = c.user_id
+             WHERE c.code = $1
+               AND c.consumed_at IS NULL
+               AND c.expires_at > current_timestamp",
+            &[&code],
+        )
+        .await?;
+
+    let Some(row) = row else {
+        bail!("link code expired or not found");
+    };
+    let user_id = row.get("id");
+    if user_id == current_user_id {
+        bail!("enter a code from the other account");
+    }
+
+    Ok(AccountLinkPeer {
+        user_id,
+        username: row.get("username"),
+        created: row.get("created"),
+    })
+}
+
+pub async fn complete(
+    client: &mut Client,
+    current_user_id: Uuid,
+    peer_user_id: Uuid,
+    peer_code: &str,
+    kept_user_id: Uuid,
+) -> Result<AccountLinkResult> {
+    if current_user_id == peer_user_id {
+        bail!("cannot link an account to itself");
+    }
+    if kept_user_id != current_user_id && kept_user_id != peer_user_id {
+        bail!("kept account must be one of the linked accounts");
+    }
+
+    let tx = client.transaction().await?;
+    let peer_code = normalize_code(peer_code);
+    let code_owner = tx
+        .query_opt(
+            "SELECT user_id
+             FROM account_link_codes
+             WHERE code = $1
+               AND user_id = $2
+               AND consumed_at IS NULL
+               AND expires_at > current_timestamp
+             FOR UPDATE",
+            &[&peer_code, &peer_user_id],
+        )
+        .await?;
+    if code_owner.is_none() {
+        bail!("link code expired or already used");
+    }
+
+    let rows = tx
+        .query(
+            "SELECT id, username
+             FROM users
+             WHERE id = ANY($1)
+             FOR UPDATE",
+            &[&vec![current_user_id, peer_user_id]],
+        )
+        .await?;
+    if rows.len() != 2 {
+        bail!("one account no longer exists");
+    }
+
+    let mut current_username = None;
+    let mut peer_username = None;
+    for row in rows {
+        let user_id: Uuid = row.get("id");
+        let username: String = row.get("username");
+        if user_id == current_user_id {
+            current_username = Some(username);
+        } else if user_id == peer_user_id {
+            peer_username = Some(username);
+        }
+    }
+    let current_username = current_username.ok_or_else(|| anyhow::anyhow!("current account missing"))?;
+    let peer_username = peer_username.ok_or_else(|| anyhow::anyhow!("peer account missing"))?;
+
+    let abandoned_user_id = if kept_user_id == current_user_id {
+        peer_user_id
+    } else {
+        current_user_id
+    };
+    let kept_username = if kept_user_id == current_user_id {
+        current_username.clone()
+    } else {
+        peer_username.clone()
+    };
+    let abandoned_username = if abandoned_user_id == current_user_id {
+        current_username
+    } else {
+        peer_username
+    };
+
+    move_ssh_keys(&tx, abandoned_user_id, kept_user_id).await?;
+    tx.execute(
+        "UPDATE account_link_codes
+         SET consumed_at = current_timestamp, updated = current_timestamp
+         WHERE user_id = $1 OR user_id = $2",
+        &[&current_user_id, &peer_user_id],
+    )
+    .await?;
+    tx.execute("DELETE FROM users WHERE id = $1", &[&abandoned_user_id])
+        .await?;
+    tx.commit().await?;
+
+    Ok(AccountLinkResult {
+        kept_user_id,
+        kept_username,
+        abandoned_user_id,
+        abandoned_username,
+    })
+}
+
+async fn move_ssh_keys(
+    client: &impl GenericClient,
+    from_user_id: Uuid,
+    to_user_id: Uuid,
+) -> Result<()> {
+    client
+        .execute(
+            "UPDATE user_ssh_keys
+             SET user_id = $1, updated = current_timestamp
+             WHERE user_id = $2",
+            &[&to_user_id, &from_user_id],
+        )
+        .await?;
+    Ok(())
+}
+
+fn generate_code() -> String {
+    Uuid::new_v4()
+        .simple()
+        .to_string()
+        .chars()
+        .take(8)
+        .collect::<String>()
+        .to_ascii_uppercase()
+}
+
+pub fn normalize_code(code: &str) -> String {
+    code.chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .take(16)
+        .collect::<String>()
+        .to_ascii_uppercase()
+}

--- a/late-core/src/models/chat_room_member.rs
+++ b/late-core/src/models/chat_room_member.rs
@@ -70,9 +70,21 @@ impl ChatRoomMember {
         let count = client
             .execute(
                 "INSERT INTO chat_room_members (room_id, user_id)
-                 SELECT $1, id
-                 FROM users
-                 WHERE fingerprint = $2
+                 SELECT $1, resolved.user_id
+                 FROM (
+                     SELECT k.user_id
+                     FROM user_ssh_keys k
+                     WHERE k.fingerprint = $2
+                     UNION
+                     SELECT u.id
+                     FROM users u
+                     WHERE u.fingerprint = $2
+                       AND NOT EXISTS (
+                           SELECT 1
+                           FROM user_ssh_keys k
+                           WHERE k.fingerprint = $2
+                       )
+                 ) resolved
                  ON CONFLICT (room_id, user_id) DO NOTHING",
                 &[&room_id, &fingerprint],
             )

--- a/late-core/src/models/mod.rs
+++ b/late-core/src/models/mod.rs
@@ -1,5 +1,6 @@
 pub mod artboard;
 pub mod artboard_ban;
+pub mod account_link;
 pub mod article;
 pub mod article_feed_read;
 pub mod asterion;

--- a/late-core/src/models/user.rs
+++ b/late-core/src/models/user.rs
@@ -111,11 +111,55 @@ impl User {
     pub async fn find_by_fingerprint(client: &Client, fingerprint: &str) -> Result<Option<Self>> {
         let row = client
             .query_opt(
+                "SELECT u.*
+                 FROM user_ssh_keys k
+                 JOIN users u ON u.id = k.user_id
+                 WHERE k.fingerprint = $1",
+                &[&fingerprint],
+            )
+            .await?;
+        if let Some(row) = row {
+            return Ok(Some(Self::from(row)));
+        }
+
+        let row = client
+            .query_opt(
                 "SELECT * FROM users WHERE fingerprint = $1",
                 &[&fingerprint],
             )
             .await?;
         Ok(row.map(Self::from))
+    }
+
+    pub async fn ensure_ssh_key(
+        client: &impl GenericClient,
+        user_id: Uuid,
+        fingerprint: &str,
+    ) -> Result<()> {
+        client
+            .execute(
+                "INSERT INTO user_ssh_keys (user_id, fingerprint)
+                 VALUES ($1, $2)
+                 ON CONFLICT (fingerprint) DO UPDATE
+                 SET user_id = EXCLUDED.user_id,
+                     last_seen = current_timestamp,
+                     updated = current_timestamp",
+                &[&user_id, &fingerprint],
+            )
+            .await?;
+        Ok(())
+    }
+
+    pub async fn touch_ssh_key(client: &Client, fingerprint: &str) -> Result<()> {
+        client
+            .execute(
+                "UPDATE user_ssh_keys
+                 SET last_seen = current_timestamp, updated = current_timestamp
+                 WHERE fingerprint = $1",
+                &[&fingerprint],
+            )
+            .await?;
+        Ok(())
     }
     pub async fn update_last_seen(&mut self, client: &Client) -> Result<()> {
         self.last_seen = Utc::now();

--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -987,9 +987,10 @@ impl GhostService {
             } else {
                 User::update_settings(&client, existing.id, &settings).await?;
             }
+            User::ensure_ssh_key(&client, existing.id, fingerprint).await?;
             existing
         } else {
-            User::create(
+            let created = User::create(
                 &client,
                 UserParams {
                     fingerprint: fingerprint.to_string(),
@@ -997,7 +998,9 @@ impl GhostService {
                     settings,
                 },
             )
-            .await?
+            .await?;
+            User::ensure_ssh_key(&client, created.id, fingerprint).await?;
+            created
         };
 
         ChatRoomMember::auto_join_public_rooms(&client, user.id).await?;

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -490,7 +490,7 @@ fn architecture_lines() -> Vec<String> {
         "",
         "Important characteristics",
         "  terminal-first, always-on, social, and zero-signup",
-        "  SSH key fingerprint is the identity anchor",
+        "  SSH keys are identity/device anchors; linked keys can point to one late.sh identity",
         "",
         "Highest-risk runtime areas are render-loop backpressure, chat sync consistency, connection limiting, and paired-client state drift.",
         "",

--- a/late-ssh/src/app/profile/svc.rs
+++ b/late-ssh/src/app/profile/svc.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use chrono::{DateTime, NaiveDate, Utc};
+use late_core::models::account_link;
 use late_core::models::bonsai::Tree;
 use late_core::models::profile::{Profile, ProfileParams};
 use late_core::models::user::{User, sanitize_username_input};
@@ -39,6 +40,23 @@ pub struct ProfileSnapshot {
 pub enum ProfileEvent {
     Saved {
         user_id: Uuid,
+    },
+    AccountLinkCodeCreated {
+        user_id: Uuid,
+        code: String,
+        expires_at: DateTime<Utc>,
+    },
+    AccountLinkPeerLoaded {
+        user_id: Uuid,
+        peer_user_id: Uuid,
+        peer_username: String,
+        peer_created: DateTime<Utc>,
+    },
+    AccountLinked {
+        kept_user_id: Uuid,
+        abandoned_user_id: Uuid,
+        kept_username: String,
+        abandoned_username: String,
     },
     Error {
         user_id: Uuid,
@@ -327,7 +345,8 @@ impl ProfileService {
             anyhow::bail!("user not found");
         }
 
-        self.terminate_active_sessions(user_id).await;
+        self.terminate_active_sessions(user_id, "account deleted")
+            .await;
         if let Ok(mut users) = self.active_users.lock() {
             users.remove(&user_id);
         }
@@ -337,7 +356,142 @@ impl ProfileService {
         Ok(())
     }
 
-    async fn terminate_active_sessions(&self, user_id: Uuid) {
+    pub fn create_account_link_code(&self, user_id: Uuid) {
+        let service = self.clone();
+        tokio::spawn(
+            async move {
+                if let Err(e) = service.do_create_account_link_code(user_id).await {
+                    late_core::error_span!(
+                        "account_link_code_create_failed",
+                        error = ?e,
+                        user_id = %user_id,
+                        "failed to create account link code"
+                    );
+                    service.publish_event(ProfileEvent::Error {
+                        user_id,
+                        message: account_link_error_message(&e),
+                    });
+                }
+            }
+            .instrument(info_span!("profile.account_link_code_task", user_id = %user_id)),
+        );
+    }
+
+    #[tracing::instrument(skip(self), fields(user_id = %user_id))]
+    async fn do_create_account_link_code(&self, user_id: Uuid) -> Result<()> {
+        let client = self.db.get().await?;
+        let (code, expires_at) = account_link::create_code(&client, user_id).await?;
+        self.publish_event(ProfileEvent::AccountLinkCodeCreated {
+            user_id,
+            code,
+            expires_at,
+        });
+        Ok(())
+    }
+
+    pub fn preview_account_link_code(&self, user_id: Uuid, code: String) {
+        let service = self.clone();
+        tokio::spawn(
+            async move {
+                if let Err(e) = service.do_preview_account_link_code(user_id, &code).await {
+                    late_core::error_span!(
+                        "account_link_preview_failed",
+                        error = ?e,
+                        user_id = %user_id,
+                        "failed to preview account link code"
+                    );
+                    service.publish_event(ProfileEvent::Error {
+                        user_id,
+                        message: account_link_error_message(&e),
+                    });
+                }
+            }
+            .instrument(info_span!("profile.account_link_preview_task", user_id = %user_id)),
+        );
+    }
+
+    #[tracing::instrument(skip(self, code), fields(user_id = %user_id))]
+    async fn do_preview_account_link_code(&self, user_id: Uuid, code: &str) -> Result<()> {
+        let client = self.db.get().await?;
+        let peer = account_link::peer_for_code(&client, user_id, code).await?;
+        self.publish_event(ProfileEvent::AccountLinkPeerLoaded {
+            user_id,
+            peer_user_id: peer.user_id,
+            peer_username: peer.username,
+            peer_created: peer.created,
+        });
+        Ok(())
+    }
+
+    pub fn complete_account_link(
+        &self,
+        current_user_id: Uuid,
+        peer_user_id: Uuid,
+        code: String,
+        kept_user_id: Uuid,
+    ) {
+        let service = self.clone();
+        tokio::spawn(
+            async move {
+                if let Err(e) = service
+                    .do_complete_account_link(current_user_id, peer_user_id, &code, kept_user_id)
+                    .await
+                {
+                    late_core::error_span!(
+                        "account_link_complete_failed",
+                        error = ?e,
+                        current_user_id = %current_user_id,
+                        peer_user_id = %peer_user_id,
+                        kept_user_id = %kept_user_id,
+                        "failed to complete account link"
+                    );
+                    service.publish_event(ProfileEvent::Error {
+                        user_id: current_user_id,
+                        message: account_link_error_message(&e),
+                    });
+                }
+            }
+            .instrument(info_span!(
+                "profile.account_link_complete_task",
+                current_user_id = %current_user_id,
+                peer_user_id = %peer_user_id,
+                kept_user_id = %kept_user_id
+            )),
+        );
+    }
+
+    #[tracing::instrument(skip(self, code), fields(current_user_id = %current_user_id, peer_user_id = %peer_user_id, kept_user_id = %kept_user_id))]
+    async fn do_complete_account_link(
+        &self,
+        current_user_id: Uuid,
+        peer_user_id: Uuid,
+        code: &str,
+        kept_user_id: Uuid,
+    ) -> Result<()> {
+        let mut client = self.db.get().await?;
+        let result =
+            account_link::complete(&mut *client, current_user_id, peer_user_id, code, kept_user_id)
+                .await?;
+
+        self.find_profile(result.kept_user_id);
+        self.publish_event(ProfileEvent::AccountLinked {
+            kept_user_id: result.kept_user_id,
+            abandoned_user_id: result.abandoned_user_id,
+            kept_username: result.kept_username,
+            abandoned_username: result.abandoned_username,
+        });
+        self.terminate_active_sessions(result.abandoned_user_id, "account linked")
+            .await;
+        if let Ok(mut users) = self.active_users.lock() {
+            users.remove(&result.abandoned_user_id);
+        }
+        if let Some(directory) = &self.username_directory {
+            usernames::remove(directory, result.abandoned_user_id);
+        }
+        Ok(())
+    }
+
+    async fn terminate_active_sessions(&self, user_id: Uuid, reason: &str) {
         let Some(registry) = self.session_registry.clone() else {
             return;
         };
@@ -358,7 +512,7 @@ impl ProfileService {
                 .send_message(
                     &token,
                     SessionMessage::Terminate {
-                        reason: "account deleted".to_string(),
+                        reason: reason.to_string(),
                     },
                 )
                 .await;
@@ -383,6 +537,13 @@ fn profile_error_message(error: &anyhow::Error) -> &'static str {
         SqlState::CHECK_VIOLATION => "Username must be between 1 and 32 characters.",
         _ => "Could not save profile. Please try again.",
     }
+}
+
+fn account_link_error_message(error: &anyhow::Error) -> String {
+    if error.downcast_ref::<tokio_postgres::Error>().is_some() {
+        return "Could not link accounts. Please try again.".to_string();
+    }
+    error.to_string()
 }
 
 #[cfg(test)]

--- a/late-ssh/src/app/settings_modal/input.rs
+++ b/late-ssh/src/app/settings_modal/input.rs
@@ -3,10 +3,15 @@ use crate::app::state::App;
 use late_core::models::user::RightSidebarMode;
 
 use super::gem::GemKey;
-use super::state::{PickerKind, Row, Tab};
+use super::state::{AccountRow, LinkAccountStep, PickerKind, Row, Tab};
 use crate::app::settings_modal::state::SettingsModalState;
 
 pub fn handle_input(app: &mut App, event: ParsedInput) {
+    if app.settings_modal_state.link_account_dialog().open() {
+        handle_link_account_dialog_input(app, event);
+        return;
+    }
+
     if app.settings_modal_state.delete_account_dialog().open() {
         handle_delete_account_dialog_input(app, event);
         return;
@@ -227,8 +232,17 @@ fn open_help(app: &mut App) {
 fn handle_account_tab_input(app: &mut App, event: ParsedInput) {
     match event {
         ParsedInput::Byte(b'?') | ParsedInput::Char('?') => open_help(app),
+        ParsedInput::Byte(b'j' | b'J')
+        | ParsedInput::Char('j' | 'J')
+        | ParsedInput::Arrow(b'B') => app.settings_modal_state.move_account_row(1),
+        ParsedInput::Byte(b'k' | b'K')
+        | ParsedInput::Char('k' | 'K')
+        | ParsedInput::Arrow(b'A') => app.settings_modal_state.move_account_row(-1),
         ParsedInput::Byte(b'\r') | ParsedInput::Byte(b' ') => {
-            app.settings_modal_state.open_delete_account_dialog();
+            match app.settings_modal_state.selected_account_row() {
+                AccountRow::LinkAccounts => app.settings_modal_state.open_link_account_dialog(),
+                AccountRow::DeleteAccount => app.settings_modal_state.open_delete_account_dialog(),
+            }
         }
         _ => {}
     }
@@ -372,6 +386,64 @@ fn handle_username_input(app: &mut App, event: ParsedInput) {
         ParsedInput::Char(ch) if !ch.is_control() => state.username_push(ch),
         ParsedInput::Byte(byte) if byte.is_ascii_graphic() || byte == b' ' => {
             state.username_push(byte as char)
+        }
+        _ => {}
+    }
+}
+
+fn handle_link_account_dialog_input(app: &mut App, event: ParsedInput) {
+    let state = &mut app.settings_modal_state;
+    if state.link_account_dialog().pending() {
+        return;
+    }
+
+    match event {
+        ParsedInput::Byte(0x1B) => state.close_link_account_dialog(),
+        ParsedInput::Byte(b'\r') => match state.link_account_dialog().step() {
+            LinkAccountStep::EnterCode => state.submit_link_account_code(),
+            LinkAccountStep::Confirm => state.submit_link_account_confirmation(),
+            LinkAccountStep::Pending => state.close_link_account_dialog(),
+        },
+        ParsedInput::Arrow(b'A') | ParsedInput::Arrow(b'D')
+            if state.link_account_dialog().step() == LinkAccountStep::Confirm =>
+        {
+            state.select_link_account_main(true);
+        }
+        ParsedInput::Arrow(b'B') | ParsedInput::Arrow(b'C')
+            if state.link_account_dialog().step() == LinkAccountStep::Confirm =>
+        {
+            state.select_link_account_main(false);
+        }
+        ParsedInput::Byte(0x15) => state.clear_link_account_input(),
+        ParsedInput::Byte(0x01) => state.link_account_cursor_home(),
+        ParsedInput::Byte(0x05) => state.link_account_cursor_end(),
+        ParsedInput::Home => state.link_account_cursor_home(),
+        ParsedInput::End => state.link_account_cursor_end(),
+        ParsedInput::Byte(0x7F) => state.link_account_backspace(),
+        ParsedInput::Delete => state.link_account_delete_right(),
+        ParsedInput::CtrlBackspace | ParsedInput::Byte(0x08) => {
+            state.link_account_delete_word_left()
+        }
+        ParsedInput::CtrlDelete => state.link_account_delete_word_right(),
+        ParsedInput::Arrow(b'C') => state.link_account_cursor_right(),
+        ParsedInput::Arrow(b'D') => state.link_account_cursor_left(),
+        ParsedInput::CtrlArrow(b'C') | ParsedInput::AltArrow(b'C') => {
+            state.link_account_cursor_word_right()
+        }
+        ParsedInput::CtrlArrow(b'D') | ParsedInput::AltArrow(b'D') => {
+            state.link_account_cursor_word_left()
+        }
+        ParsedInput::Paste(pasted) => {
+            let cleaned = sanitize_paste_markers(&String::from_utf8_lossy(&pasted));
+            for ch in cleaned.chars() {
+                if !ch.is_control() && ch != '\n' && ch != '\r' {
+                    state.link_account_push(ch);
+                }
+            }
+        }
+        ParsedInput::Char(ch) if !ch.is_control() => state.link_account_push(ch),
+        ParsedInput::Byte(byte) if byte.is_ascii_graphic() || byte == b' ' => {
+            state.link_account_push(byte as char)
         }
         _ => {}
     }

--- a/late-ssh/src/app/settings_modal/state.rs
+++ b/late-ssh/src/app/settings_modal/state.rs
@@ -1,5 +1,6 @@
 use std::cell::Cell;
 
+use chrono::{DateTime, Utc};
 use late_core::models::profile::{Profile, ProfileParams, normalize_profile_tags};
 use late_core::models::rss_feed::RssFeed;
 use late_core::models::user::{
@@ -11,7 +12,7 @@ use tokio::sync::{broadcast, watch};
 use uuid::Uuid;
 
 use crate::app::common::theme;
-use crate::app::profile::svc::ProfileService;
+use crate::app::profile::svc::{ProfileEvent, ProfileService};
 use crate::app::{
     chat::feeds::svc::{FeedEvent, FeedService, FeedSnapshot},
     common::primitives::Banner,
@@ -22,10 +23,13 @@ use super::gem::GemState;
 
 const USERNAME_MAX_LEN: usize = 12;
 const DELETE_CONFIRM_USERNAME_MAX_LEN: usize = late_core::models::user::USERNAME_MAX_LEN;
+const LINK_CODE_MAX_LEN: usize = 16;
+const LINK_CONFIRM_USERNAME_MAX_LEN: usize = late_core::models::user::USERNAME_MAX_LEN;
 const SYSTEM_FIELD_MAX_LEN: usize = 48;
 const FEED_URL_MAX_LEN: usize = 2000;
 pub const BIO_MAX_LEN: usize = 1000;
 pub const DELETE_CONFIRM_MISMATCH: &str = "Typed username does not match current username.";
+pub const LINK_CONFIRM_MISMATCH: &str = "Typed username does not match the main username.";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PickerKind {
@@ -78,6 +82,23 @@ impl Row {
         Row::Cooldown,
         Row::NotifyFormat,
     ];
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AccountRow {
+    LinkAccounts,
+    DeleteAccount,
+}
+
+impl AccountRow {
+    pub const ALL: [AccountRow; 2] = [AccountRow::LinkAccounts, AccountRow::DeleteAccount];
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum LinkAccountStep {
+    EnterCode,
+    Confirm,
+    Pending,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -219,6 +240,88 @@ impl DeleteAccountDialogState {
     }
 }
 
+pub struct LinkAccountDialogState {
+    open: bool,
+    step: LinkAccountStep,
+    own_code: Option<String>,
+    expires_at: Option<DateTime<Utc>>,
+    code_input: TextArea<'static>,
+    peer_user_id: Option<Uuid>,
+    peer_username: Option<String>,
+    peer_created: Option<DateTime<Utc>>,
+    keep_current: bool,
+    confirm_input: TextArea<'static>,
+    status: Option<String>,
+    pending: bool,
+}
+
+impl LinkAccountDialogState {
+    fn new() -> Self {
+        Self {
+            open: false,
+            step: LinkAccountStep::EnterCode,
+            own_code: None,
+            expires_at: None,
+            code_input: new_short_textarea(false),
+            peer_user_id: None,
+            peer_username: None,
+            peer_created: None,
+            keep_current: true,
+            confirm_input: new_short_textarea(false),
+            status: None,
+            pending: false,
+        }
+    }
+
+    pub fn open(&self) -> bool {
+        self.open
+    }
+
+    pub fn step(&self) -> LinkAccountStep {
+        self.step
+    }
+
+    pub fn own_code(&self) -> Option<&str> {
+        self.own_code.as_deref()
+    }
+
+    pub fn expires_at(&self) -> Option<DateTime<Utc>> {
+        self.expires_at.as_ref().cloned()
+    }
+
+    pub fn code_input(&self) -> &TextArea<'static> {
+        &self.code_input
+    }
+
+    pub fn peer_user_id(&self) -> Option<Uuid> {
+        self.peer_user_id
+    }
+
+    pub fn peer_username(&self) -> Option<&str> {
+        self.peer_username.as_deref()
+    }
+
+    pub fn peer_created(&self) -> Option<DateTime<Utc>> {
+        self.peer_created.as_ref().cloned()
+    }
+
+    pub fn keep_current(&self) -> bool {
+        self.keep_current
+    }
+
+    pub fn confirm_input(&self) -> &TextArea<'static> {
+        &self.confirm_input
+    }
+
+    pub fn status(&self) -> Option<&str> {
+        self.status.as_deref()
+    }
+
+    pub fn pending(&self) -> bool {
+        self.pending
+    }
+}
+
 pub struct SettingsModalState {
     profile_service: ProfileService,
     feed_service: FeedService,
@@ -226,6 +329,7 @@ pub struct SettingsModalState {
     draft: Profile,
     selected_tab: Tab,
     row_index: usize,
+    account_row_index: usize,
     theme_index: usize,
     theme_selected_row: usize,
     theme_scroll_offset: usize,
@@ -238,6 +342,7 @@ pub struct SettingsModalState {
     editing_bio: bool,
     bio_input: TextArea<'static>,
     picker: PickerState,
+    link_account: LinkAccountDialogState,
     delete_account: DeleteAccountDialogState,
     right_sidebar_custom_open: bool,
     right_sidebar_custom_index: usize,
@@ -247,6 +352,7 @@ pub struct SettingsModalState {
     feed_url_input: TextArea<'static>,
     feed_snapshot_rx: watch::Receiver<FeedSnapshot>,
     feed_event_rx: broadcast::Receiver<FeedEvent>,
+    profile_event_rx: broadcast::Receiver<ProfileEvent>,
     /// Per-session gem easter egg on the Special tab. Persists across modal
     /// open/close cycles for the lifetime of the SSH session.
     gem: GemState,
@@ -256,6 +362,7 @@ impl SettingsModalState {
     pub fn new(profile_service: ProfileService, feed_service: FeedService, user_id: Uuid) -> Self {
         let feed_snapshot_rx = feed_service.subscribe_snapshot();
         let feed_event_rx = feed_service.subscribe_events();
+        let profile_event_rx = profile_service.subscribe_events();
         feed_service.list_task(user_id);
         Self {
             profile_service,
@@ -264,6 +371,7 @@ impl SettingsModalState {
             draft: Profile::default(),
             selected_tab: Tab::Settings,
             row_index: 0,
+            account_row_index: 0,
             theme_index: 0,
             theme_selected_row: 0,
             theme_scroll_offset: 0,
@@ -276,6 +384,7 @@ impl SettingsModalState {
             editing_bio: false,
             bio_input: new_bio_textarea(false),
             picker: PickerState::default(),
+            link_account: LinkAccountDialogState::new(),
             delete_account: DeleteAccountDialogState::new(),
             right_sidebar_custom_open: false,
             right_sidebar_custom_index: 0,
@@ -285,6 +394,7 @@ impl SettingsModalState {
             feed_url_input: new_short_textarea(false),
             feed_snapshot_rx,
             feed_event_rx,
+            profile_event_rx,
             gem: GemState::new(),
         }
     }
@@ -301,6 +411,7 @@ impl SettingsModalState {
         self.draft = profile.clone();
         self.selected_tab = Tab::Settings;
         self.row_index = 0;
+        self.account_row_index = 0;
         self.sync_theme_index_to_draft();
         self.editing_username = false;
         self.username_input = new_username_textarea(false);
@@ -309,6 +420,7 @@ impl SettingsModalState {
         self.editing_bio = false;
         self.bio_input = bio_textarea_for_readonly_text(&self.draft.bio);
         self.picker = PickerState::default();
+        self.link_account = LinkAccountDialogState::new();
         self.delete_account = DeleteAccountDialogState::new();
         self.right_sidebar_custom_open = false;
         self.right_sidebar_custom_index = 0;
@@ -317,7 +429,11 @@ impl SettingsModalState {
 
     pub fn tick(&mut self) -> Option<Banner> {
         self.drain_feed_snapshot();
-        self.drain_feed_events()
+        let mut banner = self.drain_profile_events();
+        if let Some(feed_banner) = self.drain_feed_events() {
+            banner = Some(feed_banner);
+        }
+        banner
     }
 
     pub fn selected_tab(&self) -> Tab {
@@ -449,6 +565,224 @@ impl SettingsModalState {
             self.draft.right_sidebar_screens.sort_unstable();
         }
         self.save();
+    }
+
+    pub fn selected_account_row(&self) -> AccountRow {
+        AccountRow::ALL[self.account_row_index]
+    }
+
+    pub fn move_account_row(&mut self, delta: isize) {
+        let last = AccountRow::ALL.len().saturating_sub(1) as isize;
+        self.account_row_index =
+            (self.account_row_index as isize + delta).clamp(0, last) as usize;
+    }
+
+    pub fn link_account_dialog(&self) -> &LinkAccountDialogState {
+        &self.link_account
+    }
+
+    pub fn open_link_account_dialog(&mut self) {
+        self.link_account = LinkAccountDialogState {
+            open: true,
+            step: LinkAccountStep::EnterCode,
+            own_code: None,
+            expires_at: None,
+            code_input: new_short_textarea(true),
+            peer_user_id: None,
+            peer_username: None,
+            peer_created: None,
+            keep_current: true,
+            confirm_input: new_short_textarea(false),
+            status: Some("Creating link code...".to_string()),
+            pending: true,
+        };
+        self.profile_service.create_account_link_code(self.user_id);
+    }
+
+    pub fn close_link_account_dialog(&mut self) {
+        self.link_account = LinkAccountDialogState::new();
+    }
+
+    pub fn submit_link_account_code(&mut self) {
+        if self.link_account.pending {
+            return;
+        }
+        let code = self.link_account_code_text();
+        if code.trim().is_empty() {
+            self.link_account.status = Some("Enter the other account's code.".to_string());
+            return;
+        }
+        self.link_account.pending = true;
+        self.link_account.status = Some("Checking code...".to_string());
+        self.profile_service
+            .preview_account_link_code(self.user_id, code);
+    }
+
+    pub fn select_link_account_main(&mut self, keep_current: bool) {
+        if self.link_account.keep_current != keep_current {
+            self.link_account.keep_current = keep_current;
+            self.link_account.confirm_input = new_short_textarea(true);
+            self.link_account.status = None;
+        }
+    }
+
+    pub fn submit_link_account_confirmation(&mut self) {
+        if self.link_account.pending || self.link_account.step != LinkAccountStep::Confirm {
+            return;
+        }
+        let Some(peer_user_id) = self.link_account.peer_user_id else {
+            self.link_account.status = Some("Enter the other account's code first.".to_string());
+            self.link_account.step = LinkAccountStep::EnterCode;
+            return;
+        };
+        let Some(kept_username) = self.link_account_kept_username() else {
+            self.link_account.status = Some("Choose the main account to keep.".to_string());
+            return;
+        };
+        let typed = self.link_account_confirm_text();
+        if typed != kept_username {
+            self.link_account.status = Some(LINK_CONFIRM_MISMATCH.to_string());
+            return;
+        }
+        let kept_user_id = if self.link_account.keep_current {
+            self.user_id
+        } else {
+            peer_user_id
+        };
+        let code = self.link_account_code_text();
+        self.link_account.pending = true;
+        self.link_account.step = LinkAccountStep::Pending;
+        self.link_account.status = Some("Linking accounts...".to_string());
+        self.profile_service
+            .complete_account_link(self.user_id, peer_user_id, code, kept_user_id);
+    }
+
+    pub fn link_account_kept_username(&self) -> Option<String> {
+        if self.link_account.keep_current {
+            Some(self.draft.username.clone())
+        } else {
+            self.link_account.peer_username.clone()
+        }
+    }
+
+    pub fn link_account_push(&mut self, ch: char) {
+        match self.link_account.step {
+            LinkAccountStep::EnterCode => {
+                if link_code_char_count_for_input(&self.link_account.code_input) < LINK_CODE_MAX_LEN
+                    && ch.is_ascii_alphanumeric()
+                {
+                    self.link_account
+                        .code_input
+                        .insert_char(ch.to_ascii_uppercase());
+                    self.link_account.status = None;
+                }
+            }
+            LinkAccountStep::Confirm => {
+                if link_confirm_char_count_for_input(&self.link_account.confirm_input)
+                    < LINK_CONFIRM_USERNAME_MAX_LEN
+                    && !ch.is_control()
+                    && ch != '\n'
+                    && ch != '\r'
+                {
+                    self.link_account.confirm_input.insert_char(ch);
+                    self.link_account.status = None;
+                }
+            }
+            LinkAccountStep::Pending => {}
+        }
+    }
+
+    pub fn link_account_backspace(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.delete_char();
+            self.link_account.status = None;
+        }
+    }
+
+    pub fn link_account_delete_right(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.delete_next_char();
+            self.link_account.status = None;
+        }
+    }
+
+    pub fn link_account_delete_word_left(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.delete_word();
+            self.link_account.status = None;
+        }
+    }
+
+    pub fn link_account_delete_word_right(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.delete_next_word();
+            self.link_account.status = None;
+        }
+    }
+
+    pub fn link_account_cursor_left(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.move_cursor(CursorMove::Back);
+        }
+    }
+
+    pub fn link_account_cursor_right(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.move_cursor(CursorMove::Forward);
+        }
+    }
+
+    pub fn link_account_cursor_word_left(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.move_cursor(CursorMove::WordBack);
+        }
+    }
+
+    pub fn link_account_cursor_word_right(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.move_cursor(CursorMove::WordForward);
+        }
+    }
+
+    pub fn link_account_cursor_home(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.move_cursor(CursorMove::Head);
+        }
+    }
+
+    pub fn link_account_cursor_end(&mut self) {
+        if let Some(input) = self.link_account_active_input_mut() {
+            input.move_cursor(CursorMove::End);
+        }
+    }
+
+    pub fn clear_link_account_input(&mut self) {
+        match self.link_account.step {
+            LinkAccountStep::EnterCode => {
+                self.link_account.code_input = new_short_textarea(true);
+            }
+            LinkAccountStep::Confirm => {
+                self.link_account.confirm_input = new_short_textarea(true);
+            }
+            LinkAccountStep::Pending => {}
+        }
+        self.link_account.status = None;
+    }
+
+    fn link_account_active_input_mut(&mut self) -> Option<&mut TextArea<'static>> {
+        match self.link_account.step {
+            LinkAccountStep::EnterCode => Some(&mut self.link_account.code_input),
+            LinkAccountStep::Confirm => Some(&mut self.link_account.confirm_input),
+            LinkAccountStep::Pending => None,
+        }
+    }
+
+    fn link_account_code_text(&self) -> String {
+        self.link_account.code_input.lines().join("")
+    }
+
+    fn link_account_confirm_text(&self) -> String {
+        self.link_account.confirm_input.lines().join("")
     }
 
     pub fn delete_account_dialog(&self) -> &DeleteAccountDialogState {
@@ -1314,6 +1648,75 @@ impl SettingsModalState {
         banner
     }
 
+    fn drain_profile_events(&mut self) -> Option<Banner> {
+        let mut banner = None;
+        loop {
+            match self.profile_event_rx.try_recv() {
+                Ok(ProfileEvent::AccountLinkCodeCreated {
+                    user_id,
+                    code,
+                    expires_at,
+                }) if user_id == self.user_id => {
+                    self.link_account.own_code = Some(code);
+                    self.link_account.expires_at = Some(expires_at);
+                    self.link_account.pending = false;
+                    if self.link_account.step == LinkAccountStep::EnterCode {
+                        self.link_account.status = None;
+                    }
+                }
+                Ok(ProfileEvent::AccountLinkPeerLoaded {
+                    user_id,
+                    peer_user_id,
+                    peer_username,
+                    peer_created,
+                }) if user_id == self.user_id => {
+                    self.link_account.peer_user_id = Some(peer_user_id);
+                    self.link_account.peer_username = Some(peer_username);
+                    self.link_account.peer_created = Some(peer_created);
+                    self.link_account.keep_current = true;
+                    self.link_account.confirm_input = new_short_textarea(true);
+                    self.link_account.step = LinkAccountStep::Confirm;
+                    self.link_account.pending = false;
+                    self.link_account.status = None;
+                }
+                Ok(ProfileEvent::AccountLinked {
+                    kept_user_id,
+                    abandoned_user_id,
+                    kept_username,
+                    abandoned_username: _,
+                }) if kept_user_id == self.user_id || abandoned_user_id == self.user_id => {
+                    self.link_account.pending = false;
+                    self.link_account.step = LinkAccountStep::Pending;
+                    self.link_account.status = Some(format!(
+                        "Linked. Both SSH keys now open {kept_username}."
+                    ));
+                    if kept_user_id == self.user_id {
+                        self.draft.username = kept_username.clone();
+                    }
+                    banner = Some(Banner::success(&format!(
+                        "Linked accounts. Both SSH keys now open {kept_username}."
+                    )));
+                }
+                Ok(ProfileEvent::Error { user_id, message }) if user_id == self.user_id => {
+                    if self.link_account.open {
+                        self.link_account.pending = false;
+                        if self.link_account.step == LinkAccountStep::Pending {
+                            self.link_account.step = LinkAccountStep::Confirm;
+                        }
+                        self.link_account.status = Some(message);
+                    }
+                }
+                Ok(_) => {}
+                Err(broadcast::error::TryRecvError::Empty) => break,
+                Err(e) => {
+                    tracing::error!(%e, "failed to receive settings profile event");
+                    break;
+                }
+            }
+        }
+        banner
+    }
+
     /// Cycle the value of the currently selected row and auto-persist.
     /// Username/Country/Timezone don't cycle here (they open editors/pickers);
     /// this only fires for the toggle/enum rows.
@@ -1472,6 +1875,14 @@ fn system_char_count_for_input(input: &TextArea<'static>) -> usize {
 }
 
 fn delete_account_char_count_for_input(input: &TextArea<'static>) -> usize {
+    input.lines().iter().map(|l| l.chars().count()).sum()
+}
+
+fn link_code_char_count_for_input(input: &TextArea<'static>) -> usize {
+    input.lines().iter().map(|l| l.chars().count()).sum()
+}
+
+fn link_confirm_char_count_for_input(input: &TextArea<'static>) -> usize {
     input.lines().iter().map(|l| l.chars().count()).sum()
 }
 

--- a/late-ssh/src/app/settings_modal/ui.rs
+++ b/late-ssh/src/app/settings_modal/ui.rs
@@ -13,7 +13,10 @@ use crate::app::common::{markdown::render_body_to_lines, theme};
 use super::{
     data::country_label,
     gem::{GemPosition, GemState, MoveDirection},
-    state::{BIO_MAX_LEN, PickerKind, Row, SettingsModalState, Tab, ThemeTreeRow},
+    state::{
+        AccountRow, BIO_MAX_LEN, LinkAccountStep, PickerKind, Row, SettingsModalState, Tab,
+        ThemeTreeRow,
+    },
 };
 
 pub const MODAL_WIDTH: u16 = 96;
@@ -62,6 +65,9 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
     }
     if state.right_sidebar_custom_open() {
         draw_right_sidebar_custom_dialog(frame, popup, state);
+    }
+    if state.link_account_dialog().open() {
+        draw_link_account_dialog(frame, popup, state);
     }
     if state.delete_account_dialog().open() {
         draw_delete_account_dialog(frame, popup, state);
@@ -151,8 +157,10 @@ fn draw_footer(frame: &mut Frame, area: Rect, tab: Tab, editing_bio: bool) {
         }
         (Tab::Account, _) => {
             spans.extend([
+                Span::styled("↑↓ j/k", Style::default().fg(theme::AMBER_DIM())),
+                Span::styled(" choose  ", Style::default().fg(theme::TEXT_DIM())),
                 Span::styled("↵", Style::default().fg(theme::AMBER_DIM())),
-                Span::styled(" open confirm  ", Style::default().fg(theme::TEXT_DIM())),
+                Span::styled(" open  ", Style::default().fg(theme::TEXT_DIM())),
                 Span::styled("Tab/S+Tab", Style::default().fg(theme::AMBER_DIM())),
                 Span::styled(" switch tabs  ", Style::default().fg(theme::TEXT_DIM())),
                 Span::styled("Esc/q", Style::default().fg(theme::AMBER_DIM())),
@@ -761,12 +769,15 @@ fn draw_special_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
     }
 }
 
-fn draw_account_tab(frame: &mut Frame, area: Rect, _state: &SettingsModalState) {
+fn draw_account_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
     let sections = Layout::vertical([
         Constraint::Length(1), // heading
         Constraint::Length(1), // breathing
-        Constraint::Length(1), // button
-        Constraint::Length(1), // description
+        Constraint::Length(1), // link row
+        Constraint::Length(1), // link description
+        Constraint::Length(1), // breathing
+        Constraint::Length(1), // delete row
+        Constraint::Length(1), // delete description
         Constraint::Min(0),
     ])
     .split(area);
@@ -774,29 +785,35 @@ fn draw_account_tab(frame: &mut Frame, area: Rect, _state: &SettingsModalState) 
     frame.render_widget(Paragraph::new(section_heading("Account")), sections[0]);
 
     let width = area.width as usize;
-    let label = "Delete Account";
-    let prefix = " › ";
-    let used = prefix.chars().count() + label.chars().count();
-    let trailing = " ".repeat(width.saturating_sub(used));
+    frame.render_widget(
+        Paragraph::new(account_row_line(
+            state,
+            AccountRow::LinkAccounts,
+            width,
+            "Link Accounts",
+            false,
+        )),
+        sections[2],
+    );
     frame.render_widget(
         Paragraph::new(Line::from(vec![
+            Span::raw("   "),
             Span::styled(
-                prefix,
-                Style::default()
-                    .fg(theme::ERROR())
-                    .bg(theme::BG_SELECTION())
-                    .add_modifier(Modifier::BOLD),
+                "Move this SSH key onto another late.sh account. No data is merged.",
+                Style::default().fg(theme::TEXT_DIM()),
             ),
-            Span::styled(
-                label,
-                Style::default()
-                    .fg(theme::ERROR())
-                    .bg(theme::BG_SELECTION())
-                    .add_modifier(Modifier::BOLD),
-            ),
-            Span::styled(trailing, Style::default().bg(theme::BG_SELECTION())),
         ])),
-        sections[2],
+        sections[3],
+    );
+    frame.render_widget(
+        Paragraph::new(account_row_line(
+            state,
+            AccountRow::DeleteAccount,
+            width,
+            "Delete Account",
+            true,
+        )),
+        sections[5],
     );
     frame.render_widget(
         Paragraph::new(Line::from(vec![
@@ -806,8 +823,60 @@ fn draw_account_tab(frame: &mut Frame, area: Rect, _state: &SettingsModalState) 
                 Style::default().fg(theme::TEXT_DIM()),
             ),
         ])),
-        sections[3],
+        sections[6],
     );
+}
+
+fn account_row_line(
+    state: &SettingsModalState,
+    row: AccountRow,
+    width: usize,
+    label: &str,
+    destructive: bool,
+) -> Line<'static> {
+    let selected = state.selected_account_row() == row;
+    let marker = if selected { "›" } else { " " };
+    let accent = if destructive {
+        theme::ERROR()
+    } else {
+        theme::AMBER_GLOW()
+    };
+    let prefix_style = if selected {
+        Style::default()
+            .fg(accent)
+            .bg(theme::BG_SELECTION())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT_FAINT())
+    };
+    let label_style = if selected {
+        Style::default()
+            .fg(if destructive {
+                theme::ERROR()
+            } else {
+                theme::TEXT_BRIGHT()
+            })
+            .bg(theme::BG_SELECTION())
+            .add_modifier(Modifier::BOLD)
+    } else if destructive {
+        Style::default().fg(theme::ERROR())
+    } else {
+        Style::default().fg(theme::TEXT_DIM())
+    };
+    let trailing_style = if selected {
+        Style::default().bg(theme::BG_SELECTION())
+    } else {
+        Style::default()
+    };
+
+    let prefix = format!(" {marker} ");
+    let used = prefix.chars().count() + label.chars().count();
+    let trailing = " ".repeat(width.saturating_sub(used));
+    Line::from(vec![
+        Span::styled(prefix, prefix_style),
+        Span::styled(label.to_string(), label_style),
+        Span::styled(trailing, trailing_style),
+    ])
 }
 
 fn draw_feeds_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
@@ -1418,6 +1487,319 @@ fn draw_right_sidebar_custom_dialog(frame: &mut Frame, area: Rect, state: &Setti
         Span::styled(" close", Style::default().fg(theme::TEXT_DIM())),
     ]);
     frame.render_widget(Paragraph::new(footer), layout[layout.len() - 1]);
+}
+
+fn draw_link_account_dialog(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
+    let popup = centered_rect(76, 22, area);
+    frame.render_widget(Clear, popup);
+
+    let block = Block::default()
+        .title(" Link Accounts ")
+        .title_style(
+            Style::default()
+                .fg(theme::AMBER_GLOW())
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::BORDER_ACTIVE()));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let layout = Layout::vertical([
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Length(1),
+        Constraint::Min(0),
+        Constraint::Length(1),
+    ])
+    .split(inner);
+
+    match state.link_account_dialog().step() {
+        LinkAccountStep::EnterCode => draw_link_account_enter_code(frame, &layout, state),
+        LinkAccountStep::Confirm | LinkAccountStep::Pending => {
+            draw_link_account_confirm(frame, &layout, state)
+        }
+    }
+}
+
+fn draw_link_account_enter_code(
+    frame: &mut Frame,
+    layout: &[Rect],
+    state: &SettingsModalState,
+) {
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                "Open Settings > Account on the other account and exchange codes.",
+                Style::default().fg(theme::TEXT_DIM()),
+            ),
+        ])),
+        layout[0],
+    );
+
+    let own_code = state
+        .link_account_dialog()
+        .own_code()
+        .map(str::to_string)
+        .unwrap_or_else(|| "creating...".to_string());
+    let expires = state
+        .link_account_dialog()
+        .expires_at()
+        .map(|expires| format!("  expires {}", expires.format("%H:%M UTC")))
+        .unwrap_or_default();
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw(" "),
+            Span::styled("This account code: ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(
+                own_code,
+                Style::default()
+                    .fg(theme::TEXT_BRIGHT())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(expires, Style::default().fg(theme::TEXT_FAINT())),
+        ])),
+        layout[2],
+    );
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                "Other account code:",
+                Style::default().fg(theme::TEXT_DIM()),
+            ),
+        ])),
+        layout[4],
+    );
+    frame.render_widget(
+        Paragraph::new(link_account_input_line(
+            state.link_account_dialog().code_input(),
+            "code",
+            state.link_account_dialog().pending(),
+        )),
+        layout[5],
+    );
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                "No data is merged. You will choose the main account on the next screen.",
+                Style::default().fg(theme::TEXT_DIM()),
+            ),
+        ])),
+        layout[7],
+    );
+    draw_link_account_status(frame, layout[9], state);
+    draw_link_account_footer(frame, layout[16], state);
+}
+
+fn draw_link_account_confirm(frame: &mut Frame, layout: &[Rect], state: &SettingsModalState) {
+    let dialog = state.link_account_dialog();
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                "Choose the main account to keep.",
+                Style::default()
+                    .fg(theme::TEXT_BRIGHT())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ])),
+        layout[0],
+    );
+
+    let width = layout[2].width as usize;
+    frame.render_widget(
+        Paragraph::new(link_account_choice_line(
+            dialog.keep_current(),
+            width,
+            "Current",
+            state.draft().username.as_str(),
+            state.draft().created_at.as_ref().cloned(),
+        )),
+        layout[2],
+    );
+    frame.render_widget(
+        Paragraph::new(link_account_choice_line(
+            !dialog.keep_current(),
+            width,
+            "Other",
+            dialog.peer_username().unwrap_or("unknown"),
+            dialog.peer_created(),
+        )),
+        layout[3],
+    );
+
+    let warning = [
+        "Both SSH keys will open the main account.",
+        "The other account's data will be abandoned.",
+        "No chips, messages, scores, streaks, or settings are merged.",
+    ];
+    for (idx, text) in warning.into_iter().enumerate() {
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::raw(" "),
+                Span::styled(text, Style::default().fg(theme::ERROR())),
+            ])),
+            layout[5 + idx],
+        );
+    }
+
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                "Type the main username to confirm:",
+                Style::default().fg(theme::TEXT_DIM()),
+            ),
+        ])),
+        layout[9],
+    );
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(
+                state
+                    .link_account_kept_username()
+                    .unwrap_or_else(|| "main username".to_string()),
+                Style::default()
+                    .fg(theme::TEXT_BRIGHT())
+                    .add_modifier(Modifier::BOLD),
+            ),
+        ])),
+        layout[10],
+    );
+    frame.render_widget(
+        Paragraph::new(link_account_input_line(
+            dialog.confirm_input(),
+            "main username",
+            dialog.pending(),
+        )),
+        layout[11],
+    );
+
+    draw_link_account_status(frame, layout[13], state);
+    draw_link_account_footer(frame, layout[16], state);
+}
+
+fn link_account_choice_line(
+    selected: bool,
+    width: usize,
+    label: &str,
+    username: &str,
+    created: Option<chrono::DateTime<chrono::Utc>>,
+) -> Line<'static> {
+    let marker = if selected { "●" } else { "○" };
+    let choice = if selected { "  main" } else { "" };
+    let content = format!(
+        " {marker} {label:<8} {username:<18} {}{choice}",
+        created_label(created)
+    );
+    let style = if selected {
+        Style::default()
+            .fg(theme::TEXT_BRIGHT())
+            .bg(theme::BG_SELECTION())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT_DIM())
+    };
+    Line::from(Span::styled(
+        pad_to_width(&content, width, selected),
+        style,
+    ))
+}
+
+fn created_label(created: Option<chrono::DateTime<chrono::Utc>>) -> String {
+    created
+        .map(|created| format!("created {}", created.format("%Y-%m-%d")))
+        .unwrap_or_else(|| "created unknown".to_string())
+}
+
+fn link_account_input_line(
+    input: &ratatui_textarea::TextArea<'static>,
+    placeholder: &str,
+    pending: bool,
+) -> Line<'static> {
+    let typed = input.lines().join("");
+    let text = if typed.is_empty() {
+        placeholder.to_string()
+    } else if pending {
+        typed
+    } else {
+        text_with_caret(&typed, input.cursor().1)
+    };
+    let style = if typed.is_empty() {
+        Style::default().fg(theme::TEXT_FAINT())
+    } else {
+        Style::default().fg(theme::AMBER())
+    };
+    Line::from(vec![
+        Span::styled(" › ", Style::default().fg(theme::AMBER_GLOW())),
+        Span::styled(text, style),
+    ])
+}
+
+fn draw_link_account_status(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
+    let Some(status) = state.link_account_dialog().status() else {
+        return;
+    };
+    let dialog = state.link_account_dialog();
+    let color = if dialog.pending() {
+        theme::AMBER()
+    } else if dialog.step() == LinkAccountStep::Pending {
+        theme::SUCCESS()
+    } else {
+        theme::ERROR()
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(vec![
+            Span::raw(" "),
+            Span::styled(status.to_string(), Style::default().fg(color)),
+        ])),
+        area,
+    );
+}
+
+fn draw_link_account_footer(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
+    let footer = match state.link_account_dialog().step() {
+        LinkAccountStep::EnterCode => Line::from(vec![
+            Span::raw(" "),
+            Span::styled("Enter", Style::default().fg(theme::AMBER_DIM())),
+            Span::styled(" check code  ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled("Esc", Style::default().fg(theme::AMBER_DIM())),
+            Span::styled(" cancel", Style::default().fg(theme::TEXT_DIM())),
+        ]),
+        LinkAccountStep::Confirm => Line::from(vec![
+            Span::raw(" "),
+            Span::styled("↑← / ↓→", Style::default().fg(theme::AMBER_DIM())),
+            Span::styled(" choose main  ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled("Enter", Style::default().fg(theme::AMBER_DIM())),
+            Span::styled(" link  ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled("Esc", Style::default().fg(theme::AMBER_DIM())),
+            Span::styled(" cancel", Style::default().fg(theme::TEXT_DIM())),
+        ]),
+        LinkAccountStep::Pending => Line::from(vec![
+            Span::raw(" "),
+            Span::styled("Esc", Style::default().fg(theme::AMBER_DIM())),
+            Span::styled(" close", Style::default().fg(theme::TEXT_DIM())),
+        ]),
+    };
+    frame.render_widget(Paragraph::new(footer), area);
 }
 
 fn draw_delete_account_dialog(frame: &mut Frame, area: Rect, state: &SettingsModalState) {

--- a/late-ssh/src/ssh.rs
+++ b/late-ssh/src/ssh.rs
@@ -1390,6 +1390,9 @@ async fn ensure_user(state: &State, username: &str, fingerprint: &str) -> Result
             if let Err(e) = User::update_last_seen(&mut row.clone(), &client).await {
                 tracing::warn!(error = ?e, "failed to update last_seen for user");
             }
+            if let Err(e) = User::ensure_ssh_key(&client, row.id, fingerprint).await {
+                tracing::warn!(error = ?e, "failed to ensure ssh key for user");
+            }
             (row, false)
         }
         None => {
@@ -1403,6 +1406,7 @@ async fn ensure_user(state: &State, username: &str, fingerprint: &str) -> Result
                 },
             )
             .await?;
+            User::ensure_ssh_key(&client, user.id, fingerprint).await?;
             match state.chat_service.auto_join_public_rooms(user.id).await {
                 Ok(joined) => {
                     tracing::debug!(

--- a/late-ssh/src/web_tunnel.rs
+++ b/late-ssh/src/web_tunnel.rs
@@ -553,6 +553,9 @@ async fn ensure_web_tunnel_user(state: &State, peer_ip: IpAddr) -> Result<(User,
         if let Err(err) = User::update_last_seen(&mut user, &client).await {
             tracing::warn!(error = ?err, "failed to update web tunnel user last_seen");
         }
+        if let Err(err) = User::ensure_ssh_key(&client, user.id, fingerprint).await {
+            tracing::warn!(error = ?err, "failed to ensure web tunnel ssh key");
+        }
         return Ok((user, false));
     }
 
@@ -567,6 +570,7 @@ async fn ensure_web_tunnel_user(state: &State, peer_ip: IpAddr) -> Result<(User,
         },
     )
     .await?;
+    User::ensure_ssh_key(&client, user.id, fingerprint).await?;
     if let Err(err) = state.chat_service.auto_join_public_rooms(user.id).await {
         tracing::warn!(user_id = %user.id, error = ?err, "failed to seed web tunnel chat rooms");
     }


### PR DESCRIPTION
## Summary
- Adds account linking so multiple SSH key fingerprints can resolve to one late.sh identity.
- Users can now link accounts from Settings > Account by exchanging short-lived codes, choosing the main account to keep, and confirming the destructive action.

## Changes
- Adds `user_ssh_keys` and `account_link_codes` tables, with migration backfill from existing `users.fingerprint` values.
- Resolves users through `user_ssh_keys` first, while preserving fallback lookup by the legacy `users.fingerprint`.
- Adds Settings > Account UI and input handling for link-code creation, peer preview, main-account selection, and typed confirmation.
- Updates SSH, web tunnel, ghost user creation, and chat room membership lookup to maintain and use the SSH key mapping.
- Terminates active sessions for the abandoned account after linking.

## Behavior notes
- Linking is destructive: SSH keys move to the chosen main account, the abandoned user is deleted, and user data is not merged.
- Link codes expire after 10 minutes and are consumed when replaced or completed.

## Feature flags
- None

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Not run; no test output was provided in the diff context.
- Manual: Not run; no manual verification notes were provided in the diff context.