### PR TITLE
Add Music Booth history and requeueing

### DIFF
--- a/late-core/migrations/073_create_media_history.sql
+++ b/late-core/migrations/073_create_media_history.sql
@@ -1,0 +1,37 @@
+CREATE TABLE media_history_items (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    media_kind TEXT NOT NULL DEFAULT 'youtube'
+        CHECK (media_kind IN ('youtube')),
+    external_id TEXT NOT NULL CHECK (length(trim(external_id)) > 0),
+    title TEXT,
+    channel TEXT,
+    duration_ms INTEGER CHECK (duration_ms IS NULL OR duration_ms >= 0),
+    is_stream BOOLEAN NOT NULL DEFAULT false,
+    first_played_at TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    last_played_at TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    play_count INTEGER NOT NULL DEFAULT 1 CHECK (play_count >= 1),
+    last_submitter_id UUID REFERENCES users(id) ON DELETE SET NULL
+);
+
+CREATE UNIQUE INDEX idx_media_history_kind_external
+    ON media_history_items(media_kind, external_id);
+
+CREATE INDEX idx_media_history_last_played
+    ON media_history_items(last_played_at DESC);
+
+CREATE TABLE media_history_votes (
+    id UUID PRIMARY KEY DEFAULT uuidv7(),
+    created TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    updated TIMESTAMPTZ NOT NULL DEFAULT current_timestamp,
+    item_id UUID NOT NULL REFERENCES media_history_items(id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    value SMALLINT NOT NULL CHECK (value IN (-1, 1))
+);
+
+CREATE UNIQUE INDEX idx_media_history_votes_user_item
+    ON media_history_votes (user_id, item_id);
+
+CREATE INDEX idx_media_history_votes_item
+    ON media_history_votes (item_id);

--- a/late-core/src/models/media_history_item.rs
+++ b/late-core/src/models/media_history_item.rs
@@ -28,6 +28,13 @@ impl MediaHistoryItem {
         Self::get(client, id).await
     }
 
+    pub async fn delete_by_id(client: &Client, id: Uuid) -> Result<u64> {
+        let count = client
+            .execute("DELETE FROM media_history_items WHERE id = $1", &[&id])
+            .await?;
+        Ok(count)
+    }
+
     pub async fn record_play_from_queue_item(
         client: &Client,
         item: &MediaQueueItem,

--- a/late-core/src/models/media_history_item.rs
+++ b/late-core/src/models/media_history_item.rs
@@ -1,0 +1,146 @@
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+use tokio_postgres::Client;
+use uuid::Uuid;
+
+use super::media_queue_item::MediaQueueItem;
+
+crate::model! {
+    table = "media_history_items";
+    params = MediaHistoryItemParams;
+    struct MediaHistoryItem {
+        @data
+        pub media_kind: String,
+        pub external_id: String,
+        pub title: Option<String>,
+        pub channel: Option<String>,
+        pub duration_ms: Option<i32>,
+        pub is_stream: bool,
+        pub first_played_at: DateTime<Utc>,
+        pub last_played_at: DateTime<Utc>,
+        pub play_count: i32,
+        pub last_submitter_id: Option<Uuid>,
+    }
+}
+
+impl MediaHistoryItem {
+    pub async fn find_by_id(client: &Client, id: Uuid) -> Result<Option<Self>> {
+        Self::get(client, id).await
+    }
+
+    pub async fn record_play_from_queue_item(
+        client: &Client,
+        item: &MediaQueueItem,
+        limit: i64,
+    ) -> Result<()> {
+        let existing = client
+            .query_opt(
+                "SELECT * FROM media_history_items
+                 WHERE media_kind = $1 AND external_id = $2",
+                &[&item.media_kind, &item.external_id],
+            )
+            .await?;
+
+        if let Some(row) = existing {
+            let history_item = Self::from(row);
+            client
+                .execute(
+                    "UPDATE media_history_items
+                     SET title = COALESCE($2, title),
+                         channel = COALESCE($3, channel),
+                         duration_ms = COALESCE($4, duration_ms),
+                         is_stream = $5,
+                         last_played_at = current_timestamp,
+                         play_count = play_count + 1,
+                         last_submitter_id = $6,
+                         updated = current_timestamp
+                     WHERE id = $1",
+                    &[
+                        &history_item.id,
+                        &item.title,
+                        &item.channel,
+                        &item.duration_ms,
+                        &item.is_stream,
+                        &item.submitter_id,
+                    ],
+                )
+                .await?;
+        } else {
+            let row = client
+                .query_one(
+                    "INSERT INTO media_history_items
+                        (media_kind, external_id, title, channel, duration_ms,
+                         is_stream, last_submitter_id)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7)
+                     RETURNING *",
+                    &[
+                        &item.media_kind,
+                        &item.external_id,
+                        &item.title,
+                        &item.channel,
+                        &item.duration_ms,
+                        &item.is_stream,
+                        &item.submitter_id,
+                    ],
+                )
+                .await?;
+            let history_item = Self::from(row);
+            client
+                .execute(
+                    "INSERT INTO media_history_votes (item_id, user_id, value, created, updated)
+                     SELECT $1, user_id, value, created, updated
+                     FROM media_queue_votes
+                     WHERE item_id = $2
+                     ON CONFLICT (user_id, item_id) DO NOTHING",
+                    &[&history_item.id, &item.id],
+                )
+                .await?;
+        }
+
+        Self::prune_to_limit(client, limit).await?;
+        Ok(())
+    }
+
+    pub async fn list_ranked(client: &Client, limit: i64) -> Result<Vec<(Self, i32)>> {
+        let rows = client
+            .query(
+                "SELECT mhi.*, COALESCE(SUM(mhv.value), 0)::int AS vote_score
+                 FROM media_history_items mhi
+                 LEFT JOIN media_history_votes mhv ON mhv.item_id = mhi.id
+                 GROUP BY mhi.id
+                 ORDER BY vote_score DESC, mhi.last_played_at DESC, mhi.created DESC
+                 LIMIT $1",
+                &[&limit],
+            )
+            .await?;
+        Ok(rows
+            .into_iter()
+            .map(|row| {
+                let score: i32 = row.get("vote_score");
+                (Self::from(row), score)
+            })
+            .collect())
+    }
+
+    pub async fn prune_to_limit(client: &Client, limit: i64) -> Result<u64> {
+        let deleted = client
+            .execute(
+                "WITH ranked AS (
+                    SELECT mhi.id,
+                           row_number() OVER (
+                               ORDER BY COALESCE(SUM(mhv.value), 0)::int DESC,
+                                        mhi.last_played_at DESC,
+                                        mhi.created DESC
+                           ) AS rank
+                    FROM media_history_items mhi
+                    LEFT JOIN media_history_votes mhv ON mhv.item_id = mhi.id
+                    GROUP BY mhi.id
+                 )
+                 DELETE FROM media_history_items
+                 WHERE id IN (SELECT id FROM ranked WHERE rank > $1)",
+                &[&limit],
+            )
+            .await?;
+        Ok(deleted)
+    }
+}

--- a/late-core/src/models/media_history_vote.rs
+++ b/late-core/src/models/media_history_vote.rs
@@ -1,0 +1,53 @@
+use anyhow::Result;
+use tokio_postgres::Client;
+use uuid::Uuid;
+
+crate::model! {
+    table = "media_history_votes";
+    params = MediaHistoryVoteParams;
+    struct MediaHistoryVote {
+        @data
+        pub item_id: Uuid,
+        pub user_id: Uuid,
+        pub value: i16,
+    }
+}
+
+impl MediaHistoryVote {
+    pub async fn upsert(client: &Client, user_id: Uuid, item_id: Uuid, value: i16) -> Result<i32> {
+        client
+            .execute(
+                "INSERT INTO media_history_votes (user_id, item_id, value)
+                 VALUES ($1, $2, $3)
+                 ON CONFLICT (user_id, item_id)
+                 DO UPDATE SET value = EXCLUDED.value,
+                               updated = current_timestamp",
+                &[&user_id, &item_id, &value],
+            )
+            .await?;
+        Self::aggregate_for_item(client, item_id).await
+    }
+
+    pub async fn delete_vote(client: &Client, user_id: Uuid, item_id: Uuid) -> Result<i32> {
+        client
+            .execute(
+                "DELETE FROM media_history_votes
+                 WHERE user_id = $1 AND item_id = $2",
+                &[&user_id, &item_id],
+            )
+            .await?;
+        Self::aggregate_for_item(client, item_id).await
+    }
+
+    pub async fn aggregate_for_item(client: &Client, item_id: Uuid) -> Result<i32> {
+        let row = client
+            .query_one(
+                "SELECT COALESCE(SUM(value), 0)::int AS score
+                 FROM media_history_votes
+                 WHERE item_id = $1",
+                &[&item_id],
+            )
+            .await?;
+        Ok(row.get::<_, i32>("score"))
+    }
+}

--- a/late-core/src/models/mod.rs
+++ b/late-core/src/models/mod.rs
@@ -17,6 +17,8 @@ pub mod game_payout;
 pub mod game_room;
 pub mod leaderboard;
 pub mod marketplace;
+pub mod media_history_item;
+pub mod media_history_vote;
 pub mod media_queue_item;
 pub mod media_queue_vote;
 pub mod media_source;

