### PR TITLE
Manage shop items and protect active game rooms

### DIFF
--- a/late-core/src/models/game_room.rs
+++ b/late-core/src/models/game_room.rs
@@ -205,22 +205,27 @@ impl GameRoom {
 
     pub async fn delete_inactive_open(client: &Client, ttl: Duration) -> Result<u64> {
         let ttl_seconds = ttl.as_secs() as i64;
+        let chess = GameKind::Chess.as_str();
         let row = client
             .query_one(
-                "WITH stale AS (
-                     SELECT chat_room_id
-                     FROM game_rooms
+                "WITH deleted_rooms AS (
+                     DELETE FROM game_rooms
                      WHERE status = $1
                        AND updated < current_timestamp - ($2::bigint * interval '1 second')
+                       AND (
+                         game_kind <> $3
+                         OR runtime_state->>'phase' IS DISTINCT FROM 'Active'
+                       )
+                     RETURNING chat_room_id
                  ),
-                 deleted AS (
+                 deleted_chats AS (
                      DELETE FROM chat_rooms c
-                     USING stale s
-                     WHERE c.id = s.chat_room_id
+                     USING deleted_rooms r
+                     WHERE c.id = r.chat_room_id
                      RETURNING c.id
                  )
-                 SELECT COUNT(*)::bigint AS count FROM deleted",
-                &[&Self::STATUS_OPEN, &ttl_seconds],
+                 SELECT COUNT(*)::bigint AS count FROM deleted_chats",
+                &[&Self::STATUS_OPEN, &ttl_seconds, &chess],
             )
             .await?;
         let count: i64 = row.get("count");

--- a/late-core/src/models/game_room.rs
+++ b/late-core/src/models/game_room.rs
@@ -184,7 +184,8 @@ impl GameRoom {
                 &[&user_id, &game_kind],
             )
             .await?;
-        Ok(row.get("count"))
+        let count: i64 = row.get("count");
+        Ok(count)
     }
 
     pub async fn close_inactive(client: &Client, ttl: Duration) -> Result<u64> {
@@ -202,6 +203,48 @@ impl GameRoom {
         Ok(updated)
     }
 
+    pub async fn delete_inactive_open(client: &Client, ttl: Duration) -> Result<u64> {
+        let ttl_seconds = ttl.as_secs() as i64;
+        let row = client
+            .query_one(
+                "WITH stale AS (
+                     SELECT chat_room_id
+                     FROM game_rooms
+                     WHERE status = $1
+                       AND updated < current_timestamp - ($2::bigint * interval '1 second')
+                 ),
+                 deleted AS (
+                     DELETE FROM chat_rooms c
+                     USING stale s
+                     WHERE c.id = s.chat_room_id
+                     RETURNING c.id
+                 )
+                 SELECT COUNT(*)::bigint AS count FROM deleted",
+                &[&Self::STATUS_OPEN, &ttl_seconds],
+            )
+            .await?;
+        let count: i64 = row.get("count");
+        Ok(count as u64)
+    }
+
+    pub async fn reconcile_in_round_after_restart(client: &Client) -> Result<u64> {
+        let chess = GameKind::Chess.as_str();
+        let updated = client
+            .execute(
+                "UPDATE game_rooms
+                 SET status = $1,
+                     updated = current_timestamp
+                 WHERE status = $2
+                   AND (
+                     game_kind <> $3
+                     OR runtime_state->>'phase' IS DISTINCT FROM 'Active'
+                   )",
+                &[&Self::STATUS_OPEN, &Self::STATUS_IN_ROUND, &chess],
+            )
+            .await?;
+        Ok(updated)
+    }
+
     pub async fn close_by_id(client: &Client, room_id: Uuid) -> Result<u64> {
         let updated = client
             .execute(
@@ -211,6 +254,42 @@ impl GameRoom {
                  WHERE id = $2
                    AND status <> $1",
                 &[&Self::STATUS_CLOSED, &room_id],
+            )
+            .await?;
+        Ok(updated)
+    }
+
+    pub async fn delete_by_id(client: &Client, room_id: Uuid) -> Result<u64> {
+        let row = client
+            .query_one(
+                "WITH target AS (
+                     SELECT chat_room_id
+                     FROM game_rooms
+                     WHERE id = $1
+                 ),
+                 deleted AS (
+                     DELETE FROM chat_rooms c
+                     USING target t
+                     WHERE c.id = t.chat_room_id
+                     RETURNING c.id
+                 )
+                 SELECT COUNT(*)::bigint AS count FROM deleted",
+                &[&room_id],
+            )
+            .await?;
+        let count: i64 = row.get("count");
+        Ok(count as u64)
+    }
+
+    pub async fn update_status(client: &Client, room_id: Uuid, status: &str) -> Result<u64> {
+        let updated = client
+            .execute(
+                "UPDATE game_rooms
+                 SET status = $2,
+                     updated = current_timestamp
+                 WHERE id = $1
+                   AND status <> $2",
+                &[&room_id, &status],
             )
             .await?;
         Ok(updated)

--- a/late-core/src/models/marketplace.rs
+++ b/late-core/src/models/marketplace.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail, ensure};
 use chrono::{DateTime, Duration, Utc};
 use serde_json::Value;
 use tokio_postgres::Client;
@@ -45,6 +45,47 @@ pub struct MarketplaceItem {
     pub sort_order: i32,
 }
 
+#[derive(Debug, Clone)]
+pub struct MarketplaceAdminRow {
+    pub id: Uuid,
+    pub sku: String,
+    pub item_kind: String,
+    pub slot: Option<String>,
+    pub name: String,
+    pub description: String,
+    pub price_chips: i64,
+    pub payload: Value,
+    pub active: bool,
+    pub sort_order: i32,
+}
+
+impl From<tokio_postgres::Row> for MarketplaceAdminRow {
+    fn from(row: tokio_postgres::Row) -> Self {
+        Self {
+            id: row.get("id"),
+            sku: row.get("sku"),
+            item_kind: row.get("item_kind"),
+            slot: row.get("slot"),
+            name: row.get("name"),
+            description: row.get("description"),
+            price_chips: row.get("price_chips"),
+            payload: row.get("payload"),
+            active: row.get("active"),
+            sort_order: row.get("sort_order"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MarketplaceAdminUpdate {
+    pub id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub price_chips: i64,
+    pub active: bool,
+    pub sort_order: i32,
+}
+
 impl From<tokio_postgres::Row> for MarketplaceItem {
     fn from(row: tokio_postgres::Row) -> Self {
         Self {
@@ -81,6 +122,67 @@ impl MarketplaceItem {
             .await?;
         Ok(rows.into_iter().map(Self::from).collect())
     }
+}
+
+pub async fn list_marketplace_items_for_admin(
+    client: &impl deadpool_postgres::GenericClient,
+) -> Result<Vec<MarketplaceAdminRow>> {
+    let rows = client
+        .query(
+            "SELECT id, sku, item_kind, slot, name, description, price_chips,
+                    payload, active, sort_order
+             FROM marketplace_items
+             ORDER BY item_kind ASC, sort_order ASC, sku ASC",
+            &[],
+        )
+        .await?;
+    Ok(rows.into_iter().map(MarketplaceAdminRow::from).collect())
+}
+
+pub async fn update_marketplace_item_for_admin(
+    client: &impl deadpool_postgres::GenericClient,
+    update: MarketplaceAdminUpdate,
+) -> Result<MarketplaceAdminRow> {
+    ensure!(!update.name.trim().is_empty(), "name cannot be empty");
+    ensure!(
+        !update.description.trim().is_empty(),
+        "description cannot be empty"
+    );
+    ensure!(update.price_chips >= 0, "price must be 0 or greater");
+
+    let row = client
+        .query_opt(
+            "UPDATE marketplace_items
+             SET
+                 name = $2,
+                 description = $3,
+                 price_chips = $4,
+                 active = $5,
+                 sort_order = $6,
+                 updated = current_timestamp
+             WHERE id = $1
+             RETURNING id, sku, item_kind, slot, name, description, price_chips,
+                       payload, active, sort_order",
+            &[
+                &update.id,
+                &update.name.trim(),
+                &update.description.trim(),
+                &update.price_chips,
+                &update.active,
+                &update.sort_order,
+            ],
+        )
+        .await?;
+    let row = row
+        .map(MarketplaceAdminRow::from)
+        .with_context(|| format!("marketplace item {} not found", update.id))?;
+    client
+        .execute(
+            "SELECT pg_notify($1, $2)",
+            &[&SHOP_CATALOG_CHANGED_CHANNEL, &row.sku],
+        )
+        .await?;
+    Ok(row)
 }
 
 #[derive(Debug, Clone)]

--- a/late-core/tests/game_room.rs
+++ b/late-core/tests/game_room.rs
@@ -1,0 +1,174 @@
+use std::time::Duration;
+
+use late_core::{
+    models::game_room::{GameKind, GameRoom},
+    test_utils::test_db,
+};
+use serde_json::json;
+
+#[tokio::test]
+async fn inactive_open_rooms_are_hard_deleted_with_game_chat() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+
+    let room = GameRoom::create_with_chat_room(
+        &client,
+        GameKind::Blackjack,
+        "cleanup-open",
+        "Cleanup Open",
+        json!({}),
+        None,
+    )
+    .await
+    .expect("create game room");
+    client
+        .execute(
+            "UPDATE game_rooms
+             SET updated = current_timestamp - interval '2 hours'
+             WHERE id = $1",
+            &[&room.id],
+        )
+        .await
+        .expect("age game room");
+
+    let deleted = GameRoom::delete_inactive_open(&client, Duration::from_secs(60 * 60))
+        .await
+        .expect("delete inactive open rooms");
+
+    assert_eq!(deleted, 1);
+    assert_game_room_count(&client, room.id, 0).await;
+    assert_chat_room_count(&client, room.chat_room_id, 0).await;
+}
+
+#[tokio::test]
+async fn inactive_in_round_rooms_are_not_deleted() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+
+    let room = GameRoom::create_with_chat_room(
+        &client,
+        GameKind::Tron,
+        "cleanup-active",
+        "Cleanup Active",
+        json!({}),
+        None,
+    )
+    .await
+    .expect("create game room");
+    client
+        .execute(
+            "UPDATE game_rooms
+             SET status = 'in_round',
+                 updated = current_timestamp - interval '2 hours'
+             WHERE id = $1",
+            &[&room.id],
+        )
+        .await
+        .expect("mark active and stale");
+
+    let deleted = GameRoom::delete_inactive_open(&client, Duration::from_secs(60 * 60))
+        .await
+        .expect("delete inactive open rooms");
+
+    assert_eq!(deleted, 0);
+    assert_game_room_count(&client, room.id, 1).await;
+    assert_chat_room_count(&client, room.chat_room_id, 1).await;
+}
+
+#[tokio::test]
+async fn restart_reconciliation_preserves_only_active_chess_rounds() {
+    let test_db = test_db().await;
+    let client = test_db.db.get().await.expect("db client");
+
+    let blackjack = create_in_round_room(
+        &client,
+        GameKind::Blackjack,
+        "reconcile-blackjack",
+        json!({}),
+    )
+    .await;
+    let active_chess = create_in_round_room(
+        &client,
+        GameKind::Chess,
+        "reconcile-active-chess",
+        json!({ "phase": "Active" }),
+    )
+    .await;
+    let finished_chess = create_in_round_room(
+        &client,
+        GameKind::Chess,
+        "reconcile-finished-chess",
+        json!({ "phase": "Finished" }),
+    )
+    .await;
+
+    let reconciled = GameRoom::reconcile_in_round_after_restart(&client)
+        .await
+        .expect("reconcile statuses");
+
+    assert_eq!(reconciled, 2);
+    assert_eq!(room_status(&client, blackjack.id).await, "open");
+    assert_eq!(room_status(&client, active_chess.id).await, "in_round");
+    assert_eq!(room_status(&client, finished_chess.id).await, "open");
+}
+
+async fn create_in_round_room(
+    client: &tokio_postgres::Client,
+    game_kind: GameKind,
+    slug: &str,
+    runtime_state: serde_json::Value,
+) -> GameRoom {
+    let room = GameRoom::create_with_chat_room(client, game_kind, slug, slug, json!({}), None)
+        .await
+        .expect("create game room");
+    client
+        .execute(
+            "UPDATE game_rooms
+             SET status = 'in_round',
+                 runtime_state = $2,
+                 updated = current_timestamp - interval '2 hours'
+             WHERE id = $1",
+            &[&room.id, &runtime_state],
+        )
+        .await
+        .expect("mark in round");
+    room
+}
+
+async fn assert_game_room_count(
+    client: &tokio_postgres::Client,
+    room_id: uuid::Uuid,
+    expected: i64,
+) {
+    let row = client
+        .query_one(
+            "SELECT COUNT(*)::bigint AS count FROM game_rooms WHERE id = $1",
+            &[&room_id],
+        )
+        .await
+        .expect("count game room");
+    assert_eq!(row.get::<_, i64>("count"), expected);
+}
+
+async fn assert_chat_room_count(
+    client: &tokio_postgres::Client,
+    room_id: uuid::Uuid,
+    expected: i64,
+) {
+    let row = client
+        .query_one(
+            "SELECT COUNT(*)::bigint AS count FROM chat_rooms WHERE id = $1",
+            &[&room_id],
+        )
+        .await
+        .expect("count chat room");
+    assert_eq!(row.get::<_, i64>("count"), expected);
+}
+
+async fn room_status(client: &tokio_postgres::Client, room_id: uuid::Uuid) -> String {
+    client
+        .query_one("SELECT status FROM game_rooms WHERE id = $1", &[&room_id])
+        .await
+        .expect("load status")
+        .get("status")
+}

--- a/late-ssh/src/app/door/ui.rs
+++ b/late-ssh/src/app/door/ui.rs
@@ -32,7 +32,7 @@ pub fn draw_door_hub(frame: &mut Frame, area: Rect, view: &DoorHubView<'_>) {
         Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(8),
+                Constraint::Length(9),
                 Constraint::Length(1),
                 Constraint::Min(0),
             ])
@@ -61,17 +61,15 @@ fn draw_header(frame: &mut Frame, area: Rect) {
         r#"     ██████╔╝╚██████╔╝╚██████╔╝██║  ██║███████║"#,
         r#"     ╚═════╝  ╚═════╝  ╚═════╝ ╚═╝  ╚═╝╚══════╝"#,
     ];
-    let mut lines: Vec<Line<'static>> = art
-        .into_iter()
-        .map(|line| {
-            Line::from(Span::styled(
-                line,
-                Style::default()
-                    .fg(theme::AMBER())
-                    .add_modifier(Modifier::BOLD),
-            ))
-        })
-        .collect();
+    let mut lines: Vec<Line<'static>> = vec![Line::from("")];
+    lines.extend(art.into_iter().map(|line| {
+        Line::from(Span::styled(
+            line,
+            Style::default()
+                .fg(theme::AMBER())
+                .add_modifier(Modifier::BOLD),
+        ))
+    }));
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
         "     BBS-style persistent worlds. Browse with j/k, open with Enter.",
@@ -105,6 +103,7 @@ fn draw_game_list(frame: &mut Frame, area: Rect, selection: usize, delete_confir
             name: "Lateania",
             descriptions: &[
                 "Persistent shared adventure world with classes, rooms, combat, loot, and shops.",
+                "by hardlygospel.github.io",
             ],
             selected_style: Style::default()
                 .fg(theme::TEXT_BRIGHT())

--- a/late-ssh/src/app/hub/CONTEXT.md
+++ b/late-ssh/src/app/hub/CONTEXT.md
@@ -3,12 +3,12 @@
 ## Metadata
 - Scope: `late-ssh/src/app/hub`
 - Last updated: 2026-06-04
-- Purpose: local working context for the Hub domain: global modal, leaderboard, quests, admin reward-template editing, shop, Shop-unlocked aquarium, and future event surfaces.
+- Purpose: local working context for the Hub domain: global modal, leaderboard, quests, admin reward-template/shop-item editing, shop, Shop-unlocked aquarium, and future event surfaces.
 - Parent context: `../../../../CONTEXT.md`
 
 ## Scope
 
-`late-ssh/src/app/hub` owns the global Hub modal opened with reserved global `Ctrl+G` (except active Artboard editing) and the cross-product domains surfaced inside it: Shop, Leaderboard, Quests, Events, and the admin-only reward-template editor. Former Guide content now lives in the global `?` guide's Economy topic under `late-ssh/src/app/help_modal/hub_guide.rs`. Hub also owns the Shop-unlocked Aquarium tray toggled globally with `Ctrl+Q`.
+`late-ssh/src/app/hub` owns the global Hub modal opened with reserved global `Ctrl+G` (except active Artboard editing) and the cross-product domains surfaced inside it: Shop, Leaderboard, Quests, Events, and the admin-only reward-template/shop-item editor. Former Guide content now lives in the global `?` guide's Economy topic under `late-ssh/src/app/help_modal/hub_guide.rs`. Hub also owns the Shop-unlocked Aquarium tray toggled globally with `Ctrl+Q`.
 
 Hub is a cross-product domain surface. It may render Arcade, Rooms, economy, marketplace, and event information, but it must not own those runtimes. Arcade game state stays under `late-ssh/src/app/arcade`; Rooms/table runtime stays under `late-ssh/src/app/rooms`; generic chip earn/spend primitives stay in `late-core/src/models/chips.rs`. Hub-owned marketplace state and entitlement projections live under `hub/shop`.
 
@@ -21,9 +21,9 @@ Keep `mod.rs` declaration-only. Do not add `pub use` re-export layers.
 - `ui.rs`: modal frame, tabs, footer, and tab dispatch.
 - `leaderboard.rs`: compact leaderboard panels.
 - `admin/`:
-  - `state.rs`: admin reward-template catalog, editable draft state, async load/save result drain.
-  - `input.rs`: Admin-tab row/category/field navigation, inline text edits, numeric/toggle edits, save/reload actions.
-  - `ui.rs`: admin-only two-pane reward-template editor.
+  - `state.rs`: admin reward-template and shop-item catalogs, editable draft state, cursor-aware inline edit buffer, async load/save result drain.
+  - `input.rs`: Admin-tab row/category/field navigation, inline text edits with Left/Right/Home/End cursor movement, numeric/toggle edits, save/reload actions.
+  - `ui.rs`: admin-only two-pane reward-template/shop-item editor.
 - `dailies.rs`: module root for the Quests surface.
 - `dailies/`:
   - `svc.rs`: `QuestService`, current assignment generation, Activity-driven progress matching, per-user watch snapshots including daily streak state, completion banners, and Postgres LISTEN/NOTIFY refresh listener.
@@ -49,7 +49,7 @@ Keep `mod.rs` declaration-only. Do not add `pub use` re-export layers.
 - `Quests`: functional daily/weekly quest surface.
 - `Shop`: functional marketplace surface. Pet Companion is the durable companion unlock.
 - `Events`: placeholder for seasonal/monthly event surfaces.
-- `Admin`: admin-only reward-template editor for quest titles/descriptions/requirements/rewards/weights/active state and fixed reward payouts.
+- `Admin`: admin-only editor for quest titles/descriptions/requirements/rewards/weights/active state, fixed reward payouts, and Shop item names/descriptions/prices/sort order/active state.
 - Former `Guide`: moved to the global guide's Economy topic.
 
 If another tab is added, update `HubTab::ALL`, `HubTab::PUBLIC` if visibility differs, `HubTab::label`, `input.rs`, `ui.rs` dispatch, footer jump copy, and this file.
@@ -143,6 +143,7 @@ Durable marketplace ownership lives here with the Hub domain context.
 Implemented:
 - `late-core` owns durable data models in `late_core::models::marketplace`.
 - `marketplace_items` defines curated purchasable items; `user_purchases` records durable per-user ownership.
+- The Hub Admin tab can edit existing marketplace item names, descriptions, chip prices, sort order, and active state. It does not add SKUs or edit item kind/slot/payload/start/end windows.
 - Purchases debit `user_chips`, write `chip_ledger` with reason `shop_purchase`, then insert `user_purchases` in one transaction.
 - `ShopService` publishes per-user `ShopSnapshot` values through watch channels. UI/input reads the current snapshot and does not query the DB per keypress/render.
 - `ShopService::start_listener_task` opens a dedicated long-lived Postgres connection (outside the pool) and `LISTEN`s on marketplace channels via `late_core::models::marketplace::listen_for_shop_changes` and the generic chip channel via `late_core::models::chips::listen_for_chip_changes`; all SQL stays in `late-core`. `shop_user_changed` and `chip_user_changed` carry a `user_id` payload and refresh that user's snapshot when active; `shop_catalog_changed` refreshes every active user.
@@ -173,7 +174,7 @@ Future Events work:
 ## Known Gaps
 
 - `Events` is still a placeholder.
-- Hub Admin edits existing reward-template fields only; adding new templates, changing JSON params/kind/cadence, and rerolling current assignments still require direct DB/migration work.
+- Hub Admin edits existing reward-template and marketplace item presentation/economy fields only; adding new quest templates or Shop SKUs, changing JSON params/payload/kind/cadence/slot/windows, and rerolling current assignments still require direct DB/migration work.
 - Shop has implemented categories for Companions, Chat, Aquarium, Badges, Flags, and Ultimates; keep this context in sync when adding another category or changing unlock gates.
 - Leaderboard refresh is polling-based, so Activity events can appear before leaderboard panels catch up. Quest and Shop snapshots refresh on session init, local mutations, and Postgres notifications.
 - There is no paginated detail view yet; compact panels only show top rows plus an around-you tail where implemented.

--- a/late-ssh/src/app/hub/admin/input.rs
+++ b/late-ssh/src/app/hub/admin/input.rs
@@ -21,7 +21,12 @@ pub fn handle_input(app: &mut App, event: &ParsedInput) -> bool {
             ParsedInput::Byte(0x08 | 0x7F) | ParsedInput::CtrlBackspace => {
                 app.hub_admin_state.backspace_edit();
             }
-            ParsedInput::Delete => app.hub_admin_state.clear_edit(),
+            ParsedInput::Delete => app.hub_admin_state.delete_edit(),
+            ParsedInput::CtrlDelete => app.hub_admin_state.clear_edit(),
+            ParsedInput::Arrow(b'C') => app.hub_admin_state.move_edit_cursor(1),
+            ParsedInput::Arrow(b'D') => app.hub_admin_state.move_edit_cursor(-1),
+            ParsedInput::Home => app.hub_admin_state.edit_cursor_home(),
+            ParsedInput::End => app.hub_admin_state.edit_cursor_end(),
             ParsedInput::Char(ch) => app.hub_admin_state.push_edit_char(*ch),
             _ => {}
         }

--- a/late-ssh/src/app/hub/admin/state.rs
+++ b/late-ssh/src/app/hub/admin/state.rs
@@ -1,8 +1,14 @@
-use late_core::models::quest::{RewardTemplateAdminRow, RewardTemplateAdminUpdate};
+use late_core::models::{
+    marketplace::{MarketplaceAdminRow, MarketplaceAdminUpdate},
+    quest::{RewardTemplateAdminRow, RewardTemplateAdminUpdate},
+};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::app::{common::primitives::Banner, hub::dailies::svc::QuestService};
+use crate::app::{
+    common::primitives::Banner,
+    hub::{dailies::svc::QuestService, shop::svc::ShopService},
+};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum AdminCategory {
@@ -10,15 +16,17 @@ pub enum AdminCategory {
     WeeklyQuests,
     PuzzleRewards,
     GameRewards,
+    ShopItems,
     All,
 }
 
 impl AdminCategory {
-    pub const ALL: [Self; 5] = [
+    pub const ALL: [Self; 6] = [
         Self::DailyQuests,
         Self::WeeklyQuests,
         Self::PuzzleRewards,
         Self::GameRewards,
+        Self::ShopItems,
         Self::All,
     ];
 
@@ -28,18 +36,24 @@ impl AdminCategory {
             Self::WeeklyQuests => "Weekly quests",
             Self::PuzzleRewards => "Puzzle rewards",
             Self::GameRewards => "Game rewards",
+            Self::ShopItems => "Shop items",
             Self::All => "All",
         }
     }
 
-    fn matches(self, row: &RewardTemplateAdminRow) -> bool {
+    fn matches_reward(self, row: &RewardTemplateAdminRow) -> bool {
         match self {
             Self::DailyQuests => row.is_quest && row.cadence.as_deref() == Some("daily"),
             Self::WeeklyQuests => row.is_quest && row.cadence.as_deref() == Some("weekly"),
             Self::PuzzleRewards => !row.is_quest && row.domain == "puzzle",
             Self::GameRewards => !row.is_quest && row.domain != "puzzle",
+            Self::ShopItems => false,
             Self::All => true,
         }
+    }
+
+    fn matches_shop(self, _row: &MarketplaceAdminRow) -> bool {
+        matches!(self, Self::ShopItems | Self::All)
     }
 }
 
@@ -54,7 +68,7 @@ pub enum AdminField {
 }
 
 impl AdminField {
-    pub const ALL: [Self; 6] = [
+    const REWARD_FIELDS: [Self; 6] = [
         Self::Title,
         Self::Description,
         Self::Target,
@@ -62,15 +76,25 @@ impl AdminField {
         Self::Weight,
         Self::Active,
     ];
+    const SHOP_FIELDS: [Self; 5] = [
+        Self::Title,
+        Self::Description,
+        Self::Reward,
+        Self::Weight,
+        Self::Active,
+    ];
 
-    pub fn label(self) -> &'static str {
-        match self {
-            Self::Title => "title",
-            Self::Description => "desc",
-            Self::Target => "req",
-            Self::Reward => "reward",
-            Self::Weight => "weight",
-            Self::Active => "active",
+    pub fn label(self, draft_kind: AdminDraftKind) -> &'static str {
+        match (draft_kind, self) {
+            (AdminDraftKind::Shop, Self::Title) => "name",
+            (AdminDraftKind::Shop, Self::Reward) => "price",
+            (AdminDraftKind::Shop, Self::Weight) => "sort",
+            (_, Self::Title) => "title",
+            (_, Self::Description) => "desc",
+            (_, Self::Target) => "req",
+            (_, Self::Reward) => "reward",
+            (_, Self::Weight) => "weight",
+            (_, Self::Active) => "active",
         }
     }
 
@@ -79,8 +103,74 @@ impl AdminField {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AdminDraftKind {
+    Reward,
+    Shop,
+}
+
 #[derive(Clone, Debug)]
-pub struct AdminDraft {
+pub enum AdminEntryRef<'a> {
+    Reward(&'a RewardTemplateAdminRow),
+    Shop(&'a MarketplaceAdminRow),
+}
+
+impl AdminEntryRef<'_> {
+    pub fn title(&self) -> &str {
+        match self {
+            Self::Reward(row) => &row.title,
+            Self::Shop(row) => &row.name,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum AdminDraft {
+    Reward(RewardAdminDraft),
+    Shop(ShopAdminDraft),
+}
+
+impl AdminDraft {
+    fn from_reward(row: &RewardTemplateAdminRow) -> Self {
+        Self::Reward(RewardAdminDraft {
+            id: row.id,
+            title: row.title.clone(),
+            description: row.description.clone(),
+            target: row.target,
+            reward_chips: row.reward_chips,
+            weight: row.weight,
+            active: row.active,
+        })
+    }
+
+    fn from_shop(row: &MarketplaceAdminRow) -> Self {
+        Self::Shop(ShopAdminDraft {
+            id: row.id,
+            name: row.name.clone(),
+            description: row.description.clone(),
+            price_chips: row.price_chips,
+            sort_order: row.sort_order,
+            active: row.active,
+        })
+    }
+
+    pub fn kind(&self) -> AdminDraftKind {
+        match self {
+            Self::Reward(_) => AdminDraftKind::Reward,
+            Self::Shop(_) => AdminDraftKind::Shop,
+        }
+    }
+
+    fn fields(&self) -> &'static [AdminField] {
+        match self {
+            Self::Reward(_) => &AdminField::REWARD_FIELDS,
+            Self::Shop(_) => &AdminField::SHOP_FIELDS,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct RewardAdminDraft {
     pub id: Uuid,
     pub title: String,
     pub description: String,
@@ -90,42 +180,32 @@ pub struct AdminDraft {
     pub active: bool,
 }
 
-impl AdminDraft {
-    fn from_row(row: &RewardTemplateAdminRow) -> Self {
-        Self {
-            id: row.id,
-            title: row.title.clone(),
-            description: row.description.clone(),
-            target: row.target,
-            reward_chips: row.reward_chips,
-            weight: row.weight,
-            active: row.active,
-        }
-    }
-
-    fn update(&self) -> RewardTemplateAdminUpdate {
-        RewardTemplateAdminUpdate {
-            id: self.id,
-            title: self.title.clone(),
-            description: self.description.clone(),
-            target: self.target,
-            reward_chips: self.reward_chips,
-            weight: self.weight,
-            active: self.active,
-        }
-    }
+#[derive(Clone, Debug)]
+pub struct ShopAdminDraft {
+    pub id: Uuid,
+    pub name: String,
+    pub description: String,
+    pub price_chips: i64,
+    pub sort_order: i32,
+    pub active: bool,
 }
 
 #[derive(Clone, Debug)]
 enum AdminAsyncResult {
-    Loaded(Vec<RewardTemplateAdminRow>),
-    Saved(Box<RewardTemplateAdminRow>),
+    Loaded {
+        templates: Vec<RewardTemplateAdminRow>,
+        shop_items: Vec<MarketplaceAdminRow>,
+    },
+    SavedReward(Box<RewardTemplateAdminRow>),
+    SavedShop(Box<MarketplaceAdminRow>),
     Failed(String),
 }
 
 pub struct AdminState {
-    service: QuestService,
+    quest_service: QuestService,
+    shop_service: ShopService,
     templates: Vec<RewardTemplateAdminRow>,
+    shop_items: Vec<MarketplaceAdminRow>,
     category_index: usize,
     selected_index: usize,
     field_index: usize,
@@ -133,6 +213,7 @@ pub struct AdminState {
     dirty: bool,
     editing: bool,
     edit_buffer: String,
+    edit_cursor: usize,
     loading: bool,
     saving: bool,
     loaded_once: bool,
@@ -145,11 +226,13 @@ pub struct AdminTick {
 }
 
 impl AdminState {
-    pub fn new(service: QuestService) -> Self {
+    pub fn new(quest_service: QuestService, shop_service: ShopService) -> Self {
         let (tx, rx) = mpsc::unbounded_channel();
         Self {
-            service,
+            quest_service,
+            shop_service,
             templates: Vec::new(),
+            shop_items: Vec::new(),
             category_index: 0,
             selected_index: 0,
             field_index: 0,
@@ -157,6 +240,7 @@ impl AdminState {
             dirty: false,
             editing: false,
             edit_buffer: String::new(),
+            edit_cursor: 0,
             loading: false,
             saving: false,
             loaded_once: false,
@@ -173,14 +257,18 @@ impl AdminState {
         let mut banner = None;
         while let Ok(result) = self.rx.try_recv() {
             match result {
-                AdminAsyncResult::Loaded(rows) => {
+                AdminAsyncResult::Loaded {
+                    templates,
+                    shop_items,
+                } => {
                     self.loading = false;
                     self.loaded_once = true;
-                    self.templates = rows;
+                    self.templates = templates;
+                    self.shop_items = shop_items;
                     self.clamp_selection();
                     self.sync_draft_to_selected();
                 }
-                AdminAsyncResult::Saved(row) => {
+                AdminAsyncResult::SavedReward(row) => {
                     self.saving = false;
                     if let Some(existing) = self.templates.iter_mut().find(|item| item.id == row.id)
                     {
@@ -189,6 +277,17 @@ impl AdminState {
                     self.sync_draft_to_selected();
                     self.dirty = false;
                     banner = Some(Banner::success("Saved reward template"));
+                }
+                AdminAsyncResult::SavedShop(row) => {
+                    self.saving = false;
+                    if let Some(existing) =
+                        self.shop_items.iter_mut().find(|item| item.id == row.id)
+                    {
+                        *existing = *row;
+                    }
+                    self.sync_draft_to_selected();
+                    self.dirty = false;
+                    banner = Some(Banner::success("Saved shop item"));
                 }
                 AdminAsyncResult::Failed(message) => {
                     self.loading = false;
@@ -205,16 +304,29 @@ impl AdminState {
         &self.templates
     }
 
-    pub fn visible_templates(&self) -> Vec<&RewardTemplateAdminRow> {
-        let category = self.selected_category();
-        self.templates
-            .iter()
-            .filter(|row| category.matches(row))
-            .collect()
+    pub fn shop_items(&self) -> &[MarketplaceAdminRow] {
+        &self.shop_items
     }
 
-    pub fn selected_template(&self) -> Option<&RewardTemplateAdminRow> {
-        self.visible_templates().get(self.selected_index).copied()
+    pub fn visible_entries(&self) -> Vec<AdminEntryRef<'_>> {
+        let category = self.selected_category();
+        let mut rows = self
+            .templates
+            .iter()
+            .filter(|row| category.matches_reward(row))
+            .map(AdminEntryRef::Reward)
+            .collect::<Vec<_>>();
+        rows.extend(
+            self.shop_items
+                .iter()
+                .filter(|row| category.matches_shop(row))
+                .map(AdminEntryRef::Shop),
+        );
+        rows
+    }
+
+    pub fn selected_entry(&self) -> Option<AdminEntryRef<'_>> {
+        self.visible_entries().get(self.selected_index).cloned()
     }
 
     pub fn selected_category(&self) -> AdminCategory {
@@ -230,11 +342,21 @@ impl AdminState {
     }
 
     pub fn selected_field(&self) -> AdminField {
-        AdminField::ALL[self.field_index.min(AdminField::ALL.len() - 1)]
+        self.available_fields()[self
+            .field_index
+            .min(self.available_fields().len().saturating_sub(1))]
     }
 
     pub fn selected_field_index(&self) -> usize {
         self.field_index
+            .min(self.available_fields().len().saturating_sub(1))
+    }
+
+    pub fn available_fields(&self) -> &'static [AdminField] {
+        self.draft
+            .as_ref()
+            .map(AdminDraft::fields)
+            .unwrap_or(&AdminField::REWARD_FIELDS)
     }
 
     pub fn draft(&self) -> Option<&AdminDraft> {
@@ -253,6 +375,10 @@ impl AdminState {
         &self.edit_buffer
     }
 
+    pub fn edit_cursor(&self) -> usize {
+        self.edit_cursor.min(char_count(&self.edit_buffer))
+    }
+
     pub fn is_loading(&self) -> bool {
         self.loading
     }
@@ -265,7 +391,7 @@ impl AdminState {
         if self.editing {
             return;
         }
-        let len = self.visible_templates().len();
+        let len = self.visible_entries().len();
         if len == 0 {
             self.selected_index = 0;
             self.draft = None;
@@ -299,14 +425,15 @@ impl AdminState {
         if self.editing {
             return;
         }
-        self.field_index = (self.field_index + 1) % AdminField::ALL.len();
+        self.field_index = (self.field_index + 1) % self.available_fields().len();
     }
 
     pub fn select_previous_field(&mut self) {
         if self.editing {
             return;
         }
-        self.field_index = (self.field_index + AdminField::ALL.len() - 1) % AdminField::ALL.len();
+        let len = self.available_fields().len();
+        self.field_index = (self.field_index + len - 1) % len;
     }
 
     pub fn begin_edit(&mut self) -> Option<Banner> {
@@ -315,13 +442,19 @@ impl AdminState {
             return self.adjust_or_toggle(1);
         }
         let draft = self.draft.as_ref()?;
-        self.edit_buffer = match field {
-            AdminField::Title => draft.title.clone(),
-            AdminField::Description => draft.description.clone(),
+        self.edit_buffer = match (field, draft) {
+            (AdminField::Title, AdminDraft::Reward(draft)) => draft.title.clone(),
+            (AdminField::Title, AdminDraft::Shop(draft)) => draft.name.clone(),
+            (AdminField::Description, AdminDraft::Reward(draft)) => draft.description.clone(),
+            (AdminField::Description, AdminDraft::Shop(draft)) => draft.description.clone(),
             _ => String::new(),
         };
+        self.edit_cursor = char_count(&self.edit_buffer);
         self.editing = true;
-        Some(Banner::success(&format!("Editing {}", field.label())))
+        Some(Banner::success(&format!(
+            "Editing {}",
+            field.label(draft.kind())
+        )))
     }
 
     pub fn cancel_edit(&mut self) -> Option<Banner> {
@@ -330,6 +463,7 @@ impl AdminState {
         }
         self.editing = false;
         self.edit_buffer.clear();
+        self.edit_cursor = 0;
         Some(Banner::success("Edit cancelled"))
     }
 
@@ -343,55 +477,112 @@ impl AdminState {
         }
         let field = self.selected_field();
         let draft = self.draft.as_mut()?;
-        match field {
-            AdminField::Title => draft.title = value,
-            AdminField::Description => draft.description = value,
+        match (field, draft) {
+            (AdminField::Title, AdminDraft::Reward(draft)) => draft.title = value,
+            (AdminField::Title, AdminDraft::Shop(draft)) => draft.name = value,
+            (AdminField::Description, AdminDraft::Reward(draft)) => draft.description = value,
+            (AdminField::Description, AdminDraft::Shop(draft)) => draft.description = value,
             _ => {}
         }
         self.editing = false;
         self.edit_buffer.clear();
+        self.edit_cursor = 0;
         self.dirty = true;
         Some(Banner::success("Draft updated"))
     }
 
     pub fn push_edit_char(&mut self, ch: char) {
-        if self.editing && !ch.is_control() {
-            self.edit_buffer.push(ch);
+        if !self.editing || ch.is_control() {
+            return;
         }
+        let index = byte_index_for_char(&self.edit_buffer, self.edit_cursor);
+        self.edit_buffer.insert(index, ch);
+        self.edit_cursor += 1;
     }
 
     pub fn backspace_edit(&mut self) {
-        if self.editing {
-            self.edit_buffer.pop();
+        if !self.editing || self.edit_cursor == 0 {
+            return;
         }
+        self.edit_cursor -= 1;
+        let start = byte_index_for_char(&self.edit_buffer, self.edit_cursor);
+        let end = byte_index_for_char(&self.edit_buffer, self.edit_cursor + 1);
+        self.edit_buffer.replace_range(start..end, "");
+    }
+
+    pub fn delete_edit(&mut self) {
+        if !self.editing || self.edit_cursor >= char_count(&self.edit_buffer) {
+            return;
+        }
+        let start = byte_index_for_char(&self.edit_buffer, self.edit_cursor);
+        let end = byte_index_for_char(&self.edit_buffer, self.edit_cursor + 1);
+        self.edit_buffer.replace_range(start..end, "");
     }
 
     pub fn clear_edit(&mut self) {
         if self.editing {
             self.edit_buffer.clear();
+            self.edit_cursor = 0;
+        }
+    }
+
+    pub fn move_edit_cursor(&mut self, delta: isize) {
+        if !self.editing {
+            return;
+        }
+        let len = char_count(&self.edit_buffer) as isize;
+        self.edit_cursor = (self.edit_cursor as isize + delta).clamp(0, len) as usize;
+    }
+
+    pub fn edit_cursor_home(&mut self) {
+        if self.editing {
+            self.edit_cursor = 0;
+        }
+    }
+
+    pub fn edit_cursor_end(&mut self) {
+        if self.editing {
+            self.edit_cursor = char_count(&self.edit_buffer);
         }
     }
 
     pub fn adjust_or_toggle(&mut self, direction: i32) -> Option<Banner> {
         let field = self.selected_field();
         let draft = self.draft.as_mut()?;
-        match field {
-            AdminField::Target => {
-                let step = target_step(draft.target);
-                draft.target = (draft.target + direction.signum() * step).max(1);
-            }
-            AdminField::Reward => {
-                let step = reward_step(draft.reward_chips);
-                draft.reward_chips =
-                    (draft.reward_chips + i64::from(direction.signum()) * step).max(0);
-            }
-            AdminField::Weight => {
-                draft.weight = (draft.weight + direction.signum() * 10).max(1);
-            }
-            AdminField::Active => {
-                draft.active = !draft.active;
-            }
-            AdminField::Title | AdminField::Description => return self.begin_edit(),
+        match draft {
+            AdminDraft::Reward(draft) => match field {
+                AdminField::Target => {
+                    let step = target_step(draft.target);
+                    draft.target = (draft.target + direction.signum() * step).max(1);
+                }
+                AdminField::Reward => {
+                    let step = chip_step(draft.reward_chips);
+                    draft.reward_chips =
+                        (draft.reward_chips + i64::from(direction.signum()) * step).max(0);
+                }
+                AdminField::Weight => {
+                    draft.weight = (draft.weight + direction.signum() * 10).max(1);
+                }
+                AdminField::Active => {
+                    draft.active = !draft.active;
+                }
+                AdminField::Title | AdminField::Description => return self.begin_edit(),
+            },
+            AdminDraft::Shop(draft) => match field {
+                AdminField::Reward => {
+                    let step = chip_step(draft.price_chips);
+                    draft.price_chips =
+                        (draft.price_chips + i64::from(direction.signum()) * step).max(0);
+                }
+                AdminField::Weight => {
+                    draft.sort_order += direction.signum() * 10;
+                }
+                AdminField::Active => {
+                    draft.active = !draft.active;
+                }
+                AdminField::Title | AdminField::Description => return self.begin_edit(),
+                AdminField::Target => {}
+            },
         }
         self.dirty = true;
         Some(Banner::success("Draft updated"))
@@ -402,11 +593,21 @@ impl AdminState {
             return;
         }
         self.loading = true;
-        let service = self.service.clone();
+        let quest_service = self.quest_service.clone();
+        let shop_service = self.shop_service.clone();
         let tx = self.tx.clone();
         tokio::spawn(async move {
-            let result = match service.list_reward_templates_for_admin(true).await {
-                Ok(rows) => AdminAsyncResult::Loaded(rows),
+            let result = async {
+                let templates = quest_service.list_reward_templates_for_admin(true).await?;
+                let shop_items = shop_service.list_marketplace_items_for_admin(true).await?;
+                Ok::<_, anyhow::Error>((templates, shop_items))
+            }
+            .await;
+            let result = match result {
+                Ok((templates, shop_items)) => AdminAsyncResult::Loaded {
+                    templates,
+                    shop_items,
+                },
                 Err(error) => AdminAsyncResult::Failed(format!("Admin load failed: {error:#}")),
             };
             let _ = tx.send(result);
@@ -421,36 +622,82 @@ impl AdminState {
             return Some(Banner::success("Save already in progress"));
         }
         let draft = self.draft.clone()?;
+        let saving_message = match draft.kind() {
+            AdminDraftKind::Reward => "Saving reward template",
+            AdminDraftKind::Shop => "Saving shop item",
+        };
         self.saving = true;
-        let service = self.service.clone();
+        let quest_service = self.quest_service.clone();
+        let shop_service = self.shop_service.clone();
         let tx = self.tx.clone();
         tokio::spawn(async move {
-            let result = match service
-                .update_reward_template_for_admin(true, draft.update())
-                .await
-            {
-                Ok(row) => AdminAsyncResult::Saved(Box::new(row)),
+            let result = match draft {
+                AdminDraft::Reward(draft) => quest_service
+                    .update_reward_template_for_admin(
+                        true,
+                        RewardTemplateAdminUpdate {
+                            id: draft.id,
+                            title: draft.title,
+                            description: draft.description,
+                            target: draft.target,
+                            reward_chips: draft.reward_chips,
+                            weight: draft.weight,
+                            active: draft.active,
+                        },
+                    )
+                    .await
+                    .map(|row| AdminAsyncResult::SavedReward(Box::new(row))),
+                AdminDraft::Shop(draft) => shop_service
+                    .update_marketplace_item_for_admin(
+                        true,
+                        MarketplaceAdminUpdate {
+                            id: draft.id,
+                            name: draft.name,
+                            description: draft.description,
+                            price_chips: draft.price_chips,
+                            active: draft.active,
+                            sort_order: draft.sort_order,
+                        },
+                    )
+                    .await
+                    .map(|row| AdminAsyncResult::SavedShop(Box::new(row))),
+            };
+            let result = match result {
+                Ok(result) => result,
                 Err(error) => AdminAsyncResult::Failed(format!("Admin save failed: {error:#}")),
             };
             let _ = tx.send(result);
         });
-        Some(Banner::success("Saving reward template"))
+        Some(Banner::success(saving_message))
     }
 
     fn clamp_selection(&mut self) {
-        let len = self.visible_templates().len();
+        let len = self.visible_entries().len();
         if len == 0 {
             self.selected_index = 0;
         } else {
             self.selected_index = self.selected_index.min(len - 1);
         }
+        self.clamp_field();
+    }
+
+    fn clamp_field(&mut self) {
+        let len = self.available_fields().len();
+        if len > 0 {
+            self.field_index = self.field_index.min(len - 1);
+        }
     }
 
     fn sync_draft_to_selected(&mut self) {
-        self.draft = self.selected_template().map(AdminDraft::from_row);
+        self.draft = self.selected_entry().map(|entry| match entry {
+            AdminEntryRef::Reward(row) => AdminDraft::from_reward(row),
+            AdminEntryRef::Shop(row) => AdminDraft::from_shop(row),
+        });
+        self.clamp_field();
         self.dirty = false;
         self.editing = false;
         self.edit_buffer.clear();
+        self.edit_cursor = 0;
     }
 }
 
@@ -466,6 +713,18 @@ fn target_step(current: i32) -> i32 {
     }
 }
 
-fn reward_step(current: i64) -> i64 {
+fn chip_step(current: i64) -> i64 {
     if current >= 1_000 { 100 } else { 25 }
+}
+
+fn char_count(value: &str) -> usize {
+    value.chars().count()
+}
+
+fn byte_index_for_char(value: &str, char_index: usize) -> usize {
+    value
+        .char_indices()
+        .map(|(index, _)| index)
+        .nth(char_index)
+        .unwrap_or(value.len())
 }

--- a/late-ssh/src/app/hub/admin/ui.rs
+++ b/late-ssh/src/app/hub/admin/ui.rs
@@ -1,4 +1,3 @@
-use late_core::models::quest::RewardTemplateAdminRow;
 use ratatui::{
     Frame,
     layout::{Constraint, Layout, Rect},
@@ -9,7 +8,9 @@ use ratatui::{
 
 use crate::app::{
     common::theme,
-    hub::admin::state::{AdminCategory, AdminField, AdminState},
+    hub::admin::state::{
+        AdminCategory, AdminDraft, AdminDraftKind, AdminEntryRef, AdminField, AdminState,
+    },
 };
 
 pub fn draw(frame: &mut Frame, area: Rect, state: &AdminState, is_admin: bool) {
@@ -77,7 +78,11 @@ fn draw_status(frame: &mut Frame, area: Rect, state: &AdminState) {
         Paragraph::new(Line::from(vec![
             Span::raw("  "),
             Span::styled(
-                format!("{} templates", state.templates().len()),
+                format!(
+                    "{} rewards  {} shop",
+                    state.templates().len(),
+                    state.shop_items().len()
+                ),
                 Style::default().fg(theme::TEXT_DIM()),
             ),
             Span::raw("  "),
@@ -95,15 +100,12 @@ fn draw_body(frame: &mut Frame, area: Rect, state: &AdminState) {
 }
 
 fn draw_template_list(frame: &mut Frame, area: Rect, state: &AdminState) {
-    let rows = state.visible_templates();
+    let rows = state.visible_entries();
     if rows.is_empty() {
         frame.render_widget(
             Paragraph::new(Line::from(vec![
                 Span::raw("  "),
-                Span::styled(
-                    "no matching templates",
-                    Style::default().fg(theme::TEXT_FAINT()),
-                ),
+                Span::styled("no matching rows", Style::default().fg(theme::TEXT_FAINT())),
             ])),
             area,
         );
@@ -117,41 +119,39 @@ fn draw_template_list(frame: &mut Frame, area: Rect, state: &AdminState) {
         .enumerate()
         .skip(start)
         .take(height)
-        .map(|(index, row)| template_row(index == state.selected_index(), row))
+        .map(|(index, row)| entry_row(index == state.selected_index(), row))
         .collect::<Vec<_>>();
     frame.render_widget(Paragraph::new(lines), area);
 }
 
 fn draw_detail(frame: &mut Frame, area: Rect, state: &AdminState) {
-    let Some(row) = state.selected_template() else {
+    let Some(row) = state.selected_entry() else {
         return;
     };
     let Some(draft) = state.draft() else {
         return;
     };
+    let draft_kind = draft.kind();
 
     let mut lines = vec![
-        section_heading(&row.title),
+        section_heading(row.title()),
         Line::from(vec![
             Span::raw("  key    "),
-            Span::styled(row.key.clone(), Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(entry_key(&row), Style::default().fg(theme::TEXT_DIM())),
         ]),
         Line::from(vec![
             Span::raw("  kind   "),
-            Span::styled(row.kind.clone(), Style::default().fg(theme::TEXT_DIM())),
-            Span::styled(
-                format!("  {}", row.claim_policy),
-                Style::default().fg(theme::TEXT_FAINT()),
-            ),
+            Span::styled(entry_kind(&row), Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(entry_policy(&row), Style::default().fg(theme::TEXT_FAINT())),
         ]),
         Line::from(vec![
             Span::raw("  scope  "),
-            Span::styled(scope_label(row), Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(scope_label(&row), Style::default().fg(theme::TEXT_DIM())),
         ]),
         Line::from(""),
     ];
 
-    for (index, field) in AdminField::ALL.iter().copied().enumerate() {
+    for (index, field) in state.available_fields().iter().copied().enumerate() {
         let selected = index == state.selected_field_index();
         let value = if state.is_editing() && selected {
             state.edit_buffer().to_string()
@@ -160,6 +160,7 @@ fn draw_detail(frame: &mut Frame, area: Rect, state: &AdminState) {
         };
         lines.push(field_line(
             field,
+            draft_kind,
             selected,
             &value,
             state.is_editing() && selected,
@@ -170,11 +171,13 @@ fn draw_detail(frame: &mut Frame, area: Rect, state: &AdminState) {
     lines.push(Line::from(vec![
         Span::raw("  params "),
         Span::styled(
-            row.params.to_string(),
+            entry_payload(&row),
             Style::default().fg(theme::TEXT_FAINT()),
         ),
     ]));
-    if let Some(seconds) = row.cooldown_seconds {
+    if let AdminEntryRef::Reward(row) = row
+        && let Some(seconds) = row.cooldown_seconds
+    {
         lines.push(Line::from(vec![
             Span::raw("  cd     "),
             Span::styled(
@@ -185,6 +188,7 @@ fn draw_detail(frame: &mut Frame, area: Rect, state: &AdminState) {
     }
 
     frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: true }), area);
+    draw_edit_cursor(frame, area, state);
 }
 
 fn draw_footer(frame: &mut Frame, area: Rect, state: &AdminState) {
@@ -197,8 +201,12 @@ fn draw_footer(frame: &mut Frame, area: Rect, state: &AdminState) {
             Span::styled(" accept  ", text),
             Span::styled("Esc", key),
             Span::styled(" cancel  ", text),
+            Span::styled("<-/->", key),
+            Span::styled(" cursor  ", text),
             Span::styled("Backspace", key),
-            Span::styled(" delete", text),
+            Span::styled(" delete  ", text),
+            Span::styled("Del", key),
+            Span::styled(" delete right", text),
         ]
     } else {
         vec![
@@ -222,9 +230,13 @@ fn draw_footer(frame: &mut Frame, area: Rect, state: &AdminState) {
     frame.render_widget(Paragraph::new(Line::from(spans)), area);
 }
 
-fn template_row(selected: bool, row: &RewardTemplateAdminRow) -> Line<'static> {
+fn entry_row(selected: bool, row: &AdminEntryRef<'_>) -> Line<'static> {
     let marker = if selected { ">" } else { " " };
-    let status = if row.active { "on " } else { "off" };
+    let status = if entry_active(row) { "on " } else { "off" };
+    let suffix = match row {
+        AdminEntryRef::Reward(row) => format!("  {}  {}c", status, row.reward_chips),
+        AdminEntryRef::Shop(row) => format!("  {}  {}c", status, row.price_chips),
+    };
     let style = if selected {
         Style::default()
             .fg(theme::AMBER_GLOW())
@@ -234,15 +246,18 @@ fn template_row(selected: bool, row: &RewardTemplateAdminRow) -> Line<'static> {
     };
     Line::from(vec![
         Span::styled(format!("{marker} "), style),
-        Span::styled(truncate(&row.title, 28), style),
-        Span::styled(
-            format!("  {}  {}c", status, row.reward_chips),
-            Style::default().fg(theme::TEXT_FAINT()),
-        ),
+        Span::styled(truncate(row.title(), 28), style),
+        Span::styled(suffix, Style::default().fg(theme::TEXT_FAINT())),
     ])
 }
 
-fn field_line(field: AdminField, selected: bool, value: &str, editing: bool) -> Line<'static> {
+fn field_line(
+    field: AdminField,
+    draft_kind: AdminDraftKind,
+    selected: bool,
+    value: &str,
+    editing: bool,
+) -> Line<'static> {
     let label_style = if selected {
         Style::default()
             .fg(theme::AMBER_GLOW())
@@ -261,37 +276,115 @@ fn field_line(field: AdminField, selected: bool, value: &str, editing: bool) -> 
     };
     Line::from(vec![
         Span::raw(if selected { "> " } else { "  " }),
-        Span::styled(format!("{:<7}", field.label()), label_style),
+        Span::styled(format!("{:<7}", field.label(draft_kind)), label_style),
         Span::styled(truncate(value, 80), value_style),
     ])
 }
 
-fn field_value(field: AdminField, draft: &crate::app::hub::admin::state::AdminDraft) -> String {
-    match field {
-        AdminField::Title => draft.title.clone(),
-        AdminField::Description => draft.description.clone(),
-        AdminField::Target => draft.target.to_string(),
-        AdminField::Reward => format!("{} chips", draft.reward_chips),
-        AdminField::Weight => draft.weight.to_string(),
-        AdminField::Active => {
-            if draft.active {
-                "true".to_string()
-            } else {
-                "false".to_string()
-            }
+fn field_value(field: AdminField, draft: &AdminDraft) -> String {
+    match draft {
+        AdminDraft::Reward(draft) => match field {
+            AdminField::Title => draft.title.clone(),
+            AdminField::Description => draft.description.clone(),
+            AdminField::Target => draft.target.to_string(),
+            AdminField::Reward => format!("{} chips", draft.reward_chips),
+            AdminField::Weight => draft.weight.to_string(),
+            AdminField::Active => bool_label(draft.active),
+        },
+        AdminDraft::Shop(draft) => match field {
+            AdminField::Title => draft.name.clone(),
+            AdminField::Description => draft.description.clone(),
+            AdminField::Target => String::new(),
+            AdminField::Reward => format!("{} chips", draft.price_chips),
+            AdminField::Weight => draft.sort_order.to_string(),
+            AdminField::Active => bool_label(draft.active),
+        },
+    }
+}
+
+fn scope_label(row: &AdminEntryRef<'_>) -> String {
+    match row {
+        AdminEntryRef::Reward(row) => {
+            let quest = if row.is_quest { "quest" } else { "reward" };
+            let cadence = row.cadence.as_deref().unwrap_or("-");
+            let bucket = row.bucket.as_deref().unwrap_or("-");
+            let difficulty = row.difficulty.as_deref().unwrap_or("-");
+            format!(
+                "{quest} / {cadence} / {} / {bucket} / {difficulty}",
+                row.domain
+            )
+        }
+        AdminEntryRef::Shop(row) => {
+            let slot = row.slot.as_deref().unwrap_or("-");
+            format!("shop / {} / slot {slot}", row.item_kind)
         }
     }
 }
 
-fn scope_label(row: &RewardTemplateAdminRow) -> String {
-    let quest = if row.is_quest { "quest" } else { "reward" };
-    let cadence = row.cadence.as_deref().unwrap_or("-");
-    let bucket = row.bucket.as_deref().unwrap_or("-");
-    let difficulty = row.difficulty.as_deref().unwrap_or("-");
-    format!(
-        "{quest} / {cadence} / {} / {bucket} / {difficulty}",
-        row.domain
-    )
+fn entry_key(row: &AdminEntryRef<'_>) -> String {
+    match row {
+        AdminEntryRef::Reward(row) => row.key.clone(),
+        AdminEntryRef::Shop(row) => row.sku.clone(),
+    }
+}
+
+fn entry_kind(row: &AdminEntryRef<'_>) -> String {
+    match row {
+        AdminEntryRef::Reward(row) => row.kind.clone(),
+        AdminEntryRef::Shop(row) => row.item_kind.clone(),
+    }
+}
+
+fn entry_policy(row: &AdminEntryRef<'_>) -> String {
+    match row {
+        AdminEntryRef::Reward(row) => format!("  {}", row.claim_policy),
+        AdminEntryRef::Shop(row) => row
+            .slot
+            .as_ref()
+            .map(|slot| format!("  {slot}"))
+            .unwrap_or_default(),
+    }
+}
+
+fn entry_payload(row: &AdminEntryRef<'_>) -> String {
+    match row {
+        AdminEntryRef::Reward(row) => row.params.to_string(),
+        AdminEntryRef::Shop(row) => row.payload.to_string(),
+    }
+}
+
+fn entry_active(row: &AdminEntryRef<'_>) -> bool {
+    match row {
+        AdminEntryRef::Reward(row) => row.active,
+        AdminEntryRef::Shop(row) => row.active,
+    }
+}
+
+fn bool_label(value: bool) -> String {
+    if value {
+        "true".to_string()
+    } else {
+        "false".to_string()
+    }
+}
+
+fn draw_edit_cursor(frame: &mut Frame, area: Rect, state: &AdminState) {
+    if !state.is_editing() {
+        return;
+    }
+    let y = area
+        .y
+        .saturating_add(5 + state.selected_field_index() as u16);
+    if y >= area.y.saturating_add(area.height) {
+        return;
+    }
+    let cursor = state.edit_cursor().min(80) as u16;
+    let x = area
+        .x
+        .saturating_add(9)
+        .saturating_add(cursor)
+        .min(area.x.saturating_add(area.width.saturating_sub(1)));
+    frame.set_cursor_position((x, y));
 }
 
 fn section_heading(label: &str) -> Line<'static> {

--- a/late-ssh/src/app/hub/shop/svc.rs
+++ b/late-ssh/src/app/hub/shop/svc.rs
@@ -18,7 +18,8 @@ use late_core::{
             PurchaseStatus, SHOP_CATALOG_CHANGED_CHANNEL, SHOP_USER_CHANGED_CHANNEL,
             ULTIMATE_SPELL_KIND, UserPurchase, adjust_aquarium_fish_active_by_sku,
             aquarium_is_hungry, consume_aquarium_food_pinch, equip_owned_item_by_sku,
-            listen_for_shop_changes, purchase_item_by_sku_with_chat_effect, unequip_slot,
+            list_marketplace_items_for_admin, listen_for_shop_changes,
+            purchase_item_by_sku_with_chat_effect, unequip_slot, update_marketplace_item_for_admin,
         },
         shop_consumable_effect::ShopConsumableEffect,
     },
@@ -265,6 +266,28 @@ impl ShopService {
                 }
             }
         });
+    }
+
+    pub async fn list_marketplace_items_for_admin(
+        &self,
+        is_admin: bool,
+    ) -> Result<Vec<late_core::models::marketplace::MarketplaceAdminRow>> {
+        anyhow::ensure!(is_admin, "admin access required");
+        let client = self.db.get().await?;
+        list_marketplace_items_for_admin(&client).await
+    }
+
+    pub async fn update_marketplace_item_for_admin(
+        &self,
+        is_admin: bool,
+        update: late_core::models::marketplace::MarketplaceAdminUpdate,
+    ) -> Result<late_core::models::marketplace::MarketplaceAdminRow> {
+        anyhow::ensure!(is_admin, "admin access required");
+        let client = self.db.get().await?;
+        let row = update_marketplace_item_for_admin(&client, update).await?;
+        drop(client);
+        self.refresh_catalog_for_active_users().await?;
+        Ok(row)
     }
 
     pub fn use_aquarium_food_task(&self, user_id: Uuid) {

--- a/late-ssh/src/app/pet/ui.rs
+++ b/late-ssh/src/app/pet/ui.rs
@@ -48,22 +48,12 @@ pub fn draw_cat_inline(frame: &mut Frame, area: Rect, state: &PetState) {
         } else {
             "cat strolling"
         };
-        vec![
-            Line::from(Span::styled(
-                format!("{pad}{ears}{}", tail[0]),
-                Style::default().fg(color),
-            )),
-            Line::from(Span::styled(
-                label,
-                Style::default()
-                    .fg(theme::AMBER_GLOW())
-                    .add_modifier(Modifier::BOLD),
-            )),
-            Line::from(Span::styled(
-                format!("{pad}{mouth_row}"),
-                Style::default().fg(color),
-            )),
-        ]
+        vec![Line::from(Span::styled(
+            label,
+            Style::default()
+                .fg(theme::AMBER_GLOW())
+                .add_modifier(Modifier::BOLD),
+        ))]
     } else {
         vec![
             Line::from(Span::styled(

--- a/late-ssh/src/app/rooms/CONTEXT.md
+++ b/late-ssh/src/app/rooms/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Scope: `late-ssh/src/app/rooms`
-- Last updated: 2026-05-28
+- Last updated: 2026-06-06
 - Purpose: local working context for the persistent game-room directory and trait-backed room game runtimes.
 
 ## Source Map
@@ -47,15 +47,17 @@
 - Global user-action activity lives outside Rooms in `late-ssh/src/app/activity`. The room `touch_activity` methods below are inactivity timers only. Asterion, Blackjack, Chess, Poker, Tic-Tac-Toe, and Tron win outcomes publish structured `ActivityEvent::game_won(...)` values through `ActivityPublisher`; add future room-game challenge signals there instead of overloading room touch state.
 
 ## Persistence Model
-- `late_core::models::game_room::GameKind` is a Rust enum over text. It currently has `Asterion`, `Blackjack`, `Chess`, `Poker`, `TicTacToe`, and `Tron`.
+- `late_core::models::game_room::GameKind` is a Rust enum over text. It currently has `Asterion`, `Blackjack`, `Chess`, `Poker`, `Sshattrick`, `TicTacToe`, and `Tron`.
 - A game room persists in `game_rooms`; its chat pane is backed by a unique `chat_room_id` pointing at `chat_rooms(kind='game', visibility='public', auto_join=false, game_kind, slug)`.
 - `GameRoom::create_with_chat_room` creates the chat room and game room in one SQL CTE. `RoomsService::create_game_room` then joins the fixed dealer user to that game chat.
 - `RoomsService` publishes `RoomsSnapshot { rooms: Vec<RoomListItem> }` through `watch` and transient `RoomsEvent` values through `broadcast`.
-- `late-ssh/src/main.rs` calls `rooms_service.refresh_task()` at startup before the hourly inactive-table cleanup loop is started.
+- `late-ssh/src/main.rs` calls `rooms_service.reconcile_round_statuses_task()` and `rooms_service.refresh_task()` at startup before the hourly inactive-table cleanup loop is started.
 - Room creation is capped at 10 non-closed tables per creator per game kind.
-- `RoomsService::cleanup_inactive_tables_task` runs hourly and marks tables `closed` after 24h without a `game_rooms.updated` touch.
-- Entering any real room calls `RoomsService::touch_room_task(room.id)`.
-- Deleting a room is a soft close through `GameRoom::close_by_id`; closed rows disappear because snapshots use `GameRoom::list_open`.
+- `RoomsService::cleanup_inactive_tables_task` runs hourly and hard-deletes `open` tables after 1h without a `game_rooms.updated` touch. The hard delete removes the associated `chat_rooms(kind='game')` row, so existing FK cascades remove game chat membership/messages/reactions/notifications and the `game_rooms` row.
+- Active rounds/matches set `game_rooms.status = 'in_round'`; cleanup never deletes `in_round` rows. When the round/match ends, the game sets status back to `open`, updating `game_rooms.updated` and giving the room a fresh 1h idle window.
+- Startup reconciliation resets stale `in_round` rows to `open` for non-durable room games because their runtime state is lost on process restart. Chess is the durable exception: `in_round` is preserved only when `game_rooms.runtime_state.phase == "Active"`; finished/non-active Chess rows reset to `open`.
+- Entering any real room calls `RoomsService::touch_room_task(room.id)`. Active-room keyboard, arrow, scroll, and in-game mouse input also touch the room through a 60s per-session throttle, so the 1h idle window reflects ongoing room use without writing on every keypress.
+- Admin deletion is also a hard delete through `GameRoom::delete_by_id`.
 
 ## Directory Behavior
 - The Rooms screen is key `3`.
@@ -114,7 +116,7 @@
 - The service uses one public `watch::Sender<AsterionPublicSnapshot>` plus per-user `watch::Sender<AsterionPrivateSnapshot>` channels keyed by `user_id`. Public snapshots expose room occupancy. Private snapshots expose only the current user's maze view, position/progression, radar, power-up stats, win/death state, and daily prize claim state.
 - Playable maze levels are 0 through 6. The sidebar presents progress as 1/7 through 7/7; stepping through the exit from maze 6 sets core `HeroState::Victory`.
 - Escaping publishes `ActivityGame::Asterion`. The first escape per UTC day atomically records `game_payout_claims` with `game=asterion`, `payout_kind=escape`, `period_kind=utc_day`, credits 4000 chips, writes `chip_ledger`, and notifies `chip_user_changed`. Later escapes that day still publish activity but do not credit chips.
-- Runtime update/render tasks are per Asterion service. They stop after the service has been empty for 5 minutes, and the manager prunes stopped services from its table map. The persistent `game_rooms` row remains open until the existing 24h inactive-room cleanup closes it.
+- Runtime update/render tasks are per Asterion service. They stop after the service has been empty for 5 minutes, and the manager prunes stopped services from its table map. Asterion marks the room `in_round` while at least one hero is present and returns it to `open` after the final hero leaves; the persistent row is then eligible for the 1h hard-delete cleanup.
 - Active-room input refreshes `game_rooms.updated` through the normal room touch path, throttled to at most once per minute. Service update/render ticks never count as persistent room activity.
 - Movement uses arrows or `w`/`a`/`s`/`d`; `h`/`l` remain accepted as legacy west/east aliases. When an embedded-chat message is selected, `d` still routes to chat delete before game input. `j/k` remain embedded-chat navigation. `,` and `.` rotate the hero's facing direction.
 - Power-ups are passive pink map cells. Walking onto one auto-applies a random available upgrade: Speed lowers movement delay, Vision widens the view, and Memory keeps previously seen tiles visible longer.
@@ -167,7 +169,7 @@
 - Chess uses `cozy-chess` for legal move generation and game status. The service stores only public state; no private snapshot channel is needed.
 - Chess UI seat labels must distinguish `None` seats from occupied seats whose username is absent from the shared username directory: empty seats render as `open seat`, while occupied-but-unresolved seats render as `player`.
 - Chess move records store Standard Algebraic Notation labels (`Nc3`, `exd5`, `O-O`) for the right-sidebar move list and status-line last move, not raw coordinate notation.
-- Chess sit, leave, ready/start, resign, accepted move, and timeout actions persist a chess-owned JSON payload into `game_rooms.runtime_state`; that write also refreshes `game_rooms.updated`. The payload stores seats, ready flags, phase/result, FEN, clocks/deadlines, SAN move history, position history for repetition checks, and a monotonic revision so older async saves cannot overwrite newer ones. Chess is currently the only room game using `runtime_state`; other games still treat it as opaque.
+- Chess sit, leave, ready/start, resign, accepted move, and timeout actions persist a chess-owned JSON payload into `game_rooms.runtime_state`; that write also refreshes `game_rooms.updated`. The payload stores seats, ready flags, phase/result, FEN, clocks/deadlines, SAN move history, position history for repetition checks, and a monotonic revision so older async saves cannot overwrite newer ones. Chess is currently the only room game using `runtime_state`; other games still treat it as opaque. Active Chess games set `game_rooms.status = 'in_round'` and are protected from idle deletion until checkmate, timeout, resignation, or draw returns status to `open`.
 - Time controls are preset-only and intentionally generous: blitz is `5+3`, rapid is `15+10`, and daily is `1d/move`. Room settings store only `blitz`, `rapid`, or `daily`; old seven-preset IDs fall back to rapid. Countdown clocks debit elapsed time idempotently as clock state is settled and add increment after a legal move. Daily clocks use a per-move deadline instead of a banked player clock.
 - When a new game starts after a finished round, the service swaps the two seated players so colours alternate. A decisive Chess win (checkmate, timeout, or resignation) credits the winner 500 chips when the user is outside the 60-minute DB-backed Chess payout cooldown; drawn games do not award chips.
 - Input is cursor-first. Seated players move the local cursor with `w/a/s/d` or arrows, click a board square, or press `Space`/`Enter` to select a piece and then a destination; promotion defaults to queen. `r` resigns an active game; `l` leaves only before/after a game.
@@ -230,7 +232,7 @@
 - Blackjack has three runtime timers. The first confirmed bet starts a fixed 30s betting/deal cap; the cap does not restart for later bets and deals immediately if all seated players lock. Player action starts a pace-specific action timer (`Quick` 2m, `Standard` 5m, `Chill` 10m) that auto-stands unresolved hands on expiry and removes those missed-action seats after settlement. Seated player inactivity is a separate 5m active-room idle timer; active-room input refreshes it, idle players leave immediately when safe or after settlement when a live bet blocks immediate removal.
 - Poker has two timer types plus a missed-action policy. The per-turn action timer starts whenever `active_seat` is assigned in an action phase and restarts when action moves; the service publishes the deadline and clients render the visible countdown locally instead of receiving per-second service snapshots. On expiry it auto-checks when nothing is owed, otherwise auto-folds. A player who misses 3 turn timers is marked to leave at the nearest safe hand boundary, so one seated player cannot repeatedly consume the full turn clock. The existing 5m seat idle timer remains broader AFK cleanup: idle players leave outside active hands, and during active hands they fold and leave after the hand.
 - Tic-Tac-Toe has no service-side turn clock or AFK seat timer. A seated player can keep a seat until they leave, the opponent leaves/resets, or the process restarts; future timeout work should be added explicitly instead of assuming Blackjack/Poker timers apply.
-- Chess has two clock modes plus the general seated idle timer. Blitz/rapid use countdown clocks that update from monotonic elapsed time on moves; daily uses the active side's per-move deadline. Seated idle cleanup applies only outside active games so a daily game is governed by its move deadline, not the broad room-input idle timer.
+- Chess has two clock modes. Blitz/rapid use countdown clocks that update from monotonic elapsed time on moves; daily uses the active side's per-move deadline. There is no broad Chess seated idle cleanup while a game is active; active Chess is protected by `in_round`, and after the game ends the room returns to `open` for the normal 1h idle hard-delete window.
 - Tron has a service-side round tick loop and a 5m seated idle timer. Idle seated riders are removed outside a round and crash during a running round, which can immediately settle the round.
 
 ## Known Gaps

--- a/late-ssh/src/app/rooms/CONTEXT.md
+++ b/late-ssh/src/app/rooms/CONTEXT.md
@@ -53,6 +53,7 @@
 - `RoomsService` publishes `RoomsSnapshot { rooms: Vec<RoomListItem> }` through `watch` and transient `RoomsEvent` values through `broadcast`.
 - `late-ssh/src/main.rs` calls `rooms_service.reconcile_round_statuses_task()` and `rooms_service.refresh_task()` at startup before the hourly inactive-table cleanup loop is started.
 - Room creation is capped at 10 non-closed tables per creator per game kind.
+- Every room-game service requires `RoomsService`; game backends use it to persist room status transitions, runtime state, and room activity needed by cleanup.
 - `RoomsService::cleanup_inactive_tables_task` runs hourly and hard-deletes `open` tables after 1h without a `game_rooms.updated` touch. The hard delete removes the associated `chat_rooms(kind='game')` row, so existing FK cascades remove game chat membership/messages/reactions/notifications and the `game_rooms` row.
 - Active rounds/matches set `game_rooms.status = 'in_round'`; cleanup never deletes `in_round` rows. When the round/match ends, the game sets status back to `open`, updating `game_rooms.updated` and giving the room a fresh 1h idle window.
 - Startup reconciliation resets stale `in_round` rows to `open` for non-durable room games because their runtime state is lost on process restart. Chess is the durable exception: `in_round` is preserved only when `game_rooms.runtime_state.phase == "Active"`; finished/non-active Chess rows reset to `open`.

--- a/late-ssh/src/app/rooms/asterion/svc.rs
+++ b/late-ssh/src/app/rooms/asterion/svc.rs
@@ -447,15 +447,11 @@ impl AsterionService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
-        if previous == in_round {
-            return;
-        }
-        if in_round {
-            self.rooms_service.set_room_in_round_task(self.room_id);
-        } else {
-            self.rooms_service.set_room_open_task(self.room_id);
-        }
+        self.rooms_service.sync_room_status_task(
+            self.room_id,
+            self.room_in_round.clone(),
+            in_round,
+        );
     }
 
     fn publish_rejected(&self, user_id: Uuid) {

--- a/late-ssh/src/app/rooms/asterion/svc.rs
+++ b/late-ssh/src/app/rooms/asterion/svc.rs
@@ -35,6 +35,7 @@ pub struct AsterionService {
     private: Arc<StdMutex<HashMap<Uuid, watch::Sender<AsterionPrivateSnapshot>>>>,
     state: Arc<Mutex<SharedState>>,
     lifecycle: Arc<AsterionLifecycle>,
+    room_in_round: Arc<AtomicBool>,
     chip_svc: ChipService,
     rooms_service: RoomsService,
     activity: ActivityPublisher,
@@ -209,6 +210,7 @@ impl AsterionService {
             private: Arc::new(StdMutex::new(HashMap::new())),
             state: Arc::new(Mutex::new(state)),
             lifecycle: Arc::new(AsterionLifecycle::new()),
+            room_in_round: Arc::new(AtomicBool::new(false)),
             chip_svc,
             rooms_service,
             activity,
@@ -441,6 +443,19 @@ impl AsterionService {
 
     fn publish_public(&self, state: &SharedState) {
         diff_set(&self.public_tx, state.public_snapshot());
+        self.sync_room_status(state.round_active());
+    }
+
+    fn sync_room_status(&self, in_round: bool) {
+        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
+        if previous == in_round {
+            return;
+        }
+        if in_round {
+            self.rooms_service.set_room_in_round_task(self.room_id);
+        } else {
+            self.rooms_service.set_room_open_task(self.room_id);
+        }
     }
 
     fn publish_rejected(&self, user_id: Uuid) {
@@ -566,6 +581,10 @@ impl SharedState {
 
     fn hero_count(&self) -> usize {
         self.players.len()
+    }
+
+    fn round_active(&self) -> bool {
+        self.hero_count() > 0
     }
 
     fn should_stop(&self, now: Instant, ttl: Duration) -> bool {

--- a/late-ssh/src/app/rooms/blackjack/manager.rs
+++ b/late-ssh/src/app/rooms/blackjack/manager.rs
@@ -22,7 +22,7 @@ use crate::app::{
             state::{BlackjackSnapshot, Phase, State},
             svc::{BlackjackEvent, BlackjackService},
         },
-        svc::{GameKind, RoomListItem},
+        svc::{GameKind, RoomListItem, RoomsService},
     },
 };
 
@@ -31,6 +31,7 @@ pub struct BlackjackTableManager {
     chip_svc: ChipService,
     player_directory: BlackjackPlayerDirectory,
     activity: ActivityPublisher,
+    rooms_service: RoomsService,
     tables: Arc<Mutex<HashMap<Uuid, BlackjackService>>>,
     event_tx: broadcast::Sender<BlackjackEvent>,
     room_event_tx: broadcast::Sender<RoomGameEvent>,
@@ -41,6 +42,7 @@ impl BlackjackTableManager {
         chip_svc: ChipService,
         player_directory: BlackjackPlayerDirectory,
         activity: ActivityPublisher,
+        rooms_service: RoomsService,
     ) -> Self {
         let (event_tx, _) = broadcast::channel::<BlackjackEvent>(256);
         let (room_event_tx, _) = broadcast::channel::<RoomGameEvent>(256);
@@ -48,6 +50,7 @@ impl BlackjackTableManager {
             chip_svc,
             player_directory,
             activity,
+            rooms_service,
             tables: Arc::new(Mutex::new(HashMap::new())),
             event_tx,
             room_event_tx,
@@ -76,6 +79,7 @@ impl BlackjackTableManager {
                     event_tx,
                     self.activity.clone(),
                     settings,
+                    Some(self.rooms_service.clone()),
                 )
             })
             .clone()

--- a/late-ssh/src/app/rooms/blackjack/manager.rs
+++ b/late-ssh/src/app/rooms/blackjack/manager.rs
@@ -79,7 +79,7 @@ impl BlackjackTableManager {
                     event_tx,
                     self.activity.clone(),
                     settings,
-                    Some(self.rooms_service.clone()),
+                    self.rooms_service.clone(),
                 )
             })
             .clone()

--- a/late-ssh/src/app/rooms/blackjack/svc.rs
+++ b/late-ssh/src/app/rooms/blackjack/svc.rs
@@ -1,8 +1,5 @@
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 
@@ -1097,18 +1094,10 @@ impl BlackjackService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
-        if previous == in_round {
-            return;
-        }
         let Some(rooms_service) = &self.rooms_service else {
             return;
         };
-        if in_round {
-            rooms_service.set_room_in_round_task(self.room_id);
-        } else {
-            rooms_service.set_room_open_task(self.room_id);
-        }
+        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 }
 

--- a/late-ssh/src/app/rooms/blackjack/svc.rs
+++ b/late-ssh/src/app/rooms/blackjack/svc.rs
@@ -37,7 +37,7 @@ pub struct BlackjackService {
     snapshot_rx: watch::Receiver<BlackjackSnapshot>,
     event_tx: broadcast::Sender<BlackjackEvent>,
     activity: ActivityPublisher,
-    rooms_service: Option<RoomsService>,
+    rooms_service: RoomsService,
     room_in_round: Arc<AtomicBool>,
     table: Arc<Mutex<SharedTableState>>,
 }
@@ -200,6 +200,7 @@ impl BlackjackService {
         player_directory: BlackjackPlayerDirectory,
         event_tx: broadcast::Sender<BlackjackEvent>,
         activity: ActivityPublisher,
+        rooms_service: RoomsService,
     ) -> Self {
         Self::new_with_settings(
             room_id,
@@ -208,7 +209,7 @@ impl BlackjackService {
             event_tx,
             activity,
             BlackjackTableSettings::default(),
-            None,
+            rooms_service,
         )
     }
 
@@ -219,7 +220,7 @@ impl BlackjackService {
         event_tx: broadcast::Sender<BlackjackEvent>,
         activity: ActivityPublisher,
         settings: BlackjackTableSettings,
-        rooms_service: Option<RoomsService>,
+        rooms_service: RoomsService,
     ) -> Self {
         let table = SharedTableState::new(settings);
         let initial_snapshot = table.snapshot();
@@ -1094,10 +1095,8 @@ impl BlackjackService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let Some(rooms_service) = &self.rooms_service else {
-            return;
-        };
-        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
+        self.rooms_service
+            .sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 }
 

--- a/late-ssh/src/app/rooms/blackjack/svc.rs
+++ b/late-ssh/src/app/rooms/blackjack/svc.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -9,14 +12,17 @@ use uuid::Uuid;
 use crate::app::{
     activity::{event::ActivityGame, publisher::ActivityPublisher},
     games::{cards::PlayingCard, chips::svc::ChipService},
-    rooms::blackjack::{
-        player::{BlackjackPlayerDirectory, BlackjackPlayerInfo},
-        settings::BlackjackTableSettings,
-        state::{
-            Bet, BlackjackSeat, BlackjackSnapshot, MAX_SEATS, Outcome, Phase,
-            SETTLEMENT_MIN_VIEW_MS, SeatAction, SeatPhase, Shoe, can_double, dealer_must_hit,
-            is_bust, is_natural_blackjack, payout_credit, score, settle,
+    rooms::{
+        blackjack::{
+            player::{BlackjackPlayerDirectory, BlackjackPlayerInfo},
+            settings::BlackjackTableSettings,
+            state::{
+                Bet, BlackjackSeat, BlackjackSnapshot, MAX_SEATS, Outcome, Phase,
+                SETTLEMENT_MIN_VIEW_MS, SeatAction, SeatPhase, Shoe, can_double, dealer_must_hit,
+                is_bust, is_natural_blackjack, payout_credit, score, settle,
+            },
         },
+        svc::RoomsService,
     },
 };
 
@@ -34,6 +40,8 @@ pub struct BlackjackService {
     snapshot_rx: watch::Receiver<BlackjackSnapshot>,
     event_tx: broadcast::Sender<BlackjackEvent>,
     activity: ActivityPublisher,
+    rooms_service: Option<RoomsService>,
+    room_in_round: Arc<AtomicBool>,
     table: Arc<Mutex<SharedTableState>>,
 }
 
@@ -203,6 +211,7 @@ impl BlackjackService {
             event_tx,
             activity,
             BlackjackTableSettings::default(),
+            None,
         )
     }
 
@@ -213,6 +222,7 @@ impl BlackjackService {
         event_tx: broadcast::Sender<BlackjackEvent>,
         activity: ActivityPublisher,
         settings: BlackjackTableSettings,
+        rooms_service: Option<RoomsService>,
     ) -> Self {
         let table = SharedTableState::new(settings);
         let initial_snapshot = table.snapshot();
@@ -225,6 +235,8 @@ impl BlackjackService {
             snapshot_rx,
             event_tx,
             activity,
+            rooms_service,
+            room_in_round: Arc::new(AtomicBool::new(false)),
             table: Arc::new(Mutex::new(table)),
         }
     }
@@ -1081,6 +1093,22 @@ impl BlackjackService {
 
     fn publish_snapshot_locked(&self, table: &SharedTableState) {
         let _ = self.snapshot_tx.send(table.snapshot());
+        self.sync_room_status(table.round_active());
+    }
+
+    fn sync_room_status(&self, in_round: bool) {
+        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
+        if previous == in_round {
+            return;
+        }
+        let Some(rooms_service) = &self.rooms_service else {
+            return;
+        };
+        if in_round {
+            rooms_service.set_room_in_round_task(self.room_id);
+        } else {
+            rooms_service.set_room_open_task(self.room_id);
+        }
     }
 }
 
@@ -1388,6 +1416,17 @@ impl SharedTableState {
         self.phase == Phase::PlayerTurn
             && self.action_deadline.is_some()
             && self.action_countdown_id == countdown_id
+    }
+
+    fn round_active(&self) -> bool {
+        match self.phase {
+            Phase::Betting => self
+                .seats
+                .iter()
+                .any(|seat| seat.bet.is_some() || seat.pending_bet.is_some()),
+            Phase::BetPending | Phase::PlayerTurn | Phase::DealerTurn => true,
+            Phase::Settling => false,
+        }
     }
 
     fn action_countdown_secs(&self) -> Option<u64> {

--- a/late-ssh/src/app/rooms/chess/manager.rs
+++ b/late-ssh/src/app/rooms/chess/manager.rs
@@ -64,7 +64,7 @@ impl ChessTableManager {
                     Some(&room.runtime_state),
                     ChessServiceContext {
                         room_event_tx: self.event_tx.clone(),
-                        rooms_service: Some(self.rooms_service.clone()),
+                        rooms_service: self.rooms_service.clone(),
                     },
                 )
             })

--- a/late-ssh/src/app/rooms/chess/svc.rs
+++ b/late-ssh/src/app/rooms/chess/svc.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -42,6 +45,7 @@ pub struct ChessService {
     settings: ChessTableSettings,
     room_event_tx: broadcast::Sender<RoomGameEvent>,
     rooms_service: Option<RoomsService>,
+    room_in_round: Arc<AtomicBool>,
     snapshot_tx: watch::Sender<ChessSnapshot>,
     snapshot_rx: watch::Receiver<ChessSnapshot>,
     state: Arc<Mutex<SharedState>>,
@@ -156,6 +160,7 @@ impl ChessService {
         let state = runtime_state
             .and_then(|value| SharedState::from_runtime_state(room_id, settings, value))
             .unwrap_or_else(|| SharedState::new(room_id, settings));
+        let initial_in_round = state.round_active();
         let initial_deadline = state.current_deadline();
         let initial_snapshot = state.snapshot();
         let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
@@ -166,10 +171,12 @@ impl ChessService {
             settings,
             room_event_tx,
             rooms_service,
+            room_in_round: Arc::new(AtomicBool::new(false)),
             snapshot_tx,
             snapshot_rx,
             state: Arc::new(Mutex::new(state)),
         };
+        svc.sync_room_status(initial_in_round);
         svc.schedule_deadline(initial_deadline);
         svc
     }
@@ -307,6 +314,22 @@ impl ChessService {
 
     fn publish(&self, state: &SharedState) {
         let _ = self.snapshot_tx.send(state.snapshot());
+        self.sync_room_status(state.round_active());
+    }
+
+    fn sync_room_status(&self, in_round: bool) {
+        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
+        if previous == in_round {
+            return;
+        }
+        let Some(rooms_service) = &self.rooms_service else {
+            return;
+        };
+        if in_round {
+            rooms_service.set_room_in_round_task(self.room_id);
+        } else {
+            rooms_service.set_room_open_task(self.room_id);
+        }
     }
 
     fn publish_game_end(&self, game_end: Option<GameEndEvents>) {
@@ -526,6 +549,10 @@ impl SharedState {
             generation: self.deadline_generation,
             at: self.active_deadline?,
         })
+    }
+
+    fn round_active(&self) -> bool {
+        self.phase == ChessPhase::Active
     }
 
     fn bump_runtime_revision(&mut self) {

--- a/late-ssh/src/app/rooms/chess/svc.rs
+++ b/late-ssh/src/app/rooms/chess/svc.rs
@@ -41,7 +41,7 @@ pub struct ChessService {
     activity: ActivityPublisher,
     settings: ChessTableSettings,
     room_event_tx: broadcast::Sender<RoomGameEvent>,
-    rooms_service: Option<RoomsService>,
+    rooms_service: RoomsService,
     room_in_round: Arc<AtomicBool>,
     snapshot_tx: watch::Sender<ChessSnapshot>,
     snapshot_rx: watch::Receiver<ChessSnapshot>,
@@ -111,11 +111,16 @@ struct GameEndEvents {
 #[derive(Clone)]
 pub struct ChessServiceContext {
     pub room_event_tx: broadcast::Sender<RoomGameEvent>,
-    pub rooms_service: Option<RoomsService>,
+    pub rooms_service: RoomsService,
 }
 
 impl ChessService {
-    pub fn new(room_id: Uuid, chip_svc: ChipService, activity: ActivityPublisher) -> Self {
+    pub fn new(
+        room_id: Uuid,
+        chip_svc: ChipService,
+        activity: ActivityPublisher,
+        rooms_service: RoomsService,
+    ) -> Self {
         let (room_event_tx, _) = broadcast::channel::<RoomGameEvent>(16);
         let settings = ChessTableSettings::default();
         Self::new_with_events(
@@ -125,7 +130,7 @@ impl ChessService {
             settings,
             ChessServiceContext {
                 room_event_tx,
-                rooms_service: None,
+                rooms_service,
             },
         )
     }
@@ -283,9 +288,8 @@ impl ChessService {
     }
 
     fn persist_runtime_state(&self, state: &SharedState) {
-        if let Some(rooms_service) = &self.rooms_service {
-            rooms_service.save_runtime_state_task(self.room_id, state.runtime_state());
-        }
+        self.rooms_service
+            .save_runtime_state_task(self.room_id, state.runtime_state());
     }
 
     fn schedule_deadline(&self, deadline: Option<Deadline>) {
@@ -315,10 +319,8 @@ impl ChessService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let Some(rooms_service) = &self.rooms_service else {
-            return;
-        };
-        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
+        self.rooms_service
+            .sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 
     fn publish_game_end(&self, game_end: Option<GameEndEvents>) {

--- a/late-ssh/src/app/rooms/chess/svc.rs
+++ b/late-ssh/src/app/rooms/chess/svc.rs
@@ -1,8 +1,5 @@
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 
@@ -318,18 +315,10 @@ impl ChessService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
-        if previous == in_round {
-            return;
-        }
         let Some(rooms_service) = &self.rooms_service else {
             return;
         };
-        if in_round {
-            rooms_service.set_room_in_round_task(self.room_id);
-        } else {
-            rooms_service.set_room_open_task(self.room_id);
-        }
+        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 
     fn publish_game_end(&self, game_end: Option<GameEndEvents>) {

--- a/late-ssh/src/app/rooms/input.rs
+++ b/late-ssh/src/app/rooms/input.rs
@@ -1,4 +1,6 @@
 use crate::app::state::DashboardGameToggleTarget;
+use std::time::{Duration, Instant};
+
 use crate::app::{
     common::primitives::Banner,
     input::{MouseButton, MouseEvent, MouseEventKind, ParsedInput, sanitize_paste_markers},
@@ -15,6 +17,7 @@ use ratatui::{
 };
 
 const SEARCH_QUERY_MAX_LEN: usize = 32;
+const ROOM_TOUCH_INTERVAL: Duration = Duration::from_secs(60);
 
 pub(crate) fn handle_event(app: &mut App, event: &ParsedInput) -> bool {
     if app.rooms_active_room.is_some() && app.rooms_create_flow.is_none() {
@@ -460,6 +463,8 @@ pub(crate) fn enter_room(app: &mut App, room: crate::app::rooms::svc::RoomListIt
     app.chat.join_game_room_chat(room.chat_room_id);
     app.chat.request_room_tail(room.chat_room_id);
     app.rooms_service.touch_room_task(room.id);
+    app.rooms_last_touched_room_id = Some(room.id);
+    app.rooms_last_touched_at = Some(Instant::now());
     let same_room = app
         .active_room_game
         .as_ref()
@@ -611,6 +616,18 @@ fn rect_contains_mouse(area: Rect, mouse: MouseEvent) -> bool {
 }
 
 fn touch_active_room_activity(app: &mut App) {
+    if let Some(room_id) = app.rooms_active_room.as_ref().map(|room| room.id) {
+        let now = Instant::now();
+        let should_touch = app.rooms_last_touched_room_id != Some(room_id)
+            || app
+                .rooms_last_touched_at
+                .is_none_or(|last| now.duration_since(last) >= ROOM_TOUCH_INTERVAL);
+        if should_touch {
+            app.rooms_service.touch_room_task(room_id);
+            app.rooms_last_touched_room_id = Some(room_id);
+            app.rooms_last_touched_at = Some(now);
+        }
+    }
     if let Some(active_room_game) = &app.active_room_game {
         active_room_game.touch_activity();
     }

--- a/late-ssh/src/app/rooms/poker/manager.rs
+++ b/late-ssh/src/app/rooms/poker/manager.rs
@@ -19,7 +19,7 @@ use crate::app::{
             create_modal::PokerCreateModal, settings::PokerTableSettings, state::State,
             svc::PokerService,
         },
-        svc::{GameKind, RoomListItem},
+        svc::{GameKind, RoomListItem, RoomsService},
     },
 };
 
@@ -27,16 +27,22 @@ use crate::app::{
 pub struct PokerTableManager {
     chip_svc: ChipService,
     activity: ActivityPublisher,
+    rooms_service: RoomsService,
     tables: Arc<Mutex<HashMap<Uuid, PokerService>>>,
     event_tx: broadcast::Sender<RoomGameEvent>,
 }
 
 impl PokerTableManager {
-    pub fn new(chip_svc: ChipService, activity: ActivityPublisher) -> Self {
+    pub fn new(
+        chip_svc: ChipService,
+        activity: ActivityPublisher,
+        rooms_service: RoomsService,
+    ) -> Self {
         let (event_tx, _) = broadcast::channel::<RoomGameEvent>(256);
         Self {
             chip_svc,
             activity,
+            rooms_service,
             tables: Arc::new(Mutex::new(HashMap::new())),
             event_tx,
         }
@@ -53,6 +59,7 @@ impl PokerTableManager {
                     self.activity.clone(),
                     settings,
                     self.event_tx.clone(),
+                    Some(self.rooms_service.clone()),
                 )
             })
             .clone()

--- a/late-ssh/src/app/rooms/poker/manager.rs
+++ b/late-ssh/src/app/rooms/poker/manager.rs
@@ -59,7 +59,7 @@ impl PokerTableManager {
                     self.activity.clone(),
                     settings,
                     self.event_tx.clone(),
-                    Some(self.rooms_service.clone()),
+                    self.rooms_service.clone(),
                 )
             })
             .clone()

--- a/late-ssh/src/app/rooms/poker/svc.rs
+++ b/late-ssh/src/app/rooms/poker/svc.rs
@@ -34,7 +34,7 @@ pub struct PokerService {
     public_tx: watch::Sender<PokerPublicSnapshot>,
     public_rx: watch::Receiver<PokerPublicSnapshot>,
     private_txs: Arc<StdMutex<HashMap<Uuid, watch::Sender<PokerPrivateSnapshot>>>>,
-    rooms_service: Option<RoomsService>,
+    rooms_service: RoomsService,
     room_in_round: Arc<AtomicBool>,
     state: Arc<Mutex<SharedState>>,
 }
@@ -149,8 +149,19 @@ impl PokerAction {
 }
 
 impl PokerService {
-    pub fn new(room_id: Uuid, chip_svc: ChipService, activity: ActivityPublisher) -> Self {
-        Self::new_with_settings(room_id, chip_svc, activity, PokerTableSettings::default())
+    pub fn new(
+        room_id: Uuid,
+        chip_svc: ChipService,
+        activity: ActivityPublisher,
+        rooms_service: RoomsService,
+    ) -> Self {
+        Self::new_with_settings(
+            room_id,
+            chip_svc,
+            activity,
+            PokerTableSettings::default(),
+            rooms_service,
+        )
     }
 
     pub fn new_with_settings(
@@ -158,6 +169,7 @@ impl PokerService {
         chip_svc: ChipService,
         activity: ActivityPublisher,
         settings: PokerTableSettings,
+        rooms_service: RoomsService,
     ) -> Self {
         let (room_event_tx, _) = broadcast::channel::<RoomGameEvent>(16);
         Self::new_with_settings_and_events(
@@ -166,7 +178,7 @@ impl PokerService {
             activity,
             settings,
             room_event_tx,
-            None,
+            rooms_service,
         )
     }
 
@@ -176,7 +188,7 @@ impl PokerService {
         activity: ActivityPublisher,
         settings: PokerTableSettings,
         room_event_tx: broadcast::Sender<RoomGameEvent>,
-        rooms_service: Option<RoomsService>,
+        rooms_service: RoomsService,
     ) -> Self {
         let state = SharedState::new_with_settings(room_id, settings);
         let initial_snapshot = state.public_snapshot();
@@ -654,10 +666,8 @@ impl PokerService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let Some(rooms_service) = &self.rooms_service else {
-            return;
-        };
-        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
+        self.rooms_service
+            .sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 
     fn publish_private_to(

--- a/late-ssh/src/app/rooms/poker/svc.rs
+++ b/late-ssh/src/app/rooms/poker/svc.rs
@@ -1,9 +1,6 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::{
-        Arc, Mutex as StdMutex,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, Mutex as StdMutex, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 
@@ -657,18 +654,10 @@ impl PokerService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
-        if previous == in_round {
-            return;
-        }
         let Some(rooms_service) = &self.rooms_service else {
             return;
         };
-        if in_round {
-            rooms_service.set_room_in_round_task(self.room_id);
-        } else {
-            rooms_service.set_room_open_task(self.room_id);
-        }
+        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 
     fn publish_private_to(

--- a/late-ssh/src/app/rooms/poker/svc.rs
+++ b/late-ssh/src/app/rooms/poker/svc.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, Mutex as StdMutex},
+    sync::{
+        Arc, Mutex as StdMutex,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -15,7 +18,7 @@ use crate::app::{
         cards::{CardRank, CardSuit, PlayingCard},
         chips::svc::ChipService,
     },
-    rooms::backend::RoomGameEvent,
+    rooms::{backend::RoomGameEvent, svc::RoomsService},
 };
 
 use super::settings::PokerTableSettings;
@@ -34,6 +37,8 @@ pub struct PokerService {
     public_tx: watch::Sender<PokerPublicSnapshot>,
     public_rx: watch::Receiver<PokerPublicSnapshot>,
     private_txs: Arc<StdMutex<HashMap<Uuid, watch::Sender<PokerPrivateSnapshot>>>>,
+    rooms_service: Option<RoomsService>,
+    room_in_round: Arc<AtomicBool>,
     state: Arc<Mutex<SharedState>>,
 }
 
@@ -158,7 +163,14 @@ impl PokerService {
         settings: PokerTableSettings,
     ) -> Self {
         let (room_event_tx, _) = broadcast::channel::<RoomGameEvent>(16);
-        Self::new_with_settings_and_events(room_id, chip_svc, activity, settings, room_event_tx)
+        Self::new_with_settings_and_events(
+            room_id,
+            chip_svc,
+            activity,
+            settings,
+            room_event_tx,
+            None,
+        )
     }
 
     pub fn new_with_settings_and_events(
@@ -167,6 +179,7 @@ impl PokerService {
         activity: ActivityPublisher,
         settings: PokerTableSettings,
         room_event_tx: broadcast::Sender<RoomGameEvent>,
+        rooms_service: Option<RoomsService>,
     ) -> Self {
         let state = SharedState::new_with_settings(room_id, settings);
         let initial_snapshot = state.public_snapshot();
@@ -179,6 +192,8 @@ impl PokerService {
             public_tx,
             public_rx,
             private_txs: Arc::new(StdMutex::new(HashMap::new())),
+            rooms_service,
+            room_in_round: Arc::new(AtomicBool::new(false)),
             state: Arc::new(Mutex::new(state)),
         }
     }
@@ -632,11 +647,27 @@ impl PokerService {
 
     fn publish(&self, state: &SharedState) {
         let _ = self.public_tx.send(state.public_snapshot());
+        self.sync_room_status(state.round_active());
 
         let mut private_txs = self.private_txs.lock_recover();
         private_txs.retain(|_, tx| tx.receiver_count() > 0);
         for (user_id, tx) in private_txs.iter() {
             self.publish_private_to(state, *user_id, tx);
+        }
+    }
+
+    fn sync_room_status(&self, in_round: bool) {
+        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
+        if previous == in_round {
+            return;
+        }
+        let Some(rooms_service) = &self.rooms_service else {
+            return;
+        };
+        if in_round {
+            rooms_service.set_room_in_round_task(self.room_id);
+        } else {
+            rooms_service.set_room_open_task(self.room_id);
         }
     }
 
@@ -768,6 +799,10 @@ impl SharedState {
             action_deadline: self.action_deadline,
             settlement_pending: self.settlement_pending,
         }
+    }
+
+    fn round_active(&self) -> bool {
+        self.phase == PokerPhase::PostingBlinds || self.phase.is_action_phase()
     }
 
     fn private_snapshot_for(&self, user_id: Uuid) -> PokerPrivateSnapshot {

--- a/late-ssh/src/app/rooms/sshattrick/svc.rs
+++ b/late-ssh/src/app/rooms/sshattrick/svc.rs
@@ -460,15 +460,11 @@ impl SshattrickService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
-        if previous == in_round {
-            return;
-        }
-        if in_round {
-            self.rooms_service.set_room_in_round_task(self.room_id);
-        } else {
-            self.rooms_service.set_room_open_task(self.room_id);
-        }
+        self.rooms_service.sync_room_status_task(
+            self.room_id,
+            self.room_in_round.clone(),
+            in_round,
+        );
     }
 
     fn publish_win(&self, winner_user_id: Option<Uuid>) {

--- a/late-ssh/src/app/rooms/sshattrick/svc.rs
+++ b/late-ssh/src/app/rooms/sshattrick/svc.rs
@@ -120,6 +120,7 @@ pub struct SshattrickService {
     private: Arc<StdMutex<HashMap<Uuid, watch::Sender<SshattrickPrivateSnapshot>>>>,
     state: Arc<Mutex<SharedState>>,
     lifecycle: Arc<Lifecycle>,
+    room_in_round: Arc<AtomicBool>,
     rooms_service: RoomsService,
     chip_svc: ChipService,
     activity: ActivityPublisher,
@@ -228,6 +229,7 @@ impl SshattrickService {
             private: Arc::new(StdMutex::new(HashMap::new())),
             state: Arc::new(Mutex::new(state)),
             lifecycle: Arc::new(Lifecycle::new()),
+            room_in_round: Arc::new(AtomicBool::new(false)),
             rooms_service,
             chip_svc,
             activity,
@@ -454,6 +456,19 @@ impl SshattrickService {
 
     fn publish_public(&self, state: &SharedState) {
         diff_set(&self.public_tx, state.public_snapshot());
+        self.sync_room_status(state.round_active());
+    }
+
+    fn sync_room_status(&self, in_round: bool) {
+        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
+        if previous == in_round {
+            return;
+        }
+        if in_round {
+            self.rooms_service.set_room_in_round_task(self.room_id);
+        } else {
+            self.rooms_service.set_room_open_task(self.room_id);
+        }
     }
 
     fn publish_win(&self, winner_user_id: Option<Uuid>) {
@@ -653,6 +668,15 @@ impl SharedState {
             changed: true,
             winner_user_id: None,
         }
+    }
+
+    fn round_active(&self) -> bool {
+        self.game.as_ref().is_some_and(|game| {
+            matches!(
+                Phase::from_game(&game.state),
+                Phase::Starting | Phase::Running | Phase::AfterGoal
+            )
+        })
     }
 
     fn user_for_side(&self, side: GameSide) -> Option<Uuid> {

--- a/late-ssh/src/app/rooms/svc.rs
+++ b/late-ssh/src/app/rooms/svc.rs
@@ -1,6 +1,9 @@
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
     time::Duration,
 };
 
@@ -211,12 +214,22 @@ impl RoomsService {
         touch_room_activity(&client, room_id).await
     }
 
-    pub fn set_room_in_round_task(&self, room_id: Uuid) {
-        self.set_room_status_task(room_id, GameRoom::STATUS_IN_ROUND);
-    }
-
-    pub fn set_room_open_task(&self, room_id: Uuid) {
-        self.set_room_status_task(room_id, GameRoom::STATUS_OPEN);
+    pub fn sync_room_status_task(
+        &self,
+        room_id: Uuid,
+        room_in_round: Arc<AtomicBool>,
+        in_round: bool,
+    ) {
+        let previous = room_in_round.swap(in_round, Ordering::AcqRel);
+        if previous == in_round {
+            return;
+        }
+        let status = if in_round {
+            GameRoom::STATUS_IN_ROUND
+        } else {
+            GameRoom::STATUS_OPEN
+        };
+        self.set_room_status_task(room_id, status);
     }
 
     fn set_room_status_task(&self, room_id: Uuid, status: &'static str) {
@@ -232,13 +245,37 @@ impl RoomsService {
             generation
         };
         tokio::spawn(async move {
-            if let Err(e) = svc
-                .set_room_status_if_current(room_id, status, generation)
-                .await
-            {
-                tracing::error!(error = ?e, %room_id, status, "failed to update game room status");
+            loop {
+                match svc
+                    .set_room_status_if_current(room_id, status, generation)
+                    .await
+                {
+                    Ok(()) => break,
+                    Err(e) => {
+                        tracing::error!(
+                            error = ?e,
+                            %room_id,
+                            status,
+                            "failed to update game room status"
+                        );
+                        if svc.current_status_generation(room_id) != Some(generation) {
+                            break;
+                        }
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        if svc.current_status_generation(room_id) != Some(generation) {
+                            break;
+                        }
+                    }
+                }
             }
         });
+    }
+
+    fn current_status_generation(&self, room_id: Uuid) -> Option<u64> {
+        self.status_generations
+            .lock_recover()
+            .get(&room_id)
+            .copied()
     }
 
     async fn set_room_status_if_current(

--- a/late-ssh/src/app/rooms/svc.rs
+++ b/late-ssh/src/app/rooms/svc.rs
@@ -1,6 +1,11 @@
-use std::{collections::HashMap, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use late_core::{
+    MutexRecover,
     db::Db,
     models::{chat_room_member::ChatRoomMember, game_room::GameRoom, user::User},
 };
@@ -13,12 +18,14 @@ use crate::app::ai::ghost::DEALER_FINGERPRINT;
 pub use late_core::models::game_room::GameKind;
 
 const MAX_TABLES_PER_USER: i64 = 10;
-const INACTIVE_TABLE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const INACTIVE_TABLE_TTL: Duration = Duration::from_secs(60 * 60);
 const INACTIVE_TABLE_CLEANUP_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
 #[derive(Clone)]
 pub struct RoomsService {
     db: Db,
+    status_generations: Arc<Mutex<HashMap<Uuid, u64>>>,
+    status_update_lock: Arc<tokio::sync::Mutex<()>>,
     snapshot_tx: watch::Sender<RoomsSnapshot>,
     snapshot_rx: watch::Receiver<RoomsSnapshot>,
     event_tx: broadcast::Sender<RoomsEvent>,
@@ -102,6 +109,8 @@ impl RoomsService {
         let (event_tx, _) = broadcast::channel(256);
         Self {
             db,
+            status_generations: Arc::new(Mutex::new(HashMap::new())),
+            status_update_lock: Arc::new(tokio::sync::Mutex::new(())),
             snapshot_tx,
             snapshot_rx,
             event_tx,
@@ -129,10 +138,19 @@ impl RoomsService {
         let svc = self.clone();
         tokio::spawn(async move {
             loop {
-                if let Err(e) = svc.close_inactive_tables(INACTIVE_TABLE_TTL).await {
-                    tracing::error!(error = ?e, "failed to close inactive game rooms");
+                if let Err(e) = svc.delete_inactive_tables(INACTIVE_TABLE_TTL).await {
+                    tracing::error!(error = ?e, "failed to delete inactive game rooms");
                 }
                 tokio::time::sleep(INACTIVE_TABLE_CLEANUP_INTERVAL).await;
+            }
+        });
+    }
+
+    pub fn reconcile_round_statuses_task(&self) {
+        let svc = self.clone();
+        tokio::spawn(async move {
+            if let Err(e) = svc.reconcile_round_statuses().await {
+                tracing::error!(error = ?e, "failed to reconcile game room statuses");
             }
         });
     }
@@ -159,14 +177,24 @@ impl RoomsService {
         Ok(())
     }
 
-    async fn close_inactive_tables(&self, ttl: Duration) -> anyhow::Result<u64> {
+    async fn delete_inactive_tables(&self, ttl: Duration) -> anyhow::Result<u64> {
         let client = self.db.get().await?;
-        let closed = close_inactive_rooms(&client, ttl).await?;
-        if closed > 0 {
-            tracing::info!(closed, "closed inactive game rooms");
+        let deleted = delete_inactive_rooms(&client, ttl).await?;
+        if deleted > 0 {
+            tracing::info!(deleted, "deleted inactive game rooms");
             self.publish_rooms(&client).await?;
         }
-        Ok(closed)
+        Ok(deleted)
+    }
+
+    async fn reconcile_round_statuses(&self) -> anyhow::Result<u64> {
+        let client = self.db.get().await?;
+        let reconciled = GameRoom::reconcile_in_round_after_restart(&client).await?;
+        if reconciled > 0 {
+            tracing::info!(reconciled, "reconciled stale in-round game rooms");
+            self.publish_rooms(&client).await?;
+        }
+        Ok(reconciled)
     }
 
     pub fn touch_room_task(&self, room_id: Uuid) {
@@ -181,6 +209,58 @@ impl RoomsService {
     async fn touch_room(&self, room_id: Uuid) -> anyhow::Result<()> {
         let client = self.db.get().await?;
         touch_room_activity(&client, room_id).await
+    }
+
+    pub fn set_room_in_round_task(&self, room_id: Uuid) {
+        self.set_room_status_task(room_id, GameRoom::STATUS_IN_ROUND);
+    }
+
+    pub fn set_room_open_task(&self, room_id: Uuid) {
+        self.set_room_status_task(room_id, GameRoom::STATUS_OPEN);
+    }
+
+    fn set_room_status_task(&self, room_id: Uuid, status: &'static str) {
+        let svc = self.clone();
+        let generation = {
+            let mut generations = self.status_generations.lock_recover();
+            let generation = generations
+                .get(&room_id)
+                .copied()
+                .unwrap_or_default()
+                .wrapping_add(1);
+            generations.insert(room_id, generation);
+            generation
+        };
+        tokio::spawn(async move {
+            if let Err(e) = svc
+                .set_room_status_if_current(room_id, status, generation)
+                .await
+            {
+                tracing::error!(error = ?e, %room_id, status, "failed to update game room status");
+            }
+        });
+    }
+
+    async fn set_room_status_if_current(
+        &self,
+        room_id: Uuid,
+        status: &str,
+        generation: u64,
+    ) -> anyhow::Result<()> {
+        let _guard = self.status_update_lock.lock().await;
+        if self
+            .status_generations
+            .lock_recover()
+            .get(&room_id)
+            .copied()
+            != Some(generation)
+        {
+            return Ok(());
+        }
+        let client = self.db.get().await?;
+        GameRoom::update_status(&client, room_id, status).await?;
+        self.publish_rooms(&client).await?;
+        Ok(())
     }
 
     pub fn save_runtime_state_task(&self, room_id: Uuid, runtime_state: Value) {
@@ -315,7 +395,7 @@ impl RoomsService {
 
     async fn delete_game_room(&self, room_id: Uuid) -> anyhow::Result<()> {
         let client = self.db.get().await?;
-        let count = GameRoom::close_by_id(&client, room_id).await?;
+        let count = GameRoom::delete_by_id(&client, room_id).await?;
         if count == 0 {
             anyhow::bail!("table already deleted");
         }
@@ -340,11 +420,11 @@ async fn count_open_rooms_created_by(
     GameRoom::count_open_created_by(client, user_id, game_kind).await
 }
 
-async fn close_inactive_rooms(
+async fn delete_inactive_rooms(
     client: &tokio_postgres::Client,
     ttl: Duration,
 ) -> anyhow::Result<u64> {
-    GameRoom::close_inactive(client, ttl).await
+    GameRoom::delete_inactive_open(client, ttl).await
 }
 
 async fn touch_room_activity(client: &tokio_postgres::Client, room_id: Uuid) -> anyhow::Result<()> {

--- a/late-ssh/src/app/rooms/tictactoe/manager.rs
+++ b/late-ssh/src/app/rooms/tictactoe/manager.rs
@@ -51,7 +51,7 @@ impl TicTacToeTableManager {
                     room.id,
                     self.activity.clone(),
                     self.event_tx.clone(),
-                    Some(self.rooms_service.clone()),
+                    self.rooms_service.clone(),
                 )
             })
             .clone()

--- a/late-ssh/src/app/rooms/tictactoe/manager.rs
+++ b/late-ssh/src/app/rooms/tictactoe/manager.rs
@@ -14,7 +14,7 @@ use crate::app::{
             ActiveRoomBackend, CreateRoomModal, DirectoryHints, DirectoryMeta, RoomGameEvent,
             RoomGameManager,
         },
-        svc::{GameKind, RoomListItem},
+        svc::{GameKind, RoomListItem, RoomsService},
         tictactoe::{
             create_modal::TicTacToeCreateModal,
             state::{State, Winner},
@@ -26,15 +26,17 @@ use crate::app::{
 #[derive(Clone)]
 pub struct TicTacToeTableManager {
     activity: ActivityPublisher,
+    rooms_service: RoomsService,
     tables: Arc<Mutex<HashMap<Uuid, TicTacToeService>>>,
     event_tx: broadcast::Sender<RoomGameEvent>,
 }
 
 impl TicTacToeTableManager {
-    pub fn new(activity: ActivityPublisher) -> Self {
+    pub fn new(activity: ActivityPublisher, rooms_service: RoomsService) -> Self {
         let (event_tx, _) = broadcast::channel::<RoomGameEvent>(256);
         Self {
             activity,
+            rooms_service,
             tables: Arc::new(Mutex::new(HashMap::new())),
             event_tx,
         }
@@ -49,6 +51,7 @@ impl TicTacToeTableManager {
                     room.id,
                     self.activity.clone(),
                     self.event_tx.clone(),
+                    Some(self.rooms_service.clone()),
                 )
             })
             .clone()

--- a/late-ssh/src/app/rooms/tictactoe/svc.rs
+++ b/late-ssh/src/app/rooms/tictactoe/svc.rs
@@ -1,8 +1,5 @@
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 
@@ -181,18 +178,10 @@ impl TicTacToeService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
-        if previous == in_round {
-            return;
-        }
         let Some(rooms_service) = &self.rooms_service else {
             return;
         };
-        if in_round {
-            rooms_service.set_room_in_round_task(self.room_id);
-        } else {
-            rooms_service.set_room_open_task(self.room_id);
-        }
+        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 }
 

--- a/late-ssh/src/app/rooms/tictactoe/svc.rs
+++ b/late-ssh/src/app/rooms/tictactoe/svc.rs
@@ -22,7 +22,7 @@ pub struct TicTacToeService {
     room_event_tx: broadcast::Sender<RoomGameEvent>,
     snapshot_tx: watch::Sender<TicTacToeSnapshot>,
     snapshot_rx: watch::Receiver<TicTacToeSnapshot>,
-    rooms_service: Option<RoomsService>,
+    rooms_service: RoomsService,
     room_in_round: Arc<AtomicBool>,
     state: Arc<Mutex<SharedState>>,
 }
@@ -38,16 +38,16 @@ pub struct TicTacToeSnapshot {
 }
 
 impl TicTacToeService {
-    pub fn new(room_id: Uuid, activity: ActivityPublisher) -> Self {
+    pub fn new(room_id: Uuid, activity: ActivityPublisher, rooms_service: RoomsService) -> Self {
         let (room_event_tx, _) = broadcast::channel::<RoomGameEvent>(16);
-        Self::new_with_events(room_id, activity, room_event_tx, None)
+        Self::new_with_events(room_id, activity, room_event_tx, rooms_service)
     }
 
     pub fn new_with_events(
         room_id: Uuid,
         activity: ActivityPublisher,
         room_event_tx: broadcast::Sender<RoomGameEvent>,
-        rooms_service: Option<RoomsService>,
+        rooms_service: RoomsService,
     ) -> Self {
         let state = SharedState::new(room_id);
         let initial_snapshot = state.snapshot();
@@ -178,10 +178,8 @@ impl TicTacToeService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let Some(rooms_service) = &self.rooms_service else {
-            return;
-        };
-        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
+        self.rooms_service
+            .sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 }
 

--- a/late-ssh/src/app/rooms/tictactoe/svc.rs
+++ b/late-ssh/src/app/rooms/tictactoe/svc.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -8,7 +11,7 @@ use uuid::Uuid;
 
 use crate::app::{
     activity::{event::ActivityGame, publisher::ActivityPublisher},
-    rooms::backend::RoomGameEvent,
+    rooms::{backend::RoomGameEvent, svc::RoomsService},
 };
 
 use super::state::{Mark, Winner, winning_mark};
@@ -22,6 +25,8 @@ pub struct TicTacToeService {
     room_event_tx: broadcast::Sender<RoomGameEvent>,
     snapshot_tx: watch::Sender<TicTacToeSnapshot>,
     snapshot_rx: watch::Receiver<TicTacToeSnapshot>,
+    rooms_service: Option<RoomsService>,
+    room_in_round: Arc<AtomicBool>,
     state: Arc<Mutex<SharedState>>,
 }
 
@@ -38,13 +43,14 @@ pub struct TicTacToeSnapshot {
 impl TicTacToeService {
     pub fn new(room_id: Uuid, activity: ActivityPublisher) -> Self {
         let (room_event_tx, _) = broadcast::channel::<RoomGameEvent>(16);
-        Self::new_with_events(room_id, activity, room_event_tx)
+        Self::new_with_events(room_id, activity, room_event_tx, None)
     }
 
     pub fn new_with_events(
         room_id: Uuid,
         activity: ActivityPublisher,
         room_event_tx: broadcast::Sender<RoomGameEvent>,
+        rooms_service: Option<RoomsService>,
     ) -> Self {
         let state = SharedState::new(room_id);
         let initial_snapshot = state.snapshot();
@@ -55,6 +61,8 @@ impl TicTacToeService {
             room_event_tx,
             snapshot_tx,
             snapshot_rx,
+            rooms_service,
+            room_in_round: Arc::new(AtomicBool::new(false)),
             state: Arc::new(Mutex::new(state)),
         }
     }
@@ -169,6 +177,22 @@ impl TicTacToeService {
 
     fn publish(&self, state: &SharedState) {
         let _ = self.snapshot_tx.send(state.snapshot());
+        self.sync_room_status(state.round_active());
+    }
+
+    fn sync_room_status(&self, in_round: bool) {
+        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
+        if previous == in_round {
+            return;
+        }
+        let Some(rooms_service) = &self.rooms_service else {
+            return;
+        };
+        if in_round {
+            rooms_service.set_room_in_round_task(self.room_id);
+        } else {
+            rooms_service.set_room_open_task(self.room_id);
+        }
     }
 }
 
@@ -300,6 +324,10 @@ impl SharedState {
         self.last_activity[seat_index] = Instant::now();
         self.activity_generation[seat_index] = self.activity_generation[seat_index].wrapping_add(1);
         Some(self.activity_generation[seat_index])
+    }
+
+    fn round_active(&self) -> bool {
+        self.winner.is_none() && self.board.iter().any(Option::is_some)
     }
 
     fn kick_inactive_user(&mut self, user_id: Uuid, activity_generation: u64) -> bool {

--- a/late-ssh/src/app/rooms/tron/manager.rs
+++ b/late-ssh/src/app/rooms/tron/manager.rs
@@ -15,7 +15,7 @@ use crate::app::{
             ActiveRoomBackend, CreateRoomModal, DirectoryHints, DirectoryMeta, RoomGameEvent,
             RoomGameManager,
         },
-        svc::{GameKind, RoomListItem},
+        svc::{GameKind, RoomListItem, RoomsService},
         tron::{
             create_modal::TronCreateModal,
             settings::TronTableSettings,
@@ -32,16 +32,22 @@ use crate::app::{
 pub struct TronTableManager {
     chip_svc: ChipService,
     activity: ActivityPublisher,
+    rooms_service: RoomsService,
     tables: Arc<Mutex<HashMap<Uuid, TronService>>>,
     event_tx: broadcast::Sender<RoomGameEvent>,
 }
 
 impl TronTableManager {
-    pub fn new(chip_svc: ChipService, activity: ActivityPublisher) -> Self {
+    pub fn new(
+        chip_svc: ChipService,
+        activity: ActivityPublisher,
+        rooms_service: RoomsService,
+    ) -> Self {
         let (event_tx, _) = broadcast::channel::<RoomGameEvent>(256);
         Self {
             chip_svc,
             activity,
+            rooms_service,
             tables: Arc::new(Mutex::new(HashMap::new())),
             event_tx,
         }
@@ -60,6 +66,7 @@ impl TronTableManager {
                     settings,
                     TronServiceContext {
                         room_event_tx: self.event_tx.clone(),
+                        rooms_service: Some(self.rooms_service.clone()),
                     },
                 )
             })

--- a/late-ssh/src/app/rooms/tron/manager.rs
+++ b/late-ssh/src/app/rooms/tron/manager.rs
@@ -66,7 +66,7 @@ impl TronTableManager {
                     settings,
                     TronServiceContext {
                         room_event_tx: self.event_tx.clone(),
-                        rooms_service: Some(self.rooms_service.clone()),
+                        rooms_service: self.rooms_service.clone(),
                     },
                 )
             })

--- a/late-ssh/src/app/rooms/tron/svc.rs
+++ b/late-ssh/src/app/rooms/tron/svc.rs
@@ -46,7 +46,7 @@ pub struct TronService {
     room_event_tx: broadcast::Sender<RoomGameEvent>,
     snapshot_tx: watch::Sender<TronSnapshot>,
     snapshot_rx: watch::Receiver<TronSnapshot>,
-    rooms_service: Option<RoomsService>,
+    rooms_service: RoomsService,
     room_in_round: Arc<AtomicBool>,
     state: Arc<Mutex<SharedState>>,
 }
@@ -113,7 +113,7 @@ struct GameEndEvents {
 #[derive(Clone)]
 pub struct TronServiceContext {
     pub room_event_tx: broadcast::Sender<RoomGameEvent>,
-    pub rooms_service: Option<RoomsService>,
+    pub rooms_service: RoomsService,
 }
 
 impl TronService {
@@ -286,10 +286,8 @@ impl TronService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let Some(rooms_service) = &self.rooms_service else {
-            return;
-        };
-        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
+        self.rooms_service
+            .sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 
     fn publish_game_end(&self, game_end: Option<GameEndEvents>) {

--- a/late-ssh/src/app/rooms/tron/svc.rs
+++ b/late-ssh/src/app/rooms/tron/svc.rs
@@ -1,5 +1,8 @@
 use std::{
-    sync::Arc,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     time::{Duration, Instant},
 };
 
@@ -12,6 +15,7 @@ use crate::app::{
     games::chips::svc::ChipService,
     rooms::{
         backend::RoomGameEvent,
+        svc::RoomsService,
         tron::{
             settings::TronTableSettings,
             state::{
@@ -45,6 +49,8 @@ pub struct TronService {
     room_event_tx: broadcast::Sender<RoomGameEvent>,
     snapshot_tx: watch::Sender<TronSnapshot>,
     snapshot_rx: watch::Receiver<TronSnapshot>,
+    rooms_service: Option<RoomsService>,
+    room_in_round: Arc<AtomicBool>,
     state: Arc<Mutex<SharedState>>,
 }
 
@@ -110,6 +116,7 @@ struct GameEndEvents {
 #[derive(Clone)]
 pub struct TronServiceContext {
     pub room_event_tx: broadcast::Sender<RoomGameEvent>,
+    pub rooms_service: Option<RoomsService>,
 }
 
 impl TronService {
@@ -120,7 +127,10 @@ impl TronService {
         settings: TronTableSettings,
         context: TronServiceContext,
     ) -> Self {
-        let TronServiceContext { room_event_tx } = context;
+        let TronServiceContext {
+            room_event_tx,
+            rooms_service,
+        } = context;
         let state = SharedState::new(room_id, settings);
         let initial_snapshot = state.snapshot();
         let (snapshot_tx, snapshot_rx) = watch::channel(initial_snapshot);
@@ -132,6 +142,8 @@ impl TronService {
             room_event_tx,
             snapshot_tx,
             snapshot_rx,
+            rooms_service,
+            room_in_round: Arc::new(AtomicBool::new(false)),
             state: Arc::new(Mutex::new(state)),
         }
     }
@@ -273,6 +285,22 @@ impl TronService {
 
     fn publish(&self, state: &SharedState) {
         let _ = self.snapshot_tx.send(state.snapshot());
+        self.sync_room_status(state.round_active());
+    }
+
+    fn sync_room_status(&self, in_round: bool) {
+        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
+        if previous == in_round {
+            return;
+        }
+        let Some(rooms_service) = &self.rooms_service else {
+            return;
+        };
+        if in_round {
+            rooms_service.set_room_in_round_task(self.room_id);
+        } else {
+            rooms_service.set_room_open_task(self.room_id);
+        }
     }
 
     fn publish_game_end(&self, game_end: Option<GameEndEvents>) {
@@ -827,6 +855,10 @@ impl SharedState {
 
     fn seat_index(&self, user_id: Uuid) -> Option<usize> {
         self.seats.iter().position(|seat| *seat == Some(user_id))
+    }
+
+    fn round_active(&self) -> bool {
+        self.phase == TronPhase::Running
     }
 
     fn record_activity(&mut self, user_id: Uuid) -> Option<u64> {

--- a/late-ssh/src/app/rooms/tron/svc.rs
+++ b/late-ssh/src/app/rooms/tron/svc.rs
@@ -1,8 +1,5 @@
 use std::{
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
+    sync::{Arc, atomic::AtomicBool},
     time::{Duration, Instant},
 };
 
@@ -289,18 +286,10 @@ impl TronService {
     }
 
     fn sync_room_status(&self, in_round: bool) {
-        let previous = self.room_in_round.swap(in_round, Ordering::AcqRel);
-        if previous == in_round {
-            return;
-        }
         let Some(rooms_service) = &self.rooms_service else {
             return;
         };
-        if in_round {
-            rooms_service.set_room_in_round_task(self.room_id);
-        } else {
-            rooms_service.set_room_open_task(self.room_id);
-        }
+        rooms_service.sync_room_status_task(self.room_id, self.room_in_round.clone(), in_round);
     }
 
     fn publish_game_end(&self, game_end: Option<GameEndEvents>) {

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -410,6 +410,8 @@ pub struct App {
     pub(crate) rooms_selected_index: usize,
     pub(crate) rooms_active_room: Option<crate::app::rooms::svc::RoomListItem>,
     pub(crate) rooms_last_active_room_id: Option<Uuid>,
+    pub(crate) rooms_last_touched_room_id: Option<Uuid>,
+    pub(crate) rooms_last_touched_at: Option<Instant>,
     pub(crate) rooms_create_flow: Option<crate::app::rooms::backend::CreateRoomFlow>,
     pub(crate) rooms_filter: crate::app::rooms::filter::RoomsFilter,
     pub(crate) rooms_search_active: bool,
@@ -782,8 +784,10 @@ impl App {
             config.shop_service.clone(),
             config.shop_snapshot_rx,
         );
-        let hub_admin_state =
-            crate::app::hub::admin::state::AdminState::new(config.quest_service.clone());
+        let hub_admin_state = crate::app::hub::admin::state::AdminState::new(
+            config.quest_service.clone(),
+            config.shop_service.clone(),
+        );
         let aquarium_area = aquarium_area_for_terminal(cols, rows);
         let mut aquarium_state =
             crate::app::hub::aquarium::state::AquariumState::default_for_area(aquarium_area)?;
@@ -922,6 +926,8 @@ impl App {
             rooms_selected_index: 0,
             rooms_active_room: None,
             rooms_last_active_room_id: None,
+            rooms_last_touched_room_id: None,
+            rooms_last_touched_at: None,
             rooms_create_flow: None,
             rooms_filter: crate::app::rooms::filter::RoomsFilter::default(),
             rooms_search_active: false,

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -189,6 +189,7 @@ async fn main() -> anyhow::Result<()> {
     let chip_service = late_ssh::app::games::chips::svc::ChipService::new(db.clone());
     let _chip_activity_reward_task = chip_service.start_activity_reward_task(activity_tx.clone());
     let rooms_service = late_ssh::app::rooms::svc::RoomsService::new(db.clone());
+    rooms_service.reconcile_round_statuses_task();
     rooms_service.refresh_task();
     rooms_service.cleanup_inactive_tables_task();
     let asterion_room_manager = late_ssh::app::rooms::asterion::manager::AsterionRoomManager::new(
@@ -202,10 +203,12 @@ async fn main() -> anyhow::Result<()> {
             chip_service.clone(),
             late_ssh::app::rooms::blackjack::player::BlackjackPlayerDirectory::new(db.clone()),
             activity_publisher.clone(),
+            rooms_service.clone(),
         );
     let tictactoe_table_manager =
         late_ssh::app::rooms::tictactoe::manager::TicTacToeTableManager::new(
             activity_publisher.clone(),
+            rooms_service.clone(),
         );
     let chess_table_manager = late_ssh::app::rooms::chess::manager::ChessTableManager::new(
         chip_service.clone(),
@@ -215,10 +218,12 @@ async fn main() -> anyhow::Result<()> {
     let poker_table_manager = late_ssh::app::rooms::poker::manager::PokerTableManager::new(
         chip_service.clone(),
         activity_publisher.clone(),
+        rooms_service.clone(),
     );
     let tron_table_manager = late_ssh::app::rooms::tron::manager::TronTableManager::new(
         chip_service.clone(),
         activity_publisher.clone(),
+        rooms_service.clone(),
     );
     let lateania_service = late_ssh::app::door::lateania::svc::LateaniaService::new(
         activity_publisher.clone(),

--- a/late-ssh/tests/helpers/mod.rs
+++ b/late-ssh/tests/helpers/mod.rs
@@ -79,6 +79,7 @@ fn test_room_game_registry(db: Db) -> RoomGameRegistry {
         chip_service.clone(),
         BlackjackPlayerDirectory::new(db.clone()),
         activity_publisher.clone(),
+        rooms_service.clone(),
     );
     RoomGameRegistry::new(
         asterion_room_manager,
@@ -88,15 +89,23 @@ fn test_room_game_registry(db: Db) -> RoomGameRegistry {
             activity_publisher.clone(),
             rooms_service.clone(),
         ),
-        PokerTableManager::new(chip_service.clone(), activity_publisher.clone()),
+        PokerTableManager::new(
+            chip_service.clone(),
+            activity_publisher.clone(),
+            rooms_service.clone(),
+        ),
         SshattrickRoomManager::new(
-            rooms_service,
+            rooms_service.clone(),
             chip_service.clone(),
             activity_publisher.clone(),
             db,
         ),
-        TicTacToeTableManager::new(activity_publisher.clone()),
-        TronTableManager::new(chip_service, activity_publisher.clone()),
+        TicTacToeTableManager::new(activity_publisher.clone(), rooms_service.clone()),
+        TronTableManager::new(
+            chip_service,
+            activity_publisher.clone(),
+            rooms_service.clone(),
+        ),
     )
 }
 
@@ -197,6 +206,7 @@ pub fn test_app_state(db: Db, config: Config) -> State {
         chip_service.clone(),
         blackjack_player_directory.clone(),
         activity_publisher.clone(),
+        rooms_service.clone(),
     );
     let sudoku_service = SudokuService::new(db.clone(), activity_tx.clone());
     let nonogram_service = NonogramService::new(db.clone(), activity_tx.clone());
@@ -261,15 +271,23 @@ pub fn test_app_state(db: Db, config: Config) -> State {
                 activity_publisher.clone(),
                 rooms_service.clone(),
             ),
-            PokerTableManager::new(chip_service.clone(), activity_publisher.clone()),
+            PokerTableManager::new(
+                chip_service.clone(),
+                activity_publisher.clone(),
+                rooms_service.clone(),
+            ),
             SshattrickRoomManager::new(
                 rooms_service.clone(),
                 chip_service.clone(),
                 activity_publisher.clone(),
                 db.clone(),
             ),
-            TicTacToeTableManager::new(activity_publisher.clone()),
-            TronTableManager::new(chip_service.clone(), activity_publisher.clone()),
+            TicTacToeTableManager::new(activity_publisher.clone(), rooms_service.clone()),
+            TronTableManager::new(
+                chip_service.clone(),
+                activity_publisher.clone(),
+                rooms_service.clone(),
+            ),
         ),
         dartboard_server,
         dartboard_provenance: test_dartboard_provenance(),


### PR DESCRIPTION
## Summary
- Extends Hub Admin so admins can edit existing Shop item presentation/economy fields, and tightens Rooms cleanup so active games are protected while stale open tables are removed faster.

## Changes
- Hub Admin now loads reward templates and marketplace items, adds a Shop Items category, and can edit Shop item name, description, chip price, sort order, and active state.
- Admin inline editing now supports cursor movement, Delete, Home, and End.
- Room games now publish `in_round`/`open` status updates so cleanup can distinguish active rounds from idle tables.
- Inactive open game rooms are hard-deleted after 1 hour, including their associated game chat through existing cascades.
- Active-room input touches room activity at most once per minute.
- Startup reconciles stale `in_round` rooms after restart, preserving only active durable Chess rounds.
- Includes small Door Games and pet inline UI polish.

## Behavior notes
- Admin Shop editing does not add SKUs or edit item kind, slot, payload, or schedule windows.
- Hard-deleting an inactive room removes the associated game chat history/membership records through DB cascades.
- Non-durable room games reset stale `in_round` rows to `open` on restart; active Chess runtime state remains protected.

## Feature flags
- None

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Added `late-core/tests/game_room.rs` coverage for inactive open-room hard deletion, active `in_round` protection, and restart reconciliation. Not run locally per repo agent policy.
- Manual: Not run.