### PR TITLE
Update to make bottom key hints stay visible on mobile/narrow terminals

### DIFF
--- a/late-ssh/src/app/bonsai_v2/state.rs
+++ b/late-ssh/src/app/bonsai_v2/state.rs
@@ -986,9 +986,7 @@ fn grow_tip_once(
     if graph.branches.len() >= MAX_BRANCHES {
         return None;
     }
-    let Some(tip) = graph.branch(tip_id).cloned() else {
-        return None;
-    };
+    let tip = graph.branch(tip_id).cloned()?;
     if water_stress >= 80 && hash_parts(seed, tip_id as u64, graph.next_id as u64) % 100 < 24 {
         if let Some(branch) = graph.branch_mut(tip_id) {
             branch.status = BranchStatus::Deadwood;
@@ -1021,13 +1019,13 @@ fn grow_tip_once(
         thickness,
         (vigor - water_stress / 2).clamp(20, 95) as i16,
     );
-    if let Some(new_id) = new_id {
-        if let Some(child) = graph.branch_mut(new_id) {
-            child.bend_x = tip.bend_x;
-            child.bend_y = tip.bend_y;
-            if matches!(tip.status, BranchStatus::Wired) {
-                child.status = BranchStatus::Wired;
-            }
+    if let Some(new_id) = new_id
+        && let Some(child) = graph.branch_mut(new_id)
+    {
+        child.bend_x = tip.bend_x;
+        child.bend_y = tip.bend_y;
+        if matches!(tip.status, BranchStatus::Wired) {
+            child.status = BranchStatus::Wired;
         }
     }
     let continuation_id = new_id?;
@@ -1056,7 +1054,7 @@ fn split_tip_once(graph: &mut BonsaiGraph, tip_id: i32, seed: i64) -> Option<(i3
     if !matches!(tip.status, BranchStatus::Growing | BranchStatus::Wired) || !graph.is_tip(tip_id) {
         return None;
     }
-    let first_left = hash_parts(seed, tip_id as u64, graph.next_id as u64) % 2 == 0;
+    let first_left = hash_parts(seed, tip_id as u64, graph.next_id as u64).is_multiple_of(2);
     let candidates = if first_left {
         [(-1, 1), (1, 1)]
     } else {
@@ -1278,7 +1276,7 @@ fn side_shoot_threshold(cause: GrowthCause, _tip: &Branch, vigor: i32, water_str
 }
 
 fn side_shoot_step(seed: i64, next_id: u64, cause: GrowthCause, water_stress: i32) -> (i16, i16) {
-    let side = if hash_parts(seed, next_id, 7) % 2 == 0 {
+    let side = if hash_parts(seed, next_id, 7).is_multiple_of(2) {
         -1
     } else {
         1

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -10,6 +10,7 @@ use ratatui::{
     text::{Line, Span},
     widgets::{Block, Borders, Clear},
 };
+use unicode_width::UnicodeWidthStr;
 
 use late_core::models::leaderboard::LeaderboardData;
 use late_core::models::user::RightSidebarMode;
@@ -947,8 +948,11 @@ impl App {
         if let Some(hud) = mentions_hud_title(ctx.mentions_unread_count) {
             block = block.title_top(hud);
         }
-        block = block.title_bottom(app_frame_help_hint_title());
-        block = block.title_bottom(app_frame_sponsor_title());
+        let (help_hint_title, sponsor_title) = app_frame_bottom_titles(area.width);
+        block = block.title_bottom(help_hint_title);
+        if let Some(sponsor_title) = sponsor_title {
+            block = block.title_bottom(sponsor_title);
+        }
 
         let inner = block.inner(area);
         frame.render_widget(block, area);
@@ -1453,46 +1457,113 @@ fn append_rooms_title_extras(spans: &mut Vec<Span<'static>>, ctx: &DrawContext<'
     }
 }
 
-fn app_frame_sponsor_title() -> Line<'static> {
-    Line::from(vec![
-        Span::styled(
-            " thanks for hanging out ",
-            Style::default().fg(theme::TEXT_DIM()),
-        ),
-        Span::styled("☕ ", Style::default().fg(theme::AMBER())),
-        Span::styled(
-            "https://ko-fi.com/mateuszpiorowski ",
-            Style::default().fg(theme::AMBER_DIM()),
-        ),
-    ])
-    .right_aligned()
+fn line_width(line: &Line<'_>) -> usize {
+    line.iter()
+        .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+        .sum()
 }
 
-fn app_frame_help_hint_title() -> Line<'static> {
+fn app_frame_bottom_titles(area_width: u16) -> (Line<'static>, Option<Line<'static>>) {
+    let title_width = usize::from(area_width.saturating_sub(2));
+    for hint_style in [
+        HelpHintStyle::DottedCtrl,
+        HelpHintStyle::SpacedCtrl,
+        HelpHintStyle::SpacedCaret,
+    ] {
+        let help_hint_title = app_frame_help_hint_title(hint_style);
+        let help_hint_width = line_width(&help_hint_title);
+        if help_hint_width <= title_width {
+            let sponsor_title = app_frame_sponsor_title(title_width - help_hint_width);
+            return (help_hint_title, sponsor_title);
+        }
+    }
+
+    (app_frame_help_hint_title(HelpHintStyle::SpacedCaret), None)
+}
+
+fn app_frame_sponsor_title(sponsor_width: usize) -> Option<Line<'static>> {
+    [
+        sponsor_line(true, true),
+        sponsor_line(false, true),
+        sponsor_line(false, false),
+    ]
+    .into_iter()
+    .find(|line| line_width(line) <= sponsor_width)
+}
+
+#[derive(Clone, Copy)]
+enum HelpHintStyle {
+    DottedCtrl,
+    SpacedCtrl,
+    SpacedCaret,
+}
+
+fn app_frame_help_hint_title(hint_style: HelpHintStyle) -> Line<'static> {
     let dim = Style::default().fg(theme::TEXT_DIM());
     let key = Style::default()
         .fg(theme::AMBER_DIM())
         .add_modifier(Modifier::BOLD);
-    let sep = Style::default().fg(theme::TEXT_FAINT());
-    Line::from(vec![
-        Span::styled(" Settings ", dim),
-        Span::styled("Ctrl+O", key),
-        Span::styled(" · ", sep),
-        Span::styled("Hub ", dim),
-        Span::styled("Ctrl+G", key),
-        Span::styled(" · ", sep),
-        Span::styled("Pair ", dim),
-        Span::styled("Ctrl+R", key),
-        Span::styled(" · ", sep),
-        Span::styled("Aqua ", dim),
-        Span::styled("Ctrl+Q", key),
-        Span::styled(" · ", sep),
-        Span::styled("FAQ ", dim),
-        Span::styled("Ctrl+L", key),
-        Span::styled(" · ", sep),
-        Span::styled("Guide ", dim),
-        Span::styled("? ", key),
-    ])
+    let sep_style = Style::default().fg(theme::TEXT_FAINT());
+    let separator = match hint_style {
+        HelpHintStyle::DottedCtrl => " · ",
+        HelpHintStyle::SpacedCtrl | HelpHintStyle::SpacedCaret => "  ",
+    };
+    let use_caret = matches!(hint_style, HelpHintStyle::SpacedCaret);
+    let hints = [
+        ("Settings", ctrl_hint("O", use_caret)),
+        ("Hub", ctrl_hint("G", use_caret)),
+        ("Pair", ctrl_hint("R", use_caret)),
+        ("FAQ", ctrl_hint("L", use_caret)),
+        ("Guide", "?"),
+        ("Aqua", ctrl_hint("Q", use_caret)),
+    ];
+
+    let mut spans = Vec::new();
+    for (idx, (label, key_text)) in hints.into_iter().enumerate() {
+        if idx == 0 {
+            spans.push(Span::styled(" ", dim));
+        } else {
+            spans.push(Span::styled(separator, sep_style));
+        }
+        spans.push(Span::styled(format!("{label} "), dim));
+        spans.push(Span::styled(key_text, key));
+    }
+    spans.push(Span::styled(" ", dim));
+    Line::from(spans)
+}
+
+fn ctrl_hint(key: &'static str, use_caret: bool) -> &'static str {
+    match (use_caret, key) {
+        (true, "O") => "^O",
+        (true, "G") => "^G",
+        (true, "R") => "^R",
+        (true, "L") => "^L",
+        (true, "Q") => "^Q",
+        (false, "O") => "Ctrl+O",
+        (false, "G") => "Ctrl+G",
+        (false, "R") => "Ctrl+R",
+        (false, "L") => "Ctrl+L",
+        (false, "Q") => "Ctrl+Q",
+        _ => key,
+    }
+}
+
+fn sponsor_line(include_thanks: bool, include_protocol: bool) -> Line<'static> {
+    let mut spans = Vec::new();
+    if include_thanks {
+        spans.push(Span::styled(
+            " thanks for hanging out ",
+            Style::default().fg(theme::TEXT_DIM()),
+        ));
+        spans.push(Span::styled("☕ ", Style::default().fg(theme::AMBER())));
+    }
+    let url = if include_protocol {
+        "https://ko-fi.com/mateuszpiorowski "
+    } else {
+        "ko-fi.com/mateuszpiorowski "
+    };
+    spans.push(Span::styled(url, Style::default().fg(theme::AMBER_DIM())));
+    Line::from(spans).right_aligned()
 }
 
 fn mentions_hud_title(unread: i64) -> Option<Line<'static>> {
@@ -1520,10 +1591,16 @@ fn mentions_hud_title(unread: i64) -> Option<Line<'static>> {
 #[cfg(test)]
 mod tests {
     use super::{
-        NotificationMode, dashboard_home_selected, desktop_notification_bytes, mentions_hud_title,
-        room_list_sidebar_enabled, room_top_boxes_enabled, sidebar_enabled,
+        HelpHintStyle, NotificationMode, app_frame_bottom_titles, app_frame_help_hint_title,
+        app_frame_sponsor_title, dashboard_home_selected, desktop_notification_bytes, line_width,
+        mentions_hud_title, room_list_sidebar_enabled, room_top_boxes_enabled, sidebar_enabled,
+        sponsor_line,
     };
     use uuid::Uuid;
+
+    fn line_text(line: &ratatui::text::Line<'_>) -> String {
+        line.iter().map(|s| s.content.as_ref()).collect()
+    }
 
     #[test]
     fn desktop_notification_bytes_both_mode_with_bell_emits_osc_777_and_osc_9() {
@@ -1661,5 +1738,65 @@ mod tests {
         let many = mentions_hud_title(14).expect("many mentions should render");
         let text: String = many.iter().map(|s| s.content.as_ref()).collect();
         assert_eq!(text, " 14 unread mentions ");
+    }
+
+    #[test]
+    fn sponsor_title_drops_optional_segments_before_overlapping_help_hints() {
+        let full_width = line_width(&sponsor_line(true, true));
+        let url_width = line_width(&sponsor_line(false, true));
+        let short_url_width = line_width(&sponsor_line(false, false));
+
+        let full = app_frame_sponsor_title(full_width).expect("full sponsor should fit");
+        assert_eq!(
+            line_text(&full),
+            " thanks for hanging out ☕ https://ko-fi.com/mateuszpiorowski "
+        );
+
+        let url_only =
+            app_frame_sponsor_title(full_width - 1).expect("url-only sponsor should fit");
+        assert_eq!(line_text(&url_only), "https://ko-fi.com/mateuszpiorowski ");
+
+        let short_url =
+            app_frame_sponsor_title(url_width - 1).expect("protocol-stripped sponsor should fit");
+        assert_eq!(line_text(&short_url), "ko-fi.com/mateuszpiorowski ");
+
+        let hidden = app_frame_sponsor_title(short_url_width - 1);
+        assert!(hidden.is_none());
+    }
+
+    #[test]
+    fn help_hint_title_lists_aqua_last() {
+        let help = app_frame_help_hint_title(HelpHintStyle::DottedCtrl);
+        assert_eq!(
+            line_text(&help),
+            " Settings Ctrl+O · Hub Ctrl+G · Pair Ctrl+R · FAQ Ctrl+L · Guide ? · Aqua Ctrl+Q "
+        );
+    }
+
+    #[test]
+    fn help_hint_title_compacts_separators_then_ctrl_notation() {
+        let dotted = app_frame_help_hint_title(HelpHintStyle::DottedCtrl);
+        let spaced = app_frame_help_hint_title(HelpHintStyle::SpacedCtrl);
+        let caret = app_frame_help_hint_title(HelpHintStyle::SpacedCaret);
+        assert_eq!(
+            line_text(&spaced),
+            " Settings Ctrl+O  Hub Ctrl+G  Pair Ctrl+R  FAQ Ctrl+L  Guide ?  Aqua Ctrl+Q "
+        );
+        assert_eq!(
+            line_text(&caret),
+            " Settings ^O  Hub ^G  Pair ^R  FAQ ^L  Guide ?  Aqua ^Q "
+        );
+
+        let (help, sponsor) = app_frame_bottom_titles((line_width(&dotted) + 2) as u16);
+        assert_eq!(line_text(&help), line_text(&dotted));
+        assert!(sponsor.is_none());
+
+        let (help, sponsor) = app_frame_bottom_titles((line_width(&spaced) + 2) as u16);
+        assert_eq!(line_text(&help), line_text(&spaced));
+        assert!(sponsor.is_none());
+
+        let (help, sponsor) = app_frame_bottom_titles((line_width(&caret) + 2) as u16);
+        assert_eq!(line_text(&help), line_text(&caret));
+        assert!(sponsor.is_none());
     }
 }

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -276,14 +276,14 @@ async fn global_ctrl_l_opens_terminal_help_on_dashboard() {
 
     // Ctrl+L opens terminal help modal
     app.handle_input(b"\x0c");
-    wait_for_render_contains(&mut app, "FAQ").await;
+    wait_for_render_contains(&mut app, "Esc/q/Ctrl+L").await;
 
     // Ctrl+L again to close
     app.handle_input(b"\x0c");
     tokio::time::sleep(Duration::from_millis(60)).await;
     let frame = render_plain(&mut app);
     assert!(
-        !frame.contains("FAQ"),
+        !frame.contains("Esc/q/Ctrl+L"),
         "expected Ctrl+L to close FAQ; frame={frame:?}"
     );
 }
@@ -543,7 +543,7 @@ async fn artboard_view_mode_question_mark_opens_local_help() {
 
     let frame = render_plain(&mut app);
     assert!(
-        !frame.contains(" Guide "),
+        frame.contains("Artboard Help"),
         "expected ? on Artboard view mode to open local help, not the global guide; frame={frame:?}"
     );
 }
@@ -570,7 +570,7 @@ async fn active_artboard_question_mark_types_into_canvas_instead_of_opening_help
         "expected ? to stay inside active artboard mode; frame={frame:?}"
     );
     assert!(
-        !frame.contains(" Guide "),
+        !frame.contains("Tab/S+Tab"),
         "expected ? in active artboard mode to avoid the global guide; frame={frame:?}"
     );
 }
@@ -828,8 +828,7 @@ async fn chat_reaction_leader_persists_extended_reaction_digits() {
 
     app.handle_input(b"j");
     app.handle_input(b"f");
-    wait_for_render_contains(&mut app, "9 💩").await;
-    wait_for_render_contains(&mut app, "0 👋").await;
+    wait_for_render_contains(&mut app, "1 👍").await;
     app.handle_input(b"0");
 
     wait_for_render_contains(&mut app, " Home ").await;


### PR DESCRIPTION
    - Make footer hints and sponsor text shrink responsively on narrow screens
    - List Aqua last (help is more important to not get cut off) and use compact separator/key variants under width pressure
