### PR TITLE
Show Bonsai and Aquarium in Profiles

### DIFF
--- a/late-core/src/models/marketplace.rs
+++ b/late-core/src/models/marketplace.rs
@@ -594,6 +594,59 @@ pub async fn unequip_slot(client: &mut Client, user_id: Uuid, slot: &str) -> Res
     Ok(updated > 0)
 }
 
+/// Active aquarium creatures `(creature_name, count)` a user is currently
+/// displaying. Mirrors `ShopState::active_aquarium_fish` but reads from the
+/// database for an arbitrary user, so profile views can render someone else's
+/// tank.
+pub async fn active_aquarium_fish_for_user(
+    client: &Client,
+    user_id: Uuid,
+) -> Result<Vec<(String, usize)>> {
+    let rows = client
+        .query(
+            "SELECT i.payload->>'creature' AS creature,
+                    p.active_quantity AS count
+             FROM user_purchases p
+             JOIN marketplace_items i ON i.id = p.item_id
+             WHERE p.user_id = $1
+               AND i.item_kind = $2
+               AND p.active_quantity > 0
+               AND i.payload->>'creature' IS NOT NULL
+             ORDER BY creature",
+            &[&user_id, &AQUARIUM_FISH_ITEM_KIND],
+        )
+        .await?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|row| {
+            let creature: Option<String> = row.get("creature");
+            let count: i32 = row.get("count");
+            creature
+                .filter(|creature| !creature.is_empty())
+                .map(|creature| (creature, count.max(0) as usize))
+        })
+        .collect())
+}
+
+/// Whether the user has Dynamic Bonsai equipped in the `bonsai_variant` slot.
+/// Same rule the chat badge uses, exposed for the profile view.
+pub async fn is_dynamic_bonsai_selected(client: &Client, user_id: Uuid) -> Result<bool> {
+    let row = client
+        .query_one(
+            "SELECT EXISTS (
+                 SELECT 1
+                 FROM user_purchases p
+                 JOIN marketplace_items i ON i.id = p.item_id
+                 WHERE p.user_id = $1
+                   AND p.equipped_slot = $2
+                   AND i.sku = $3
+             ) AS selected",
+            &[&user_id, &BONSAI_VARIANT_SLOT, &DYNAMIC_BONSAI_SKU],
+        )
+        .await?;
+    Ok(row.get("selected"))
+}
+
 async fn aquarium_fish_active_quantity_in_tx(
     tx: &tokio_postgres::Transaction<'_>,
     user_id: Uuid,

--- a/late-ssh/src/app/bonsai_v2/state.rs
+++ b/late-ssh/src/app/bonsai_v2/state.rs
@@ -218,7 +218,7 @@ impl BonsaiV2State {
             vigor: tree.vigor,
             water_stress: tree.water_stress.max(0),
             last_simulated_date: tree.last_simulated_date,
-            age_days: (today - tree.planted_at.date_naive()).num_days().max(0),
+            age_days: simulated_age_days(tree.planted_at, tree.last_simulated_date),
             graph,
             selected_branch_id,
             mode: BonsaiV2Mode::from_str(&tree.mode),
@@ -258,7 +258,7 @@ impl BonsaiV2State {
             vigor: tree.vigor,
             water_stress: tree.water_stress.max(0),
             last_simulated_date: tree.last_simulated_date,
-            age_days: (today - tree.planted_at.date_naive()).num_days().max(0),
+            age_days: simulated_age_days(tree.planted_at, tree.last_simulated_date),
             graph,
             selected_branch_id,
             mode: BonsaiV2Mode::from_str(&tree.mode),
@@ -730,6 +730,12 @@ impl BonsaiV2State {
             state_revision: self.state_revision,
         });
     }
+}
+
+fn simulated_age_days(planted_at: DateTime<Utc>, last_simulated_date: NaiveDate) -> i64 {
+    (last_simulated_date - planted_at.date_naive())
+        .num_days()
+        .max(0)
 }
 
 #[derive(Debug, Clone, Copy)]

--- a/late-ssh/src/app/bonsai_v2/state.rs
+++ b/late-ssh/src/app/bonsai_v2/state.rs
@@ -233,6 +233,46 @@ impl BonsaiV2State {
         state
     }
 
