### PR TITLE
Voice: per-room voice flag — make a room VC or text-only

### DIFF
--- a/late-core/migrations/074_add_chat_room_voice_enabled.sql
+++ b/late-core/migrations/074_add_chat_room_voice_enabled.sql
@@ -1,0 +1,4 @@
+-- Whether a room is voice-enabled (VC) or text-only. Defaults to false so every
+-- existing room stays text-only until a moderator turns voice on for it.
+ALTER TABLE chat_rooms
+    ADD COLUMN voice_enabled BOOLEAN NOT NULL DEFAULT false;

--- a/late-core/src/models/chat_room.rs
+++ b/late-core/src/models/chat_room.rs
@@ -19,6 +19,8 @@ crate::model! {
         pub language_code: Option<String>,
         pub dm_user_a: Option<Uuid>,
         pub dm_user_b: Option<Uuid>,
+        // True when this room offers a voice channel (VC); false is text-only.
+        pub voice_enabled: bool,
     }
 }
 
@@ -428,6 +430,22 @@ impl ChatRoom {
                  SET auto_join = $2, updated = current_timestamp
                  WHERE id = $1",
                 &[&room_id, &auto_join],
+            )
+            .await?;
+        Ok(count)
+    }
+
+    pub async fn set_voice_enabled(
+        client: &impl GenericClient,
+        room_id: Uuid,
+        voice_enabled: bool,
+    ) -> Result<u64> {
+        let count = client
+            .execute(
+                "UPDATE chat_rooms
+                 SET voice_enabled = $2, updated = current_timestamp
+                 WHERE id = $1",
+                &[&room_id, &voice_enabled],
             )
             .await?;
         Ok(count)

--- a/late-ssh/src/app/chat/commands.rs
+++ b/late-ssh/src/app/chat/commands.rs
@@ -141,6 +141,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         }
     }
 

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -5092,6 +5092,7 @@ mod tests {
                 language_code: None,
                 dm_user_a: None,
                 dm_user_b: None,
+                voice_enabled: false,
             },
             Vec::new(),
         )
@@ -5400,6 +5401,7 @@ mod tests {
                     language_code: None,
                     dm_user_a: None,
                     dm_user_b: None,
+                    voice_enabled: false,
                 },
                 vec![],
             ),
@@ -5416,6 +5418,7 @@ mod tests {
                     language_code: None,
                     dm_user_a: None,
                     dm_user_b: None,
+                    voice_enabled: false,
                 },
                 vec![],
             ),
@@ -5992,6 +5995,7 @@ mod tests {
             language_code: None,
             dm_user_a: Some(user_a),
             dm_user_b: Some(user_b),
+            voice_enabled: false,
         }
     }
 

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -4225,6 +4225,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         };
         let rooms = vec![(general.clone(), Vec::new())];
         let mut rows_cache = ChatRowsCache::default();
@@ -4330,6 +4331,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         };
         let rust = ChatRoom {
             id: Uuid::from_u128(2),
@@ -4343,6 +4345,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         };
         let rooms = vec![(general.clone(), Vec::new()), (rust.clone(), Vec::new())];
         let mut rows_cache = ChatRowsCache::default();
@@ -4407,6 +4410,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         };
         let rust = ChatRoom {
             id: Uuid::from_u128(2),
@@ -4420,6 +4424,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         };
         let dm = ChatRoom {
             id: Uuid::from_u128(3),
@@ -4433,6 +4438,7 @@ mod tests {
             language_code: None,
             dm_user_a: Some(Uuid::nil()),
             dm_user_b: Some(Uuid::from_u128(4)),
+            voice_enabled: false,
         };
         let rooms = vec![
             (general.clone(), Vec::new()),
@@ -4504,6 +4510,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         };
         let game = ChatRoom {
             id: Uuid::now_v7(),
@@ -4517,6 +4524,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         };
         let rooms = vec![(general.clone(), Vec::new()), (game.clone(), Vec::new())];
         let mut rows_cache = ChatRowsCache::default();
@@ -4563,6 +4571,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         };
         let rust = ChatRoom {
             id: Uuid::now_v7(),
@@ -4576,6 +4585,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         };
         let rooms = vec![(general.clone(), Vec::new()), (rust.clone(), Vec::new())];
         let mut rows_cache = ChatRowsCache::default();

--- a/late-ssh/src/app/room_search_modal/state.rs
+++ b/late-ssh/src/app/room_search_modal/state.rs
@@ -311,6 +311,7 @@ mod tests {
             language_code: None,
             dm_user_a: None,
             dm_user_b: None,
+            voice_enabled: false,
         }
     }
 

