### PR TITLE
feat(nonogram): improve visual contrast

### DIFF
--- a/late-ssh/src/app/arcade/nonogram/ui.rs
+++ b/late-ssh/src/app/arcade/nonogram/ui.rs
@@ -241,8 +241,8 @@ fn cell_span(state: &State, row: usize, col: usize) -> Span<'static> {
     }
 
     let glyph = match filled {
-        1 => " # ",
-        2 => " x ",
+        1 => " █ ",
+        2 => " ✕ ",
         _ => " · ",
     };
 


### PR DESCRIPTION
I've found the contrast between `x` and `#` to be too low to play the nonograms comfortably, feel free to close if you don't like this new look 😄 

Before:

<img width="546" height="345" alt="Screenshot 2026-05-27 at 11 31 28 PM" src="https://github.com/user-attachments/assets/e022f3b7-d53a-458d-8678-f22438c12a16" />

After:

<img width="561" height="364" alt="Screenshot 2026-05-27 at 11 40 29 PM" src="https://github.com/user-attachments/assets/09042015-defe-4bfe-b3a8-8fc9b6dd3848" />
