### PR TITLE
Mirror Bonsai watering and simplify Chess piece rendering

### DIFF
--- a/late-ssh/src/app/bonsai/modal_input.rs
+++ b/late-ssh/src/app/bonsai/modal_input.rs
@@ -64,8 +64,19 @@ fn water(app: &mut App) {
         app.bonsai_care_state.message = Some("New seed planted".to_string());
         return;
     }
+    let dynamic_unlocked = app.shop_state.has_dynamic_bonsai();
+    let dynamic_was_dead = dynamic_unlocked && !app.bonsai_v2_state.is_alive;
+    if dynamic_was_dead {
+        app.bonsai_v2_state.respawn();
+    }
     let earns_chips = app.bonsai_state.last_watered != Some(BonsaiService::today());
-    if let Some(gained) = app.bonsai_state.water() {
+    let classic_gain = app.bonsai_state.water();
+    let dynamic_changed = if dynamic_unlocked && !dynamic_was_dead {
+        app.bonsai_v2_state.water()
+    } else {
+        false
+    };
+    if let Some(gained) = classic_gain {
         app.bonsai_care_state.mark_watered();
         let chip_bonus = if earns_chips {
             format!(", +{WATER_CHIP_BONUS} chips")
@@ -77,10 +88,24 @@ fn water(app: &mut App) {
         } else {
             "growth maxed".to_string()
         };
-        app.bonsai_care_state.message = Some(format!("Watered: {growth_text}{chip_bonus}"));
+        let dynamic_text = if dynamic_was_dead {
+            ", dynamic replanted"
+        } else if dynamic_changed {
+            ", dynamic watered"
+        } else {
+            ""
+        };
+        app.bonsai_care_state.message =
+            Some(format!("Watered: {growth_text}{chip_bonus}{dynamic_text}"));
     } else {
         app.bonsai_care_state.watered = true;
-        app.bonsai_care_state.message = Some("Already watered today".to_string());
+        app.bonsai_care_state.message = Some(if dynamic_was_dead {
+            "Already watered today, dynamic replanted".to_string()
+        } else if dynamic_changed {
+            "Already watered today, dynamic watered".to_string()
+        } else {
+            "Already watered today".to_string()
+        });
     }
 }
 

--- a/late-ssh/src/app/bonsai_v2/CONTEXT.md
+++ b/late-ssh/src/app/bonsai_v2/CONTEXT.md
@@ -81,11 +81,11 @@ Session state:
 - `App::use_bonsai_v2()` follows `ShopState::dynamic_bonsai_enabled()`.
 - Global `w` opens Dynamic Bonsai when selected; otherwise it opens classic Bonsai.
 - Global `Ctrl+B` no longer opens this modal.
-- Classic Bonsai remains present for all users. Dynamic Bonsai watering still calls classic Bonsai watering for existing daily chip/water compatibility.
+- Classic Bonsai remains present for all users. Watering either unlocked Bonsai variant mirrors the care action to the other tree for existing daily chip/water compatibility.
 - Decision: neither tree freezes. Both run their life/death clocks on real calendar dates regardless of which variant is equipped. A freeze model (rebase the inactive tree's clock on re-equip plus skip its death check while inactive) was considered and deferred.
   - Classic is always loaded, and `bonsai_state.tick()` runs unconditionally in `App::tick()`, so it keeps passive-growing in-session and its 7-dry-day death is checked live and at login.
   - Dynamic is loaded at every login whenever the user OWNS it (`has_dynamic_bonsai()` = owns, gated in `session_bootstrap.rs`, not equip). `BonsaiV2State::new` runs `apply_elapsed_days`, which applies dry-day decay and death on real dates even when classic is the active tree. Only the in-session passive-growth `bonsai_v2_state.tick(active)` call is gated by `use_bonsai_v2()` and recent input activity; the death clock still catches up at the next login.
-- The watering bridge is one-directional. Watering Dynamic also waters classic (keeps classic alive under daily Dynamic care), but watering classic does NOT water Dynamic. So an owned-but-unequipped Dynamic tree gets no water and can die unattended in the background (roughly 10-15 dry days, see section 5), and re-equipping it later can surface a dead or near-dead tree.
+- The watering bridge is bidirectional after Dynamic Bonsai is owned. Watering Dynamic also waters classic; watering classic waters Dynamic only after the `dynamic_bonsai` entitlement exists, so new users cannot create or care for a Dynamic tree before unlocking it.
 - Admin sessions can temporarily repeat-water Dynamic Bonsai from the modal for preview/growth testing. Legacy chips and classic Bonsai growth remain daily-gated.
 
 Rendering:
@@ -197,8 +197,8 @@ Current interaction limitations:
 - Selection is branch-cycle based, not cursor/mouse picking.
 - Wiring records future growth bias; it does not instantly extend the branch.
 - Pruning the trunk is intentionally blocked in the prototype.
-- Watering Dynamic Bonsai also calls classic Bonsai watering for chip compatibility when the old tree is alive.
-- If either classic Bonsai or Dynamic Bonsai is dead, the first `w` replants and returns; a later `w` waters.
+- Watering either unlocked Bonsai variant also calls the other variant for chip and daily-care compatibility when the other tree is alive.
+- If the currently opened tree is dead, the first `w` replants and returns; a later `w` waters. A dead mirrored Dynamic tree is replanted from classic watering and can be watered on a later `w`.
 - Foliage is earned: pinch a tip, wait for it to become ready again, and repeat until the third pinch turns it into a leaf pad.
 - Splits are explicit: `s` marks a tip, and the next growth wave forks it only when both split target cells are unoccupied. High stress can still create messier random side shoots.
 

--- a/late-ssh/src/app/files/terminal_image.rs
+++ b/late-ssh/src/app/files/terminal_image.rs
@@ -108,6 +108,10 @@ impl TerminalImageFrame {
         self.placements.push(placement);
     }
 
+    pub(crate) fn clear(&mut self) {
+        self.placements.clear();
+    }
+
     fn keys(&self) -> Vec<TerminalImagePlacementKey> {
         self.placements
             .iter()

--- a/late-ssh/src/app/hub/shop/state.rs
+++ b/late-ssh/src/app/hub/shop/state.rs
@@ -143,6 +143,10 @@ impl ShopState {
             .any(|item| item.is_dynamic_bonsai() && item.equipped)
     }
 
+    pub fn has_dynamic_bonsai(&self) -> bool {
+        self.snapshot.entitlements.has_dynamic_bonsai()
+    }
+
     pub fn selected_index(&self) -> usize {
         self.selected_index
     }

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -662,9 +662,12 @@ impl App {
             || self.show_aquarium_tray
             || self.show_profile_modal
             || self.show_bonsai_modal
+            || self.show_bonsai_v2_modal
             || self.show_cat_modal
             || self.show_help
+            || self.show_ultimate_modal
             || self.show_splash
+            || news_modal.is_some()
             || self.icon_picker_open
             || self.room_search_modal_state.is_open()
             || self.booth_modal_state.is_open();
@@ -674,9 +677,12 @@ impl App {
             || self.show_aquarium_tray
             || self.show_profile_modal
             || self.show_bonsai_modal
+            || self.show_bonsai_v2_modal
             || self.show_cat_modal
             || self.show_help
+            || self.show_ultimate_modal
             || self.show_splash
+            || news_modal.is_some()
             || self.icon_picker_open
             || self.room_search_modal_state.is_open()
             || self.booth_modal_state.is_open();
@@ -996,6 +1002,7 @@ impl App {
         } else {
             (app_inner, None)
         };
+        let foreground_overlay_open = foreground_terminal_overlay_open(&ctx);
         match screen {
             Screen::Dashboard => {
                 const HOME_RAIL_WIDTH: u16 = 24;
@@ -1147,6 +1154,10 @@ impl App {
             );
         }
 
+        if foreground_overlay_open {
+            terminal_images.clear();
+        }
+
         // Toast banner overlay at top of content area
         let banner = if ctx.is_draining {
             Some(Banner {
@@ -1280,6 +1291,24 @@ impl App {
             icon_picker::picker::render(frame, area, ctx.icon_picker_state, catalog);
         }
     }
+}
+
+fn foreground_terminal_overlay_open(ctx: &DrawContext<'_>) -> bool {
+    ctx.show_settings
+        || ctx.show_quit_confirm
+        || ctx.show_mod_modal
+        || ctx.show_hub_modal
+        || ctx.show_aquarium_tray
+        || ctx.show_profile_modal
+        || ctx.show_bonsai_modal
+        || ctx.show_bonsai_v2_modal
+        || ctx.show_cat_modal
+        || ctx.show_help
+        || ctx.show_ultimate_modal
+        || ctx.news_modal.is_some()
+        || ctx.room_search_modal_open
+        || ctx.booth_modal_open
+        || ctx.icon_picker_open
 }
 
 fn app_frame_title(screen: Screen, ctx: &DrawContext<'_>) -> Line<'static> {

--- a/late-ssh/src/app/rooms/chess/input.rs
+++ b/late-ssh/src/app/rooms/chess/input.rs
@@ -50,10 +50,6 @@ pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
             state.toggle_piece_graphics();
             InputAction::Handled
         }
-        b'v' | b'V' => {
-            state.toggle_non_png_piece_render_mode();
-            InputAction::Handled
-        }
         _ => InputAction::Ignored,
     }
 }

--- a/late-ssh/src/app/rooms/chess/piece_art.rs
+++ b/late-ssh/src/app/rooms/chess/piece_art.rs
@@ -1,11 +1,7 @@
 use std::{io::Cursor, sync::LazyLock};
 
 use image::{ExtendedColorType, ImageEncoder, RgbaImage, codecs::png::PngEncoder};
-use ratatui::text::Line;
 
-use crate::app::files::inline_image::{
-    InlineImageRenderSettings, InlineImageSymbolMode, render_rgba_preview,
-};
 use crate::app::files::terminal_image::TerminalImageData;
 use crate::app::rooms::chess::state::{ChessColor, ChessPieceKind};
 
@@ -13,13 +9,6 @@ use crate::app::rooms::chess::state::{ChessColor, ChessPieceKind};
 pub enum GraphicsTier {
     Large,
     Medium,
-}
-
-#[derive(Clone, Copy)]
-pub enum HalfBlockTier {
-    Large,  // 4 rows of 8 chars (8x8 half-pixel canvas)
-    Medium, // 3 rows of 6 chars (6x6 half-pixel canvas)
-    Small,  // 2 rows of 4 chars (4x4 half-pixel canvas)
 }
 
 const LARGE_COLS: u16 = 8;
@@ -66,42 +55,13 @@ const SOURCE_BYTES: [[&[u8]; 6]; 2] = [
     ],
 ];
 
-const SMALL_SOURCE_BYTES: [[&[u8]; 6]; 2] = [
-    [
-        include_bytes!("../../../../assets/chess/pieces/small/white_pawn.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/white_knight.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/white_bishop.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/white_rook.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/white_queen.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/white_king.png"),
-    ],
-    [
-        include_bytes!("../../../../assets/chess/pieces/small/black_pawn.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/black_knight.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/black_bishop.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/black_rook.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/black_queen.png"),
-        include_bytes!("../../../../assets/chess/pieces/small/black_king.png"),
-    ],
-];
-
 struct PieceImages {
     large: TerminalImageData,
     medium: TerminalImageData,
 }
 
-struct PieceHalfBlock {
-    large: Vec<Line<'static>>,
-    medium: Vec<Line<'static>>,
-    small: Vec<Line<'static>>,
-}
-
 static GRAPHICS: LazyLock<[[PieceImages; 6]; 2]> = LazyLock::new(|| {
     std::array::from_fn(|c| std::array::from_fn(|k| build_piece(SOURCE_BYTES[c][k])))
-});
-
-static HALF_BLOCK: LazyLock<[[PieceHalfBlock; 6]; 2]> = LazyLock::new(|| {
-    std::array::from_fn(|c| std::array::from_fn(|k| build_half_block(SMALL_SOURCE_BYTES[c][k])))
 });
 
 pub fn graphics_image(
@@ -114,21 +74,6 @@ pub fn graphics_image(
         GraphicsTier::Large => &entry.large,
         GraphicsTier::Medium => &entry.medium,
     }
-}
-
-pub fn half_block_line(
-    color: ChessColor,
-    kind: ChessPieceKind,
-    tier: HalfBlockTier,
-    sub: usize,
-) -> Option<&'static Line<'static>> {
-    let entry = &HALF_BLOCK[color_index(color)][kind_index(kind)];
-    let lines = match tier {
-        HalfBlockTier::Large => &entry.large,
-        HalfBlockTier::Medium => &entry.medium,
-        HalfBlockTier::Small => &entry.small,
-    };
-    lines.get(sub)
 }
 
 fn build_piece(src: &[u8]) -> PieceImages {
@@ -171,49 +116,4 @@ fn render_at(src: &RgbaImage, cols: u16, rows: u16) -> TerminalImageData {
         .expect("png encode of static chess canvas");
 
     TerminalImageData::new(png, None, cols, rows)
-}
-
-fn build_half_block(src: &[u8]) -> PieceHalfBlock {
-    let img = image::load_from_memory(src)
-        .unwrap_or_else(|err| panic!("chess piece small asset decode failed: {err}"))
-        .to_rgba8();
-    let canonical = normalize_to_canvas(&img, 8, 8);
-    PieceHalfBlock {
-        large: chafa_piece_lines(&canonical, 8, 4),
-        medium: chafa_piece_lines(&downsample(&canonical, 6, 6), 6, 3),
-        small: chafa_piece_lines(&downsample(&canonical, 4, 4), 4, 2),
-    }
-}
-
-fn chafa_piece_lines(src: &RgbaImage, cols: u32, rows: u32) -> Vec<Line<'static>> {
-    render_rgba_preview(
-        src,
-        cols,
-        rows,
-        InlineImageRenderSettings {
-            symbol_mode: InlineImageSymbolMode::Default,
-            background_rgb: None,
-        },
-    )
-    .unwrap_or_default()
-}
-
-fn normalize_to_canvas(src: &RgbaImage, width: u32, height: u32) -> RgbaImage {
-    debug_assert!(
-        src.width() <= width && src.height() <= height,
-        "symbol-render source {}x{} exceeds canvas {width}x{height}",
-        src.width(),
-        src.height(),
-    );
-    let mut canvas = RgbaImage::from_pixel(width, height, image::Rgba([0, 0, 0, 0]));
-    let x_off = width.saturating_sub(src.width()) / 2;
-    let y_off = height.saturating_sub(src.height());
-    image::imageops::overlay(&mut canvas, src, x_off.into(), y_off.into());
-    canvas
-}
-
-fn downsample(src: &RgbaImage, target_w: u32, target_h: u32) -> RgbaImage {
-    image::DynamicImage::ImageRgba8(src.clone())
-        .resize_exact(target_w, target_h, image::imageops::FilterType::Nearest)
-        .to_rgba8()
 }

--- a/late-ssh/src/app/rooms/chess/state.rs
+++ b/late-ssh/src/app/rooms/chess/state.rs
@@ -75,37 +75,8 @@ pub struct ChessMoveRecord {
 pub enum ChessPieceRenderMode {
     /// Hand-drawn ASCII silhouettes, universal fallback.
     Ascii,
-    /// 8x8 PNG rendered as Chafa symbols; works on any terminal.
-    HalfBlock,
     /// Full-resolution PNG via Kitty/iTerm2/Sixel terminal-image protocols.
     Graphics,
-}
-
-impl ChessPieceRenderMode {
-    pub fn label(self) -> &'static str {
-        match self {
-            ChessPieceRenderMode::Ascii => "ascii",
-            ChessPieceRenderMode::HalfBlock => "8x8",
-            ChessPieceRenderMode::Graphics => "png",
-        }
-    }
-
-    pub fn cycle(self) -> Self {
-        match self {
-            ChessPieceRenderMode::Graphics => ChessPieceRenderMode::HalfBlock,
-            ChessPieceRenderMode::HalfBlock => ChessPieceRenderMode::Ascii,
-            ChessPieceRenderMode::Ascii => ChessPieceRenderMode::Graphics,
-        }
-    }
-
-    fn fallback_toggle(self) -> Self {
-        match self {
-            ChessPieceRenderMode::Ascii => ChessPieceRenderMode::HalfBlock,
-            ChessPieceRenderMode::HalfBlock | ChessPieceRenderMode::Graphics => {
-                ChessPieceRenderMode::Ascii
-            }
-        }
-    }
 }
 
 pub struct State {
@@ -116,7 +87,6 @@ pub struct State {
     svc: ChessService,
     snapshot_rx: watch::Receiver<ChessSnapshot>,
     piece_render_mode: ChessPieceRenderMode,
-    non_png_piece_render_mode: ChessPieceRenderMode,
 }
 
 impl State {
@@ -131,16 +101,11 @@ impl State {
             svc,
             snapshot_rx,
             piece_render_mode: ChessPieceRenderMode::Graphics,
-            non_png_piece_render_mode: ChessPieceRenderMode::HalfBlock,
         }
     }
 
     pub fn piece_render_mode(&self) -> ChessPieceRenderMode {
         self.piece_render_mode
-    }
-
-    pub fn non_png_piece_render_mode(&self) -> ChessPieceRenderMode {
-        self.non_png_piece_render_mode
     }
 
     pub fn graphics_enabled(&self) -> bool {
@@ -149,17 +114,10 @@ impl State {
 
     pub fn toggle_piece_graphics(&mut self) {
         self.piece_render_mode = if self.graphics_enabled() {
-            self.non_png_piece_render_mode
+            ChessPieceRenderMode::Ascii
         } else {
             ChessPieceRenderMode::Graphics
         };
-    }
-
-    pub fn toggle_non_png_piece_render_mode(&mut self) {
-        self.non_png_piece_render_mode = self.non_png_piece_render_mode.fallback_toggle();
-        if !self.graphics_enabled() {
-            self.piece_render_mode = self.non_png_piece_render_mode;
-        }
     }
 
     pub fn room_id(&self) -> Uuid {

--- a/late-ssh/src/app/rooms/chess/ui.rs
+++ b/late-ssh/src/app/rooms/chess/ui.rs
@@ -239,7 +239,6 @@ pub fn draw_game(frame: &mut Frame, area: Rect, state: &State, ctx: GameDrawCtx<
         ctx.usernames,
         area.height as usize,
         state.piece_render_mode(),
-        state.non_png_piece_render_mode(),
     );
     let content = draw_game_frame_with_info_sidebar(frame, area, "Chess", info, show_sidebar);
 
@@ -296,7 +295,6 @@ pub fn draw_game(frame: &mut Frame, area: Rect, state: &State, ctx: GameDrawCtx<
         ctx.image_protocol,
         ctx.terminal_images,
         state.piece_render_mode(),
-        state.non_png_piece_render_mode(),
     );
     draw_player_bar(
         frame,
@@ -337,7 +335,6 @@ fn draw_board(
     image_protocol: Option<TerminalImageProtocol>,
     terminal_images: &mut TerminalImageFrame,
     render_mode: ChessPieceRenderMode,
-    non_png_render_mode: ChessPieceRenderMode,
 ) {
     if area.height == 0 || area.width == 0 {
         return;
@@ -363,8 +360,10 @@ fn draw_board(
     };
 
     let finished_overlay_open = snapshot.phase == ChessPhase::Finished && snapshot.result.is_some();
-    let graphics_squares =
-        if render_mode == ChessPieceRenderMode::Graphics && !finished_overlay_open {
+    let graphics_squares = if render_mode == ChessPieceRenderMode::Graphics {
+        if finished_overlay_open {
+            occupied_piece_mask(snapshot)
+        } else {
             schedule_piece_graphics(
                 terminal_images,
                 board_area,
@@ -374,15 +373,12 @@ fn draw_board(
                 image_protocol,
                 room_id,
             )
-        } else {
-            0
-        };
-
-    let fallback_mode = match render_mode {
-        ChessPieceRenderMode::Graphics => non_png_render_mode,
-        ChessPieceRenderMode::HalfBlock | ChessPieceRenderMode::Ascii => render_mode,
+        }
+    } else {
+        0
     };
-    let lines = board_lines(snapshot, tier, &ctx, legal, graphics_squares, fallback_mode);
+
+    let lines = board_lines(snapshot, tier, &ctx, legal, graphics_squares);
     frame.render_widget(Paragraph::new(lines), board_area);
 
     if let Some(result) = finished_overlay_open.then_some(snapshot.result).flatten() {
@@ -463,6 +459,20 @@ fn piece_placement_id(room_id: Uuid, index: usize) -> Uuid {
     Uuid::from_bytes(bytes)
 }
 
+fn occupied_piece_mask(snapshot: &ChessSnapshot) -> u64 {
+    snapshot
+        .pieces
+        .iter()
+        .enumerate()
+        .fold(0u64, |mask, (index, piece)| {
+            if piece.is_some() {
+                mask | (1u64 << index)
+            } else {
+                mask
+            }
+        })
+}
+
 #[allow(clippy::too_many_arguments)]
 fn board_lines(
     snapshot: &ChessSnapshot,
@@ -470,7 +480,6 @@ fn board_lines(
     ctx: &BoardCtx,
     legal: &[usize],
     graphics_mask: u64,
-    render_mode: ChessPieceRenderMode,
 ) -> Vec<Line<'static>> {
     let mut lines = Vec::with_capacity(tier.ch * 8 + 2);
     lines.push(file_label_line(ctx.orientation, tier));
@@ -499,7 +508,6 @@ fn board_lines(
                     snapshot,
                     legal,
                     graphics_mask,
-                    render_mode,
                 );
             }
             spans.push(gutter_span(tier.gutter, label));
@@ -521,7 +529,6 @@ fn push_cell_spans(
     snapshot: &ChessSnapshot,
     legal: &[usize],
     graphics_mask: u64,
-    render_mode: ChessPieceRenderMode,
 ) {
     let piece = snapshot.pieces[index];
     let bg = square_bg(index, ctx, legal, piece.is_some());
@@ -538,7 +545,7 @@ fn push_cell_spans(
 
     match piece {
         Some(piece) => {
-            push_piece_spans(spans, piece.color, piece.kind, tier, sub, bg, render_mode);
+            push_piece_spans(spans, piece.color, piece.kind, tier, sub, bg);
         }
         None if legal.contains(&index) => {
             spans.push(Span::styled(
@@ -555,18 +562,6 @@ fn push_cell_spans(
     }
 }
 
-fn half_block_tier_for(tier: Tier) -> Option<piece_art::HalfBlockTier> {
-    if tier.cw >= 8 && tier.ch >= 4 {
-        Some(piece_art::HalfBlockTier::Large)
-    } else if tier.cw >= 6 && tier.ch >= 3 {
-        Some(piece_art::HalfBlockTier::Medium)
-    } else if tier.cw >= 4 && tier.ch >= 2 {
-        Some(piece_art::HalfBlockTier::Small)
-    } else {
-        None
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 fn push_piece_spans(
     spans: &mut Vec<Span<'static>>,
@@ -575,51 +570,19 @@ fn push_piece_spans(
     tier: Tier,
     sub: usize,
     bg: Color,
-    mode: ChessPieceRenderMode,
 ) {
     let theme_fg = match color {
         ChessColor::White => PIECE_WHITE,
         ChessColor::Black => PIECE_BLACK,
     };
-    let cw = tier.cw;
-    let tier_kind = half_block_tier_for(tier);
-
-    if matches!(mode, ChessPieceRenderMode::Ascii) {
-        let cell = ascii_piece_line(kind, tier, sub);
-        spans.push(Span::styled(
-            cell,
-            Style::default()
-                .bg(bg)
-                .fg(theme_fg)
-                .add_modifier(Modifier::BOLD),
-        ));
-        return;
-    }
-
-    let Some(tier_kind) = tier_kind else {
-        spans.push(Span::styled(
-            small_tier_letter(kind, tier, sub),
-            Style::default()
-                .bg(bg)
-                .fg(theme_fg)
-                .add_modifier(Modifier::BOLD),
-        ));
-        return;
-    };
-
-    let Some(line) = piece_art::half_block_line(color, kind, tier_kind, sub) else {
-        spans.push(Span::styled(" ".repeat(cw), Style::default().bg(bg)));
-        return;
-    };
-
-    for span in &line.spans {
-        let style = if span.style.bg.is_none() {
-            span.style.bg(bg)
-        } else {
-            span.style
-        };
-        spans.push(Span::styled(span.content.to_string(), style));
-    }
+    let cell = ascii_piece_line(kind, tier, sub);
+    spans.push(Span::styled(
+        cell,
+        Style::default()
+            .bg(bg)
+            .fg(theme_fg)
+            .add_modifier(Modifier::BOLD),
+    ));
 }
 
 fn ascii_piece_line(kind: ChessPieceKind, tier: Tier, sub: usize) -> String {
@@ -1004,16 +967,11 @@ fn key_line(state: &State) -> Line<'static> {
     }
     hint(
         &mut spans,
-        "v",
-        &format!("fallback ({})", state.non_png_piece_render_mode().label()),
-    );
-    hint(
-        &mut spans,
         "p",
         if state.graphics_enabled() {
-            "png on"
+            "pieces png"
         } else {
-            "png off"
+            "pieces ascii"
         },
     );
     hint(&mut spans, "q", "leave room");
@@ -1064,7 +1022,6 @@ fn info_lines(
     usernames: &UsernameLookup<'_>,
     area_height: usize,
     render_mode: ChessPieceRenderMode,
-    non_png_render_mode: ChessPieceRenderMode,
 ) -> Vec<Line<'static>> {
     let white = seat_name(snapshot.seats[0], usernames);
     let black = seat_name(snapshot.seats[1], usernames);
@@ -1100,13 +1057,12 @@ fn info_lines(
         key_hint("n", "ready / start"),
         key_hint("l", "stand up"),
         key_hint("r", "resign active"),
-        key_hint("v", &format!("fallback ({})", non_png_render_mode.label())),
         key_hint(
             "p",
             if render_mode == ChessPieceRenderMode::Graphics {
-                "png on"
+                "pieces png"
             } else {
-                "png off"
+                "pieces ascii"
             },
         ),
         key_hint("q", "leave room"),
@@ -1268,14 +1224,7 @@ mod tests {
                 last: Some((52, 36)),
                 check_sq: None,
             };
-            let lines = board_lines(
-                &snapshot,
-                tier,
-                &ctx,
-                &[36, 28],
-                0,
-                ChessPieceRenderMode::Graphics,
-            );
+            let lines = board_lines(&snapshot, tier, &ctx, &[36, 28], 0);
             assert_eq!(lines.len(), tier.ch * 8 + 2, "row count for cw={}", tier.cw);
             for line in &lines {
                 let width: usize = line


### PR DESCRIPTION
## Summary
- Keeps owned Dynamic Bonsai in sync when users water classic Bonsai, so unequipped Dynamic trees no longer silently dry out after unlock.
- Simplifies Chess piece rendering to a two-mode PNG/ASCII toggle and removes the old half-block fallback path.

## Changes
- Classic Bonsai watering now also waters an owned Dynamic Bonsai, or replants it if the dynamic tree was dead.
- Adds a Shop state helper for checking Dynamic Bonsai ownership separately from whether it is equipped.
- Removes Chess `v` fallback-mode input and the Chafa half-block rendering assets/path.
- Updates Chess UI hints to show `p` as the PNG/ASCII piece toggle.

## Behavior notes
- Dynamic Bonsai mirroring only applies after the user owns the `dynamic_bonsai` entitlement.
- Chess no longer offers the intermediate `8x8` half-block fallback; non-PNG rendering is ASCII.

## Feature flags
- None.

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Not run; repo policy says agents should not run `cargo test`, `cargo nextest`, or `cargo clippy`.
- Manual: Not run; PR draft based on the provided diff context.