--- a/late-ssh/src/moderation/command.rs
+++ b/late-ssh/src/moderation/command.rs
@@ -29,6 +29,11 @@ pub(crate) enum ModCommand {
         username: String,
         new_username: String,
     },
+    /// Turn a room's voice channel (VC) on or off.
+    RoomVoice {
+        slug: String,
+        enabled: bool,
+    },
     RoomAction {
         action: RoomModAction,
         slug: String,
@@ -219,6 +224,7 @@ pub(crate) fn parse_mod_command(input: &str) -> Result<ModCommand> {
         "view" => parse_view_mod_command(&rest),
         "rename-room" => parse_rename_room_mod_command(&rest),
         "rename-user" => parse_rename_user_mod_command(&rest),
+        "room-voice" => parse_room_voice_mod_command(&rest),
         "kick" => parse_kick_mod_command(&rest),
         "ban" => parse_ban_mod_command(&rest),
         "unban" => parse_unban_mod_command(&rest),
@@ -351,6 +357,20 @@ fn parse_rename_room_mod_command(parts: &[&str]) -> Result<ModCommand> {
         slug: required_slug(parts.first().copied(), USAGE)?,
         new_slug: required_slug(parts.get(1).copied(), USAGE)?,
     })
+}
+
+fn parse_room_voice_mod_command(parts: &[&str]) -> Result<ModCommand> {
+    const USAGE: &str = "usage: room-voice #roomname <on|off>";
+    if parts.len() != 2 {
+        anyhow::bail!(USAGE);
+    }
+    let slug = required_slug(parts.first().copied(), USAGE)?;
+    let enabled = match parts[1].to_ascii_lowercase().as_str() {
+        "on" | "enable" | "true" => true,
+        "off" | "disable" | "false" => false,
+        _ => anyhow::bail!(USAGE),
+    };
+    Ok(ModCommand::RoomVoice { slug, enabled })
 }
 
 fn parse_rename_user_mod_command(parts: &[&str]) -> Result<ModCommand> {
@@ -694,6 +714,7 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "--- general ---",
             "rename-room <#oldname> <#newname>",
             "rename-user <@oldname> <@newname>",
+            "room-voice <#room> <on|off>",
             "view   <@user|#room|bans|audit|artboard|help> [pagenumber]",
             "artboard curate <live|YYYY-MM-DD> [reason...]",
             "artboard restore [YYYY-MM-DD] [reason...]",
@@ -732,6 +753,11 @@ pub(crate) fn mod_help_lines(topic: Option<&str>) -> Vec<String> {
             "Renames a user account.",
             "@oldname: existing username; bare oldname is also accepted.",
             "@newname: desired username; bare newname is also accepted and sanitized with normal username rules.",
+            "Moderator or admin only. Writes a moderation audit entry.",
+        ],
+        "room-voice" | "room voice" => &[
+            "room-voice #roomname <on|off>",
+            "Turns a room's voice channel (VC) on or off, e.g. room-voice #general on.",
             "Moderator or admin only. Writes a moderation audit entry.",
         ],
         "view" => &[
@@ -1291,6 +1317,27 @@ mod tests {
         assert!(parse_mod_command("server unban-ip 2001:db8::1").is_err());
     }
 
+    #[test]
+    fn parses_room_voice_commands() {
+        assert_eq!(
+            parse_mod_command("room-voice #general on").unwrap(),
+            ModCommand::RoomVoice {
+                slug: "general".to_string(),
+                enabled: true,
+            }
+        );
+        assert_eq!(
+            parse_mod_command("room-voice #general off").unwrap(),
+            ModCommand::RoomVoice {
+                slug: "general".to_string(),
+                enabled: false,
+            }
+        );
+        // Needs a room and an on/off state.
+        assert!(parse_mod_command("room-voice #general").is_err());
+        assert!(parse_mod_command("room-voice #general maybe").is_err());
+    }
+
     fn primary_username(command: &ModCommand) -> &str {
         match command {
             ModCommand::User { username }
@@ -1307,6 +1354,7 @@ mod tests {
             | ModCommand::Audit { .. }
             | ModCommand::ArtboardSnapshots { .. }
             | ModCommand::RenameRoom { .. }
+            | ModCommand::RoomVoice { .. }
             | ModCommand::ArtboardRestore { .. }
             | ModCommand::ArtboardCurate { .. } => {
                 panic!("command does not have a primary username: {command:?}")

--- a/late-ssh/src/moderation/policy.rs
+++ b/late-ssh/src/moderation/policy.rs
@@ -45,6 +45,7 @@ bitflags! {
         const UNBAN_FROM_AUDIO = 1 << 19;
         const DELETE_PINSTAR_GRAPH = 1 << 20;
         const DELETE_AUDIO_TRACK = 1 << 21;
+        const SET_ROOM_VOICE = 1 << 22;
     }
 }
 
@@ -68,7 +69,8 @@ const MODERATOR: Caps = Caps::EDIT_OTHER_MESSAGE
     .union(Caps::BAN_FROM_AUDIO)
     .union(Caps::UNBAN_FROM_AUDIO)
     .union(Caps::DELETE_PINSTAR_GRAPH)
-    .union(Caps::DELETE_AUDIO_TRACK);
+    .union(Caps::DELETE_AUDIO_TRACK)
+    .union(Caps::SET_ROOM_VOICE);
 
 const ADMIN: Caps = Caps::all();
 

--- a/late-ssh/src/moderation/service.rs
+++ b/late-ssh/src/moderation/service.rs
@@ -133,6 +133,10 @@ impl ModerationService {
                 self.rename_user(actor_user_id, permissions, &username, &new_username)
                     .await
             }
+            ModCommand::RoomVoice { slug, enabled } => {
+                self.room_voice(actor_user_id, permissions, &slug, enabled)
+                    .await
+            }
             ModCommand::RoomAction {
                 action,
                 slug,
@@ -253,6 +257,7 @@ impl ModerationService {
             format!("visibility: {}", room.visibility),
             format!("auto_join: {}", room.auto_join),
             format!("permanent: {}", room.permanent),
+            format!("voice: {}", if room.voice_enabled { "on" } else { "off" }),
             format!("members: {member_count}"),
         ])
     }
@@ -447,6 +452,41 @@ impl ModerationService {
             new_slug: new_slug.clone(),
         });
         Ok(vec![format!("renamed #{current_slug} to #{new_slug}")])
+    }
+
+    async fn room_voice(
+        &self,
+        actor_user_id: Uuid,
+        permissions: Permissions,
+        slug: &str,
+        enabled: bool,
+    ) -> Result<Vec<String>> {
+        ensure_has(permissions, Caps::SET_ROOM_VOICE)?;
+        let slug = normalize_mod_slug(slug)?;
+        let mut client = self.db.get().await?;
+        let room = find_room_by_mod_slug(&client, &slug).await?;
+        let room_slug = room.slug.clone().unwrap_or_else(|| room.kind.clone());
+        if room.voice_enabled == enabled {
+            let state = if enabled { "on" } else { "off" };
+            return Ok(vec![format!("voice already {state} for #{room_slug}")]);
+        }
+
+        let tx = client.transaction().await?;
+        ChatRoom::set_voice_enabled(&tx, room.id, enabled).await?;
+        ModerationAuditLog::record_if(
+            &tx,
+            permissions.should_audit(false),
+            actor_user_id,
+            "set_room_voice",
+            "room",
+            Some(room.id),
+            json!({ "slug": room_slug, "voice_enabled": enabled }),
+        )
+        .await?;
+        tx.commit().await?;
+
+        let state = if enabled { "on" } else { "off" };
+        Ok(vec![format!("turned voice {state} for #{room_slug}")])
     }
 
     async fn rename_user(


### PR DESCRIPTION
## What

Voice is currently a single server-wide channel with no per-room control. This adds the **control plane to make a room VC or text-only**:

- `room-voice #room on` / `room-voice #room off` in the `/mod` console.
- `view #room` now shows the room's `voice: on/off` flag.

## How

- **Schema:** new `chat_rooms.voice_enabled` column (migration `074`), **defaults to `false`** so every existing room stays text-only until a moderator opts it in. Model gains the field and a `ChatRoom::set_voice_enabled` setter.
- **Command:** folded into the moderation module exactly like `rename-room` — new `RoomVoice { slug, enabled }` command, a new `SET_ROOM_VOICE` capability granted to moderators, an audit-log entry, and help text (`help room-voice`).

## Scope / follow-up

This is the **per-room control + data layer** — the part that makes "a room is VC or not" a real, mod-managed property. Giving each enabled room its **own separate call** (room-keyed LiveKit rooms instead of the one shared channel) is a deliberate follow-up: voice presence and join/listen tickets are currently keyed to one fixed room over the native CLI websocket and the browser listener HTTP endpoint, so true per-room calls need matching changes on both clients. I kept this PR server-side and migration-light so the flag can land and be built on.

## Tests

- Command parser: `room-voice #x on/off` parse correctly and reject missing/invalid state.
- Existing chat/room-search suites updated for the new model field and stay green.

`cargo build` + the moderation/chat/room-search suites pass; no new clippy warnings.

## Thanks 🙏
- **mat (@mpiorowski)** — for late.sh, and for the voice + moderation foundations this extends. The room model and mod-command framework made this a small, clean addition. Thank you.