--- a/late-ssh/src/app/audio/CONTEXT.md
+++ b/late-ssh/src/app/audio/CONTEXT.md
@@ -114,6 +114,7 @@ Keep `mod.rs` declaration-only — no `pub use` re-exports.
 - `report_player_state` / `report_player_state_task` — `api.rs:329`, ingress for browser `player_state` reports.
 - `cast_history_vote` / `clear_history_vote` — same `+/-/0` voting semantics as queue votes, but against `media_history_votes`.
 - `requeue_history_item` — inserts a fresh `media_queue_items` row from stored validated history metadata. Live queue votes always start at 0.
+- `delete_history_item` — requires centralized `Caps::DELETE_AUDIO_TRACK` via `Permissions::can_delete_audio_track(false)`.
 
 ### Startup lifecycle
 1. `sweep_orphan_playing` (`svc.rs:425-438`) marks any `status='playing'` row older than `now - 1h` as `failed` with `error = "orphan playing row swept at startup"`.
@@ -138,7 +139,8 @@ All transitions go through `svc.rs`:
 - If the same YouTube video plays again, history updates `last_played_at`, `play_count`, and metadata, but it does not overwrite existing history votes. The historical score remains a durable community rating.
 - History pruning sorts by `history vote score DESC`, then `last_played_at DESC`, then `created DESC`; rows after rank 30 are deleted. A weak new track can insert and immediately prune itself if the full history already has 30 better/newer rows.
 - Requeueing from history uses stored validated metadata to create a new `media_queue_items` row. It does not copy history votes into live queue votes; the fresh queue item starts with score 0 and competes normally.
-- The booth modal switches between `Queue` and `History` lists. Queue mode keeps `+/-/0`, `s`, `d`, and staff `u`; History mode uses `+/-/0` for history votes and Enter to requeue.
+- Queue deletion and History deletion share one moderation-policy permission: `Caps::DELETE_AUDIO_TRACK`. Queue deletion passes `is_owner=true` for the submitter, so users can still delete their own queued rows; History deletion always passes `false`.
+- The booth modal switches between `Queue` and `History` lists. Queue mode keeps `+/-/0`, `s`, `d`, and staff `u`; History mode uses `+/-/0` for history votes, Enter to requeue, and permission-gated `d` to delete a history row.
 
 ### Timers
 - **Playback timer** (`schedule_playback_timer`): one `tokio::select!` task per playing item. Sleeps `duration - elapsed` then calls `finish_item_due_to_timer`. Also re-broadcasts `LoadVideo` for the current item every `PLAYBACK_HEARTBEAT_INTERVAL = 10s` from inside the same task — the safety-net heartbeat. Browsers ignore the heartbeat when they're already showing the right item; otherwise they force-swap.
@@ -424,7 +426,7 @@ No copy anywhere reads "queue empty". The user has pushed back on that wording m
 Model helpers (`late-core/src/models/media_queue_item.rs`, `media_source.rs`):
 - `MediaQueueItem::{insert_youtube, find_by_id, list_snapshot, queued_before_count, recent_submission_count, first_queued, current_playing, mark_playing, mark_played, mark_failed, mark_skipped, sweep_orphan_playing}`. Status/kind constants: `STATUS_QUEUED`, `STATUS_PLAYING`, `STATUS_PLAYED`, `STATUS_SKIPPED`, `STATUS_FAILED`, `KIND_YOUTUBE`.
 - `MediaSource::{youtube_fallback, upsert_youtube_fallback}`. Constants: `KIND_YOUTUBE_FALLBACK`, `MEDIA_KIND_YOUTUBE`.
-- `MediaHistoryItem::{record_play_from_queue_item, list_ranked, prune_to_limit}` and `MediaHistoryVote::{upsert, delete_vote, aggregate_for_item}`.
+- `MediaHistoryItem::{record_play_from_queue_item, list_ranked, prune_to_limit, delete_by_id}` and `MediaHistoryVote::{upsert, delete_vote, aggregate_for_item}`.
 
 ---
 

--- a/late-ssh/src/app/audio/CONTEXT.md
+++ b/late-ssh/src/app/audio/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: late.sh audio — Icecast house radio, global YouTube queue, browser/CLI source arbitration, synthetic browser-pair visualizer, and now-playing poller
 - Primary audience: LLM agents working in `late-ssh/src/app/audio` and the music/audio touchpoints it owns in `late-cli` and `late-web/src/pages/connect`
-- Last updated: 2026-06-03 (voice-room details moved to `late-ssh/src/app/voice/CONTEXT.md`; this file now stays scoped to music/audio queue, playback, source switching, visualizer, and now-playing)
+- Last updated: 2026-06-06 (Music Booth gained community History: max 30 unique tracks, independent history votes, and requeue-from-history with fresh live votes)
 - Previously: source arbitration simplified — no `ForceMute`; CLI gates Icecast on `set_playback_source`, and browsers only play web Icecast when no CLI is paired. Booth modal surfaces track durations: queue list has a right-aligned `m:ss` column between title and submitter, and the Now Playing row shows the same `m:ss` next to the title. Streams render `live`; unknown durations are blank. Both booth and staff `/audio` submit paths now validate through the YouTube Data API before insert, so queued rows carry server-side title/channel/`duration_ms`/`is_stream`. Browser/CLI player reports are diagnostics only; they never backfill duration or advance the shared queue.
 - Status: Active
 - Parent context: `../../../../CONTEXT.md`
@@ -15,6 +15,7 @@
 Owned by this domain:
 - Always-on Icecast house radio playback (the `<audio>` and CLI symphonia path).
 - Global, DB-backed YouTube queue: submission, persistence, single-playing invariant, server-driven track switching (per-browser playback timeline), fallback debounce.
+- Community Booth History: max 30 unique previously played YouTube tracks, independent history votes, and requeue-from-history.
 - The singleton "YouTube fallback" stream that plays when the queue is empty.
 - Audio source arbitration between paired CLI and paired browser clients on the same SSH token (`set_playback_source` + browser Icecast gate).
 - Synthetic browser-pair visualizer used for both Icecast and YouTube.
