### PR TITLE
Highlight satisfied rows/cols in nonogram clue labels

### DIFF
--- a/late-ssh/src/app/arcade/nonogram/state.rs
+++ b/late-ssh/src/app/arcade/nonogram/state.rs
@@ -207,6 +207,11 @@ impl State {
             .unwrap_or(0)
     }
 
+    pub fn satisfied_rows_and_cols(&self) -> Option<(Vec<bool>, Vec<bool>)> {
+        let puzzle = self.puzzle()?;
+        Some(row_col_satisfaction(puzzle, &self.player_grid))
+    }
+
     pub fn show_personal(&mut self) {
         self.store_active_snapshot();
         self.mode = Mode::Personal;
@@ -497,6 +502,40 @@ fn board_matches_clues(puzzle: &NonogramPuzzle, player_grid: &[Vec<u8>]) -> bool
     row_clues == puzzle.row_clues && col_clues == puzzle.col_clues
 }
 
+fn row_col_satisfaction(
+    puzzle: &NonogramPuzzle,
+    player_grid: &[Vec<u8>],
+) -> (Vec<bool>, Vec<bool>) {
+    let normalized: Vec<Vec<u8>> = player_grid
+        .iter()
+        .take(puzzle.height as usize)
+        .map(|row| {
+            row.iter()
+                .take(puzzle.width as usize)
+                .map(|&cell| u8::from(cell == CELL_FILLED))
+                .collect()
+        })
+        .collect();
+
+    let (derived_rows, derived_cols) = late_core::nonogram::derive_clues(&normalized);
+
+    let rows = puzzle
+        .row_clues
+        .iter()
+        .zip(derived_rows.iter())
+        .map(|(e, d)| d == e)
+        .collect();
+
+    let cols = puzzle
+        .col_clues
+        .iter()
+        .zip(derived_cols.iter())
+        .map(|(e, d)| d == e)
+        .collect();
+
+    (rows, cols)
+}
+
 fn snapshot_from_game(game: &Game, pack: &NonogramPack) -> Option<PuzzleSnapshot> {
     let puzzle = pack
         .puzzles
@@ -665,5 +704,66 @@ mod tests {
         ];
 
         assert!(!board_matches_clues(puzzle, &player_grid));
+    }
+
+    #[test]
+    fn row_col_satisfaction_all_true_on_solution() {
+        let puzzle = &sample_library().packs[0].puzzles[0];
+        let (rows, cols) = row_col_satisfaction(puzzle, &puzzle.solution);
+        assert!(rows.iter().all(|&r| r), "all rows should be satisfied");
+        assert!(cols.iter().all(|&c| c), "all cols should be satisfied");
+    }
+
+    #[test]
+    fn row_col_satisfaction_empty_grid_is_all_false() {
+        let puzzle = &sample_library().packs[0].puzzles[0];
+        let empty = vec![vec![0u8; puzzle.width as usize]; puzzle.height as usize];
+        let (rows, cols) = row_col_satisfaction(puzzle, &empty);
+        let any_empty_row_in_solution = puzzle.row_clues.iter().any(|c| c.is_empty());
+        let any_empty_col_in_solution = puzzle.col_clues.iter().any(|c| c.is_empty());
+        assert_eq!(
+            rows.iter().any(|&r| r),
+            any_empty_row_in_solution,
+            "only empty-clue rows can be satisfied by an empty grid"
+        );
+        assert_eq!(
+            cols.iter().any(|&c| c),
+            any_empty_col_in_solution,
+            "only empty-clue cols can be satisfied by an empty grid"
+        );
+    }
+
+    #[test]
+    fn row_col_satisfaction_partial_only_matching_lines_true() {
+        let puzzle = &sample_library().packs[0].puzzles[0];
+        let mut grid = vec![vec![0u8; puzzle.width as usize]; puzzle.height as usize];
+        grid[0] = vec![0, 1, 1, 1, 0];
+
+        let (rows, cols) = row_col_satisfaction(puzzle, &grid);
+        assert!(rows[0], "row 0 matches its clue");
+        assert!(!rows[1..].iter().any(|&r| r), "other rows not satisfied");
+        assert_eq!(rows.len(), puzzle.height as usize);
+        assert_eq!(cols.len(), puzzle.width as usize);
+    }
+
+    #[test]
+    fn row_col_satisfaction_treats_marks_as_empty() {
+        let puzzle = &sample_library().packs[0].puzzles[0];
+        let marked_grid = vec![
+            vec![2, 1, 1, 1, 2],
+            vec![1, 2, 0, 0, 1],
+            vec![1, 0, 1, 2, 1],
+            vec![1, 2, 0, 0, 1],
+            vec![0, 1, 1, 1, 2],
+        ];
+        let (rows, cols) = row_col_satisfaction(puzzle, &marked_grid);
+        assert!(
+            rows.iter().all(|&r| r),
+            "marks treated as empty → all rows satisfied"
+        );
+        assert!(
+            cols.iter().all(|&c| c),
+            "marks treated as empty → all cols satisfied"
+        );
     }
 }

