### PR TITLE
Voice: moderator kick/unblock from the mod console

### DIFF
--- a/late-ssh/src/app/voice/svc.rs
+++ b/late-ssh/src/app/voice/svc.rs
@@ -6,7 +6,7 @@ use late_core::MutexRecover;
 use serde::Serialize;
 use sha2::Sha256;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fmt,
     sync::{Arc, Mutex},
 };
@@ -136,6 +136,10 @@ pub struct VoiceService {
 #[derive(Default)]
 struct VoiceInner {
     participants: HashMap<Uuid, VoiceParticipant>,
+    /// Users a moderator has removed from voice. While blocked, no join ticket
+    /// is minted and any self-reported presence is dropped. Runtime-only - the
+    /// block clears on `allow` or a server restart (it is not persisted).
+    blocked: HashSet<Uuid>,
 }
 
 impl VoiceService {
@@ -175,6 +179,9 @@ impl VoiceService {
     ) -> anyhow::Result<VoiceJoinTicket> {
         if !self.config.enabled {
             anyhow::bail!("Voice is not configured");
+        }
+        if self.is_blocked(user_id) {
+            anyhow::bail!("You have been removed from voice by a moderator");
         }
 
         let room = self.config.room_name.clone();
@@ -232,6 +239,13 @@ impl VoiceService {
             return;
         }
 
+        // A moderator-blocked user stays out even if their client keeps
+        // reporting presence.
+        if self.is_blocked(user_id) {
+            self.leave(user_id);
+            return;
+        }
+
         {
             let mut inner = self.inner.lock_recover();
             inner.participants.insert(
@@ -257,6 +271,32 @@ impl VoiceService {
         if removed {
             self.publish_snapshot();
         }
+    }
+
+    /// Moderator action: remove a user from voice now and block them from
+    /// rejoining (no join ticket is minted) until `allow` lifts it or the server
+    /// restarts. Enforcement is the token gate in `join_ticket`, so a blocked
+    /// user genuinely cannot publish or subscribe. Runtime-only; not persisted.
+    pub fn kick(&self, user_id: Uuid) -> bool {
+        let changed = {
+            let mut inner = self.inner.lock_recover();
+            let newly_blocked = inner.blocked.insert(user_id);
+            let was_present = inner.participants.remove(&user_id).is_some();
+            newly_blocked || was_present
+        };
+        if changed {
+            self.publish_snapshot();
+        }
+        changed
+    }
+
+    /// Lift a moderator voice block. Returns whether the user was blocked.
+    pub fn allow(&self, user_id: Uuid) -> bool {
+        self.inner.lock_recover().blocked.remove(&user_id)
+    }
+
+    pub fn is_blocked(&self, user_id: Uuid) -> bool {
+        self.inner.lock_recover().blocked.contains(&user_id)
     }
 
     pub fn update_local_state(
@@ -470,5 +510,38 @@ mod tests {
         assert_eq!(claims["video"]["canPublish"], false);
         assert_eq!(claims["video"]["canSubscribe"], true);
         assert_eq!(claims["video"]["canPublishData"], false);
+    }
+
+    #[test]
+    fn kicked_user_is_denied_a_join_ticket_until_allowed() {
+        let service = enabled_service();
+        let user = Uuid::from_u128(7);
+
+        assert!(service.join_ticket(user, "spammer", true, false).is_ok());
+        assert!(service.kick(user));
+        assert!(service.is_blocked(user));
+        // The token gate is the enforcement: no ticket means no LiveKit access.
+        assert!(service.join_ticket(user, "spammer", true, false).is_err());
+
+        assert!(service.allow(user));
+        assert!(!service.is_blocked(user));
+        assert!(service.join_ticket(user, "spammer", true, false).is_ok());
+    }
+
+    #[test]
+    fn kick_removes_a_present_participant_and_keeps_them_out() {
+        let service = enabled_service();
+        let _rx = service.subscribe();
+        let user = Uuid::from_u128(9);
+
+        service.update_local_state(user, "noisy".to_string(), false, false, true);
+        assert!(service.snapshot().participant(user).is_some());
+
+        service.kick(user);
+        assert!(service.snapshot().participant(user).is_none());
+
+        // A blocked client that keeps reporting presence is dropped, not re-added.
+        service.update_local_state(user, "noisy".to_string(), false, false, true);
+        assert!(service.snapshot().participant(user).is_none());
     }
 }

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -281,7 +281,8 @@ async fn main() -> anyhow::Result<()> {
     let chat_service = chat_service.with_moderation_infra(
         ModerationInfra::default()
             .with_force_admin(config.force_admin)
-            .with_artboard_handles(dartboard_server.clone(), dartboard_provenance.clone()),
+            .with_artboard_handles(dartboard_server.clone(), dartboard_provenance.clone())
+            .with_voice(voice_service.clone()),
     );
     let leaderboard_service = late_ssh::app::LeaderboardService::new(db.clone());
     let quest_service = late_ssh::app::QuestService::new(db.clone(), activity_tx.clone());

--- a/late-ssh/src/moderation/command.rs
+++ b/late-ssh/src/moderation/command.rs
@@ -62,6 +62,11 @@ pub(crate) enum ModCommand {
         duration: Option<chrono::Duration>,
         reason: String,
     },
+    Voice {
+        action: VoiceAction,
+        username: String,
+        reason: String,
+    },
     Role {
         action: RoleAction,
         username: String,
@@ -176,6 +181,30 @@ impl AudioAction {
         match self {
             Self::Ban => "audio_ban",
             Self::Unban => "audio_unban",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum VoiceAction {
+    /// Remove from voice now and block rejoin until lifted (runtime-only).
+    Kick,
+    /// Lift a voice block.
+    Allow,
+}
+
+impl VoiceAction {
+    pub(crate) const fn past_tense(self) -> &'static str {
+        match self {
+            Self::Kick => "removed from voice",
+            Self::Allow => "restored voice access for",
+        }
+    }
+
+    pub(crate) const fn audit_name(self) -> &'static str {
+        match self {
+            Self::Kick => "voice_kick",
+            Self::Allow => "voice_unblock",
         }
     }
 }
@@ -365,7 +394,7 @@ fn parse_rename_user_mod_command(parts: &[&str]) -> Result<ModCommand> {
 }
 
 fn parse_kick_mod_command(parts: &[&str]) -> Result<ModCommand> {
-    const USAGE: &str = "usage: kick <server|#roomname> @name [reason...]";
+    const USAGE: &str = "usage: kick <server|voice|#roomname> @name [reason...]";
     let Some(target) = parts.first().copied() else {
         anyhow::bail!(USAGE);
     };
@@ -376,6 +405,13 @@ fn parse_kick_mod_command(parts: &[&str]) -> Result<ModCommand> {
             action: ServerUserAction::Kick,
             username,
             duration: None,
+            reason,
+        });
+    }
+    if target == "voice" {
+        return Ok(ModCommand::Voice {
+            action: VoiceAction::Kick,
+            username,
             reason,
         });
     }
@@ -430,7 +466,7 @@ fn parse_ban_mod_command(parts: &[&str]) -> Result<ModCommand> {
 }
 
 fn parse_unban_mod_command(parts: &[&str]) -> Result<ModCommand> {
-    const USAGE: &str = "usage: unban <server|#roomname|artboard|audio> @name [reason...]";
+    const USAGE: &str = "usage: unban <server|#roomname|artboard|audio|voice> @name [reason...]";
     let Some(target) = parts.first().copied() else {
         anyhow::bail!(USAGE);
     };
@@ -447,6 +483,11 @@ fn parse_unban_mod_command(parts: &[&str]) -> Result<ModCommand> {
             action: ArtboardAction::Unban,
             username,
             duration: None,
+            reason,
+        }),
+        "voice" => Ok(ModCommand::Voice {
+            action: VoiceAction::Allow,
+            username,
             reason,
         }),
         "audio" => Ok(ModCommand::Audio {
@@ -699,9 +740,9 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "artboard restore [YYYY-MM-DD] [reason...]",
             "",
             "--- bans, etc. ---",
-            "kick   <server|#room> @name [reason...]",
+            "kick   <server|voice|#room> @name [reason...]",
             "ban    <server|#room|artboard|audio> @name [duration] [reason...]",
-            "unban  <server|#room|artboard|audio> @name [reason...]",
+            "unban  <server|#room|artboard|audio|voice> @name [reason...]",
             "",
             "--- help & admin ---",
             "admin           - show admin commands",
@@ -780,15 +821,20 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "pagenumber: optional positive page number; 15 rows per page.",
         ],
         "kick" => &[
-            "kick <server|#room> @name [reason...]",
-            "Terminates active sessions for server, or removes a user from a room.",
+            "kick <server|voice|#room> @name [reason...]",
+            "Terminates active sessions for server, removes a user from voice, or removes a user from a room.",
             "#roomname is required for room operations, e.g. #general.",
             "@name: username; bare name is also accepted. reason: optional audit text.",
-            "Subtopics: help kick server, help kick room.",
+            "Subtopics: help kick server, help kick voice, help kick room.",
         ],
         "kick server" => &[
             "kick server @name [reason...]",
             "Terminates active sessions for one user.",
+        ],
+        "kick voice" => &[
+            "kick voice @name [reason...]",
+            "Removes one user from voice now and blocks them from rejoining until",
+            "'unban voice @name' lifts it (or the server restarts). Runtime-only.",
         ],
         "kick room" => &[
             "kick #roomname @name [reason...]",
@@ -820,11 +866,15 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "Blocks a user from submitting YouTube tracks and from casting skip-votes.",
         ],
         "unban" => &[
-            "unban <server|#room|artboard|audio> @name [reason...]",
-            "Removes active server, artboard, audio, or room bans for a user.",
+            "unban <server|#room|artboard|audio|voice> @name [reason...]",
+            "Removes active server, artboard, audio, or room bans, or lifts a voice block.",
             "#roomname is required for room operations, e.g. #general.",
             "@name: username; bare name is also accepted. reason: optional audit text.",
-            "Subtopics: help unban server, help unban room, help unban artboard, help unban audio.",
+            "Subtopics: help unban server, help unban room, help unban artboard, help unban audio, help unban voice.",
+        ],
+        "unban voice" => &[
+            "unban voice @name [reason...]",
+            "Lifts a 'kick voice' block so the user can rejoin voice.",
         ],
         "unban server" => &[
             "unban server @name [reason...]",
@@ -1291,6 +1341,28 @@ mod tests {
         assert!(parse_mod_command("server unban-ip 2001:db8::1").is_err());
     }
 
+    #[test]
+    fn parses_voice_moderation_commands() {
+        assert_eq!(
+            parse_mod_command("kick voice @spammer too loud").unwrap(),
+            ModCommand::Voice {
+                action: VoiceAction::Kick,
+                username: "spammer".to_string(),
+                reason: "too loud".to_string(),
+            }
+        );
+        assert_eq!(
+            parse_mod_command("unban voice @spammer").unwrap(),
+            ModCommand::Voice {
+                action: VoiceAction::Allow,
+                username: "spammer".to_string(),
+                reason: String::new(),
+            }
+        );
+        // A target user is required.
+        assert!(parse_mod_command("kick voice").is_err());
+    }
+
     fn primary_username(command: &ModCommand) -> &str {
         match command {
             ModCommand::User { username }
@@ -1299,6 +1371,7 @@ mod tests {
             | ModCommand::ServerUser { username, .. }
             | ModCommand::Artboard { username, .. }
             | ModCommand::Audio { username, .. }
+            | ModCommand::Voice { username, .. }
             | ModCommand::Role { username, .. } => username,
             ModCommand::Help { .. }
             | ModCommand::AdminUltimateCast { .. }

--- a/late-ssh/src/moderation/policy.rs
+++ b/late-ssh/src/moderation/policy.rs
@@ -45,6 +45,8 @@ bitflags! {
         const UNBAN_FROM_AUDIO = 1 << 19;
         const DELETE_PINSTAR_GRAPH = 1 << 20;
         const DELETE_AUDIO_TRACK = 1 << 21;
+        const KICK_FROM_VOICE = 1 << 22;
+        const UNBLOCK_VOICE = 1 << 23;
     }
 }
 
@@ -68,7 +70,9 @@ const MODERATOR: Caps = Caps::EDIT_OTHER_MESSAGE
     .union(Caps::BAN_FROM_AUDIO)
     .union(Caps::UNBAN_FROM_AUDIO)
     .union(Caps::DELETE_PINSTAR_GRAPH)
-    .union(Caps::DELETE_AUDIO_TRACK);
+    .union(Caps::DELETE_AUDIO_TRACK)
+    .union(Caps::KICK_FROM_VOICE)
+    .union(Caps::UNBLOCK_VOICE);
 
 const ADMIN: Caps = Caps::all();
 

--- a/late-ssh/src/moderation/service.rs
+++ b/late-ssh/src/moderation/service.rs
@@ -23,11 +23,12 @@ use uuid::Uuid;
 
 use crate::app::artboard::provenance::{ArtboardProvenance, SharedArtboardProvenance};
 use crate::app::ultimates::UltimateKind;
+use crate::app::voice::svc::VoiceService;
 use crate::authz::{Caps, Permissions, Tier};
 use crate::dartboard;
 use crate::moderation::command::{
     ArtboardAction, ArtboardCurateSource, AudioAction, BanListScope, LIST_PAGE_SIZE, ModCommand,
-    RoleAction, RoomModAction, ServerUserAction, mod_help_lines, normalize_mod_slug,
+    RoleAction, RoomModAction, ServerUserAction, VoiceAction, mod_help_lines, normalize_mod_slug,
     parse_mod_command, strip_user_prefix,
 };
 use crate::moderation::event::ModerationEvent;
@@ -45,6 +46,7 @@ pub(crate) struct ModerationService {
 pub struct ModerationInfra {
     force_admin: bool,
     artboard: Option<ArtboardRestoreHandles>,
+    voice: Option<VoiceService>,
 }
 
 #[derive(Clone)]
@@ -92,8 +94,17 @@ impl ModerationInfra {
         self
     }
 
+    pub fn with_voice(mut self, voice: VoiceService) -> Self {
+        self.voice = Some(voice);
+        self
+    }
+
     fn force_admin(&self) -> bool {
         self.force_admin
+    }
+
+    fn voice(&self) -> Option<&VoiceService> {
+        self.voice.as_ref()
     }
 
     fn artboard_handles(
@@ -208,6 +219,14 @@ impl ModerationService {
                     reason,
                 )
                 .await
+            }
+            ModCommand::Voice {
+                action,
+                username,
+                reason,
+            } => {
+                self.voice_action(actor_user_id, permissions, action, &username, reason)
+                    .await
             }
             ModCommand::Role { action, username } => {
                 self.role(actor_user_id, permissions, action, &username)
@@ -826,6 +845,59 @@ impl ModerationService {
             expires_at,
             reason,
         });
+        Ok(vec![format!(
+            "{} @{}",
+            action.past_tense(),
+            target.username
+        )])
+    }
+
+    async fn voice_action(
+        &self,
+        actor_user_id: Uuid,
+        permissions: Permissions,
+        action: VoiceAction,
+        username: &str,
+        reason: String,
+    ) -> Result<Vec<String>> {
+        let voice = self
+            .infra
+            .voice()
+            .ok_or_else(|| anyhow::anyhow!("voice is not configured"))?;
+        let mut client = self.db.get().await?;
+        let target = find_user_by_mod_name(&client, username).await?;
+        ensure_not_self(actor_user_id, target.id)?;
+        let target_tier = tier_for_user(&target);
+        let cap = match action {
+            VoiceAction::Kick => Caps::KICK_FROM_VOICE,
+            VoiceAction::Allow => Caps::UNBLOCK_VOICE,
+        };
+        ensure_can(permissions, cap, target_tier)?;
+
+        // Runtime enforcement lives in the shared VoiceService (token gate); the
+        // DB write here is only the audit trail, matching the other surfaces.
+        match action {
+            VoiceAction::Kick => {
+                voice.kick(target.id);
+            }
+            VoiceAction::Allow => {
+                voice.allow(target.id);
+            }
+        }
+
+        let tx = client.transaction().await?;
+        ModerationAuditLog::record_if(
+            &tx,
+            permissions.should_audit(false),
+            actor_user_id,
+            action.audit_name(),
+            "user",
+            Some(target.id),
+            json!({ "reason": reason }),
+        )
+        .await?;
+        tx.commit().await?;
+
         Ok(vec![format!(
             "{} @{}",
             action.past_tense(),


### PR DESCRIPTION
## What

Voice had **no moderation path** — a disruptive user in the call couldn't be removed. This adds two commands to the `/mod` console:

- `kick voice @user [reason]` — removes the user from voice now and blocks them from rejoining.
- `unban voice @user [reason]` — lifts the block.

## How it's enforced

The shared `VoiceService` gains a runtime block set:

- `kick()` drops the user from the roster **and** records the block. Enforcement is the **LiveKit token gate**: `join_ticket` refuses a blocked user, so they genuinely can't publish or subscribe — not just hidden from the roster. Self-reported presence from a blocked client is also dropped.
- `allow()` lifts the block.
- The block is **runtime-only by design** (clears on restart). A DB-backed `voice_ban` table with durations could be a follow-up if you'd like persistence — I kept this PR migration-free.

## Wiring

- New caps `KICK_FROM_VOICE` / `UNBLOCK_VOICE`, granted to moderators, gated **per target tier** like every other surface, and written to the moderation **audit log**.
- Folded into the existing `kick` / `unban` grammar and `/mod` help text (`help kick voice`, `help unban voice`), so it reads exactly like the server/room/audio actions already do.
- The shared `VoiceService` is threaded into `ModerationInfra` alongside the existing artboard handles.

## Tests

- `VoiceService`: token-gate denial while blocked, roster removal, and that a blocked client re-reporting presence stays out.
- Command parser: `kick voice` / `unban voice` parse to the right action and require a target.

`cargo build -p late-ssh` and the voice + moderation test suites are green; no new clippy warnings.

## Thanks 🙏
- **mat (@mpiorowski)** — for late.sh and the voice + moderation systems this slots into. The mod console and permission tiers made this a clean, small addition. Thank you.