@@ -35,7 +36,7 @@ Out of scope here (lives elsewhere):
 ```text
 late-ssh/src/app/audio/
 ├── mod.rs                  # declarations only (booth, client_state, liquidsoap, now_playing, state, svc, viz, youtube)
-├── svc.rs                  # AudioService: queue state machine, WS broadcast, resume, fallback debounce, periodic LoadVideo heartbeat, votes/skip-vote
+├── svc.rs                  # AudioService: queue/history state machine, WS broadcast, resume, fallback debounce, periodic LoadVideo heartbeat, votes/skip-vote
 ├── state.rs                # AudioState: per-session UI shim — proxies submits/votes and turns AudioEvent into Banners
 ├── client_state.rs         # ClientAudioState + ClientKind/SshMode/Platform enums (the client_state WS payload)
 ├── liquidsoap.rs           # LiquidsoapController telnet client (NOT used by AudioService — only by app/vote/svc.rs)
@@ -43,9 +44,9 @@ late-ssh/src/app/audio/
 ├── youtube.rs              # URL parsing + optional YouTube Data API validation client
 ├── booth/
 │   ├── mod.rs
-│   ├── state.rs            # BoothModalState: open flag, submit input, selected index, focus
-│   ├── input.rs            # modal-open key dispatch (submit/queue focus, +/- vote, s skip)
-│   └── ui.rs               # ratatui modal: submit row, current track, queue list with duration + score
+│   ├── state.rs            # BoothModalState: open flag, submit input, queue/history selections, focus
+│   ├── input.rs            # modal-open key dispatch (submit/queue/history focus, +/- vote, s skip, Enter requeue)
+│   └── ui.rs               # ratatui modal: submit row, current track, queue/history lists with duration + score
 └── now_playing/
     ├── mod.rs
     └── svc.rs              # NowPlayingService: 10s Icecast title poll, watch<Option<NowPlaying>>
@@ -53,10 +54,12 @@ late-ssh/src/app/audio/
 
 Cross-crate touchpoints:
 - `late-core/src/models/media_queue_item.rs`, `media_source.rs`,
-  `media_queue_vote.rs` — DB models.
+  `media_queue_vote.rs`, `media_history_item.rs`,
+  `media_history_vote.rs` — DB models.
 - `late-core/migrations/047_create_media_queue_items.sql`,
   `048_create_media_sources.sql`,
-  `049_create_media_queue_votes.sql`.
+  `049_create_media_queue_votes.sql`,
+  `073_create_media_history.sql`.
 - `late-core/src/audio.rs` — `VizFrame { bands[8], rms, track_pos_ms }` shared between server and CLI.
 - `late-ssh/src/paired_clients.rs` — `PairedClientRegistry`, `PairControlMessage::SetPlaybackSource`, source/surface policy.
 - `late-ssh/src/api.rs` — `/api/ws/pair` multiplexes `AudioWsMessage` + `PairControlMessage`; `/api/now-playing`.
@@ -84,7 +87,7 @@ Keep `mod.rs` declaration-only — no `pub use` re-exports.
 
 ### Channels and state
 - `ws_tx: broadcast::Sender<AudioWsMessage>` (cap 512) — server-authoritative pair-WS events, fanned out to every paired client.
-- `event_tx: broadcast::Sender<AudioEvent>` (cap 256) — per-user banners (success/failure on submit, fallback set). Consumed only by `AudioState`.
+- `event_tx: broadcast::Sender<AudioEvent>` (cap 256) — per-user banners (success/failure on submit, fallback set, history vote/requeue). Consumed only by `AudioState`.
 - `state: Arc<Mutex<QueueState>>` — `{ mode: AudioMode, current_item_id, sequence, playback_cancel: Option<oneshot>, fallback_cancel: Option<oneshot> }`.
 
 ### Constants (`svc.rs:15-21`)
@@ -95,6 +98,7 @@ Keep `mod.rs` declaration-only — no `pub use` re-exports.
 - `RECONCILE_INTERVAL = 60s` — background DB reconcile safety net. If memory drifts from the singleton `playing` row (e.g. rollout overlap), the service adopts the DB current, cancels/re-arms timers, and republishes state.
 - `STREAM_CAP = 1h` — hard cap on any single playing row's wall-clock lifetime.
 - `SKIP_VOTE_FRACTION = 0.3` + `SKIP_VOTE_MIN = 2` — `skip_threshold(youtube_total) = max(ceil(0.3 * youtube_total), 2)`. **Denominator is active users whose persisted `users.settings.audio_source` is `youtube`**, not paired-client/browser presence. Floor of 2 means a lone active YouTube-pref user can't solo-skip; the 30% ceil kicks in above 6 active YouTube-pref users.
+- `HISTORY_LIMIT = 30` — community Booth History keeps at most 30 unique YouTube tracks.
 
 ### Public API
 - `new(db, youtube_api_key)` — `main.rs:123`.
@@ -102,12 +106,14 @@ Keep `mod.rs` declaration-only — no `pub use` re-exports.
 - `subscribe_ws()` — `api.rs:237` (pair WS upgrade).
 - `subscribe_events()` — `app/audio/state.rs`.
 - `initial_ws_messages()` (`svc.rs:393-423`) — catch-up burst sent on every new pair-WS connect: `source_changed`, `queue_update`, and `load_video` for the current playing item or for the configured fallback.
-- `snapshot()` — returns `QueueSnapshot { mode, current, queue }`. Type exists but no HTTP route exposes it (see §14).
+- `snapshot()` — returns `QueueSnapshot { mode, current, queue, history }`. Type exists but no HTTP route exposes it (see §14).
 - `submit_url` / `submit_url_task` — un-trusted, rate-limited, validates via YouTube Data API. **Called by `booth_submit_public_task`** (the in-TUI booth modal submit). Requires `LATE_YOUTUBE_API_KEY`; when unset, `booth_submit_enabled()` returns false and the modal disables the submit row. Inserted rows carry `title`, `channel`, `duration_ms`, and `is_stream` from the Data API — so booth-queued items render their `m:ss` duration in the queue list immediately.
 - `booth_submit_public_task` — wraps `submit_url` for the booth modal: emits `AudioEvent::BoothSubmit{Queued,Failed}` (user-scoped banners) and shows "Disabled" if the API key is missing. **This is the user-facing submit path.**
 - `submit_trusted_url` / `submit_trusted_url_task` — used by `/audio` (staff). Bypasses rate limit but still validates via YouTube Data API. Normal videos require a server-side duration; live streams set `is_stream=true` and use the 1h cap.
 - `set_trusted_youtube_fallback` / `set_trusted_youtube_fallback_task` — used by `/audio fallback`. Also validates via YouTube Data API before upserting the singleton `media_sources` row.
 - `report_player_state` / `report_player_state_task` — `api.rs:329`, ingress for browser `player_state` reports.
+- `cast_history_vote` / `clear_history_vote` — same `+/-/0` voting semantics as queue votes, but against `media_history_votes`.
+- `requeue_history_item` — inserts a fresh `media_queue_items` row from stored validated history metadata. Live queue votes always start at 0.
 
 ### Startup lifecycle
 1. `sweep_orphan_playing` (`svc.rs:425-438`) marks any `status='playing'` row older than `now - 1h` as `failed` with `error = "orphan playing row swept at startup"`.
@@ -124,6 +130,15 @@ All transitions go through `svc.rs`:
 - `playing → skipped`: staff `/audio skip` and threshold skip use `mark_skipped` (`WHERE status='playing'`). A stale pod cannot mutate an already-played row to `skipped`; zero-row updates reconcile and ask the caller to retry.
 
 `advance_to_next_with_guard` is the *only* advancer. It adopts a DB current first, otherwise picks `MediaQueueItem::first_queued()`, tries to flip it, on success broadcasts `SourceChanged: youtube` + `LoadVideo` + `QueueUpdate`. If the queue is empty it tries `publish_youtube_fallback_with_guard`; if no fallback row exists, `schedule_fallback` arms the 10s debounce, after which `finish_fallback_debounce` flips `mode = Icecast` (and re-checks `current_item_id.is_none()` to avoid races).
+
+### Booth History
+- History is community-wide and unique by `(media_kind, external_id)`, currently YouTube-only.
+- A track is recorded when `advance_to_next_with_guard` successfully promotes a queued row to `playing`. This is the moment it "lands" in history.
+- On first history insert, live queue votes for that queue row are copied into `media_history_votes`, preserving the up/down signal that got the track into Now Playing.
+- If the same YouTube video plays again, history updates `last_played_at`, `play_count`, and metadata, but it does not overwrite existing history votes. The historical score remains a durable community rating.
+- History pruning sorts by `history vote score DESC`, then `last_played_at DESC`, then `created DESC`; rows after rank 30 are deleted. A weak new track can insert and immediately prune itself if the full history already has 30 better/newer rows.
+- Requeueing from history uses stored validated metadata to create a new `media_queue_items` row. It does not copy history votes into live queue votes; the fresh queue item starts with score 0 and competes normally.
+- The booth modal switches between `Queue` and `History` lists. Queue mode keeps `+/-/0`, `s`, `d`, and staff `u`; History mode uses `+/-/0` for history votes and Enter to requeue.
 
 ### Timers
 - **Playback timer** (`schedule_playback_timer`): one `tokio::select!` task per playing item. Sleeps `duration - elapsed` then calls `finish_item_due_to_timer`. Also re-broadcasts `LoadVideo` for the current item every `PLAYBACK_HEARTBEAT_INTERVAL = 10s` from inside the same task — the safety-net heartbeat. Browsers ignore the heartbeat when they're already showing the right item; otherwise they force-swap.
@@ -400,16 +415,23 @@ No copy anywhere reads "queue empty". The user has pushed back on that wording m
 - `external_id` non-empty, `title`, `channel`, `is_stream BOOLEAN NOT NULL DEFAULT true`, `updated_by → users ON DELETE SET NULL`.
 - Unique index on `source_kind` → singleton fallback row, upserted via `MediaSource::upsert_youtube_fallback`.
 
+### `media_history_items` / `media_history_votes` (migration `073`)
+- `media_history_items` stores community Booth History rows, unique by `(media_kind, external_id)`.
+- Columns mirror validated queue metadata (`title`, `channel`, `duration_ms`, `is_stream`) plus `first_played_at`, `last_played_at`, `play_count`, and nullable `last_submitter_id`.
+- `media_history_votes` mirrors live queue votes structurally: one `-1`/`+1` vote per `(user_id, item_id)`.
+- History is pruned to 30 rows by rank: aggregate score descending, `last_played_at` descending, `created` descending.
+
 Model helpers (`late-core/src/models/media_queue_item.rs`, `media_source.rs`):
 - `MediaQueueItem::{insert_youtube, find_by_id, list_snapshot, queued_before_count, recent_submission_count, first_queued, current_playing, mark_playing, mark_played, mark_failed, mark_skipped, sweep_orphan_playing}`. Status/kind constants: `STATUS_QUEUED`, `STATUS_PLAYING`, `STATUS_PLAYED`, `STATUS_SKIPPED`, `STATUS_FAILED`, `KIND_YOUTUBE`.
 - `MediaSource::{youtube_fallback, upsert_youtube_fallback}`. Constants: `KIND_YOUTUBE_FALLBACK`, `MEDIA_KIND_YOUTUBE`.
+- `MediaHistoryItem::{record_play_from_queue_item, list_ranked, prune_to_limit}` and `MediaHistoryVote::{upsert, delete_vote, aggregate_for_item}`.
 
 ---
 
 ## 14. Known Gaps and Things to Watch
 
 - **`GET /api/queue` is intentionally not exposed.** `AudioService::snapshot()` and `QueueSnapshot` exist for in-process use only. The TUI booth modal reads the snapshot from `AudioState::queue_snapshot()` (a `watch::Receiver<QueueSnapshot>` populated by `publish_queue_update_with_guard`); browsers receive state via the `initial_ws_messages` catch-up burst and live `queue_update` events. An external route would only matter for non-paired observers, which we do not have today.
-- **Booth modal renders from `watch::Receiver<QueueSnapshot>`.** `AudioService` keeps a `snapshot_tx` watch sender alongside the broadcast channels; every `publish_queue_update_with_guard` uses `send_replace` to store the latest snapshot even when zero receivers are alive (startup often publishes before any SSH booth exists), and `AudioState::queue_snapshot()` borrows the current value. Skip progress (`votes/threshold`) is folded into the snapshot before it ships.
+- **Booth modal renders from `watch::Receiver<QueueSnapshot>`.** `AudioService` keeps a `snapshot_tx` watch sender alongside the broadcast channels; every `publish_queue_update_with_guard` uses `send_replace` to store the latest snapshot even when zero receivers are alive (startup often publishes before any SSH booth exists), and `AudioState::queue_snapshot()` borrows the current value. Skip progress (`votes/threshold`) and Booth History are folded into the snapshot before it ships.
 - **`liquidsoap.rs` lives here but is only used by `app/vote/svc.rs`.** AudioService does *not* drive Liquidsoap. Treat `AudioMode::Icecast` as a hint to the browser/CLI, not a Liquidsoap state change.
 - **`/music` ≠ `/audio`.** `/music` is a help-topic command. `/audio` (and `/audio fallback`) are the submit commands. Don't conflate.
 - **No `GET /api/queue` HTTP route.** Submit and visibility for end users happen through the SSH booth modal (submit + queue list) and the staff `/audio` chat command. Non-paired observers have no way to see the queue today.

--- a/late-ssh/src/app/audio/booth/input.rs
+++ b/late-ssh/src/app/audio/booth/input.rs
@@ -1,5 +1,5 @@
 use crate::app::{
-    input::{ParsedInput, sanitize_paste_markers},
+    input::{sanitize_paste_markers, ParsedInput},
     state::App,
 };
 
@@ -8,7 +8,8 @@ use super::state::BoothFocus;
 pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
     let snapshot = app.audio.queue_snapshot();
     let queue_len = snapshot.queue.len();
-    app.booth_modal_state.clamp(queue_len);
+    let history_len = snapshot.history.len();
+    app.booth_modal_state.clamp(queue_len, history_len);
 
     match event {
         ParsedInput::Byte(0x1B) => {
@@ -16,7 +17,8 @@ pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
             return;
         }
         ParsedInput::Byte(b'\t') => {
-            app.booth_modal_state.toggle_focus();
+            app.booth_modal_state
+                .cycle_focus(app.audio.booth_submit_enabled());
             return;
         }
         _ => {}
@@ -25,10 +27,12 @@ pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
     match app.booth_modal_state.focus() {
         BoothFocus::Submit => handle_submit_input(app, event),
         BoothFocus::Queue => handle_queue_input(app, event, queue_len),
+        BoothFocus::History => handle_history_input(app, event, history_len),
     }
 
     let queue_len = app.audio.queue_snapshot().queue.len();
-    app.booth_modal_state.clamp(queue_len);
+    let history_len = app.audio.queue_snapshot().history.len();
+    app.booth_modal_state.clamp(queue_len, history_len);
 }
 
 fn handle_submit_input(app: &mut App, event: ParsedInput) {
@@ -70,7 +74,7 @@ fn handle_submit_input(app: &mut App, event: ParsedInput) {
 fn handle_queue_input(app: &mut App, event: ParsedInput, queue_len: usize) {
     match event {
         ParsedInput::Arrow(b'A') | ParsedInput::Byte(0x0B) => {
-            if app.booth_modal_state.selected() == 0 {
+            if app.booth_modal_state.selected_queue() == 0 {
                 app.booth_modal_state.set_focus(BoothFocus::Submit);
             } else {
                 app.booth_modal_state.move_selection(-1, queue_len);
@@ -92,6 +96,30 @@ fn handle_queue_input(app: &mut App, event: ParsedInput, queue_len: usize) {
         }
         ParsedInput::Char('u') | ParsedInput::Char('U') => {
             toggle_unskippable_selected(app);
+        }
+        ParsedInput::Char(']') | ParsedInput::Char('[') => {
+            app.booth_modal_state.set_focus(BoothFocus::History);
+        }
+        _ => {}
+    }
+}
+
+fn handle_history_input(app: &mut App, event: ParsedInput, history_len: usize) {
+    match event {
+        ParsedInput::Arrow(b'A') | ParsedInput::Byte(0x0B) => {
+            app.booth_modal_state.move_selection(-1, history_len);
+        }
+        ParsedInput::Arrow(b'B') | ParsedInput::Byte(0x0A) => {
+            app.booth_modal_state.move_selection(1, history_len);
+        }
+        ParsedInput::PageUp => app.booth_modal_state.move_selection(-8, history_len),
+        ParsedInput::PageDown => app.booth_modal_state.move_selection(8, history_len),
+        ParsedInput::Char('+') | ParsedInput::Char('=') => cast_selected_history_vote(app, 1),
+        ParsedInput::Char('-') | ParsedInput::Char('_') => cast_selected_history_vote(app, -1),
+        ParsedInput::Char('0') => clear_selected_history_vote(app),
+        ParsedInput::Byte(b'\r') => requeue_selected_history(app),
+        ParsedInput::Char(']') | ParsedInput::Char('[') => {
+            app.booth_modal_state.set_focus(BoothFocus::Queue);
         }
         _ => {}
     }
@@ -127,4 +155,37 @@ fn toggle_unskippable_selected(app: &mut App) {
         return;
     };
     app.audio.booth_toggle_unskippable(item_id);
+}
+
+fn cast_selected_history_vote(app: &mut App, value: i16) {
+    let snapshot = app.audio.queue_snapshot();
+    let Some(item_id) = app
+        .booth_modal_state
+        .selected_history_item_id(&snapshot.history)
+    else {
+        return;
+    };
+    app.audio.booth_history_vote(item_id, value);
+}
+
+fn clear_selected_history_vote(app: &mut App) {
+    let snapshot = app.audio.queue_snapshot();
+    let Some(item_id) = app
+        .booth_modal_state
+        .selected_history_item_id(&snapshot.history)
+    else {
+        return;
+    };
+    app.audio.booth_history_clear_vote(item_id);
+}
+
+fn requeue_selected_history(app: &mut App) {
+    let snapshot = app.audio.queue_snapshot();
+    let Some(item_id) = app
+        .booth_modal_state
+        .selected_history_item_id(&snapshot.history)
+    else {
+        return;
+    };
+    app.audio.booth_history_requeue(item_id);
 }

--- a/late-ssh/src/app/audio/booth/input.rs
+++ b/late-ssh/src/app/audio/booth/input.rs
@@ -118,6 +118,7 @@ fn handle_history_input(app: &mut App, event: ParsedInput, history_len: usize) {
         ParsedInput::Char('-') | ParsedInput::Char('_') => cast_selected_history_vote(app, -1),
         ParsedInput::Char('0') => clear_selected_history_vote(app),
         ParsedInput::Byte(b'\r') => requeue_selected_history(app),
+        ParsedInput::Char('d') | ParsedInput::Char('D') => delete_selected_history(app),
         ParsedInput::Char(']') | ParsedInput::Char('[') => {
             app.booth_modal_state.set_focus(BoothFocus::Queue);
         }
@@ -188,4 +189,15 @@ fn requeue_selected_history(app: &mut App) {
         return;
     };
     app.audio.booth_history_requeue(item_id);
+}
+
+fn delete_selected_history(app: &mut App) {
+    let snapshot = app.audio.queue_snapshot();
+    let Some(item_id) = app
+        .booth_modal_state
+        .selected_history_item_id(&snapshot.history)
+    else {
+        return;
+    };
+    app.audio.booth_history_delete(item_id);
 }

--- a/late-ssh/src/app/audio/booth/state.rs
+++ b/late-ssh/src/app/audio/booth/state.rs
@@ -1,19 +1,21 @@
 use uuid::Uuid;
 
-use crate::app::audio::svc::QueueItemView;
+use crate::app::audio::svc::{HistoryItemView, QueueItemView};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub(crate) enum BoothFocus {
     #[default]
     Submit,
     Queue,
+    History,
 }
 
 #[derive(Clone, Debug, Default)]
 pub(crate) struct BoothModalState {
     open: bool,
     submit_input: String,
-    selected: usize,
+    selected_queue: usize,
+    selected_history: usize,
     focus: BoothFocus,
 }
 
@@ -21,7 +23,8 @@ impl BoothModalState {
     pub(crate) fn open(&mut self, submit_enabled: bool) {
         self.open = true;
         self.submit_input.clear();
-        self.selected = 0;
+        self.selected_queue = 0;
+        self.selected_history = 0;
         self.focus = if submit_enabled {
             BoothFocus::Submit
         } else {
@@ -32,7 +35,8 @@ impl BoothModalState {
     pub(crate) fn close(&mut self) {
         self.open = false;
         self.submit_input.clear();
-        self.selected = 0;
+        self.selected_queue = 0;
+        self.selected_history = 0;
         self.focus = BoothFocus::Submit;
     }
 
@@ -49,7 +53,18 @@ impl BoothModalState {
     }
 
     pub(crate) fn selected(&self) -> usize {
-        self.selected
+        match self.focus {
+            BoothFocus::Submit | BoothFocus::Queue => self.selected_queue,
+            BoothFocus::History => self.selected_history,
+        }
+    }
+
+    pub(crate) fn selected_queue(&self) -> usize {
+        self.selected_queue
+    }
+
+    pub(crate) fn selected_history(&self) -> usize {
+        self.selected_history
     }
 
     pub(crate) fn push(&mut self, ch: char) {
@@ -68,25 +83,33 @@ impl BoothModalState {
 
     pub(crate) fn move_selection(&mut self, delta: isize, len: usize) {
         if len == 0 {
-            self.selected = 0;
+            self.set_selected_for_focus(0);
             return;
         }
-        let next = (self.selected as isize + delta).rem_euclid(len as isize) as usize;
-        self.selected = next;
+        let current = self.selected();
+        let next = (current as isize + delta).rem_euclid(len as isize) as usize;
+        self.set_selected_for_focus(next);
     }
 
-    pub(crate) fn clamp(&mut self, len: usize) {
-        if len == 0 {
-            self.selected = 0;
+    pub(crate) fn clamp(&mut self, queue_len: usize, history_len: usize) {
+        if queue_len == 0 {
+            self.selected_queue = 0;
         } else {
-            self.selected = self.selected.min(len - 1);
+            self.selected_queue = self.selected_queue.min(queue_len - 1);
+        }
+        if history_len == 0 {
+            self.selected_history = 0;
+        } else {
+            self.selected_history = self.selected_history.min(history_len - 1);
         }
     }
 
-    pub(crate) fn toggle_focus(&mut self) {
+    pub(crate) fn cycle_focus(&mut self, submit_enabled: bool) {
         self.focus = match self.focus {
             BoothFocus::Submit => BoothFocus::Queue,
-            BoothFocus::Queue => BoothFocus::Submit,
+            BoothFocus::Queue => BoothFocus::History,
+            BoothFocus::History if submit_enabled => BoothFocus::Submit,
+            BoothFocus::History => BoothFocus::Queue,
         };
     }
 
@@ -98,10 +121,28 @@ impl BoothModalState {
         &self,
         queue: &'a [QueueItemView],
     ) -> Option<&'a QueueItemView> {
-        queue.get(self.selected)
+        queue.get(self.selected_queue)
     }
 
     pub(crate) fn selected_item_id(&self, queue: &[QueueItemView]) -> Option<Uuid> {
         self.selected_item(queue).map(|item| item.id)
+    }
+
+    pub(crate) fn selected_history_item<'a>(
+        &self,
+        history: &'a [HistoryItemView],
+    ) -> Option<&'a HistoryItemView> {
+        history.get(self.selected_history)
+    }
+
+    pub(crate) fn selected_history_item_id(&self, history: &[HistoryItemView]) -> Option<Uuid> {
+        self.selected_history_item(history).map(|item| item.id)
+    }
+
+    fn set_selected_for_focus(&mut self, selected: usize) {
+        match self.focus {
+            BoothFocus::Submit | BoothFocus::Queue => self.selected_queue = selected,
+            BoothFocus::History => self.selected_history = selected,
+        }
     }
 }

--- a/late-ssh/src/app/audio/booth/ui.rs
+++ b/late-ssh/src/app/audio/booth/ui.rs
@@ -568,6 +568,13 @@ fn draw_footer(
             " queue  ",
             Style::default().fg(theme::TEXT_DIM()),
         ));
+        if is_staff {
+            spans.push(Span::styled("d", Style::default().fg(theme::AMBER_DIM())));
+            spans.push(Span::styled(
+                " delete  ",
+                Style::default().fg(theme::TEXT_DIM()),
+            ));
+        }
     } else {
         spans.push(Span::styled("s", Style::default().fg(theme::AMBER_DIM())));
         spans.push(Span::styled(

--- a/late-ssh/src/app/audio/booth/ui.rs
+++ b/late-ssh/src/app/audio/booth/ui.rs
@@ -1,14 +1,14 @@
 use ratatui::{
-    Frame,
     layout::{Constraint, Flex, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
+    Frame,
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
 use crate::app::{
-    audio::svc::{AudioMode, QueueItemView, QueueSnapshot, SkipProgress},
+    audio::svc::{AudioMode, HistoryItemView, QueueItemView, QueueSnapshot, SkipProgress},
     common::theme,
 };
 
@@ -83,10 +83,13 @@ pub(crate) fn draw(
         snapshot.skip_progress(),
     );
 
-    frame.render_widget(Paragraph::new(section_heading("Queue")), layout[9]);
-    draw_queue(frame, layout[11], state, &snapshot.queue);
+    frame.render_widget(Paragraph::new(list_heading(state.focus())), layout[9]);
+    match state.focus() {
+        BoothFocus::History => draw_history(frame, layout[11], state, &snapshot.history),
+        _ => draw_queue(frame, layout[11], state, &snapshot.queue),
+    }
 
-    draw_footer(frame, layout[12], submit_enabled, is_staff);
+    draw_footer(frame, layout[12], state.focus(), submit_enabled, is_staff);
 }
 
 fn draw_submit(
@@ -237,7 +240,7 @@ fn draw_queue(frame: &mut Frame, area: Rect, state: &BoothModalState, queue: &[Q
         return;
     }
 
-    let selected = state.selected().min(queue.len().saturating_sub(1));
+    let selected = state.selected_queue().min(queue.len().saturating_sub(1));
     let focused = state.focus() == BoothFocus::Queue;
     let height = area.height as usize;
     if height == 0 {
@@ -256,6 +259,50 @@ fn draw_queue(frame: &mut Frame, area: Rect, state: &BoothModalState, queue: &[Q
         .map(|(index, item)| {
             let active = focused && index == selected;
             queue_line(item, active, width)
+        })
+        .collect();
+
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn draw_history(
+    frame: &mut Frame,
+    area: Rect,
+    state: &BoothModalState,
+    history: &[HistoryItemView],
+) {
+    if history.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::raw("   "),
+                Span::styled("history empty", Style::default().fg(theme::TEXT_DIM())),
+            ])),
+            area,
+        );
+        return;
+    }
+
+    let selected = state
+        .selected_history()
+        .min(history.len().saturating_sub(1));
+    let focused = state.focus() == BoothFocus::History;
+    let height = area.height as usize;
+    if height == 0 {
+        return;
+    }
+    let width = area.width as usize;
+    let start = selected
+        .saturating_sub(height.saturating_sub(1))
+        .min(history.len().saturating_sub(height.min(history.len())));
+
+    let lines: Vec<Line<'static>> = history
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(height)
+        .map(|(index, item)| {
+            let active = focused && index == selected;
+            history_line(item, active, width)
         })
         .collect();
 
@@ -365,6 +412,102 @@ fn queue_line(item: &QueueItemView, active: bool, width: usize) -> Line<'static>
     ])
 }
 
+fn history_line(item: &HistoryItemView, active: bool, width: usize) -> Line<'static> {
+    let marker = if active { "›" } else { " " };
+    let prefix_style = if active {
+        Style::default()
+            .fg(theme::AMBER_GLOW())
+            .bg(theme::BG_SELECTION())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT_FAINT())
+    };
+    let label_style = if active {
+        Style::default()
+            .fg(theme::TEXT_BRIGHT())
+            .bg(theme::BG_SELECTION())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT())
+    };
+    let meta_style = if active {
+        Style::default()
+            .fg(theme::TEXT_DIM())
+            .bg(theme::BG_SELECTION())
+    } else {
+        Style::default().fg(theme::TEXT_FAINT())
+    };
+    let trailing_style = if active {
+        Style::default().bg(theme::BG_SELECTION())
+    } else {
+        Style::default()
+    };
+    let score = format!("{:+}", item.vote_score);
+    let score_style = if item.vote_score > 0 {
+        let base = Style::default()
+            .fg(theme::AMBER_GLOW())
+            .add_modifier(Modifier::BOLD);
+        if active {
+            base.bg(theme::BG_SELECTION())
+        } else {
+            base
+        }
+    } else if item.vote_score < 0 {
+        let base = Style::default().fg(theme::TEXT_DIM());
+        if active {
+            base.bg(theme::BG_SELECTION())
+        } else {
+            base
+        }
+    } else {
+        meta_style
+    };
+
+    let title = item
+        .title
+        .clone()
+        .unwrap_or_else(|| format!("yt:{}", item.video_id));
+    let duration_text = format_history_duration(item);
+    let plays = format!("{}x", item.play_count.max(1));
+    let prefix = format!(" {marker} ");
+    let prefix_w = prefix.chars().count();
+    const RIGHT_PAD: usize = 3;
+    let inner_width = width.saturating_sub(RIGHT_PAD);
+    let duration_width = 5usize.min(inner_width.saturating_sub(prefix_w + 4));
+    let plays_width = 5usize.min(inner_width.saturating_sub(prefix_w + duration_width + 5));
+    let score_width =
+        5usize.min(inner_width.saturating_sub(prefix_w + duration_width + plays_width + 6));
+    let label_width =
+        inner_width.saturating_sub(prefix_w + duration_width + plays_width + score_width + 3);
+
+    Line::from(vec![
+        Span::styled(prefix, prefix_style),
+        Span::styled(
+            pad_right(&truncate_to_width(&title, label_width), label_width),
+            label_style,
+        ),
+        Span::styled(" ", trailing_style),
+        Span::styled(
+            pad_left(
+                &truncate_to_width(&duration_text, duration_width),
+                duration_width,
+            ),
+            meta_style,
+        ),
+        Span::styled(" ", trailing_style),
+        Span::styled(
+            pad_left(&truncate_to_width(&plays, plays_width), plays_width),
+            meta_style,
+        ),
+        Span::styled(" ", trailing_style),
+        Span::styled(
+            pad_left(&truncate_to_width(&score, score_width), score_width),
+            score_style,
+        ),
+        Span::styled(" ".repeat(RIGHT_PAD), trailing_style),
+    ])
+}
+
 fn format_queue_duration(item: &QueueItemView) -> String {
     if item.is_stream {
         return "live".to_string();
@@ -381,7 +524,29 @@ fn format_queue_duration(item: &QueueItemView) -> String {
     format!("{minutes}:{seconds:02}")
 }
 
-fn draw_footer(frame: &mut Frame, area: Rect, submit_enabled: bool, is_staff: bool) {
+fn format_history_duration(item: &HistoryItemView) -> String {
+    if item.is_stream {
+        return "live".to_string();
+    }
+    let Some(ms) = item.duration_ms else {
+        return String::new();
+    };
+    if ms <= 0 {
+        return String::new();
+    }
+    let secs = (ms as u64) / 1000;
+    let minutes = secs / 60;
+    let seconds = secs % 60;
+    format!("{minutes}:{seconds:02}")
+}
+
+fn draw_footer(
+    frame: &mut Frame,
+    area: Rect,
+    focus: BoothFocus,
+    submit_enabled: bool,
+    is_staff: bool,
+) {
     if area.width == 0 || area.height == 0 {
         return;
     }
@@ -392,14 +557,30 @@ fn draw_footer(frame: &mut Frame, area: Rect, submit_enabled: bool, is_staff: bo
         Span::styled(" focus  ", Style::default().fg(theme::TEXT_DIM())),
         Span::styled("↑↓ Ctrl+J/K", Style::default().fg(theme::AMBER_DIM())),
         Span::styled(" select  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("[/]", Style::default().fg(theme::AMBER_DIM())),
+        Span::styled(" list  ", Style::default().fg(theme::TEXT_DIM())),
         Span::styled("+/-/0", Style::default().fg(theme::AMBER_DIM())),
         Span::styled(" vote  ", Style::default().fg(theme::TEXT_DIM())),
-        Span::styled("s", Style::default().fg(theme::AMBER_DIM())),
-        Span::styled(" skip  ", Style::default().fg(theme::TEXT_DIM())),
-        Span::styled("d", Style::default().fg(theme::AMBER_DIM())),
-        Span::styled(" delete  ", Style::default().fg(theme::TEXT_DIM())),
     ];
-    if is_staff {
+    if focus == BoothFocus::History {
+        spans.push(Span::styled("↵", Style::default().fg(theme::AMBER_DIM())));
+        spans.push(Span::styled(
+            " queue  ",
+            Style::default().fg(theme::TEXT_DIM()),
+        ));
+    } else {
+        spans.push(Span::styled("s", Style::default().fg(theme::AMBER_DIM())));
+        spans.push(Span::styled(
+            " skip  ",
+            Style::default().fg(theme::TEXT_DIM()),
+        ));
+        spans.push(Span::styled("d", Style::default().fg(theme::AMBER_DIM())));
+        spans.push(Span::styled(
+            " delete  ",
+            Style::default().fg(theme::TEXT_DIM()),
+        ));
+    }
+    if is_staff && focus != BoothFocus::History {
         spans.push(Span::styled("u", Style::default().fg(theme::AMBER_DIM())));
         spans.push(Span::styled(
             " lock  ",
@@ -432,6 +613,35 @@ fn section_heading(title: &str) -> Line<'static> {
     Line::from(vec![
         Span::styled("  ── ", dim),
         Span::styled(title.to_string(), accent),
+        Span::styled(" ──", dim),
+    ])
+}
+
+fn list_heading(focus: BoothFocus) -> Line<'static> {
+    let dim = Style::default().fg(theme::BORDER());
+    let active = Style::default()
+        .fg(theme::AMBER())
+        .add_modifier(Modifier::BOLD);
+    let inactive = Style::default().fg(theme::TEXT_DIM());
+    Line::from(vec![
+        Span::styled("  ── ", dim),
+        Span::styled(
+            "Queue",
+            if focus == BoothFocus::History {
+                inactive
+            } else {
+                active
+            },
+        ),
+        Span::styled(" | ", dim),
+        Span::styled(
+            "History",
+            if focus == BoothFocus::History {
+                active
+            } else {
+                inactive
+            },
+        ),
         Span::styled(" ──", dim),
     ])
 }

--- a/late-ssh/src/app/audio/state.rs
+++ b/late-ssh/src/app/audio/state.rs
@@ -85,6 +85,20 @@ impl AudioState {
         self.service.toggle_unskippable_task(self.user_id, item_id);
     }
 
+    pub fn booth_history_vote(&self, item_id: Uuid, value: i16) {
+        self.service
+            .cast_history_vote_task(self.user_id, item_id, value);
+    }
+
+    pub fn booth_history_clear_vote(&self, item_id: Uuid) {
+        self.service.clear_history_vote_task(self.user_id, item_id);
+    }
+
+    pub fn booth_history_requeue(&self, item_id: Uuid) {
+        self.service
+            .requeue_history_item_task(self.user_id, item_id);
+    }
+
     /// Spawn an audio-source persist task that surfaces failures as banners
     /// via `AudioEvent::AudioSourcePersistFailed`. Caller is expected to have
     /// already optimistically updated local UI state.
@@ -172,6 +186,32 @@ impl AudioState {
                     banner = Some(Banner::success(&format!(
                         "Skip vote registered ({votes}/{threshold})"
                     )));
+                }
+                AudioEvent::BoothHistoryVoteApplied { user_id, score }
+                    if user_id == self.user_id =>
+                {
+                    banner = Some(Banner::success(&format!(
+                        "History vote registered (score {score})"
+                    )));
+                }
+                AudioEvent::BoothHistoryVoteFailed { user_id, message }
+                    if user_id == self.user_id =>
+                {
+                    banner = Some(Banner::error(&message));
+                }
+                AudioEvent::BoothHistoryRequeued { user_id, position }
+                    if user_id == self.user_id =>
+                {
+                    banner = Some(if position == 0 {
+                        Banner::success("Queued from history - up next")
+                    } else {
+                        Banner::success(&format!("Queued from history - #{position} in line"))
+                    });
+                }
+                AudioEvent::BoothHistoryRequeueFailed { user_id, message }
+                    if user_id == self.user_id =>
+                {
+                    banner = Some(Banner::error(&message));
                 }
                 AudioEvent::AudioSourcePersistFailed { user_id, message }
                     if user_id == self.user_id =>

--- a/late-ssh/src/app/audio/state.rs
+++ b/late-ssh/src/app/audio/state.rs
@@ -99,6 +99,10 @@ impl AudioState {
             .requeue_history_item_task(self.user_id, item_id);
     }
 
+    pub fn booth_history_delete(&self, item_id: Uuid) {
+        self.service.delete_history_item_task(self.user_id, item_id);
+    }
+
     /// Spawn an audio-source persist task that surfaces failures as banners
     /// via `AudioEvent::AudioSourcePersistFailed`. Caller is expected to have
     /// already optimistically updated local UI state.
@@ -209,6 +213,14 @@ impl AudioState {
                     });
                 }
                 AudioEvent::BoothHistoryRequeueFailed { user_id, message }
+                    if user_id == self.user_id =>
+                {
+                    banner = Some(Banner::error(&message));
+                }
+                AudioEvent::BoothHistoryItemDeleted { user_id } if user_id == self.user_id => {
+                    banner = Some(Banner::success("Deleted history track"));
+                }
+                AudioEvent::BoothHistoryItemDeleteFailed { user_id, message }
                     if user_id == self.user_id =>
                 {
                     banner = Some(Banner::error(&message));

--- a/late-ssh/src/app/audio/svc.rs
+++ b/late-ssh/src/app/audio/svc.rs
@@ -24,7 +24,7 @@ use tokio::sync::{Mutex, broadcast, oneshot, watch};
 use uuid::Uuid;
 
 use super::youtube::YoutubeClient;
-use crate::{paired_clients::PairedClientRegistry, state::ActiveUsers};
+use crate::{authz::Permissions, paired_clients::PairedClientRegistry, state::ActiveUsers};
 
 const QUEUE_SNAPSHOT_LIMIT: i64 = 50;
 const MAX_SUBMISSIONS_PER_WINDOW: i64 = 10;
@@ -179,6 +179,13 @@ pub enum AudioEvent {
         position: i64,
     },
     BoothHistoryRequeueFailed {
+        user_id: Uuid,
+        message: String,
+    },
+    BoothHistoryItemDeleted {
+        user_id: Uuid,
+    },
+    BoothHistoryItemDeleteFailed {
         user_id: Uuid,
         message: String,
     },
@@ -717,6 +724,15 @@ impl AudioService {
 
     pub async fn clear_history_vote(&self, user_id: Uuid, history_item_id: Uuid) -> Result<i32> {
         let client = self.db.get().await?;
+        if AudioBan::is_active_for_user(&client, user_id).await? {
+            anyhow::bail!("audio ban: voting blocked");
+        }
+        if MediaHistoryItem::find_by_id(&client, history_item_id)
+            .await?
+            .is_none()
+        {
+            anyhow::bail!("history item not found");
+        }
         let score = MediaHistoryVote::delete_vote(&client, user_id, history_item_id).await?;
         drop(client);
 
@@ -776,6 +792,22 @@ impl AudioService {
             duration_ms: item.duration_ms,
             position_in_queue,
         })
+    }
+
+    pub async fn delete_history_item(&self, user_id: Uuid, history_item_id: Uuid) -> Result<()> {
+        let client = self.db.get().await?;
+        if !user_is_staff(&client, user_id).await? {
+            anyhow::bail!("not allowed");
+        }
+        let deleted = MediaHistoryItem::delete_by_id(&client, history_item_id).await?;
+        drop(client);
+        if deleted == 0 {
+            anyhow::bail!("history item not found");
+        }
+
+        let mut state = self.state.lock().await;
+        self.publish_queue_update_with_guard(&mut state).await?;
+        Ok(())
     }
 
     /// Cast a skip-vote for the currently-playing track. Returns the new
@@ -990,6 +1022,23 @@ impl AudioService {
         });
     }
 
+    pub fn delete_history_item_task(&self, user_id: Uuid, history_item_id: Uuid) {
+        let service = self.clone();
+        tokio::spawn(async move {
+            match service.delete_history_item(user_id, history_item_id).await {
+                Ok(()) => {
+                    service.publish_event(AudioEvent::BoothHistoryItemDeleted { user_id });
+                }
+                Err(err) => {
+                    service.publish_event(AudioEvent::BoothHistoryItemDeleteFailed {
+                        user_id,
+                        message: booth_history_delete_error_message(&err),
+                    });
+                }
+            }
+        });
+    }
+
     pub fn cast_skip_vote_task(&self, user_id: Uuid) {
         let service = self.clone();
         tokio::spawn(async move {
@@ -1087,7 +1136,10 @@ impl AudioService {
             anyhow::bail!("track is no longer queued");
         }
         let is_owner = item.submitter_id == user_id;
-        if !is_owner && !user_is_staff(&client, user_id).await? {
+        if !audio_permissions_for_user(&client, user_id)
+            .await?
+            .can_delete_audio_track(is_owner)
+        {
             anyhow::bail!("not allowed");
         }
         let deleted = MediaQueueItem::delete_queued(&client, item_id).await?;
@@ -1106,7 +1158,10 @@ impl AudioService {
     /// when it left the queue.
     pub async fn toggle_unskippable(&self, user_id: Uuid, item_id: Uuid) -> Result<bool> {
         let client = self.db.get().await?;
-        if !user_is_staff(&client, user_id).await? {
+        if !audio_permissions_for_user(&client, user_id)
+            .await?
+            .can_delete_audio_track(false)
+        {
             anyhow::bail!("not allowed");
         }
         let updated = MediaQueueItem::toggle_unskippable_queued(&client, item_id)
@@ -1991,6 +2046,17 @@ fn booth_history_error_message(err: &anyhow::Error) -> String {
     }
 }
 
+fn booth_history_delete_error_message(err: &anyhow::Error) -> String {
+    let text = format!("{err:#}").to_ascii_lowercase();
+    if text.contains("not allowed") {
+        "Only staff can delete history tracks".to_string()
+    } else if text.contains("history item not found") {
+        "Track is no longer in history".to_string()
+    } else {
+        "Failed to delete history track".to_string()
+    }
+}
+
 fn trusted_submit_error_message(err: &anyhow::Error) -> String {
     let text = format!("{err:#}").to_ascii_lowercase();
     if text.contains("audio ban") {
@@ -2038,6 +2104,16 @@ async fn user_is_staff(client: &tokio_postgres::Client, user_id: Uuid) -> Result
         .await?
         .ok_or_else(|| anyhow::anyhow!("user not found"))?;
     Ok(user.is_admin || user.is_moderator)
+}
+
+async fn audio_permissions_for_user(
+    client: &tokio_postgres::Client,
+    user_id: Uuid,
+) -> Result<Permissions> {
+    let user = User::get(client, user_id)
+        .await?
+        .ok_or_else(|| anyhow::anyhow!("user not found"))?;
+    Ok(Permissions::new(user.is_admin, user.is_moderator))
 }
 
 fn queue_item_view(

--- a/late-ssh/src/app/audio/svc.rs
+++ b/late-ssh/src/app/audio/svc.rs
@@ -11,6 +11,8 @@ use late_core::{
     db::Db,
     models::{
         audio_ban::AudioBan,
+        media_history_item::MediaHistoryItem,
+        media_history_vote::MediaHistoryVote,
         media_queue_item::MediaQueueItem,
         media_queue_vote::{CastVoteOutcome, MediaQueueVote},
         media_source::MediaSource,
@@ -34,6 +36,7 @@ const STREAM_CAP: Duration = Duration::from_secs(60 * 60);
 const MIN_VIDEO_DURATION_MS: i32 = 30_000;
 const SKIP_VOTE_PERCENT: usize = 30;
 const SKIP_VOTE_MIN: u32 = 2;
+const HISTORY_LIMIT: i64 = 30;
 
 #[derive(Clone)]
 pub struct AudioService {
@@ -163,6 +166,22 @@ pub enum AudioEvent {
         votes: u32,
         threshold: u32,
     },
+    BoothHistoryVoteApplied {
+        user_id: Uuid,
+        score: i32,
+    },
+    BoothHistoryVoteFailed {
+        user_id: Uuid,
+        message: String,
+    },
+    BoothHistoryRequeued {
+        user_id: Uuid,
+        position: i64,
+    },
+    BoothHistoryRequeueFailed {
+        user_id: Uuid,
+        message: String,
+    },
     /// The spawned DB persist for `users.settings.audio_source` failed. The
     /// caller has already optimistically updated local state; this surfaces
     /// the failure as a banner so the user knows their pref didn't save.
@@ -183,6 +202,8 @@ pub struct QueueSnapshot {
     pub audio_mode: AudioMode,
     pub current: Option<QueueItemView>,
     pub queue: Vec<QueueItemView>,
+    #[serde(default)]
+    pub history: Vec<HistoryItemView>,
     #[serde(default)]
     pub skip_progress: Option<SkipProgress>,
 }
@@ -208,6 +229,20 @@ pub struct QueueItemView {
     pub vote_score: i32,
     #[serde(default)]
     pub unskippable: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct HistoryItemView {
+    pub id: Uuid,
+    pub video_id: String,
+    pub title: Option<String>,
+    pub channel: Option<String>,
+    pub duration_ms: Option<i32>,
+    pub is_stream: bool,
+    pub play_count: i32,
+    pub last_played_at_ms: i64,
+    #[serde(default)]
+    pub vote_score: i32,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -259,6 +294,7 @@ impl AudioService {
             audio_mode: AudioMode::Icecast,
             current: None,
             queue: Vec::new(),
+            history: Vec::new(),
             skip_progress: None,
         });
         Self {
@@ -651,6 +687,97 @@ impl AudioService {
         Ok(score)
     }
 
+    pub async fn cast_history_vote(
+        &self,
+        user_id: Uuid,
+        history_item_id: Uuid,
+        value: i16,
+    ) -> Result<i32> {
+        if value != 1 && value != -1 {
+            anyhow::bail!("invalid vote value");
+        }
+
+        let client = self.db.get().await?;
+        if AudioBan::is_active_for_user(&client, user_id).await? {
+            anyhow::bail!("audio ban: voting blocked");
+        }
+        if MediaHistoryItem::find_by_id(&client, history_item_id)
+            .await?
+            .is_none()
+        {
+            anyhow::bail!("history item not found");
+        }
+        let score = MediaHistoryVote::upsert(&client, user_id, history_item_id, value).await?;
+        drop(client);
+
+        let mut state = self.state.lock().await;
+        self.publish_queue_update_with_guard(&mut state).await?;
+        Ok(score)
+    }
+
+    pub async fn clear_history_vote(&self, user_id: Uuid, history_item_id: Uuid) -> Result<i32> {
+        let client = self.db.get().await?;
+        let score = MediaHistoryVote::delete_vote(&client, user_id, history_item_id).await?;
+        drop(client);
+
+        let mut state = self.state.lock().await;
+        self.publish_queue_update_with_guard(&mut state).await?;
+        Ok(score)
+    }
+
+    pub async fn requeue_history_item(
+        &self,
+        user_id: Uuid,
+        history_item_id: Uuid,
+    ) -> Result<SubmitQueueResponse> {
+        let mut state = self.state.lock().await;
+        let item = {
+            let client = self.db.get().await?;
+            if AudioBan::is_active_for_user(&client, user_id).await? {
+                anyhow::bail!("audio ban: submitting blocked");
+            }
+            let since = Utc::now() - SUBMISSION_WINDOW;
+            let recent = MediaQueueItem::recent_submission_count(&client, user_id, since).await?;
+            if recent >= MAX_SUBMISSIONS_PER_WINDOW {
+                anyhow::bail!("submission rate limit exceeded");
+            }
+            let history = MediaHistoryItem::find_by_id(&client, history_item_id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("history item not found"))?;
+            MediaQueueItem::insert_youtube(
+                &client,
+                user_id,
+                &history.external_id,
+                history.title.as_deref(),
+                history.channel.as_deref(),
+                history.duration_ms,
+                history.is_stream,
+            )
+            .await?
+        };
+
+        self.cancel_fallback(&mut state);
+        if state.current_item_id.is_none() {
+            self.advance_to_next_with_guard(&mut state).await?;
+        } else {
+            self.publish_queue_update_with_guard(&mut state).await?;
+        }
+
+        let position_in_queue = if state.current_item_id == Some(item.id) {
+            0
+        } else {
+            let client = self.db.get().await?;
+            MediaQueueItem::queued_before_count(&client, item.created).await? + 1
+        };
+
+        Ok(SubmitQueueResponse {
+            id: item.id,
+            title: item.title,
+            duration_ms: item.duration_ms,
+            position_in_queue,
+        })
+    }
+
     /// Cast a skip-vote for the currently-playing track. Returns the new
     /// progress; if the threshold has been hit, advances the queue.
     ///
@@ -800,6 +927,63 @@ impl AudioService {
                     service.publish_event(AudioEvent::BoothVoteFailed {
                         user_id,
                         message: booth_vote_error_message(&err),
+                    });
+                }
+            }
+        });
+    }
+
+    pub fn cast_history_vote_task(&self, user_id: Uuid, history_item_id: Uuid, value: i16) {
+        let service = self.clone();
+        tokio::spawn(async move {
+            match service
+                .cast_history_vote(user_id, history_item_id, value)
+                .await
+            {
+                Ok(score) => {
+                    service.publish_event(AudioEvent::BoothHistoryVoteApplied { user_id, score });
+                }
+                Err(err) => {
+                    service.publish_event(AudioEvent::BoothHistoryVoteFailed {
+                        user_id,
+                        message: booth_history_error_message(&err),
+                    });
+                }
+            }
+        });
+    }
+
+    pub fn clear_history_vote_task(&self, user_id: Uuid, history_item_id: Uuid) {
+        let service = self.clone();
+        tokio::spawn(async move {
+            match service.clear_history_vote(user_id, history_item_id).await {
+                Ok(score) => {
+                    service.publish_event(AudioEvent::BoothHistoryVoteApplied { user_id, score });
+                }
+                Err(err) => {
+                    service.publish_event(AudioEvent::BoothHistoryVoteFailed {
+                        user_id,
+                        message: booth_history_error_message(&err),
+                    });
+                }
+            }
+        });
+    }
+
+    pub fn requeue_history_item_task(&self, user_id: Uuid, history_item_id: Uuid) {
+        let service = self.clone();
+        tokio::spawn(async move {
+            match service.requeue_history_item(user_id, history_item_id).await {
+                Ok(response) => {
+                    service.publish_event(AudioEvent::BoothHistoryRequeued {
+                        user_id,
+                        position: response.position_in_queue,
+                    });
+                }
+                Err(err) => {
+                    service.publish_event(AudioEvent::BoothHistoryRequeueFailed {
+                        user_id,
+                        message: booth_history_error_message(&err),
                     });
                 }
             }
@@ -1278,7 +1462,6 @@ impl AudioService {
                 }
                 continue;
             }
-            drop(client);
             tracing::info!(
                 item_id = %item.id,
                 video_id = %item.external_id,
@@ -1286,6 +1469,18 @@ impl AudioService {
                 is_stream = item.is_stream,
                 "promoted queued media item to playing"
             );
+            if let Err(err) =
+                MediaHistoryItem::record_play_from_queue_item(&client, &item, HISTORY_LIMIT).await
+            {
+                late_core::error_span!(
+                    "audio_history_record_failed",
+                    error = ?err,
+                    item_id = %item.id,
+                    video_id = %item.external_id,
+                    "failed to record media queue item in booth history"
+                );
+            }
+            drop(client);
             state.current_item_id = Some(item.id);
             state.skip_votes.clear();
             state.mode = AudioMode::Youtube;
@@ -1464,6 +1659,7 @@ impl AudioService {
     async fn load_snapshot(&self, mode: AudioMode) -> Result<QueueSnapshot> {
         let client = self.db.get().await?;
         let items = MediaQueueItem::list_snapshot(&client, QUEUE_SNAPSHOT_LIMIT).await?;
+        let history_items = MediaHistoryItem::list_ranked(&client, HISTORY_LIMIT).await?;
         let user_ids = items
             .iter()
             .map(|(item, _)| item.submitter_id)
@@ -1485,6 +1681,10 @@ impl AudioService {
             audio_mode: mode,
             current,
             queue,
+            history: history_items
+                .into_iter()
+                .map(|(item, score)| history_item_view(item, score))
+                .collect(),
             skip_progress: None,
         })
     }
@@ -1778,6 +1978,19 @@ fn booth_delete_error_message(err: &anyhow::Error) -> String {
     }
 }
 
+fn booth_history_error_message(err: &anyhow::Error) -> String {
+    let text = format!("{err:#}").to_ascii_lowercase();
+    if text.contains("audio ban") {
+        "Banned from audio history actions".to_string()
+    } else if text.contains("rate limit") || text.contains("submission rate limit") {
+        "Slow down - too many submissions".to_string()
+    } else if text.contains("history item not found") {
+        "Track is no longer in history".to_string()
+    } else {
+        "History action failed".to_string()
+    }
+}
+
 fn trusted_submit_error_message(err: &anyhow::Error) -> String {
     let text = format!("{err:#}").to_ascii_lowercase();
     if text.contains("audio ban") {
@@ -1847,6 +2060,20 @@ fn queue_item_view(
         submitter_id: item.submitter_id,
         vote_score,
         unskippable: item.unskippable,
+    }
+}
+
+fn history_item_view(item: MediaHistoryItem, vote_score: i32) -> HistoryItemView {
+    HistoryItemView {
+        id: item.id,
+        video_id: item.external_id,
+        title: item.title,
+        channel: item.channel,
+        duration_ms: item.duration_ms,
+        is_stream: item.is_stream,
+        play_count: item.play_count,
+        last_played_at_ms: item.last_played_at.timestamp_millis(),
+        vote_score,
     }
 }
 

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -1024,9 +1024,10 @@ Swap which source you hear
 
 Music Booth (v then v)
 
-  Opens a modal with a URL submit row on top and the queue below.
+  Opens a modal with a URL submit row on top and Queue/History below.
 
-  Tab               switch focus between submit and queue
+  Tab               switch focus between submit, queue, and history
+  [ or ]            switch Queue / History
   Esc               close
 
   Submit focus:
@@ -1046,7 +1047,17 @@ Music Booth (v then v)
     d               delete your own queued item
     ↑ at the top    back to the submit row
 
+  History focus:
+    ↑ / ↓ or Ctrl+K/J
+                     move selection
+    PageUp/PageDown jump 8 rows
+    + or =          upvote historical track
+    - or _          downvote historical track
+    0               clear your history vote
+    Enter           queue selected track fresh
+
   The queue is ordered by score, so upvotes pull tracks toward the front. You can't vote on the track that's already playing, but you can skip-vote it.
+  History keeps up to 30 unique played tracks, ranked by separate history votes. Requeued history tracks start with 0 live queue votes.
 
 Skip the current track
   v then s          add your vote to skip. The track skips once enough paired users agree.

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -1055,6 +1055,7 @@ Music Booth (v then v)
     - or _          downvote historical track
     0               clear your history vote
     Enter           queue selected track fresh
+    d               delete selected track (staff)
 
   The queue is ordered by score, so upvotes pull tracks toward the front. You can't vote on the track that's already playing, but you can skip-vote it.
   History keeps up to 30 unique played tracks, ranked by separate history votes. Requeued history tracks start with 0 live queue votes.

--- a/late-ssh/src/moderation/policy.rs
+++ b/late-ssh/src/moderation/policy.rs
@@ -44,6 +44,7 @@ bitflags! {
         const BAN_FROM_AUDIO = 1 << 18;
         const UNBAN_FROM_AUDIO = 1 << 19;
         const DELETE_PINSTAR_GRAPH = 1 << 20;
+        const DELETE_AUDIO_TRACK = 1 << 21;
     }
 }
 
@@ -66,7 +67,8 @@ const MODERATOR: Caps = Caps::EDIT_OTHER_MESSAGE
     .union(Caps::RENAME_USER)
     .union(Caps::BAN_FROM_AUDIO)
     .union(Caps::UNBAN_FROM_AUDIO)
-    .union(Caps::DELETE_PINSTAR_GRAPH);
+    .union(Caps::DELETE_PINSTAR_GRAPH)
+    .union(Caps::DELETE_AUDIO_TRACK);
 
 const ADMIN: Caps = Caps::all();
 
@@ -130,6 +132,10 @@ impl Permissions {
         is_owner || self.can(Caps::DELETE_PINSTAR_GRAPH, target)
     }
 
+    pub const fn can_delete_audio_track(self, is_owner: bool) -> bool {
+        is_owner || self.has(Caps::DELETE_AUDIO_TRACK)
+    }
+
     pub const fn caps(self) -> Caps {
         match self.tier {
             Tier::Regular => REGULAR,
@@ -172,6 +178,7 @@ mod tests {
         assert!(permissions.has(Caps::RENAME_USER));
         assert!(permissions.has(Caps::RESTORE_ARTBOARD));
         assert!(permissions.has(Caps::DELETE_PINSTAR_GRAPH));
+        assert!(permissions.has(Caps::DELETE_AUDIO_TRACK));
         assert!(!permissions.has(Caps::PERMA_BAN_USER));
         assert!(!permissions.has(Caps::GRANT_MOD));
     }
@@ -186,10 +193,14 @@ mod tests {
         assert!(!moderator.can(Caps::BAN_FROM_ROOM, Tier::Admin));
         assert!(moderator.can_delete_pinstar_graph(false, Tier::Regular));
         assert!(!moderator.can_delete_pinstar_graph(false, Tier::Moderator));
+        assert!(moderator.can_delete_audio_track(false));
         assert!(admin.can(Caps::BAN_FROM_ROOM, Tier::Moderator));
         assert!(!admin.can(Caps::BAN_FROM_ROOM, Tier::Admin));
         assert!(admin.can_delete_pinstar_graph(false, Tier::Moderator));
         assert!(!admin.can_delete_pinstar_graph(false, Tier::Admin));
+        assert!(admin.can_delete_audio_track(false));
+        assert!(Permissions::default().can_delete_audio_track(true));
+        assert!(!Permissions::default().can_delete_audio_track(false));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds a community Music Booth History so previously played YouTube tracks can be reviewed, voted on, and queued again without past votes affecting the new queue item.

## Changes
- Adds DB-backed `media_history_items` and `media_history_votes` tables/models.
- Records tracks into history when they are promoted to Now Playing.
- Adds a Queue/History switch in the Music Booth modal.
- Supports history upvotes/downvotes/clearing votes and Enter-to-requeue.
- Updates booth help text and audio context docs for the new history behavior.

## Behavior notes
- History keeps up to 30 unique YouTube tracks, ranked by history vote score and recency.
- Requeued history tracks create fresh queue rows with 0 live queue votes.
- Audio bans block history voting and requeueing; normal submission rate limits apply to requeueing.
- This includes a new migration, `073_create_media_history.sql`.

## Feature flags
- None.

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Not run; repo policy says agents should not run `cargo test`, `cargo nextest`, or `cargo clippy`.
- Manual: Not run; no live TUI verification was performed for this draft.