--- a/late-ssh/src/app/arcade/nonogram/ui.rs
+++ b/late-ssh/src/app/arcade/nonogram/ui.rs
@@ -136,6 +136,13 @@ fn board_lines(state: &State, puzzle: &late_core::nonogram::NonogramPuzzle) -> V
     let cursor_row = state.cursor.0;
     let clue_active = Style::default().fg(theme::TEXT_BRIGHT());
     let clue_normal = Style::default().fg(theme::AMBER_DIM());
+    let clue_satisfied = Style::default()
+        .fg(theme::SUCCESS())
+        .add_modifier(Modifier::DIM);
+
+    let (satisfied_rows, satisfied_cols) = state
+        .satisfied_rows_and_cols()
+        .unwrap_or_else(|| (vec![], vec![]));
 
     // Column clue rows (offset by 1 to align with cells inside │)
     for clue_row in 0..max_col_clues {
@@ -149,6 +156,8 @@ fn board_lines(state: &State, puzzle: &late_core::nonogram::NonogramPuzzle) -> V
             };
             let style = if ci == cursor_col {
                 clue_active
+            } else if satisfied_cols.get(ci).copied().unwrap_or(false) {
+                clue_satisfied
             } else {
                 clue_normal
             };
@@ -178,6 +187,8 @@ fn board_lines(state: &State, puzzle: &late_core::nonogram::NonogramPuzzle) -> V
         let pad = max_row_clues.saturating_sub(row_clues.len());
         let row_style = if row == cursor_row {
             clue_active
+        } else if satisfied_rows.get(row).copied().unwrap_or(false) {
+            clue_satisfied
         } else {
             clue_normal
         };

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -530,7 +530,7 @@ impl App {
         let voice_snapshot = self.voice.snapshot();
         let voice_participant_count = voice_snapshot.participants.len();
         let voice_view = crate::app::voice::ui::VoiceRoomView {
-            snapshot: &voice_snapshot,
+            snapshot: voice_snapshot,
             current_user_id: self.user_id,
             paired_cli_supports_voice,
             browser_listen_url: &voice_browser_listen_url,


### PR DESCRIPTION
# Description

This change introduces a highlight for row/column clue headers when the puzzle satisfies their local constraint (i.e. when their run-length sequence exactly matches the puzzle clue). This **does not** indicate anything about whether the filled in pixels are in the correct location for the puzzle as a whole; only the specific row/column.

# Examples

```
2 3 3 2 | ▒▒  ▒▒▒  ▒▒▒  ▒▒        // Highlights
2 3 3 2 | ▒▒        ▒▒▒ ▒▒▒    ▒▒ // Highlights
2 3 3 2 | ▒▒▒  ▒▒  ▒▒  ▒▒▒        // Does not highlight (3 2 2 3)
```