### PR TITLE
fix: connect_local_user.sh always lands on the host's default identity

### DIFF
--- a/scripts/connect_local_user.sh
+++ b/scripts/connect_local_user.sh
@@ -19,4 +19,4 @@ if [[ ! -f "$key_path" ]]; then
   ssh-keygen -t ed25519 -f "$key_path" -N "" -C "late-local-${name}" >/dev/null
 fi
 
-exec ssh -i "$key_path" -p 2222 "${name}@localhost"
+exec ssh -i "$key_path" -o IdentitiesOnly=yes -p 2222 "${name}@localhost"


### PR DESCRIPTION
Without `IdentitiesOnly=yes`, ssh tries default keys / ssh-agent identities before the `-i` key. With `LATE_SSH_OPEN=1` the server accepts the first match, so every invocation of this script authenticates as the host user's default key and lands on the same in-game account defeating the script's purpose.