### PR TITLE
Add large-screen profile dashboard layout

### DIFF
--- a/late-ssh/src/app/profile_modal/badges.rs
+++ b/late-ssh/src/app/profile_modal/badges.rs
@@ -36,7 +36,7 @@ pub(crate) fn badges_for(_user_id: Uuid) -> Vec<Badge> {
 const CELL_W: usize = 24;
 
 pub(crate) fn draw(frame: &mut Frame, area: Rect, badges: &[Badge], scroll: u16) {
-    if area.width < 14 || area.height < 4 {
+    if area.width < 14 || area.height < 2 {
         return;
     }
     if badges.is_empty() {
@@ -81,42 +81,47 @@ fn draw_grid(frame: &mut Frame, area: Rect, badges: &[Badge], scroll: u16) {
     frame.render_widget(Paragraph::new(lines).scroll((scroll, 0)), area);
 }
 
-/// Current state: empty shelf of dim placeholder slots plus a caption, so the
-/// tab reads as "this will fill up" rather than broken.
+/// Current state: empty shelf of dim placeholder slots. In a short strip (the
+/// dashboard) it is literally two rows of slots; given more room (the Badges
+/// tab) it adds the "this will fill up" caption.
 fn draw_placeholder(frame: &mut Frame, area: Rect) {
     let slot = Style::default().fg(theme::BORDER());
-    let cols = (area.width as usize / 8).clamp(3, 6);
-    let rows = 2usize;
+    let cols = (area.width as usize / 8).clamp(3, 8);
+    let height = area.height as usize;
+    let show_caption = height >= 5;
+    let slot_rows = if show_caption { 2 } else { height.max(1) };
 
     let mut content: Vec<Line> = Vec::new();
-    for _ in 0..rows {
+    for _ in 0..slot_rows {
         let mut spans = Vec::new();
         for _ in 0..cols {
             spans.push(Span::styled("⬡", slot));
             spans.push(Span::raw("     "));
         }
         content.push(Line::from(spans).centered());
-        content.push(Line::from(""));
     }
-    content.push(Line::from(""));
-    content.push(
-        Line::from(Span::styled(
-            "No badges yet",
-            Style::default()
-                .fg(theme::TEXT())
-                .add_modifier(Modifier::BOLD),
-        ))
-        .centered(),
-    );
-    content.push(
-        Line::from(Span::styled(
-            "achievements you earn will appear here, with the date and what they were for",
-            Style::default().fg(theme::TEXT_DIM()),
-        ))
-        .centered(),
-    );
 
-    let top_pad = (area.height as usize).saturating_sub(content.len()) / 2;
+    if show_caption {
+        content.push(Line::from(""));
+        content.push(
+            Line::from(Span::styled(
+                "No badges yet",
+                Style::default()
+                    .fg(theme::TEXT())
+                    .add_modifier(Modifier::BOLD),
+            ))
+            .centered(),
+        );
+        content.push(
+            Line::from(Span::styled(
+                "achievements you earn will appear here, with the date and what they were for",
+                Style::default().fg(theme::TEXT_DIM()),
+            ))
+            .centered(),
+        );
+    }
+
+    let top_pad = height.saturating_sub(content.len()) / 2;
     let mut lines = vec![Line::from(""); top_pad];
     lines.extend(content);
     frame.render_widget(Paragraph::new(lines), area);

--- a/late-ssh/src/app/profile_modal/input.rs
+++ b/late-ssh/src/app/profile_modal/input.rs
@@ -1,5 +1,6 @@
 use crate::app::{
     input::{MouseEventKind, ParsedInput},
+    profile_modal::state::ProfileTab,
     state::App,
 };
 
@@ -10,6 +11,21 @@ pub fn handle_input(app: &mut App, event: ParsedInput) {
     }
 
     match event {
+        ParsedInput::Byte(b'\t') => app.profile_modal_state.cycle_tab(1),
+        ParsedInput::BackTab => app.profile_modal_state.cycle_tab(-1),
+        ParsedInput::Byte(b'l' | b'L')
+        | ParsedInput::Char('l' | 'L')
+        | ParsedInput::Arrow(b'C') => {
+            app.profile_modal_state.cycle_tab(1);
+        }
+        ParsedInput::Byte(b'h' | b'H')
+        | ParsedInput::Char('h' | 'H')
+        | ParsedInput::Arrow(b'D') => {
+            app.profile_modal_state.cycle_tab(-1);
+        }
+        ParsedInput::Byte(b'b' | b'B') | ParsedInput::Char('b' | 'B') => {
+            app.profile_modal_state.set_tab(ProfileTab::Badges);
+        }
         ParsedInput::Byte(b'j' | b'J')
         | ParsedInput::Char('j' | 'J')
         | ParsedInput::Arrow(b'B') => {

--- a/late-ssh/src/app/profile_modal/input.rs
+++ b/late-ssh/src/app/profile_modal/input.rs
@@ -1,6 +1,5 @@
 use crate::app::{
     input::{MouseEventKind, ParsedInput},
-    profile_modal::state::ProfileTab,
     state::App,
 };
 
@@ -11,21 +10,6 @@ pub fn handle_input(app: &mut App, event: ParsedInput) {
     }
 
     match event {
-        ParsedInput::Byte(b'\t') => app.profile_modal_state.cycle_tab(1),
-        ParsedInput::BackTab => app.profile_modal_state.cycle_tab(-1),
-        ParsedInput::Byte(b'l' | b'L')
-        | ParsedInput::Char('l' | 'L')
-        | ParsedInput::Arrow(b'C') => {
-            app.profile_modal_state.cycle_tab(1);
-        }
-        ParsedInput::Byte(b'h' | b'H')
-        | ParsedInput::Char('h' | 'H')
-        | ParsedInput::Arrow(b'D') => {
-            app.profile_modal_state.cycle_tab(-1);
-        }
-        ParsedInput::Byte(b'b' | b'B') | ParsedInput::Char('b' | 'B') => {
-            app.profile_modal_state.set_tab(ProfileTab::Badges);
-        }
         ParsedInput::Byte(b'j' | b'J')
         | ParsedInput::Char('j' | 'J')
         | ParsedInput::Arrow(b'B') => {

--- a/late-ssh/src/app/profile_modal/state.rs
+++ b/late-ssh/src/app/profile_modal/state.rs
@@ -14,39 +14,6 @@ use crate::app::profile::svc::{ProfileService, ProfileSnapshot};
 
 use super::badges::{Badge, badges_for};
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub(crate) enum ProfileTab {
-    Overview,
-    Bonsai,
-    Aquarium,
-    Badges,
-}
-
-impl ProfileTab {
-    pub(crate) const ALL: [ProfileTab; 4] = [
-        ProfileTab::Overview,
-        ProfileTab::Bonsai,
-        ProfileTab::Aquarium,
-        ProfileTab::Badges,
-    ];
-
-    pub(crate) fn title(self) -> &'static str {
-        match self {
-            ProfileTab::Overview => "Overview",
-            ProfileTab::Bonsai => "Bonsai",
-            ProfileTab::Aquarium => "Aquarium",
-            ProfileTab::Badges => "Badges",
-        }
-    }
-
-    fn index(self) -> usize {
-        ProfileTab::ALL
-            .iter()
-            .position(|tab| *tab == self)
-            .unwrap_or(0)
-    }
-}
-
 pub struct ProfileModalState {
     profile_service: ProfileService,
     showcase_service: ShowcaseService,
@@ -63,12 +30,11 @@ pub struct ProfileModalState {
     bonsai_v2: Option<BonsaiV2State>,
     dynamic_bonsai_selected: bool,
     aquarium_fish: Vec<(String, usize)>,
-    /// Lazily built/ticked for the Aquarium tab. Interior mutability so the
+    /// Lazily built/ticked for the aquarium panel. Interior mutability so the
     /// immutable `draw` path can animate and rebuild on resize.
     aquarium: RefCell<Option<AquariumState>>,
     aquarium_area: Cell<Rect>,
     badges: Vec<Badge>,
-    tab: ProfileTab,
     snapshot_rx: Option<watch::Receiver<ProfileSnapshot>>,
     scroll_offset: u16,
 }
@@ -104,7 +70,6 @@ impl ProfileModalState {
             aquarium: RefCell::new(None),
             aquarium_area: Cell::new(Rect::default()),
             badges: Vec::new(),
-            tab: ProfileTab::Overview,
             snapshot_rx: None,
             scroll_offset: 0,
         }
@@ -115,7 +80,6 @@ impl ProfileModalState {
         self.viewed_user_id = Some(user_id);
         self.fallback_name = fallback_name.into();
         self.scroll_offset = 0;
-        self.tab = ProfileTab::Overview;
         self.badges = badges_for(user_id);
         self.aquarium_fish.clear();
         *self.aquarium.get_mut() = None;
@@ -140,7 +104,6 @@ impl ProfileModalState {
         self.aquarium_fish.clear();
         *self.aquarium.get_mut() = None;
         self.badges.clear();
-        self.tab = ProfileTab::Overview;
         self.scroll_offset = 0;
         self.snapshot_rx = None;
     }
@@ -213,23 +176,6 @@ impl ProfileModalState {
             .iter()
             .filter(|item| item.showcase.user_id == user_id)
             .collect()
-    }
-
-    pub(crate) fn tab(&self) -> ProfileTab {
-        self.tab
-    }
-
-    pub(crate) fn set_tab(&mut self, tab: ProfileTab) {
-        if self.tab != tab {
-            self.tab = tab;
-            self.scroll_offset = 0;
-        }
-    }
-
-    pub(crate) fn cycle_tab(&mut self, delta: isize) {
-        let len = ProfileTab::ALL.len() as isize;
-        let next = (self.tab.index() as isize + delta).rem_euclid(len) as usize;
-        self.set_tab(ProfileTab::ALL[next]);
     }
 
     pub fn bonsai(&self) -> Option<&Tree> {

--- a/late-ssh/src/app/profile_modal/state.rs
+++ b/late-ssh/src/app/profile_modal/state.rs
@@ -14,6 +14,41 @@ use crate::app::profile::svc::{ProfileService, ProfileSnapshot};
 
 use super::badges::{Badge, badges_for};
 
+/// Tabs for the compact fallback layout (small terminals). The dashboard shows
+/// everything at once and ignores this.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ProfileTab {
+    Overview,
+    Bonsai,
+    Aquarium,
+    Badges,
+}
+
+impl ProfileTab {
+    pub(crate) const ALL: [ProfileTab; 4] = [
+        ProfileTab::Overview,
+        ProfileTab::Bonsai,
+        ProfileTab::Aquarium,
+        ProfileTab::Badges,
+    ];
+
+    pub(crate) fn title(self) -> &'static str {
+        match self {
+            ProfileTab::Overview => "Overview",
+            ProfileTab::Bonsai => "Bonsai",
+            ProfileTab::Aquarium => "Aquarium",
+            ProfileTab::Badges => "Badges",
+        }
+    }
+
+    fn index(self) -> usize {
+        ProfileTab::ALL
+            .iter()
+            .position(|tab| *tab == self)
+            .unwrap_or(0)
+    }
+}
+
 pub struct ProfileModalState {
     profile_service: ProfileService,
     showcase_service: ShowcaseService,
@@ -35,6 +70,7 @@ pub struct ProfileModalState {
     aquarium: RefCell<Option<AquariumState>>,
     aquarium_area: Cell<Rect>,
     badges: Vec<Badge>,
+    tab: ProfileTab,
     snapshot_rx: Option<watch::Receiver<ProfileSnapshot>>,
     scroll_offset: u16,
 }
@@ -70,6 +106,7 @@ impl ProfileModalState {
             aquarium: RefCell::new(None),
             aquarium_area: Cell::new(Rect::default()),
             badges: Vec::new(),
+            tab: ProfileTab::Overview,
             snapshot_rx: None,
             scroll_offset: 0,
         }
@@ -80,6 +117,7 @@ impl ProfileModalState {
         self.viewed_user_id = Some(user_id);
         self.fallback_name = fallback_name.into();
         self.scroll_offset = 0;
+        self.tab = ProfileTab::Overview;
         self.badges = badges_for(user_id);
         self.aquarium_fish.clear();
         *self.aquarium.get_mut() = None;
@@ -104,6 +142,7 @@ impl ProfileModalState {
         self.aquarium_fish.clear();
         *self.aquarium.get_mut() = None;
         self.badges.clear();
+        self.tab = ProfileTab::Overview;
         self.scroll_offset = 0;
         self.snapshot_rx = None;
     }
@@ -176,6 +215,23 @@ impl ProfileModalState {
             .iter()
             .filter(|item| item.showcase.user_id == user_id)
             .collect()
+    }
+
+    pub(crate) fn tab(&self) -> ProfileTab {
+        self.tab
+    }
+
+    pub(crate) fn set_tab(&mut self, tab: ProfileTab) {
+        if self.tab != tab {
+            self.tab = tab;
+            self.scroll_offset = 0;
+        }
+    }
+
+    pub(crate) fn cycle_tab(&mut self, delta: isize) {
+        let len = ProfileTab::ALL.len() as isize;
+        let next = (self.tab.index() as isize + delta).rem_euclid(len) as usize;
+        self.set_tab(ProfileTab::ALL[next]);
     }
 
     pub fn bonsai(&self) -> Option<&Tree> {

--- a/late-ssh/src/app/profile_modal/ui.rs
+++ b/late-ssh/src/app/profile_modal/ui.rs
@@ -16,14 +16,12 @@ use crate::app::{
     settings_modal::data::country_label,
 };
 
-use super::{
-    badges,
-    state::{ProfileModalState, ProfileTab},
-};
+use super::{badges, state::ProfileModalState};
 
-// Match the Settings modal so the two read as the same kind of panel.
-const MODAL_WIDTH: u16 = 96;
-const MODAL_HEIGHT: u16 = 34;
+// Roomy enough for the side-by-side dashboard (aquarium + about on the left,
+// bonsai + badges on the right) while still clearing a windowed 13/14" laptop.
+const MODAL_WIDTH: u16 = 110;
+const MODAL_HEIGHT: u16 = 36;
 /// Pinned late.fetch card: 2 border rows + 3 grid rows.
 const LATE_FETCH_BOX_HEIGHT: u16 = 5;
 
@@ -49,7 +47,7 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
 
     draw_profile_box(frame, regions[0], state);
     draw_late_fetch_box(frame, regions[2], state);
-    draw_footer(frame, regions[3], state);
+    draw_footer(frame, regions[3]);
 }
 
 fn draw_profile_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
@@ -69,29 +67,92 @@ fn draw_profile_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
         return;
     }
 
-    let layout = Layout::vertical([
+    let rows = Layout::vertical([
         Constraint::Length(1), // breathing room below the title border
         Constraint::Length(1), // identity glance
         Constraint::Length(1), // breathing room
-        Constraint::Length(1), // tabs
-        Constraint::Length(1), // breathing room
-        Constraint::Min(3),    // body
+        Constraint::Min(6),    // dashboard
     ])
     .split(inner);
 
-    draw_header(frame, layout[1], state);
-    draw_tabs(frame, layout[3], state);
+    draw_header(frame, rows[1], state);
 
-    let body = layout[5].inner(Margin {
+    // Everything visible at once, no tabs: two columns of stacked panels.
+    // Left holds the aquarium over the bio; right holds the bonsai over the
+    // badges shelf.
+    let body = rows[3].inner(Margin {
         horizontal: 2,
         vertical: 0,
     });
-    match state.tab() {
-        ProfileTab::Overview => draw_overview(frame, body, state),
-        ProfileTab::Bonsai => draw_bonsai_tab(frame, body, state),
-        ProfileTab::Aquarium => draw_aquarium_tab(frame, body, state),
-        ProfileTab::Badges => badges::draw(frame, body, state.badges(), state.scroll_offset()),
+    let cols = Layout::horizontal([
+        Constraint::Min(40),    // left column
+        Constraint::Length(2),  // gutter
+        Constraint::Length(44), // right column
+    ])
+    .split(body);
+
+    let left = Layout::vertical([
+        Constraint::Length(13), // aquarium (needs >= 11 inner rows for reef)
+        Constraint::Length(1),  // breathing room
+        Constraint::Min(4),     // about
+    ])
+    .split(cols[0]);
+
+    let right = Layout::vertical([
+        Constraint::Length(15), // bonsai
+        Constraint::Length(1),  // breathing room
+        Constraint::Min(4),     // badges
+    ])
+    .split(cols[2]);
+
+    draw_aquarium_box(frame, left[0], state);
+    draw_about_box(frame, left[2], state);
+    draw_bonsai_box(frame, right[0], state);
+    draw_badges_box(frame, right[2], state);
+}
+
+/// A bordered sub-panel inside the dashboard. Returns the inner content rect.
+fn panel(frame: &mut Frame, area: Rect, title: &str) -> Rect {
+    let block = Block::default()
+        .title(format!(" {title} "))
+        .title_style(Style::default().fg(theme::AMBER_DIM()))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::BORDER()));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+    inner
+}
+
+fn draw_aquarium_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let inner = panel(frame, area, "aquarium");
+    if inner.width == 0 || inner.height == 0 {
+        return;
     }
+    draw_aquarium_tab(frame, inner, state);
+}
+
+fn draw_about_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let inner = panel(frame, area, "about");
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+    draw_overview(frame, inner, state);
+}
+
+fn draw_bonsai_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let inner = panel(frame, area, "bonsai");
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+    draw_bonsai_tab(frame, inner, state);
+}
+
+fn draw_badges_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let inner = panel(frame, area, "badges");
+    if inner.width == 0 || inner.height == 0 {
+        return;
+    }
+    badges::draw(frame, inner, state.badges(), 0);
 }
 
 /// The late.fetch card: its own framed box, holding only the neofetch-style
@@ -179,40 +240,17 @@ fn draw_header(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
-fn draw_tabs(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let selected = state.tab();
-    let active = Style::default()
-        .fg(theme::AMBER_GLOW())
-        .bg(theme::BG_HIGHLIGHT())
-        .add_modifier(Modifier::BOLD);
-    let idle = Style::default().fg(theme::TEXT_DIM());
-
-    let mut spans = vec![Span::raw("  ")];
-    for tab in ProfileTab::ALL {
-        let style = if tab == selected { active } else { idle };
-        spans.push(Span::styled(format!(" {} ", tab.title()), style));
-        spans.push(Span::raw(" "));
-    }
-    frame.render_widget(Paragraph::new(Line::from(spans)), area);
-}
-
-fn draw_footer(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+fn draw_footer(frame: &mut Frame, area: Rect) {
     let key = Style::default().fg(theme::AMBER_DIM());
     let dim = Style::default().fg(theme::TEXT_DIM());
 
-    let mut spans = vec![
+    let spans = vec![
         Span::raw("  "),
-        Span::styled("Tab/S+Tab", key),
-        Span::styled(" switch tabs  ", dim),
+        Span::styled("↑↓ j/k", key),
+        Span::styled(" scroll bio  ", dim),
+        Span::styled("Esc/q", key),
+        Span::styled(" close", dim),
     ];
-    if matches!(state.tab(), ProfileTab::Overview | ProfileTab::Badges) {
-        spans.push(Span::styled("↑↓ j/k", key));
-        spans.push(Span::styled(" scroll  ", dim));
-    }
-    spans.push(Span::styled("b", key));
-    spans.push(Span::styled(" badges  ", dim));
-    spans.push(Span::styled("Esc/q", key));
-    spans.push(Span::styled(" close", dim));
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
@@ -418,7 +456,13 @@ fn draw_aquarium_tab(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
 }
 
 fn bottom_align(frame: &mut Frame, area: Rect, mut lines: Vec<Line<'static>>) {
-    let top_pad = (area.height as usize).saturating_sub(lines.len());
+    let height = area.height as usize;
+    // When the art is taller than the space (big trees in a small panel), drop
+    // the crown rows from the top so the pot and trunk base stay anchored.
+    if lines.len() > height {
+        lines.drain(0..lines.len() - height);
+    }
+    let top_pad = height.saturating_sub(lines.len());
     let mut out = vec![Line::from(""); top_pad];
     out.append(&mut lines);
     frame.render_widget(Paragraph::new(out), area);

--- a/late-ssh/src/app/profile_modal/ui.rs
+++ b/late-ssh/src/app/profile_modal/ui.rs
@@ -16,20 +16,35 @@ use crate::app::{
     settings_modal::data::country_label,
 };
 
-use super::{badges, state::ProfileModalState};
+use super::{
+    badges,
+    state::{ProfileModalState, ProfileTab},
+};
 
-// Roomy enough for the side-by-side dashboard (aquarium + about on the left,
-// bonsai + badges on the right) while still clearing a windowed 13/14" laptop.
-const MODAL_WIDTH: u16 = 110;
-const MODAL_HEIGHT: u16 = 36;
+/// Big "dashboard" modal: every panel visible at once. Used when the terminal
+/// is large enough (fullscreen / external monitor); otherwise we fall back to
+/// the compact tabbed view, which fits small/windowed laptops.
+const DASH_WIDTH: u16 = 120;
+const DASH_HEIGHT: u16 = 44;
+/// Compact tabbed fallback for terminals too small for the dashboard.
+const TAB_WIDTH: u16 = 96;
+const TAB_HEIGHT: u16 = 34;
 /// Pinned late.fetch card: 2 border rows + 3 grid rows.
 const LATE_FETCH_BOX_HEIGHT: u16 = 5;
 
 pub fn draw(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let popup = centered_rect(MODAL_WIDTH, MODAL_HEIGHT, area);
+    // Show the roomy dashboard when the terminal can hold it; fall back to the
+    // compact tabbed layout on small screens.
+    let dashboard = area.width >= DASH_WIDTH && area.height >= DASH_HEIGHT;
+    let (width, height) = if dashboard {
+        (DASH_WIDTH, DASH_HEIGHT)
+    } else {
+        (TAB_WIDTH, TAB_HEIGHT)
+    };
+    let popup = centered_rect(width, height, area);
 
-    // Two stacked boxes with a blank row between them: the profile box (glance
-    // stats, tabs, and the active tab body) on top, and the always-visible
+    // Two stacked boxes with a blank row between them: the profile box (the
+    // dashboard, or the tabbed fallback) on top, and the always-visible
     // late.fetch card below it. Key hints live on a free line under both.
     let regions = Layout::vertical([
         Constraint::Min(8),                        // profile box
@@ -45,12 +60,18 @@ pub fn draw(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     frame.render_widget(Clear, regions[2]);
     frame.render_widget(Clear, regions[3]);
 
-    draw_profile_box(frame, regions[0], state);
+    if dashboard {
+        draw_dashboard(frame, regions[0], state);
+    } else {
+        draw_tabbed(frame, regions[0], state);
+    }
     draw_late_fetch_box(frame, regions[2], state);
-    draw_footer(frame, regions[3]);
+    draw_footer(frame, regions[3], state, dashboard);
 }
 
-fn draw_profile_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+/// Outer `profile · name` frame, shared by both layouts. Returns the inner
+/// content rect, or `None` when there is not enough room to draw anything.
+fn profile_frame(frame: &mut Frame, area: Rect, state: &ProfileModalState) -> Option<Rect> {
     let block = Block::default()
         .title(format!(" profile · {} ", header_name(state)))
         .title_style(
@@ -64,95 +85,131 @@ fn draw_profile_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     frame.render_widget(block, area);
 
     if inner.height < 6 || inner.width < 24 {
-        return;
+        return None;
     }
+    Some(inner)
+}
 
+/// The big layout: no sub-boxes, just labelled sections. The about (bio) and
+/// bonsai sit as an equal-height pair across the top, a full-width badges strip
+/// runs beneath them, and the aquarium gets the whole bottom band.
+fn draw_dashboard(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let Some(inner) = profile_frame(frame, area, state) else {
+        return;
+    };
+
+    // No breathing rows between the bands: each section's content sits flush on
+    // the next section's heading rule (bonsai pot on the aquarium rule, reef
+    // floor on the badges rule).
     let rows = Layout::vertical([
-        Constraint::Length(1), // breathing room below the title border
-        Constraint::Length(1), // identity glance
-        Constraint::Length(1), // breathing room
-        Constraint::Min(6),    // dashboard
+        Constraint::Length(1),  // breathing room below the title border
+        Constraint::Length(1),  // identity glance
+        Constraint::Length(1),  // breathing room
+        Constraint::Min(8),     // top pair: about | bonsai
+        Constraint::Length(12), // aquarium band (heading + reef, fits big fish)
+        Constraint::Length(3),  // badges strip (heading + two rows)
     ])
     .split(inner);
 
     draw_header(frame, rows[1], state);
 
-    // Everything visible at once, no tabs: two columns of stacked panels.
-    // Left holds the aquarium over the bio; right holds the bonsai over the
-    // badges shelf.
-    let body = rows[3].inner(Margin {
+    let content = Margin {
+        horizontal: 2,
+        vertical: 0,
+    };
+
+    // Top pair — about and bonsai share the same height because they split the
+    // same band.
+    let top = Layout::horizontal([
+        Constraint::Min(40),    // about / bio (gets the slack — content needs room)
+        Constraint::Length(2),  // gutter
+        Constraint::Length(40), // bonsai
+    ])
+    .split(rows[3].inner(content));
+    let about = section(frame, top[0], "about");
+    draw_overview(frame, about, state);
+    let bonsai = section(frame, top[2], "bonsai");
+    draw_bonsai_panel(frame, bonsai, state, false);
+
+    let aquarium = section(frame, rows[4].inner(content), "aquarium");
+    draw_aquarium_tab(frame, aquarium, state);
+
+    let badges_area = section(frame, rows[5].inner(content), "badges");
+    badges::draw(frame, badges_area, state.badges(), 0);
+}
+
+/// Borderless section heading: a dim label trailed by a rule. Returns the
+/// content rect below the heading row.
+fn section(frame: &mut Frame, area: Rect, label: &str) -> Rect {
+    if area.height == 0 || area.width == 0 {
+        return area;
+    }
+    let used = label.chars().count() + 1;
+    let rule = (area.width as usize).saturating_sub(used);
+    let line = Line::from(vec![
+        Span::styled(
+            label.to_string(),
+            Style::default()
+                .fg(theme::AMBER_DIM())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::raw(" "),
+        Span::styled("─".repeat(rule), Style::default().fg(theme::BORDER_DIM())),
+    ]);
+    frame.render_widget(Paragraph::new(line), Rect { height: 1, ..area });
+    Rect {
+        y: area.y + 1,
+        height: area.height - 1,
+        ..area
+    }
+}
+
+/// The compact fallback: glance, a tab strip, and one tab body at a time.
+fn draw_tabbed(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let Some(inner) = profile_frame(frame, area, state) else {
+        return;
+    };
+
+    let layout = Layout::vertical([
+        Constraint::Length(1), // breathing room below the title border
+        Constraint::Length(1), // identity glance
+        Constraint::Length(1), // breathing room
+        Constraint::Length(1), // tabs
+        Constraint::Length(1), // breathing room
+        Constraint::Min(3),    // body
+    ])
+    .split(inner);
+
+    draw_header(frame, layout[1], state);
+    draw_tabs(frame, layout[3], state);
+
+    let body = layout[5].inner(Margin {
         horizontal: 2,
         vertical: 0,
     });
-    let cols = Layout::horizontal([
-        Constraint::Min(40),    // left column
-        Constraint::Length(2),  // gutter
-        Constraint::Length(44), // right column
-    ])
-    .split(body);
-
-    let left = Layout::vertical([
-        Constraint::Length(13), // aquarium (needs >= 11 inner rows for reef)
-        Constraint::Length(1),  // breathing room
-        Constraint::Min(4),     // about
-    ])
-    .split(cols[0]);
-
-    let right = Layout::vertical([
-        Constraint::Length(15), // bonsai
-        Constraint::Length(1),  // breathing room
-        Constraint::Min(4),     // badges
-    ])
-    .split(cols[2]);
-
-    draw_aquarium_box(frame, left[0], state);
-    draw_about_box(frame, left[2], state);
-    draw_bonsai_box(frame, right[0], state);
-    draw_badges_box(frame, right[2], state);
-}
-
-/// A bordered sub-panel inside the dashboard. Returns the inner content rect.
-fn panel(frame: &mut Frame, area: Rect, title: &str) -> Rect {
-    let block = Block::default()
-        .title(format!(" {title} "))
-        .title_style(Style::default().fg(theme::AMBER_DIM()))
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(theme::BORDER()));
-    let inner = block.inner(area);
-    frame.render_widget(block, area);
-    inner
-}
-
-fn draw_aquarium_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let inner = panel(frame, area, "aquarium");
-    if inner.width == 0 || inner.height == 0 {
-        return;
+    match state.tab() {
+        ProfileTab::Overview => draw_overview(frame, body, state),
+        ProfileTab::Bonsai => draw_bonsai_tab(frame, body, state),
+        ProfileTab::Aquarium => draw_aquarium_tab(frame, body, state),
+        ProfileTab::Badges => badges::draw(frame, body, state.badges(), state.scroll_offset()),
     }
-    draw_aquarium_tab(frame, inner, state);
 }
 
-fn draw_about_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let inner = panel(frame, area, "about");
-    if inner.width == 0 || inner.height == 0 {
-        return;
-    }
-    draw_overview(frame, inner, state);
-}
+fn draw_tabs(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
+    let selected = state.tab();
+    let active = Style::default()
+        .fg(theme::AMBER_GLOW())
+        .bg(theme::BG_HIGHLIGHT())
+        .add_modifier(Modifier::BOLD);
+    let idle = Style::default().fg(theme::TEXT_DIM());
 
-fn draw_bonsai_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let inner = panel(frame, area, "bonsai");
-    if inner.width == 0 || inner.height == 0 {
-        return;
+    let mut spans = vec![Span::raw("  ")];
+    for tab in ProfileTab::ALL {
+        let style = if tab == selected { active } else { idle };
+        spans.push(Span::styled(format!(" {} ", tab.title()), style));
+        spans.push(Span::raw(" "));
     }
-    draw_bonsai_tab(frame, inner, state);
-}
-
-fn draw_badges_box(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let inner = panel(frame, area, "badges");
-    if inner.width == 0 || inner.height == 0 {
-        return;
-    }
-    badges::draw(frame, inner, state.badges(), 0);
+    frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
 /// The late.fetch card: its own framed box, holding only the neofetch-style
@@ -240,17 +297,26 @@ fn draw_header(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
-fn draw_footer(frame: &mut Frame, area: Rect) {
+fn draw_footer(frame: &mut Frame, area: Rect, state: &ProfileModalState, dashboard: bool) {
     let key = Style::default().fg(theme::AMBER_DIM());
     let dim = Style::default().fg(theme::TEXT_DIM());
 
-    let spans = vec![
-        Span::raw("  "),
-        Span::styled("↑↓ j/k", key),
-        Span::styled(" scroll bio  ", dim),
-        Span::styled("Esc/q", key),
-        Span::styled(" close", dim),
-    ];
+    let mut spans = vec![Span::raw("  ")];
+    if dashboard {
+        spans.push(Span::styled("↑↓ j/k", key));
+        spans.push(Span::styled(" scroll bio  ", dim));
+    } else {
+        spans.push(Span::styled("Tab/S+Tab", key));
+        spans.push(Span::styled(" switch tabs  ", dim));
+        if matches!(state.tab(), ProfileTab::Overview | ProfileTab::Badges) {
+            spans.push(Span::styled("↑↓ j/k", key));
+            spans.push(Span::styled(" scroll  ", dim));
+        }
+        spans.push(Span::styled("b", key));
+        spans.push(Span::styled(" badges  ", dim));
+    }
+    spans.push(Span::styled("Esc/q", key));
+    spans.push(Span::styled(" close", dim));
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
@@ -370,9 +436,19 @@ fn late_fetch_lines(
 }
 
 fn draw_bonsai_tab(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
-    let rows = Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(area);
-    let tree_area = rows[0];
-    let caption_area = rows[1];
+    draw_bonsai_panel(frame, area, state, true);
+}
+
+/// Render the bonsai. With `show_caption`, the bottom row carries the age/vigor
+/// line (tabbed view); without it the pot anchors to the bottom edge and the
+/// whole area is tree (dashboard) — one more row to grow into.
+fn draw_bonsai_panel(frame: &mut Frame, area: Rect, state: &ProfileModalState, show_caption: bool) {
+    let (tree_area, caption_area) = if show_caption {
+        let rows = Layout::vertical([Constraint::Min(3), Constraint::Length(1)]).split(area);
+        (rows[0], Some(rows[1]))
+    } else {
+        (area, None)
+    };
 
     if state.dynamic_bonsai_selected() {
         if let Some(bonsai) = state.bonsai_v2() {
@@ -383,15 +459,17 @@ fn draw_bonsai_tab(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
                 false,
             );
             bottom_align(frame, tree_area, lines);
-            render_caption(
-                frame,
-                caption_area,
-                &format!(
-                    "Dynamic Bonsai · Day {} · vigor {} · stress {}",
-                    bonsai.age_days, bonsai.vigor, bonsai.water_stress
-                ),
-                bonsai.is_alive,
-            );
+            if let Some(caption_area) = caption_area {
+                render_caption(
+                    frame,
+                    caption_area,
+                    &format!(
+                        "Dynamic Bonsai · Day {} · vigor {} · stress {}",
+                        bonsai.age_days, bonsai.vigor, bonsai.water_stress
+                    ),
+                    bonsai.is_alive,
+                );
+            }
             return;
         }
         render_centered_dim(frame, area, "Dynamic Bonsai not planted yet");
@@ -417,12 +495,14 @@ fn draw_bonsai_tab(frame: &mut Frame, area: Rect, state: &ProfileModalState) {
             None,
         );
         bottom_align(frame, tree_area, lines);
-        render_caption(
-            frame,
-            caption_area,
-            &format!("{} · {age_days}d", stage.label()),
-            tree.is_alive,
-        );
+        if let Some(caption_area) = caption_area {
+            render_caption(
+                frame,
+                caption_area,
+                &format!("{} · {age_days}d", stage.label()),
+                tree.is_alive,
+            );
+        }
         return;
     }
 


### PR DESCRIPTION
## Summary
- Updates the SSH profile modal to use a full dashboard layout on large terminals, showing about, bonsai, aquarium, badges, and late.fetch together.
- Keeps the existing compact tabbed profile layout as the fallback for smaller terminals.

## Changes
- Adds dashboard sizing at `120x44` and preserves the tabbed modal at `96x34`.
- Adds shared profile framing plus borderless section headings for dashboard panels.
- Adjusts footer hints so dashboard mode shows bio scrolling, while compact mode keeps tab navigation.
- Makes empty badges render cleanly in short dashboard strips without requiring caption space.
- Keeps bonsai art bottom-anchored and crops from the top when the panel is too short.

## Behavior notes
- Large terminals now skip profile tabs and show all profile sections at once.
- Small/windowed terminals continue to use the existing tabbed profile modal.

## Feature flags
- None

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Not run. Repository policy says LLM agents must not run `cargo test`, `cargo nextest`, or `cargo clippy`.
- Manual: Not run.