+    /// Build a read-only state for rendering another user's tree (profile
+    /// view). Catches elapsed days up in memory so the silhouette is accurate,
+    /// but never persists, so viewing never mutates the owner's tree. Always
+    /// renders standard 2D.
+    pub(crate) fn view_only(user_id: Uuid, svc: BonsaiService, tree: BonsaiV2Tree) -> Self {
+        let today = BonsaiService::today();
+        let (graph, normalized_ids) =
+            serde_json::from_value::<BonsaiGraph>(tree.branch_graph.clone())
+                .map(normalize_graph_segments)
+                .unwrap_or_else(|_| (seeded_graph(tree.seed, 0), BTreeMap::new()));
+        let selected_branch_id = tree
+            .selected_branch_id
+            .and_then(|id| normalized_ids.get(&id).copied())
+            .or(tree.selected_branch_id)
+            .or_else(|| graph.selected_fallback());
+        let mut state = Self {
+            user_id,
+            svc,
+            seed: tree.seed,
+            planted_at: tree.planted_at,
+            last_watered: tree.last_watered,
+            is_alive: tree.is_alive,
+            vigor: tree.vigor,
+            water_stress: tree.water_stress.max(0),
+            last_simulated_date: tree.last_simulated_date,
+            age_days: (today - tree.planted_at.date_naive()).num_days().max(0),
+            graph,
+            selected_branch_id,
+            mode: BonsaiV2Mode::from_str(&tree.mode),
+            message: None,
+            state_revision: tree.state_revision,
+            ticks_since_growth: 0,
+        };
+        state.ensure_selection();
+        // In-memory catch-up only; intentionally no `persist()` so a viewer
+        // never writes to the viewed user's row.
+        state.apply_elapsed_days(today);
+        state
+    }
+
     pub(crate) fn fallback(user_id: Uuid, svc: BonsaiService, seed: i64) -> Self {
         let today = BonsaiService::today();
         let graph = seeded_graph(seed, 0);

--- a/late-ssh/src/app/bonsai_v2/state.rs
+++ b/late-ssh/src/app/bonsai_v2/state.rs
@@ -984,9 +984,7 @@ fn grow_tip_once(
     if graph.branches.len() >= MAX_BRANCHES {
         return None;
     }
-    let Some(tip) = graph.branch(tip_id).cloned() else {
-        return None;
-    };
+    let tip = graph.branch(tip_id).cloned()?;
     if water_stress >= 80 && hash_parts(seed, tip_id as u64, graph.next_id as u64) % 100 < 24 {
         if let Some(branch) = graph.branch_mut(tip_id) {
             branch.status = BranchStatus::Deadwood;
@@ -1019,13 +1017,13 @@ fn grow_tip_once(
         thickness,
         (vigor - water_stress / 2).clamp(20, 95) as i16,
     );
-    if let Some(new_id) = new_id {
-        if let Some(child) = graph.branch_mut(new_id) {
-            child.bend_x = tip.bend_x;
-            child.bend_y = tip.bend_y;
-            if matches!(tip.status, BranchStatus::Wired) {
-                child.status = BranchStatus::Wired;
-            }
+    if let Some(new_id) = new_id
+        && let Some(child) = graph.branch_mut(new_id)
+    {
+        child.bend_x = tip.bend_x;
+        child.bend_y = tip.bend_y;
+        if matches!(tip.status, BranchStatus::Wired) {
+            child.status = BranchStatus::Wired;
         }
     }
     let continuation_id = new_id?;
@@ -1054,7 +1052,7 @@ fn split_tip_once(graph: &mut BonsaiGraph, tip_id: i32, seed: i64) -> Option<(i3
     if !matches!(tip.status, BranchStatus::Growing | BranchStatus::Wired) || !graph.is_tip(tip_id) {
         return None;
     }
-    let first_left = hash_parts(seed, tip_id as u64, graph.next_id as u64) % 2 == 0;
+    let first_left = hash_parts(seed, tip_id as u64, graph.next_id as u64).is_multiple_of(2);
     let candidates = if first_left {
         [(-1, 1), (1, 1)]
     } else {
@@ -1276,7 +1274,7 @@ fn side_shoot_threshold(cause: GrowthCause, _tip: &Branch, vigor: i32, water_str
 }
 
 fn side_shoot_step(seed: i64, next_id: u64, cause: GrowthCause, water_stress: i32) -> (i16, i16) {
-    let side = if hash_parts(seed, next_id, 7) % 2 == 0 {
+    let side = if hash_parts(seed, next_id, 7).is_multiple_of(2) {
         -1
     } else {
         1

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -276,42 +276,60 @@ fn pick_composer_title_text(view: &ComposerBlockView<'_>, block_width: u16) -> S
     .to_string()
 }
 
-fn reaction_picker_placeholder_line(
-    dim: Style,
-    choice_separator: &'static str,
-    include_owner_hint: bool,
-) -> Line<'static> {
-    let mut reaction_spans = Vec::new();
-    for (index, key) in REACTION_PICKER_KEYS.iter().copied().enumerate() {
-        if index > 0 {
-            reaction_spans.push(Span::styled(choice_separator, dim));
-        }
-        reaction_spans.push(Span::styled(
-            key.to_string(),
-            Style::default()
-                .fg(theme::AMBER())
-                .add_modifier(Modifier::BOLD),
-        ));
-        reaction_spans.push(Span::styled(" ", dim));
-        reaction_spans.push(Span::styled(reaction_label(key), dim));
-    }
-    if include_owner_hint {
-        reaction_spans.push(Span::styled("  ", dim));
-        reaction_spans.push(Span::styled(
-            "f",
-            Style::default()
-                .fg(theme::AMBER())
-                .add_modifier(Modifier::BOLD),
-        ));
-        reaction_spans.push(Span::styled(" list", dim));
-    }
+fn reaction_picker_choice_width(key: i16) -> usize {
+    1 + 1 + reaction_label(key).width()
+}
 
-    Line::from(reaction_spans)
+fn push_reaction_picker_choice(reaction_spans: &mut Vec<Span<'static>>, dim: Style, key: i16) {
+    reaction_spans.push(Span::styled(
+        key.to_string(),
+        Style::default()
+            .fg(theme::AMBER())
+            .add_modifier(Modifier::BOLD),
+    ));
+    reaction_spans.push(Span::styled(" ", dim));
+    reaction_spans.push(Span::styled(reaction_label(key), dim));
 }
 
 fn reaction_picker_placeholder_lines(dim: Style, width: usize) -> Vec<Line<'static>> {
-    let _ = width;
-    vec![reaction_picker_placeholder_line(dim, "  ", true)]
+    let available_width = width.max(1);
+    let mut lines = Vec::new();
+    let mut current_spans = Vec::new();
+    let mut current_width = 0usize;
+
+    for key in REACTION_PICKER_KEYS {
+        let separator_width = usize::from(!current_spans.is_empty()) * 2;
+        let choice_width = reaction_picker_choice_width(key);
+        if !current_spans.is_empty()
+            && current_width + separator_width + choice_width > available_width
+        {
+            lines.push(Line::from(std::mem::take(&mut current_spans)));
+            current_width = 0;
+        }
+        if !current_spans.is_empty() {
+            current_spans.push(Span::styled("  ", dim));
+            current_width += 2;
+        }
+        push_reaction_picker_choice(&mut current_spans, dim, key);
+        current_width += choice_width;
+    }
+
+    let owner_hint_width = 8;
+    if !current_spans.is_empty() && current_width + owner_hint_width > available_width {
+        lines.push(Line::from(std::mem::take(&mut current_spans)));
+    } else if !current_spans.is_empty() {
+        current_spans.push(Span::styled("  ", dim));
+    }
+    current_spans.push(Span::styled(
+        "f",
+        Style::default()
+            .fg(theme::AMBER())
+            .add_modifier(Modifier::BOLD),
+    ));
+    current_spans.push(Span::styled(" list", dim));
+
+    lines.push(Line::from(current_spans));
+    lines
 }
 
 fn empty_composer_placeholder(view: &ComposerBlockView<'_>, width: usize) -> Paragraph<'static> {
@@ -3508,36 +3526,41 @@ mod tests {
     }
 
     #[test]
-    fn reaction_picker_placeholder_never_compresses_at_narrow_width() {
+    fn reaction_picker_placeholder_wraps_at_narrow_width() {
         let lines = reaction_picker_placeholder_lines(Style::default(), 48);
-        assert_eq!(lines.len(), 1);
-        let rendered: String = lines[0]
-            .spans
+        assert_eq!(lines.len(), 2);
+        let rendered: Vec<String> = lines
             .iter()
-            .map(|span| span.content.as_ref())
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect()
+            })
             .collect();
 
         assert_eq!(
             rendered,
-            "1 👍  2 🧡  3 😂  4 👀  5 🔥  6 🙌  7 🚀  8 🤔  9 💩  0 👋  f list"
+            vec![
+                "1 👍  2 🧡  3 😂  4 👀  5 🔥  6 🙌  7 🚀  8 🤔",
+                "9 💩  0 👋  f list",
+            ]
         );
     }
 
     #[test]
-    fn chat_composer_placeholder_keeps_reaction_picker_on_one_line() {
+    fn chat_composer_placeholder_counts_wrapped_reaction_picker_lines() {
         let ta = TextArea::default();
         let lines = chat_composer_placeholder_lines(&ta, false, true, 48);
-        assert_eq!(lines, 1);
+        assert_eq!(lines, 2);
     }
 
     #[test]
     fn reaction_picker_placeholder_keeps_zero_choice_at_mid_width() {
         let lines = reaction_picker_placeholder_lines(Style::default(), 50);
         let rendered: String = lines
-            .first()
-            .expect("reaction picker line")
-            .spans
             .iter()
+            .flat_map(|line| line.spans.iter())
             .map(|span| span.content.as_ref())
             .collect();
 

--- a/late-ssh/src/app/profile/svc.rs
+++ b/late-ssh/src/app/profile/svc.rs
@@ -1,7 +1,8 @@
 use anyhow::Result;
 use chrono::{DateTime, NaiveDate, Utc};
 use late_core::models::account_link;
-use late_core::models::bonsai::Tree;
+use late_core::models::bonsai::{BonsaiV2Tree, Tree};
+use late_core::models::marketplace;
 use late_core::models::profile::{Profile, ProfileParams};
 use late_core::models::user::{User, sanitize_username_input};
 use tokio_postgres::error::SqlState;
@@ -34,6 +35,9 @@ pub struct ProfileSnapshot {
     pub profile: Option<Profile>,
     pub chip_balance: Option<i64>,
     pub bonsai: Option<Tree>,
+    pub bonsai_v2: Option<BonsaiV2Tree>,
+    pub dynamic_bonsai_selected: bool,
+    pub aquarium_fish: Vec<(String, usize)>,
 }
 
 #[derive(Clone, Debug)]
@@ -202,6 +206,10 @@ impl ProfileService {
         let client = self.db.get().await?;
         let profile = Profile::load_with_chip_balance(&client, user_id).await?;
         let bonsai = Tree::find_by_user_id(&client, user_id).await?;
+        let bonsai_v2 = BonsaiV2Tree::find_by_user_id(&client, user_id).await?;
+        let dynamic_bonsai_selected =
+            marketplace::is_dynamic_bonsai_selected(&client, user_id).await?;
+        let aquarium_fish = marketplace::active_aquarium_fish_for_user(&client, user_id).await?;
         self.publish_snapshot(
             user_id,
             ProfileSnapshot {
@@ -209,6 +217,9 @@ impl ProfileService {
                 profile: Some(profile.profile),
                 chip_balance: Some(profile.chip_balance),
                 bonsai,
+                bonsai_v2,
+                dynamic_bonsai_selected,
+                aquarium_fish,
             },
         )?;
         Ok(())

--- a/late-ssh/src/app/profile_modal/badges.rs
+++ b/late-ssh/src/app/profile_modal/badges.rs
@@ -64,7 +64,10 @@ fn draw_grid(frame: &mut Frame, area: Rect, badges: &[Badge], scroll: u16) {
                 pad(&format!("{} {}", badge.glyph, badge.name), CELL_W),
                 accent,
             ));
-            date_spans.push(Span::styled(pad(&format!("  {}", badge.earned), CELL_W), dim));
+            date_spans.push(Span::styled(
+                pad(&format!("  {}", badge.earned), CELL_W),
+                dim,
+            ));
             desc_spans.push(Span::styled(
                 pad(&format!("  {}", badge.description), CELL_W),
                 dim,

--- a/late-ssh/src/app/profile_modal/badges.rs
+++ b/late-ssh/src/app/profile_modal/badges.rs
@@ -1,0 +1,130 @@
+//! Profile Badges tab.
+//!
+//! There is no achievements/badges system yet. This module defines the badge
+//! shape and renders a placeholder grid so the layout is ready for a real
+//! source to populate later (each badge will carry a glyph, name, earned date,
+//! and what it was awarded for). Users are expected to accumulate many of
+//! these over time, hence the dedicated tab.
+
+use ratatui::{
+    Frame,
+    layout::Rect,
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+};
+use uuid::Uuid;
+
+use crate::app::common::theme;
+
+/// A single earned badge. Populated by a future achievements system.
+#[derive(Clone, Debug)]
+pub(crate) struct Badge {
+    pub glyph: String,
+    pub name: String,
+    /// `YYYY-MM-DD` the badge was earned.
+    pub earned: String,
+    /// What the badge was awarded for.
+    pub description: String,
+}
+
+/// Badges for a user. No backing system yet, so always empty for now.
+pub(crate) fn badges_for(_user_id: Uuid) -> Vec<Badge> {
+    Vec::new()
+}
+
+const CELL_W: usize = 24;
+
+pub(crate) fn draw(frame: &mut Frame, area: Rect, badges: &[Badge], scroll: u16) {
+    if area.width < 14 || area.height < 4 {
+        return;
+    }
+    if badges.is_empty() {
+        draw_placeholder(frame, area);
+        return;
+    }
+    draw_grid(frame, area, badges, scroll);
+}
+
+/// Future state: a scrollable grid of earned badges, newest first.
+fn draw_grid(frame: &mut Frame, area: Rect, badges: &[Badge], scroll: u16) {
+    let cols = (area.width as usize / CELL_W).max(1);
+    let accent = Style::default()
+        .fg(theme::AMBER())
+        .add_modifier(Modifier::BOLD);
+    let dim = Style::default().fg(theme::TEXT_DIM());
+
+    let mut lines: Vec<Line> = Vec::new();
+    for row in badges.chunks(cols) {
+        let mut name_spans = Vec::new();
+        let mut date_spans = Vec::new();
+        let mut desc_spans = Vec::new();
+        for badge in row {
+            name_spans.push(Span::styled(
+                pad(&format!("{} {}", badge.glyph, badge.name), CELL_W),
+                accent,
+            ));
+            date_spans.push(Span::styled(pad(&format!("  {}", badge.earned), CELL_W), dim));
+            desc_spans.push(Span::styled(
+                pad(&format!("  {}", badge.description), CELL_W),
+                dim,
+            ));
+        }
+        lines.push(Line::from(name_spans));
+        lines.push(Line::from(date_spans));
+        lines.push(Line::from(desc_spans));
+        lines.push(Line::from(""));
+    }
+    frame.render_widget(Paragraph::new(lines).scroll((scroll, 0)), area);
+}
+
+/// Current state: empty shelf of dim placeholder slots plus a caption, so the
+/// tab reads as "this will fill up" rather than broken.
+fn draw_placeholder(frame: &mut Frame, area: Rect) {
+    let slot = Style::default().fg(theme::BORDER());
+    let cols = (area.width as usize / 8).clamp(3, 6);
+    let rows = 2usize;
+
+    let mut content: Vec<Line> = Vec::new();
+    for _ in 0..rows {
+        let mut spans = Vec::new();
+        for _ in 0..cols {
+            spans.push(Span::styled("⬡", slot));
+            spans.push(Span::raw("     "));
+        }
+        content.push(Line::from(spans).centered());
+        content.push(Line::from(""));
+    }
+    content.push(Line::from(""));
+    content.push(
+        Line::from(Span::styled(
+            "No badges yet",
+            Style::default()
+                .fg(theme::TEXT())
+                .add_modifier(Modifier::BOLD),
+        ))
+        .centered(),
+    );
+    content.push(
+        Line::from(Span::styled(
+            "achievements you earn will appear here, with the date and what they were for",
+            Style::default().fg(theme::TEXT_DIM()),
+        ))
+        .centered(),
+    );
+
+    let top_pad = (area.height as usize).saturating_sub(content.len()) / 2;
+    let mut lines = vec![Line::from(""); top_pad];
+    lines.extend(content);
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn pad(text: &str, width: usize) -> String {
+    let count = text.chars().count();
+    if count >= width {
+        let keep = width.saturating_sub(1);
+        format!("{}…", text.chars().take(keep).collect::<String>())
+    } else {
+        format!("{text}{}", " ".repeat(width - count))
+    }
+}

--- a/late-ssh/src/app/profile_modal/input.rs
+++ b/late-ssh/src/app/profile_modal/input.rs
@@ -1,5 +1,6 @@
 use crate::app::{
     input::{MouseEventKind, ParsedInput},
+    profile_modal::state::ProfileTab,
     state::App,
 };
 
@@ -10,14 +11,21 @@ pub fn handle_input(app: &mut App, event: ParsedInput) {
     }
 
     match event {
-        ParsedInput::Byte(b'j' | b'J')
-        | ParsedInput::Char('j' | 'J')
-        | ParsedInput::Arrow(b'B') => {
+        ParsedInput::Byte(b'\t') => app.profile_modal_state.cycle_tab(1),
+        ParsedInput::BackTab => app.profile_modal_state.cycle_tab(-1),
+        ParsedInput::Byte(b'l' | b'L') | ParsedInput::Char('l' | 'L') | ParsedInput::Arrow(b'C') => {
+            app.profile_modal_state.cycle_tab(1);
+        }
+        ParsedInput::Byte(b'h' | b'H') | ParsedInput::Char('h' | 'H') | ParsedInput::Arrow(b'D') => {
+            app.profile_modal_state.cycle_tab(-1);
+        }
+        ParsedInput::Byte(b'b' | b'B') | ParsedInput::Char('b' | 'B') => {
+            app.profile_modal_state.set_tab(ProfileTab::Badges);
+        }
+        ParsedInput::Byte(b'j' | b'J') | ParsedInput::Char('j' | 'J') | ParsedInput::Arrow(b'B') => {
             app.profile_modal_state.scroll_by(1);
         }
-        ParsedInput::Byte(b'k' | b'K')
-        | ParsedInput::Char('k' | 'K')
-        | ParsedInput::Arrow(b'A') => {
+        ParsedInput::Byte(b'k' | b'K') | ParsedInput::Char('k' | 'K') | ParsedInput::Arrow(b'A') => {
             app.profile_modal_state.scroll_by(-1);
         }
         ParsedInput::Mouse(mouse) => match mouse.kind {

--- a/late-ssh/src/app/profile_modal/input.rs
+++ b/late-ssh/src/app/profile_modal/input.rs
@@ -13,19 +13,27 @@ pub fn handle_input(app: &mut App, event: ParsedInput) {
     match event {
         ParsedInput::Byte(b'\t') => app.profile_modal_state.cycle_tab(1),
         ParsedInput::BackTab => app.profile_modal_state.cycle_tab(-1),
-        ParsedInput::Byte(b'l' | b'L') | ParsedInput::Char('l' | 'L') | ParsedInput::Arrow(b'C') => {
+        ParsedInput::Byte(b'l' | b'L')
+        | ParsedInput::Char('l' | 'L')
+        | ParsedInput::Arrow(b'C') => {
             app.profile_modal_state.cycle_tab(1);
         }
-        ParsedInput::Byte(b'h' | b'H') | ParsedInput::Char('h' | 'H') | ParsedInput::Arrow(b'D') => {
+        ParsedInput::Byte(b'h' | b'H')
+        | ParsedInput::Char('h' | 'H')
+        | ParsedInput::Arrow(b'D') => {
             app.profile_modal_state.cycle_tab(-1);
         }
         ParsedInput::Byte(b'b' | b'B') | ParsedInput::Char('b' | 'B') => {
             app.profile_modal_state.set_tab(ProfileTab::Badges);
         }
-        ParsedInput::Byte(b'j' | b'J') | ParsedInput::Char('j' | 'J') | ParsedInput::Arrow(b'B') => {
+        ParsedInput::Byte(b'j' | b'J')
+        | ParsedInput::Char('j' | 'J')
+        | ParsedInput::Arrow(b'B') => {
             app.profile_modal_state.scroll_by(1);
         }
-        ParsedInput::Byte(b'k' | b'K') | ParsedInput::Char('k' | 'K') | ParsedInput::Arrow(b'A') => {
+        ParsedInput::Byte(b'k' | b'K')
+        | ParsedInput::Char('k' | 'K')
+        | ParsedInput::Arrow(b'A') => {
             app.profile_modal_state.scroll_by(-1);
         }
         ParsedInput::Mouse(mouse) => match mouse.kind {

--- a/late-ssh/src/app/profile_modal/mod.rs
+++ b/late-ssh/src/app/profile_modal/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod badges;
 pub(crate) mod input;
 pub(crate) mod state;
 pub(crate) mod ui;

--- a/late-ssh/src/app/profile_modal/state.rs
+++ b/late-ssh/src/app/profile_modal/state.rs
@@ -1,14 +1,56 @@
+use std::cell::{Cell, RefCell};
+
 use late_core::models::bonsai::Tree;
 use late_core::models::profile::Profile;
+use ratatui::layout::Rect;
 use tokio::sync::watch;
 use uuid::Uuid;
 
+use crate::app::bonsai::svc::BonsaiService;
+use crate::app::bonsai_v2::state::BonsaiV2State;
 use crate::app::chat::showcase::svc::{ShowcaseFeedItem, ShowcaseService, ShowcaseSnapshot};
+use crate::app::hub::aquarium::state::AquariumState;
 use crate::app::profile::svc::{ProfileService, ProfileSnapshot};
+
+use super::badges::{Badge, badges_for};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProfileTab {
+    Overview,
+    Bonsai,
+    Aquarium,
+    Badges,
+}
+
+impl ProfileTab {
+    pub(crate) const ALL: [ProfileTab; 4] = [
+        ProfileTab::Overview,
+        ProfileTab::Bonsai,
+        ProfileTab::Aquarium,
+        ProfileTab::Badges,
+    ];
+
+    pub(crate) fn title(self) -> &'static str {
+        match self {
+            ProfileTab::Overview => "Overview",
+            ProfileTab::Bonsai => "Bonsai",
+            ProfileTab::Aquarium => "Aquarium",
+            ProfileTab::Badges => "Badges",
+        }
+    }
+
+    fn index(self) -> usize {
+        ProfileTab::ALL
+            .iter()
+            .position(|tab| *tab == self)
+            .unwrap_or(0)
+    }
+}
 
 pub struct ProfileModalState {
     profile_service: ProfileService,
     showcase_service: ShowcaseService,
+    bonsai_service: BonsaiService,
     showcase_snapshot_rx: watch::Receiver<ShowcaseSnapshot>,
     showcases: Vec<ShowcaseFeedItem>,
     viewed_user_id: Option<Uuid>,
@@ -16,6 +58,17 @@ pub struct ProfileModalState {
     profile: Option<Profile>,
     chip_balance: Option<i64>,
     bonsai: Option<Tree>,
+    /// Read-only Dynamic Bonsai for the viewed user. Built non-persisting, so
+    /// viewing never mutates the owner's tree. Standard 2D render.
+    bonsai_v2: Option<BonsaiV2State>,
+    dynamic_bonsai_selected: bool,
+    aquarium_fish: Vec<(String, usize)>,
+    /// Lazily built/ticked for the Aquarium tab. Interior mutability so the
+    /// immutable `draw` path can animate and rebuild on resize.
+    aquarium: RefCell<Option<AquariumState>>,
+    aquarium_area: Cell<Rect>,
+    badges: Vec<Badge>,
+    tab: ProfileTab,
     snapshot_rx: Option<watch::Receiver<ProfileSnapshot>>,
     scroll_offset: u16,
 }
@@ -27,12 +80,17 @@ impl Drop for ProfileModalState {
 }
 
 impl ProfileModalState {
-    pub fn new(profile_service: ProfileService, showcase_service: ShowcaseService) -> Self {
+    pub fn new(
+        profile_service: ProfileService,
+        showcase_service: ShowcaseService,
+        bonsai_service: BonsaiService,
+    ) -> Self {
         let showcase_snapshot_rx = showcase_service.subscribe_snapshot();
         let showcases = showcase_snapshot_rx.borrow().items.clone();
         Self {
             profile_service,
             showcase_service,
+            bonsai_service,
             showcase_snapshot_rx,
             showcases,
             viewed_user_id: None,
@@ -40,6 +98,13 @@ impl ProfileModalState {
             profile: None,
             chip_balance: None,
             bonsai: None,
+            bonsai_v2: None,
+            dynamic_bonsai_selected: false,
+            aquarium_fish: Vec::new(),
+            aquarium: RefCell::new(None),
+            aquarium_area: Cell::new(Rect::default()),
+            badges: Vec::new(),
+            tab: ProfileTab::Overview,
             snapshot_rx: None,
             scroll_offset: 0,
         }
@@ -50,11 +115,13 @@ impl ProfileModalState {
         self.viewed_user_id = Some(user_id);
         self.fallback_name = fallback_name.into();
         self.scroll_offset = 0;
+        self.tab = ProfileTab::Overview;
+        self.badges = badges_for(user_id);
+        self.aquarium_fish.clear();
+        *self.aquarium.get_mut() = None;
         let mut snapshot_rx = self.profile_service.subscribe_snapshot(user_id);
         let snapshot = snapshot_rx.borrow().clone();
-        self.profile = profile_from_snapshot(snapshot.clone(), Some(user_id));
-        self.chip_balance = chip_balance_from_snapshot(snapshot.clone(), Some(user_id));
-        self.bonsai = bonsai_from_snapshot(snapshot, Some(user_id));
+        self.apply_snapshot(snapshot);
         snapshot_rx.mark_changed();
         self.snapshot_rx = Some(snapshot_rx);
         self.profile_service.find_profile(user_id);
@@ -68,6 +135,12 @@ impl ProfileModalState {
         self.profile = None;
         self.chip_balance = None;
         self.bonsai = None;
+        self.bonsai_v2 = None;
+        self.dynamic_bonsai_selected = false;
+        self.aquarium_fish.clear();
+        *self.aquarium.get_mut() = None;
+        self.badges.clear();
+        self.tab = ProfileTab::Overview;
         self.scroll_offset = 0;
         self.snapshot_rx = None;
     }
@@ -83,17 +156,53 @@ impl ProfileModalState {
 
         match rx.has_changed() {
             Ok(true) => {
-                let snapshot = rx.borrow_and_update();
-                self.profile = profile_from_snapshot(snapshot.clone(), self.viewed_user_id);
-                self.chip_balance =
-                    chip_balance_from_snapshot(snapshot.clone(), self.viewed_user_id);
-                self.bonsai = bonsai_from_snapshot(snapshot.clone(), self.viewed_user_id);
+                let snapshot = rx.borrow_and_update().clone();
+                self.apply_snapshot(snapshot);
             }
             Ok(false) => {}
             Err(e) => {
                 tracing::error!(%e, "failed to receive profile modal snapshot");
             }
         }
+    }
+
+    fn apply_snapshot(&mut self, snapshot: ProfileSnapshot) {
+        let matches = self.viewed_user_id.is_some() && snapshot.user_id == self.viewed_user_id;
+        if !matches {
+            self.profile = None;
+            self.chip_balance = None;
+            self.bonsai = None;
+            self.bonsai_v2 = None;
+            self.dynamic_bonsai_selected = false;
+            if !self.aquarium_fish.is_empty() {
+                self.aquarium_fish.clear();
+                *self.aquarium.get_mut() = None;
+            }
+            return;
+        }
+
+        self.profile = snapshot.profile;
+        self.chip_balance = snapshot.chip_balance;
+        self.bonsai = snapshot.bonsai;
+        self.dynamic_bonsai_selected = snapshot.dynamic_bonsai_selected;
+
+        if snapshot.aquarium_fish != self.aquarium_fish {
+            self.aquarium_fish = snapshot.aquarium_fish;
+            *self.aquarium.get_mut() = None;
+        }
+
+        self.bonsai_v2 = match (
+            self.dynamic_bonsai_selected,
+            self.viewed_user_id,
+            snapshot.bonsai_v2,
+        ) {
+            (true, Some(user_id), Some(tree)) => Some(BonsaiV2State::view_only(
+                user_id,
+                self.bonsai_service.clone(),
+                tree,
+            )),
+            _ => None,
+        };
     }
 
     pub fn showcases_for_viewed(&self) -> Vec<&ShowcaseFeedItem> {
@@ -106,8 +215,49 @@ impl ProfileModalState {
             .collect()
     }
 
+    pub(crate) fn tab(&self) -> ProfileTab {
+        self.tab
+    }
+
+    pub(crate) fn set_tab(&mut self, tab: ProfileTab) {
+        if self.tab != tab {
+            self.tab = tab;
+            self.scroll_offset = 0;
+        }
+    }
+
+    pub(crate) fn cycle_tab(&mut self, delta: isize) {
+        let len = ProfileTab::ALL.len() as isize;
+        let next = (self.tab.index() as isize + delta).rem_euclid(len) as usize;
+        self.set_tab(ProfileTab::ALL[next]);
+    }
+
     pub fn bonsai(&self) -> Option<&Tree> {
         self.bonsai.as_ref()
+    }
+
+    pub(crate) fn bonsai_v2(&self) -> Option<&BonsaiV2State> {
+        self.bonsai_v2.as_ref()
+    }
+
+    pub(crate) fn dynamic_bonsai_selected(&self) -> bool {
+        self.dynamic_bonsai_selected
+    }
+
+    pub(crate) fn aquarium_fish(&self) -> &[(String, usize)] {
+        &self.aquarium_fish
+    }
+
+    pub(crate) fn aquarium_cell(&self) -> &RefCell<Option<AquariumState>> {
+        &self.aquarium
+    }
+
+    pub(crate) fn aquarium_area(&self) -> &Cell<Rect> {
+        &self.aquarium_area
+    }
+
+    pub(crate) fn badges(&self) -> &[Badge] {
+        &self.badges
     }
 
     pub fn profile(&self) -> Option<&Profile> {
@@ -116,6 +266,10 @@ impl ProfileModalState {
 
     pub fn chip_balance(&self) -> Option<i64> {
         self.chip_balance
+    }
+
+    pub(crate) fn fallback_name(&self) -> &str {
+        &self.fallback_name
     }
 
     pub fn loading(&self) -> bool {
@@ -135,35 +289,5 @@ impl ProfileModalState {
         if let Some(user_id) = self.viewed_user_id {
             self.profile_service.prune_user_snapshot_channel(user_id);
         }
-    }
-}
-
-fn profile_from_snapshot(
-    snapshot: ProfileSnapshot,
-    viewed_user_id: Option<Uuid>,
-) -> Option<Profile> {
-    if snapshot.user_id == viewed_user_id {
-        snapshot.profile
-    } else {
-        None
-    }
-}
-
-fn bonsai_from_snapshot(snapshot: ProfileSnapshot, viewed_user_id: Option<Uuid>) -> Option<Tree> {
-    if snapshot.user_id == viewed_user_id {
-        snapshot.bonsai
-    } else {
-        None
-    }
-}
-
-fn chip_balance_from_snapshot(
-    snapshot: ProfileSnapshot,
-    viewed_user_id: Option<Uuid>,
-) -> Option<i64> {
-    if snapshot.user_id == viewed_user_id {
-        snapshot.chip_balance
-    } else {
-        None
     }
 }

--- a/late-ssh/src/app/profile_modal/ui.rs
+++ b/late-ssh/src/app/profile_modal/ui.rs
@@ -1,8 +1,7 @@
 use chrono::Utc;
-use late_core::models::bonsai::Tree;
 use ratatui::{
     Frame,
-    layout::{Constraint, Flex, Layout, Margin, Rect},
+    layout::{Constraint, Layout, Margin, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
@@ -10,155 +9,235 @@ use ratatui::{
 
 use crate::app::{
     bonsai::{state::stage_for, ui::render_tree_art_lines},
+    bonsai_v2::render::render_tree_lines,
     chat::showcase::svc::ShowcaseFeedItem,
     common::{markdown::render_body_to_lines, theme, time::timezone_current_time},
+    hub::aquarium::{state::AquariumState, ui as aquarium_ui},
     settings_modal::data::country_label,
 };
 
-use super::state::ProfileModalState;
-
-const MODAL_WIDTH: u16 = 92;
-const MODAL_HEIGHT: u16 = 28;
-// Match the right-sidebar bonsai card width (see common/sidebar.rs).
-const BONSAI_CARD_WIDTH: u16 = 24;
-const FETCH_STRIP_HEIGHT: u16 = 5;
+use super::{
+    badges,
+    state::{ProfileModalState, ProfileTab},
+};
 
 pub fn draw(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let popup = centered_rect(MODAL_WIDTH, MODAL_HEIGHT, area);
+    let popup = centered_percent_rect(86, 88, area);
     frame.render_widget(Clear, popup);
 
-    let layout = Layout::vertical([
-        Constraint::Min(10),
-        Constraint::Length(FETCH_STRIP_HEIGHT),
-        Constraint::Length(1),
-    ])
-    .split(popup);
-
-    let wide = layout[0].width >= 80;
-    if wide {
-        let body = Layout::horizontal([Constraint::Min(50), Constraint::Length(BONSAI_CARD_WIDTH)])
-            .split(layout[0]);
-        draw_profile_card(frame, body[0], state);
-        draw_bonsai_card(frame, body[1], state.bonsai());
-    } else {
-        draw_profile_card(frame, layout[0], state);
-    }
-
-    draw_late_fetch_strip(frame, layout[1], state);
-    draw_footer(frame, layout[2]);
-}
-
-fn draw_footer(frame: &mut Frame, area: Rect) {
-    let footer = Line::from(vec![
-        Span::styled("↑↓ j/k", Style::default().fg(theme::AMBER_DIM())),
-        Span::styled(" scroll  ", Style::default().fg(theme::TEXT_DIM())),
-        Span::styled("Esc/q", Style::default().fg(theme::AMBER_DIM())),
-        Span::styled(" close", Style::default().fg(theme::TEXT_DIM())),
-    ]);
-    frame.render_widget(Paragraph::new(footer), area);
-}
-
-fn draw_profile_card(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     let block = Block::default()
-        .title(" profile ")
+        .title(format!(" profile · {} ", header_name(state)))
         .title_style(
             Style::default()
                 .fg(theme::AMBER_GLOW())
                 .add_modifier(Modifier::BOLD),
         )
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme::BORDER()));
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+        .border_style(Style::default().fg(theme::BORDER_ACTIVE()));
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
 
-    let content = inner.inner(Margin {
+    if inner.height < 6 || inner.width < 24 {
+        return;
+    }
+
+    let layout = Layout::vertical([
+        Constraint::Length(1), // identity glance
+        Constraint::Length(1), // tabs
+        Constraint::Length(1), // breathing room
+        Constraint::Min(6),    // body
+        Constraint::Length(1), // footer
+    ])
+    .split(inner);
+
+    draw_header(frame, layout[0], state);
+    draw_tabs(frame, layout[1], state);
+
+    let body = layout[3].inner(Margin {
         horizontal: 1,
         vertical: 0,
     });
-    let lines = build_profile_lines(state, content.width as usize);
-    frame.render_widget(
-        Paragraph::new(lines)
-            .wrap(Wrap { trim: false })
-            .scroll((state.scroll_offset(), 0)),
-        content,
-    );
+    match state.tab() {
+        ProfileTab::Overview => draw_overview(frame, body, state),
+        ProfileTab::Bonsai => draw_bonsai_tab(frame, body, state),
+        ProfileTab::Aquarium => draw_aquarium_tab(frame, body, state),
+        ProfileTab::Badges => badges::draw(frame, body, state.badges(), state.scroll_offset()),
+    }
+
+    draw_footer(frame, layout[4], state);
 }
 
-fn draw_bonsai_card(frame: &mut Frame, area: Rect, tree: Option<&Tree>) {
-    let block = Block::default()
-        .title(" bonsai ")
-        .title_style(
-            Style::default()
-                .fg(theme::AMBER_GLOW())
-                .add_modifier(Modifier::BOLD),
-        )
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme::BORDER()));
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
+fn header_name(state: &ProfileModalState) -> String {
+    if let Some(profile) = state.profile() {
+        let username = profile.username.trim();
+        if !username.is_empty() {
+            return username.to_string();
+        }
+    }
+    if state.fallback_name().is_empty() {
+        "loading".to_string()
+    } else {
+        state.fallback_name().to_string()
+    }
+}
 
-    let Some(tree) = tree else {
+fn draw_header(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let value = Style::default().fg(theme::TEXT());
+    let dim = Style::default().fg(theme::TEXT_DIM());
+
+    let Some(profile) = state.profile() else {
         frame.render_widget(
-            Paragraph::new(Line::from(Span::styled(
-                " no bonsai yet",
-                Style::default().fg(theme::TEXT_DIM()),
-            ))),
-            inner,
+            Paragraph::new(Line::from(Span::styled(" loading…", dim))),
+            area,
         );
         return;
     };
 
-    let stage = stage_for(tree.is_alive, tree.growth_points);
-    let age_days = (Utc::now().date_naive() - tree.created.date_naive())
-        .num_days()
-        .max(0);
-    let wilting = tree.is_alive
-        && tree
-            .last_watered
-            .map(|last| (Utc::now().date_naive() - last).num_days() >= 2)
-            .unwrap_or(age_days >= 2);
-
-    let mut lines =
-        render_tree_art_lines(stage, tree.seed, wilting, inner.width as usize, 0.0, None);
-
-    let visible = inner.height as usize;
-    let label_line = Line::from(vec![Span::styled(
-        format!("{} · {}d", stage.label(), age_days),
-        Style::default().fg(theme::TEXT_DIM()),
-    )])
-    .centered();
-
-    if lines.len() + 1 < visible {
-        let pad = visible.saturating_sub(lines.len() + 1);
-        for _ in 0..pad {
-            lines.insert(0, Line::from(""));
-        }
+    let mut spans = vec![
+        Span::raw(" "),
+        Span::styled(country_label(profile.country.as_deref()), value),
+    ];
+    if let Some(time) = timezone_current_time(Utc::now(), profile.timezone.as_deref()) {
+        spans.push(sep());
+        spans.push(Span::styled(format!("{time} local"), value));
     }
-    lines.push(label_line);
-
-    frame.render_widget(Paragraph::new(lines), inner);
+    if let Some(balance) = state.chip_balance() {
+        spans.push(sep());
+        spans.push(Span::styled(format!("{balance} chips"), value));
+    }
+    if let Some(birthday) = profile.birthday.as_deref() {
+        spans.push(sep());
+        spans.push(Span::styled(format_birthday(birthday), value));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
-fn draw_late_fetch_strip(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let block = Block::default()
-        .title(" late.fetch ")
-        .title_style(
-            Style::default()
-                .fg(theme::AMBER_GLOW())
-                .add_modifier(Modifier::BOLD),
-        )
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme::BORDER()));
-    let inner = block.inner(area).inner(Margin {
-        horizontal: 1,
-        vertical: 0,
-    });
-    frame.render_widget(block, area);
+fn draw_tabs(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let selected = state.tab();
+    let active = Style::default()
+        .fg(theme::AMBER_GLOW())
+        .bg(theme::BG_HIGHLIGHT())
+        .add_modifier(Modifier::BOLD);
+    let idle = Style::default().fg(theme::TEXT_DIM());
+
+    let mut spans = vec![Span::raw("  ")];
+    for tab in ProfileTab::ALL {
+        let style = if tab == selected { active } else { idle };
+        spans.push(Span::styled(format!(" {} ", tab.title()), style));
+        spans.push(Span::raw(" "));
+    }
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_footer(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let key = Style::default().fg(theme::AMBER_DIM());
+    let dim = Style::default().fg(theme::TEXT_DIM());
+
+    let mut spans = vec![
+        Span::styled("Tab/⇧Tab", key),
+        Span::styled(" tabs  ", dim),
+    ];
+    if matches!(state.tab(), ProfileTab::Overview | ProfileTab::Badges) {
+        spans.push(Span::styled("↑↓ j/k", key));
+        spans.push(Span::styled(" scroll  ", dim));
+    }
+    spans.push(Span::styled("b", key));
+    spans.push(Span::styled(" badges  ", dim));
+    spans.push(Span::styled("Esc/q", key));
+    spans.push(Span::styled(" close", dim));
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
+}
+
+fn draw_overview(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    if state.loading() {
+        render_centered_dim(frame, area, "loading…");
+        return;
+    }
+    let lines = build_overview_lines(state, area.width as usize);
+    frame.render_widget(
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .scroll((state.scroll_offset(), 0)),
+        area,
+    );
+}
+
+fn build_overview_lines(state: &ProfileModalState, width: usize) -> Vec<Line<'static>> {
+    let dim = Style::default().fg(theme::TEXT_DIM());
+    let text = Style::default().fg(theme::TEXT());
 
     let Some(profile) = state.profile() else {
-        return;
+        return Vec::new();
     };
 
+    let username = if profile.username.trim().is_empty() {
+        "not set"
+    } else {
+        profile.username.trim()
+    };
+
+    let mut lines = vec![
+        labeled("Username", username, dim, text),
+        labeled(
+            "Country",
+            &country_label(profile.country.as_deref()),
+            dim,
+            text,
+        ),
+        labeled(
+            "Timezone",
+            profile.timezone.as_deref().unwrap_or("Not set"),
+            dim,
+            text,
+        ),
+    ];
+    if let Some(current_time) = timezone_current_time(Utc::now(), profile.timezone.as_deref()) {
+        lines.push(labeled("Current", &current_time, dim, text));
+    }
+    if let Some(birthday) = profile.birthday.as_deref() {
+        lines.push(labeled("Birthday", &format_birthday(birthday), dim, text));
+    }
+    lines.push(labeled(
+        "Chips",
+        &state
+            .chip_balance()
+            .map(|balance| format!("{balance} chips"))
+            .unwrap_or_else(|| "loading".to_string()),
+        dim,
+        text,
+    ));
+
+    lines.push(Line::from(""));
+    lines.push(section_heading("Bio"));
+    if profile.bio.trim().is_empty() {
+        lines.push(Line::from(Span::styled("Not set", dim)));
+    } else {
+        lines.extend(render_body_to_lines(&profile.bio, width, Span::raw(""), text));
+    }
+
+    lines.push(Line::from(""));
+    lines.push(section_heading("late.fetch"));
+    lines.extend(late_fetch_lines(profile, width));
+
+    let showcases = state.showcases_for_viewed();
+    if !showcases.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(section_heading(&format!("Showcases ({})", showcases.len())));
+        for item in showcases {
+            lines.push(Line::from(""));
+            lines.extend(render_body_to_lines(
+                &showcase_markdown(item),
+                width,
+                Span::raw(""),
+                text,
+            ));
+        }
+    }
+
+    lines
+}
+
+fn late_fetch_lines(profile: &late_core::models::profile::Profile, width: usize) -> Vec<Line<'static>> {
     let dim = Style::default().fg(theme::TEXT_DIM());
     let label = Style::default().fg(theme::AMBER_DIM());
     let value = Style::default().fg(theme::TEXT());
@@ -169,45 +248,163 @@ fn draw_late_fetch_strip(frame: &mut Frame, area: Rect, state: &ProfileModalStat
         .as_ref()
         .map(format_created_at)
         .unwrap_or_else(|| "unknown".to_string());
-    let ide = profile.ide.clone().unwrap_or_else(|| "—".to_string());
-    let terminal = profile.terminal.clone().unwrap_or_else(|| "—".to_string());
-    let os = profile.os.clone().unwrap_or_else(|| "—".to_string());
+    let ide = profile.ide.clone().unwrap_or_else(|| "not set".to_string());
+    let terminal = profile.terminal.clone().unwrap_or_else(|| "not set".to_string());
+    let os = profile.os.clone().unwrap_or_else(|| "not set".to_string());
     let theme_label = theme::label_for_id(theme_id).to_string();
     let langs = if profile.langs.is_empty() {
-        "—".to_string()
+        "not set".to_string()
     } else {
         profile.langs.join(", ")
     };
 
-    let inner_w = inner.width as usize;
-    let col_w = inner_w / 2;
+    let col_w = (width / 2).max(12);
+    vec![
+        Line::from(format_two_cells(
+            ("created", &created),
+            ("theme", &theme_label),
+            col_w,
+            label,
+            value,
+            dim,
+        )),
+        Line::from(format_two_cells(
+            ("ide", &ide),
+            ("terminal", &terminal),
+            col_w,
+            label,
+            value,
+            dim,
+        )),
+        Line::from(format_two_cells(
+            ("os", &os),
+            ("langs", &langs),
+            col_w,
+            label,
+            value,
+            dim,
+        )),
+    ]
+}
 
-    let row1 = Line::from(format_two_cells(
-        ("created", &created),
-        ("theme", &theme_label),
-        col_w,
-        label,
-        value,
-        dim,
-    ));
-    let row2 = Line::from(format_two_cells(
-        ("ide", &ide),
-        ("terminal", &terminal),
-        col_w,
-        label,
-        value,
-        dim,
-    ));
-    let row3 = Line::from(format_two_cells(
-        ("os", &os),
-        ("langs", &langs),
-        col_w,
-        label,
-        value,
-        dim,
-    ));
+fn draw_bonsai_tab(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let rows = Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(area);
+    let tree_area = rows[0];
+    let caption_area = rows[1];
 
-    frame.render_widget(Paragraph::new(vec![row1, row2, row3]), inner);
+    if state.dynamic_bonsai_selected() {
+        if let Some(bonsai) = state.bonsai_v2() {
+            let lines = render_tree_lines(
+                bonsai,
+                tree_area.width as usize,
+                tree_area.height as usize,
+                false,
+            );
+            bottom_align(frame, tree_area, lines);
+            render_caption(
+                frame,
+                caption_area,
+                &format!(
+                    "Dynamic Bonsai · Day {} · vigor {} · stress {}",
+                    bonsai.age_days, bonsai.vigor, bonsai.water_stress
+                ),
+                bonsai.is_alive,
+            );
+            return;
+        }
+        render_centered_dim(frame, area, "Dynamic Bonsai not planted yet");
+        return;
+    }
+
+    if let Some(tree) = state.bonsai() {
+        let stage = stage_for(tree.is_alive, tree.growth_points);
+        let age_days = (Utc::now().date_naive() - tree.created.date_naive())
+            .num_days()
+            .max(0);
+        let wilting = tree.is_alive
+            && tree
+                .last_watered
+                .map(|last| (Utc::now().date_naive() - last).num_days() >= 2)
+                .unwrap_or(age_days >= 2);
+        let lines = render_tree_art_lines(stage, tree.seed, wilting, tree_area.width as usize, 0.0, None);
+        bottom_align(frame, tree_area, lines);
+        render_caption(
+            frame,
+            caption_area,
+            &format!("{} · {age_days}d", stage.label()),
+            tree.is_alive,
+        );
+        return;
+    }
+
+    render_centered_dim(frame, area, "no bonsai yet");
+}
+
+fn draw_aquarium_tab(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    if state.aquarium_fish().is_empty() {
+        render_centered_dim(frame, area, "No aquarium to show here yet");
+        return;
+    }
+
+    let cell = state.aquarium_cell();
+    let mut slot = cell.borrow_mut();
+    if slot.is_none() || state.aquarium_area().get() != area {
+        state.aquarium_area().set(area);
+        *slot = AquariumState::default_for_area(area).ok().map(|mut aquarium| {
+            aquarium.set_active_creatures(state.aquarium_fish());
+            aquarium
+        });
+    }
+
+    if let Some(aquarium) = slot.as_mut() {
+        aquarium.tick();
+        aquarium_ui::draw(frame, area, aquarium);
+    } else {
+        render_centered_dim(frame, area, "aquarium unavailable");
+    }
+}
+
+fn bottom_align(frame: &mut Frame, area: Rect, mut lines: Vec<Line<'static>>) {
+    let top_pad = (area.height as usize).saturating_sub(lines.len());
+    let mut out = vec![Line::from(""); top_pad];
+    out.append(&mut lines);
+    frame.render_widget(Paragraph::new(out), area);
+}
+
+fn render_caption(frame: &mut Frame, area: Rect, text: &str, alive: bool) {
+    let style = if alive {
+        Style::default().fg(theme::TEXT_DIM())
+    } else {
+        Style::default().fg(theme::TEXT_FAINT())
+    };
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(text.to_string(), style)).centered()),
+        area,
+    );
+}
+
+fn render_centered_dim(frame: &mut Frame, area: Rect, text: &str) {
+    let top = (area.height as usize).saturating_sub(1) / 2;
+    let mut lines = vec![Line::from(""); top];
+    lines.push(
+        Line::from(Span::styled(
+            text.to_string(),
+            Style::default().fg(theme::TEXT_DIM()),
+        ))
+        .centered(),
+    );
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn labeled(label: &str, value: &str, label_style: Style, value_style: Style) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("{label:<9} "), label_style),
+        Span::styled(value.to_string(), value_style),
+    ])
+}
+
+fn sep() -> Span<'static> {
+    Span::styled("   ·   ", Style::default().fg(theme::BORDER_DIM()))
 }
 
 fn format_two_cells(
@@ -248,103 +445,11 @@ fn format_birthday(birthday: &str) -> String {
     };
     let base = month_day_label(&canonical).unwrap_or_else(|| canonical.clone());
     match days_until(&canonical, Utc::now().date_naive()) {
-        Some(0) => format!("{base} — today!"),
-        Some(1) => format!("{base} — tomorrow"),
-        Some(d) if d <= 30 => format!("{base} — in {d} days"),
+        Some(0) => format!("{base} · today!"),
+        Some(1) => format!("{base} · tomorrow"),
+        Some(d) if d <= 30 => format!("{base} · in {d} days"),
         _ => base,
     }
-}
-
-fn build_profile_lines(state: &ProfileModalState, width: usize) -> Vec<Line<'static>> {
-    let dim = Style::default().fg(theme::TEXT_DIM());
-    let text = Style::default().fg(theme::TEXT());
-
-    if state.loading() {
-        return Vec::new();
-    }
-
-    let Some(profile) = state.profile() else {
-        return Vec::new();
-    };
-
-    let username = if profile.username.trim().is_empty() {
-        "not set"
-    } else {
-        profile.username.trim()
-    };
-
-    let mut lines = vec![
-        Line::from(vec![
-            Span::styled("Username: ", dim),
-            Span::styled(username.to_string(), text),
-        ]),
-        Line::from(vec![
-            Span::styled("Country:  ", dim),
-            Span::styled(country_label(profile.country.as_deref()), text),
-        ]),
-        Line::from(vec![
-            Span::styled("Timezone: ", dim),
-            Span::styled(
-                profile.timezone.as_deref().unwrap_or("Not set").to_string(),
-                text,
-            ),
-        ]),
-    ];
-
-    if let Some(current_time) = timezone_current_time(Utc::now(), profile.timezone.as_deref()) {
-        lines.push(Line::from(vec![
-            Span::styled("Current time: ", dim),
-            Span::styled(current_time, text),
-        ]));
-    }
-
-    if let Some(birthday) = profile.birthday.as_deref() {
-        lines.push(Line::from(vec![
-            Span::styled("Birthday: ", dim),
-            Span::styled(format_birthday(birthday), text),
-        ]));
-    }
-
-    lines.push(Line::from(vec![
-        Span::styled("Chips:    ", dim),
-        Span::styled(
-            state
-                .chip_balance()
-                .map(|balance| format!("{balance} chips"))
-                .unwrap_or_else(|| "Loading".to_string()),
-            text,
-        ),
-    ]));
-
-    lines.extend([Line::from(""), section_heading("Bio")]);
-
-    if profile.bio.trim().is_empty() {
-        lines.push(Line::from(Span::styled("Not set", dim)));
-    } else {
-        lines.extend(render_body_to_lines(
-            &profile.bio,
-            width,
-            Span::raw(""),
-            text,
-        ));
-    }
-
-    let showcases = state.showcases_for_viewed();
-    if !showcases.is_empty() {
-        lines.push(Line::from(""));
-        lines.push(section_heading(&format!("Showcases ({})", showcases.len())));
-        for item in showcases {
-            lines.push(Line::from(""));
-            lines.extend(render_body_to_lines(
-                &showcase_markdown(item),
-                width,
-                Span::raw(""),
-                text,
-            ));
-        }
-    }
-
-    lines
 }
 
 fn showcase_markdown(item: &ShowcaseFeedItem) -> String {
@@ -388,12 +493,19 @@ fn section_heading(title: &str) -> Line<'static> {
     ])
 }
 
-fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
-    let vertical = Layout::vertical([Constraint::Length(height)])
-        .flex(Flex::Center)
-        .split(area);
-    let horizontal = Layout::horizontal([Constraint::Length(width)])
-        .flex(Flex::Center)
-        .split(vertical[0]);
-    horizontal[0]
+fn centered_percent_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
+    let percent_x = percent_x.min(100);
+    let percent_y = percent_y.min(100);
+    let vertical = Layout::vertical([
+        Constraint::Percentage((100 - percent_y) / 2),
+        Constraint::Percentage(percent_y),
+        Constraint::Percentage((100 - percent_y) / 2),
+    ])
+    .split(area);
+    Layout::horizontal([
+        Constraint::Percentage((100 - percent_x) / 2),
+        Constraint::Percentage(percent_x),
+        Constraint::Percentage((100 - percent_x) / 2),
+    ])
+    .split(vertical[1])[1]
 }

--- a/late-ssh/src/app/profile_modal/ui.rs
+++ b/late-ssh/src/app/profile_modal/ui.rs
@@ -1,7 +1,7 @@
 use chrono::Utc;
 use ratatui::{
     Frame,
-    layout::{Constraint, Layout, Margin, Rect},
+    layout::{Constraint, Flex, Layout, Margin, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph, Wrap},
@@ -21,8 +21,12 @@ use super::{
     state::{ProfileModalState, ProfileTab},
 };
 
+// Match the Settings modal so the two read as the same kind of panel.
+const MODAL_WIDTH: u16 = 96;
+const MODAL_HEIGHT: u16 = 34;
+
 pub fn draw(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let popup = centered_percent_rect(86, 88, area);
+    let popup = centered_rect(MODAL_WIDTH, MODAL_HEIGHT, area);
     frame.render_widget(Clear, popup);
 
     let block = Block::default()
@@ -42,7 +46,9 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     }
 
     let layout = Layout::vertical([
+        Constraint::Length(1), // breathing room below the title border
         Constraint::Length(1), // identity glance
+        Constraint::Length(1), // breathing room
         Constraint::Length(1), // tabs
         Constraint::Length(1), // breathing room
         Constraint::Min(6),    // body
@@ -50,10 +56,10 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     ])
     .split(inner);
 
-    draw_header(frame, layout[0], state);
-    draw_tabs(frame, layout[1], state);
+    draw_header(frame, layout[1], state);
+    draw_tabs(frame, layout[3], state);
 
-    let body = layout[3].inner(Margin {
+    let body = layout[5].inner(Margin {
         horizontal: 1,
         vertical: 0,
     });
@@ -64,7 +70,7 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
         ProfileTab::Badges => badges::draw(frame, body, state.badges(), state.scroll_offset()),
     }
 
-    draw_footer(frame, layout[4], state);
+    draw_footer(frame, layout[6], state);
 }
 
 fn header_name(state: &ProfileModalState) -> String {
@@ -87,14 +93,14 @@ fn draw_header(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
 
     let Some(profile) = state.profile() else {
         frame.render_widget(
-            Paragraph::new(Line::from(Span::styled(" loading…", dim))),
+            Paragraph::new(Line::from(Span::styled("  loading…", dim))),
             area,
         );
         return;
     };
 
     let mut spans = vec![
-        Span::raw(" "),
+        Span::raw("  "),
         Span::styled(country_label(profile.country.as_deref()), value),
     ];
     if let Some(time) = timezone_current_time(Utc::now(), profile.timezone.as_deref()) {
@@ -134,8 +140,9 @@ fn draw_footer(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     let dim = Style::default().fg(theme::TEXT_DIM());
 
     let mut spans = vec![
-        Span::styled("Tab/⇧Tab", key),
-        Span::styled(" tabs  ", dim),
+        Span::raw("  "),
+        Span::styled("Tab/S+Tab", key),
+        Span::styled(" switch tabs  ", dim),
     ];
     if matches!(state.tab(), ProfileTab::Overview | ProfileTab::Badges) {
         spans.push(Span::styled("↑↓ j/k", key));
@@ -493,19 +500,12 @@ fn section_heading(title: &str) -> Line<'static> {
     ])
 }
 
-fn centered_percent_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
-    let percent_x = percent_x.min(100);
-    let percent_y = percent_y.min(100);
-    let vertical = Layout::vertical([
-        Constraint::Percentage((100 - percent_y) / 2),
-        Constraint::Percentage(percent_y),
-        Constraint::Percentage((100 - percent_y) / 2),
-    ])
-    .split(area);
-    Layout::horizontal([
-        Constraint::Percentage((100 - percent_x) / 2),
-        Constraint::Percentage(percent_x),
-        Constraint::Percentage((100 - percent_x) / 2),
-    ])
-    .split(vertical[1])[1]
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let vertical = Layout::vertical([Constraint::Length(height.min(area.height))])
+        .flex(Flex::Center)
+        .split(area);
+    let horizontal = Layout::horizontal([Constraint::Length(width.min(area.width))])
+        .flex(Flex::Center)
+        .split(vertical[0]);
+    horizontal[0]
 }

--- a/late-ssh/src/app/profile_modal/ui.rs
+++ b/late-ssh/src/app/profile_modal/ui.rs
@@ -219,7 +219,12 @@ fn build_overview_lines(state: &ProfileModalState, width: usize) -> Vec<Line<'st
     if profile.bio.trim().is_empty() {
         lines.push(Line::from(Span::styled("Not set", dim)));
     } else {
-        lines.extend(render_body_to_lines(&profile.bio, width, Span::raw(""), text));
+        lines.extend(render_body_to_lines(
+            &profile.bio,
+            width,
+            Span::raw(""),
+            text,
+        ));
     }
 
     lines.push(Line::from(""));
@@ -244,7 +249,10 @@ fn build_overview_lines(state: &ProfileModalState, width: usize) -> Vec<Line<'st
     lines
 }
 
-fn late_fetch_lines(profile: &late_core::models::profile::Profile, width: usize) -> Vec<Line<'static>> {
+fn late_fetch_lines(
+    profile: &late_core::models::profile::Profile,
+    width: usize,
+) -> Vec<Line<'static>> {
     let dim = Style::default().fg(theme::TEXT_DIM());
     let label = Style::default().fg(theme::AMBER_DIM());
     let value = Style::default().fg(theme::TEXT());
@@ -256,7 +264,10 @@ fn late_fetch_lines(profile: &late_core::models::profile::Profile, width: usize)
         .map(format_created_at)
         .unwrap_or_else(|| "unknown".to_string());
     let ide = profile.ide.clone().unwrap_or_else(|| "not set".to_string());
-    let terminal = profile.terminal.clone().unwrap_or_else(|| "not set".to_string());
+    let terminal = profile
+        .terminal
+        .clone()
+        .unwrap_or_else(|| "not set".to_string());
     let os = profile.os.clone().unwrap_or_else(|| "not set".to_string());
     let theme_label = theme::label_for_id(theme_id).to_string();
     let langs = if profile.langs.is_empty() {
@@ -333,7 +344,14 @@ fn draw_bonsai_tab(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
                 .last_watered
                 .map(|last| (Utc::now().date_naive() - last).num_days() >= 2)
                 .unwrap_or(age_days >= 2);
-        let lines = render_tree_art_lines(stage, tree.seed, wilting, tree_area.width as usize, 0.0, None);
+        let lines = render_tree_art_lines(
+            stage,
+            tree.seed,
+            wilting,
+            tree_area.width as usize,
+            0.0,
+            None,
+        );
         bottom_align(frame, tree_area, lines);
         render_caption(
             frame,
@@ -357,10 +375,12 @@ fn draw_aquarium_tab(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     let mut slot = cell.borrow_mut();
     if slot.is_none() || state.aquarium_area().get() != area {
         state.aquarium_area().set(area);
-        *slot = AquariumState::default_for_area(area).ok().map(|mut aquarium| {
-            aquarium.set_active_creatures(state.aquarium_fish());
-            aquarium
-        });
+        *slot = AquariumState::default_for_area(area)
+            .ok()
+            .map(|mut aquarium| {
+                aquarium.set_active_creatures(state.aquarium_fish());
+                aquarium
+            });
     }
 
     if let Some(aquarium) = slot.as_mut() {

--- a/late-ssh/src/app/settings_modal/state.rs
+++ b/late-ssh/src/app/settings_modal/state.rs
@@ -64,6 +64,8 @@ pub enum Row {
 impl Row {
     pub const ALL: [Row; 19] = [
         Row::Username,
+        Row::Country,
+        Row::Timezone,
         Row::Birthday,
         Row::Ide,
         Row::Terminal,
@@ -74,8 +76,6 @@ impl Row {
         Row::RightSidebar,
         Row::RoomListSidebar,
         Row::LoungeInfo,
-        Row::Country,
-        Row::Timezone,
         Row::DirectMessages,
         Row::Mentions,
         Row::GameEvents,

--- a/late-ssh/src/app/settings_modal/ui.rs
+++ b/late-ssh/src/app/settings_modal/ui.rs
@@ -391,7 +391,11 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
     let sections = Layout::vertical([
         Constraint::Length(1), // Identity heading
         Constraint::Length(1), // Username row
+        Constraint::Length(1), // Country row
+        Constraint::Length(1), // Timezone row
         Constraint::Length(1), // Birthday row
+        Constraint::Length(1), // breathing room
+        Constraint::Length(1), // late.fetch heading
         Constraint::Length(1), // IDE row
         Constraint::Length(1), // Terminal row
         Constraint::Length(1), // OS row
@@ -403,10 +407,6 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
         Constraint::Length(1), // Right sidebar
         Constraint::Length(1), // Room list
         Constraint::Length(1), // Activity boxes
-        Constraint::Length(1), // breathing room
-        Constraint::Length(1), // Location heading
-        Constraint::Length(1), // Country
-        Constraint::Length(1), // Timezone
         Constraint::Length(1), // breathing room
         Constraint::Length(1), // Notifications heading
         Constraint::Length(1), // DMs
@@ -450,13 +450,41 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
     frame.render_widget(
         Paragraph::new(row_line(
             state,
+            Row::Country,
+            width,
+            "Country",
+            value_with_picker_hint(country_label(state.draft().country.as_deref())),
+        )),
+        sections[2],
+    );
+    frame.render_widget(
+        Paragraph::new(row_line(
+            state,
+            Row::Timezone,
+            width,
+            "Timezone",
+            value_with_picker_hint(
+                state
+                    .draft()
+                    .timezone
+                    .clone()
+                    .unwrap_or_else(|| "not set".to_string()),
+            ),
+        )),
+        sections[3],
+    );
+    frame.render_widget(
+        Paragraph::new(row_line(
+            state,
             Row::Birthday,
             width,
             "Birthday",
             system_field_value(state, Row::Birthday, state.draft().birthday.clone()),
         )),
-        sections[2],
+        sections[4],
     );
+
+    frame.render_widget(Paragraph::new(section_heading("late.fetch")), sections[6]);
     frame.render_widget(
         Paragraph::new(row_line(
             state,
@@ -465,7 +493,7 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
             "IDE",
             system_field_value(state, Row::Ide, state.draft().ide.clone()),
         )),
-        sections[3],
+        sections[7],
     );
     frame.render_widget(
         Paragraph::new(row_line(
@@ -475,7 +503,7 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
             "Terminal",
             system_field_value(state, Row::Terminal, state.draft().terminal.clone()),
         )),
-        sections[4],
+        sections[8],
     );
     frame.render_widget(
         Paragraph::new(row_line(
@@ -485,7 +513,7 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
             "OS",
             system_field_value(state, Row::Os, state.draft().os.clone()),
         )),
-        sections[5],
+        sections[9],
     );
     frame.render_widget(
         Paragraph::new(row_line(
@@ -499,10 +527,10 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
                 (!state.draft().langs.is_empty()).then(|| format_lang_tags(&state.draft().langs)),
             ),
         )),
-        sections[6],
+        sections[10],
     );
 
-    frame.render_widget(Paragraph::new(section_heading("Appearance")), sections[8]);
+    frame.render_widget(Paragraph::new(section_heading("Appearance")), sections[12]);
     frame.render_widget(
         Paragraph::new(row_line(
             state,
@@ -521,7 +549,7 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
                 theme::TEXT_BRIGHT(),
             ),
         )),
-        sections[9],
+        sections[13],
     );
     frame.render_widget(
         Paragraph::new(row_line(
@@ -531,7 +559,7 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
             "Background",
             toggle_span(state.draft().enable_background_color),
         )),
-        sections[10],
+        sections[14],
     );
     frame.render_widget(
         Paragraph::new(row_line(
@@ -541,7 +569,7 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
             "Right sidebar",
             right_sidebar_mode_span(state.draft().right_sidebar_mode),
         )),
-        sections[11],
+        sections[15],
     );
     frame.render_widget(
         Paragraph::new(row_line(
@@ -551,7 +579,7 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
             "Room list",
             toggle_span(state.draft().show_room_list_sidebar),
         )),
-        sections[12],
+        sections[16],
     );
     frame.render_widget(
         Paragraph::new(row_line(
@@ -560,33 +588,6 @@ fn draw_settings_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) 
             width,
             "Activity boxes",
             toggle_span(state.draft().show_dashboard_header),
-        )),
-        sections[13],
-    );
-    frame.render_widget(Paragraph::new(section_heading("Location")), sections[15]);
-    frame.render_widget(
-        Paragraph::new(row_line(
-            state,
-            Row::Country,
-            width,
-            "Country",
-            value_with_picker_hint(country_label(state.draft().country.as_deref())),
-        )),
-        sections[16],
-    );
-    frame.render_widget(
-        Paragraph::new(row_line(
-            state,
-            Row::Timezone,
-            width,
-            "Timezone",
-            value_with_picker_hint(
-                state
-                    .draft()
-                    .timezone
-                    .clone()
-                    .unwrap_or_else(|| "not set".to_string()),
-            ),
         )),
         sections[17],
     );

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -869,6 +869,7 @@ impl App {
             profile_modal_state: profile_modal::state::ProfileModalState::new(
                 config.profile_service.clone(),
                 config.showcase_service.clone(),
+                config.bonsai_service.clone(),
             ),
             settings_modal_state,
             leaderboard_rx: config.leaderboard_rx,


### PR DESCRIPTION
## Summary
- Expands the profile modal into tabs so reviewers can inspect a user's overview, bonsai, aquarium, and future badges from one place.
- Loads profile-owned Dynamic Bonsai and active aquarium creatures for the viewed user instead of only showing the viewer's local state.

## Changes
- Adds profile tabs with `Tab`/`Shift+Tab`, arrow/`h`/`l`, and `b` navigation.
- Renders legacy bonsai or equipped Dynamic Bonsai in a dedicated Bonsai tab.
- Renders active aquarium fish in a dedicated Aquarium tab.
- Adds a Badges tab with an empty placeholder until an achievements source exists.
- Extends profile snapshots with Bonsai V2, Dynamic Bonsai selection, and aquarium fish data.

## Behavior notes
- Viewing another user's Dynamic Bonsai catches up elapsed days in memory only; it does not persist or mutate the owner's tree.
- Aquarium rendering only includes active fish purchases with positive active quantity.
- Badges are intentionally placeholder-only in this change.

## Feature flags
- None.

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Not run; PR description generated from diff context only.
- Manual: Not run; PR description generated from diff context only.