### PR TITLE
Add poll durations and improve Lateania room view

### DIFF
--- a/late-core/migrations/082_drop_chat_poll_room_created_idx.sql
+++ b/late-core/migrations/082_drop_chat_poll_room_created_idx.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS chat_polls_room_created_idx;

--- a/late-core/src/models/chat_poll.rs
+++ b/late-core/src/models/chat_poll.rs
@@ -9,8 +9,7 @@ pub const POLL_QUESTION_MAX_CHARS: usize = 200;
 pub const POLL_OPTION_MAX_CHARS: usize = 80;
 pub const POLL_MAX_OPTIONS: usize = 3;
 pub const POLL_MIN_OPTIONS: usize = 2;
-pub const POLL_LIFETIME_SECS: i64 = 10 * 60;
-pub const POLL_COOLDOWN_SECS: i64 = 30 * 60;
+pub const POLL_DURATION_OPTIONS_SECS: [i64; 3] = [10 * 60, 20 * 60, 30 * 60];
 
 #[derive(Clone, Debug)]
 pub struct ChatPoll {
@@ -62,6 +61,7 @@ pub struct CreateChatPoll {
     pub room_id: Uuid,
     pub question: String,
     pub options: Vec<String>,
+    pub duration_secs: i64,
 }
 
 pub async fn ensure_can_start_poll(client: &Client, user_id: Uuid, room_id: Uuid) -> Result<()> {
@@ -105,31 +105,13 @@ async fn ensure_can_start_poll_with_client(
         );
     }
 
-    let cooldown = client
-        .query_opt(
-            "SELECT created + ($2::int * interval '1 second') AS available_at
-             FROM chat_polls
-             WHERE room_id = $1
-               AND created >= current_timestamp - ($2::int * interval '1 second')
-             ORDER BY created DESC
-             LIMIT 1",
-            &[&room_id, &(POLL_COOLDOWN_SECS as i32)],
-        )
-        .await?;
-    if let Some(row) = cooldown {
-        let available_at: DateTime<Utc> = row.get("available_at");
-        bail!(
-            "poll cooldown; wait {}",
-            format_poll_wait(available_at - Utc::now())
-        );
-    }
-
     Ok(())
 }
 
 pub async fn create_poll(client: &mut Client, request: CreateChatPoll) -> Result<ActiveChatPoll> {
     let question = normalize_question(&request.question)?;
     let options = normalize_options(request.options)?;
+    let duration_secs = normalize_duration_secs(request.duration_secs)?;
     let tx = client.transaction().await?;
 
     tx.query_one(
@@ -142,7 +124,7 @@ pub async fn create_poll(client: &mut Client, request: CreateChatPoll) -> Result
 
     ensure_can_start_poll_with_client(&tx, request.user_id, request.room_id).await?;
 
-    let ends_at = Utc::now() + Duration::seconds(POLL_LIFETIME_SECS);
+    let ends_at = Utc::now() + Duration::seconds(duration_secs);
     let poll = tx
         .query_one(
             "INSERT INTO chat_polls (room_id, user_id, question, ends_at)
@@ -389,6 +371,14 @@ fn normalize_options(options: Vec<String>) -> Result<Vec<String>> {
     Ok(options)
 }
 
+fn normalize_duration_secs(duration_secs: i64) -> Result<i64> {
+    ensure!(
+        POLL_DURATION_OPTIONS_SECS.contains(&duration_secs),
+        "poll duration must be 10, 20, or 30 minutes"
+    );
+    Ok(duration_secs)
+}
+
 async fn poll_option_summaries(
     client: &impl DeadpoolGenericClient,
     poll_ids: &[Uuid],
@@ -444,5 +434,26 @@ fn format_poll_wait(duration: Duration) -> String {
         format!("{hours}h")
     } else {
         format!("{hours}h {remaining_minutes}m")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_duration_accepts_configured_options() {
+        for duration_secs in POLL_DURATION_OPTIONS_SECS {
+            assert_eq!(
+                normalize_duration_secs(duration_secs).unwrap(),
+                duration_secs
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_duration_rejects_unconfigured_values() {
+        assert!(normalize_duration_secs(5 * 60).is_err());
+        assert!(normalize_duration_secs(40 * 60).is_err());
     }
 }

--- a/late-core/src/models/chat_poll.rs
+++ b/late-core/src/models/chat_poll.rs
@@ -212,7 +212,7 @@ pub async fn list_active_polls_for_rooms(
 
     let poll_rows = client
         .query(
-	            "SELECT DISTINCT ON (room_id) *
+            "SELECT DISTINCT ON (room_id) *
 	             FROM chat_polls
 	             WHERE room_id = ANY($1)
 	               AND active = true

--- a/late-core/src/models/chat_poll.rs
+++ b/late-core/src/models/chat_poll.rs
@@ -212,12 +212,12 @@ pub async fn list_active_polls_for_rooms(
 
     let poll_rows = client
         .query(
-            "SELECT DISTINCT ON (room_id) *
-             FROM chat_polls
-             WHERE room_id = ANY($1)
-               AND active = true
-               AND ends_at > current_timestamp
-             ORDER BY room_id, created DESC, id DESC",
+	            "SELECT DISTINCT ON (room_id) *
+	             FROM chat_polls
+	             WHERE room_id = ANY($1)
+	               AND active = true
+	               AND ends_at > current_timestamp
+	             ORDER BY room_id, ends_at DESC, id DESC",
             &[&room_ids],
         )
         .await?;

--- a/late-ssh/src/app/chat/CONTEXT.md
+++ b/late-ssh/src/app/chat/CONTEXT.md
@@ -244,7 +244,7 @@ User commands:
 - `/dm @user` opens/creates a DM.
 - `/exit` opens quit confirm.
 - `/icons` opens the icon picker (same as `Ctrl+]`).
-- `/poll` opens a modal for the currently visible real room. Polls are room-scoped, support two or three options, last 10 minutes, and are limited to one active poll/one started poll per room every 30 minutes. Active polls render at the top of the room message pane; while one is visible, `v1`, `v2`, and `v3` vote for poll options before falling back to music votes. Failed starts show the remaining active/cooldown wait in the banner.
+- `/poll` opens a modal for the currently visible real room. Polls are room-scoped, support two or three options, can run for 10, 20, or 30 minutes, and are limited to one active poll per room. Active polls render at the top of the room message pane; while one is visible, `v1`, `v2`, and `v3` vote for poll options before falling back to music votes. Failed starts show the remaining active wait in the banner.
 - `/ignore [@user]` mutes a user or lists muted users.
 - `/invite @user` adds a user to the selected non-DM room.
 - `/leave` leaves the selected non-permanent room.

--- a/late-ssh/src/app/chat/polls/input.rs
+++ b/late-ssh/src/app/chat/polls/input.rs
@@ -18,6 +18,41 @@ pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
         ParsedInput::BackTab | ParsedInput::Arrow(b'A') => {
             app.poll_modal_state.move_focus(-1);
         }
+        ParsedInput::Arrow(b'C')
+        | ParsedInput::Byte(b'l' | b'L')
+        | ParsedInput::Char('l' | 'L')
+            if app.poll_modal_state.focus() == super::state::PollField::Duration =>
+        {
+            app.poll_modal_state.move_duration(1);
+        }
+        ParsedInput::Arrow(b'D')
+        | ParsedInput::Byte(b'h' | b'H')
+        | ParsedInput::Char('h' | 'H')
+            if app.poll_modal_state.focus() == super::state::PollField::Duration =>
+        {
+            app.poll_modal_state.move_duration(-1);
+        }
+        ParsedInput::Byte(b'1') | ParsedInput::Char('1')
+            if app.poll_modal_state.focus() == super::state::PollField::Duration =>
+        {
+            app.poll_modal_state.set_duration_index(0);
+        }
+        ParsedInput::Byte(b'2') | ParsedInput::Char('2')
+            if app.poll_modal_state.focus() == super::state::PollField::Duration =>
+        {
+            app.poll_modal_state.set_duration_index(1);
+        }
+        ParsedInput::Byte(b'3') | ParsedInput::Char('3')
+            if app.poll_modal_state.focus() == super::state::PollField::Duration =>
+        {
+            app.poll_modal_state.set_duration_index(2);
+        }
+        ParsedInput::Byte(b'\r' | b'\n') | ParsedInput::Char('\r' | '\n')
+            if app.poll_modal_state.focus() == super::state::PollField::Duration =>
+        {
+            submit(app);
+        }
+        _ if app.poll_modal_state.focus() == super::state::PollField::Duration => {}
         event => {
             let max_chars = app.poll_modal_state.focused_max_chars();
             let outcome = handle_single_line_edit(
@@ -42,8 +77,12 @@ pub(crate) fn handle_escape(app: &mut App) {
 fn submit(app: &mut App) {
     match app.poll_modal_state.submit() {
         Ok(submit) => {
-            app.chat
-                .create_poll(submit.room_id, submit.question, submit.options);
+            app.chat.create_poll(
+                submit.room_id,
+                submit.question,
+                submit.options,
+                submit.duration_secs,
+            );
             app.poll_modal_state.close();
             app.show_poll_modal = false;
             app.banner = Some(Banner::success("Starting poll..."));

--- a/late-ssh/src/app/chat/polls/state.rs
+++ b/late-ssh/src/app/chat/polls/state.rs
@@ -1,5 +1,6 @@
 use late_core::models::chat_poll::{
-    POLL_MAX_OPTIONS, POLL_MIN_OPTIONS, POLL_OPTION_MAX_CHARS, POLL_QUESTION_MAX_CHARS,
+    POLL_DURATION_OPTIONS_SECS, POLL_MAX_OPTIONS, POLL_MIN_OPTIONS, POLL_OPTION_MAX_CHARS,
+    POLL_QUESTION_MAX_CHARS,
 };
 use ratatui_textarea::{TextArea, WrapMode};
 use uuid::Uuid;
@@ -10,6 +11,7 @@ use crate::app::common::composer::{new_themed_textarea, set_themed_textarea_curs
 pub(crate) enum PollField {
     Question,
     Option(usize),
+    Duration,
 }
 
 #[derive(Debug)]
@@ -17,6 +19,7 @@ pub(crate) struct PollSubmit {
     pub room_id: Uuid,
     pub question: String,
     pub options: Vec<String>,
+    pub duration_secs: i64,
 }
 
 #[derive(Debug)]
@@ -25,6 +28,7 @@ pub(crate) struct PollModalState {
     focus: PollField,
     question: TextArea<'static>,
     options: [TextArea<'static>; POLL_MAX_OPTIONS],
+    duration_index: usize,
 }
 
 impl PollModalState {
@@ -38,6 +42,7 @@ impl PollModalState {
                 new_input("Option 2"),
                 new_input("Option 3 (optional)"),
             ],
+            duration_index: 0,
         }
     }
 
@@ -50,6 +55,7 @@ impl PollModalState {
             new_input("Option 2"),
             new_input("Option 3 (optional)"),
         ];
+        self.duration_index = 0;
         self.sync_cursor_visibility();
     }
 
@@ -77,6 +83,7 @@ impl PollModalState {
         match self.focus {
             PollField::Question => &mut self.question,
             PollField::Option(index) => &mut self.options[index],
+            PollField::Duration => unreachable!("duration field has no text input"),
         }
     }
 
@@ -84,6 +91,7 @@ impl PollModalState {
         match self.focus {
             PollField::Question => POLL_QUESTION_MAX_CHARS,
             PollField::Option(_) => POLL_OPTION_MAX_CHARS,
+            PollField::Duration => 0,
         }
     }
 
@@ -91,14 +99,42 @@ impl PollModalState {
         let current = match self.focus {
             PollField::Question => 0,
             PollField::Option(index) => index + 1,
+            PollField::Duration => 1 + POLL_MAX_OPTIONS,
         };
-        let next = (current as isize + delta).rem_euclid(1 + POLL_MAX_OPTIONS as isize) as usize;
+        let field_count = 2 + POLL_MAX_OPTIONS as isize;
+        let next = (current as isize + delta).rem_euclid(field_count) as usize;
         self.focus = if next == 0 {
             PollField::Question
+        } else if next == 1 + POLL_MAX_OPTIONS {
+            PollField::Duration
         } else {
             PollField::Option(next - 1)
         };
         self.sync_cursor_visibility();
+    }
+
+    pub(crate) fn move_duration(&mut self, delta: isize) {
+        self.duration_index = (self.duration_index as isize + delta)
+            .rem_euclid(POLL_DURATION_OPTIONS_SECS.len() as isize)
+            as usize;
+    }
+
+    pub(crate) fn set_duration_index(&mut self, index: usize) {
+        if index < POLL_DURATION_OPTIONS_SECS.len() {
+            self.duration_index = index;
+        }
+    }
+
+    pub(crate) fn duration_index(&self) -> usize {
+        self.duration_index
+    }
+
+    pub(crate) fn duration_options_secs(&self) -> &'static [i64] {
+        &POLL_DURATION_OPTIONS_SECS
+    }
+
+    pub(crate) fn duration_secs(&self) -> i64 {
+        POLL_DURATION_OPTIONS_SECS[self.duration_index]
     }
 
     pub(crate) fn submit(&self) -> Result<PollSubmit, String> {
@@ -122,6 +158,7 @@ impl PollModalState {
             room_id,
             question,
             options,
+            duration_secs: self.duration_secs(),
         })
     }
 

--- a/late-ssh/src/app/chat/polls/ui.rs
+++ b/late-ssh/src/app/chat/polls/ui.rs
@@ -18,7 +18,7 @@ pub(crate) fn draw_modal(frame: &mut Frame, area: Rect, state: &PollModalState) 
     if !state.is_open() {
         return;
     }
-    let popup = centered_rect(area, 68, 16);
+    let popup = centered_rect(area, 68, 18);
     frame.render_widget(Clear, popup);
     let block = Block::default()
         .title(" Poll ")
@@ -30,6 +30,7 @@ pub(crate) fn draw_modal(frame: &mut Frame, area: Rect, state: &PollModalState) 
 
     let areas = Layout::vertical([
         Constraint::Length(1),
+        Constraint::Length(3),
         Constraint::Length(3),
         Constraint::Length(3),
         Constraint::Length(3),
@@ -67,6 +68,12 @@ pub(crate) fn draw_modal(frame: &mut Frame, area: Rect, state: &PollModalState) 
             POLL_OPTION_MAX_CHARS,
         );
     }
+    draw_duration_field(
+        frame,
+        areas[2 + POLL_MAX_OPTIONS],
+        state,
+        state.focus() == PollField::Duration,
+    );
 }
 
 fn draw_field(
@@ -108,6 +115,57 @@ fn draw_field(
     let inner = block.inner(area);
     frame.render_widget(block, area);
     frame.render_widget(input, inner);
+}
+
+fn draw_duration_field(frame: &mut Frame, area: Rect, state: &PollModalState, focused: bool) {
+    let border = if focused {
+        theme::BORDER_ACTIVE()
+    } else {
+        theme::BORDER()
+    };
+    let block = Block::default()
+        .title(Span::styled(
+            " Duration ",
+            Style::default()
+                .fg(if focused {
+                    theme::TEXT_BRIGHT()
+                } else {
+                    theme::TEXT_DIM()
+                })
+                .add_modifier(if focused {
+                    Modifier::BOLD
+                } else {
+                    Modifier::empty()
+                }),
+        ))
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(border))
+        .style(Style::default().bg(theme::BG_CANVAS()));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let mut spans = Vec::new();
+    for (index, duration_secs) in state.duration_options_secs().iter().enumerate() {
+        if index > 0 {
+            spans.push(Span::raw("  "));
+        }
+        let minutes = duration_secs / 60;
+        let selected = state.duration_index() == index;
+        let style = if selected {
+            Style::default()
+                .fg(theme::BG_CANVAS())
+                .bg(theme::SUCCESS())
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(theme::TEXT_DIM())
+        };
+        spans.push(Span::styled(format!(" {}m ", minutes), style));
+    }
+
+    frame.render_widget(
+        Paragraph::new(Line::from(spans)).style(Style::default().bg(theme::BG_CANVAS())),
+        inner,
+    );
 }
 
 fn centered_rect(area: Rect, width: u16, height: u16) -> Rect {

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -937,9 +937,15 @@ impl ChatState {
         self.requested_poll_room.take()
     }
 
-    pub fn create_poll(&self, room_id: Uuid, question: String, options: Vec<String>) {
+    pub fn create_poll(
+        &self,
+        room_id: Uuid,
+        question: String,
+        options: Vec<String>,
+        duration_secs: i64,
+    ) {
         self.service
-            .create_poll_task(self.user_id, room_id, question, options);
+            .create_poll_task(self.user_id, room_id, question, options, duration_secs);
     }
 
     pub fn cast_poll_vote_for_selected_room(&self, option_position: i32) -> bool {

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -116,11 +116,10 @@ fn send_error_message(error: &anyhow::Error) -> &'static str {
 fn poll_error_message(error: &anyhow::Error) -> String {
     let text = error.to_string();
     if text.contains("already has an active poll")
-        || text.contains("poll cooldown")
-        || text.contains("one poll per hour")
         || text.contains("at least two options")
         || text.contains("at most three options")
         || text.contains("too long")
+        || text.contains("duration must")
         || text.contains("question is required")
         || text.contains("join the room")
         || text.contains("no longer available")
@@ -1256,6 +1255,7 @@ impl ChatService {
         room_id: Uuid,
         question: String,
         options: Vec<String>,
+        duration_secs: i64,
     ) {
         let service = self.clone();
         tokio::spawn(
@@ -1269,6 +1269,7 @@ impl ChatService {
                             room_id,
                             question,
                             options,
+                            duration_secs,
                         },
                     )
                     .await

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -145,7 +145,7 @@ Before class choice:
 - `Quests`: read-only Frontier zone quest list.
 - `Follow`: current occupants, follow target tag, stop-follow action.
 
-UI uses a two-column log plus side panel layout, with compact fallback for terminals narrower than 50 columns or shorter than 9 rows.
+UI uses a two-column layout with compact fallback for terminals narrower than 50 columns or shorter than 9 rows. The left column splits current room context (`Now`) from newest-first action scrollback (`Recent`); service room-description lines use `LogKind::Room` and are filtered out of `Recent` so movement does not bury combat, loot, chat, and system events. Arrivals use compact `LogKind::Travel` breadcrumbs so Recent still shows where the player has just been.
 In the Room panel, the minimap is rendered in a separate bottom-aligned side-panel region, not appended to the room detail lines; keep it anchored so changing foes/features/hints does not make the map jump vertically.
 
 ---
@@ -157,7 +157,7 @@ In the Room panel, the minimap is rendered in a separate bottom-aligned side-pan
 - `World` is immutable after seeding: `rooms`, `spawns`, and `start_room`.
 - `RoomId` is `u32`. Exits are `HashMap<Dir, RoomId>`.
 - `Dir` supports cardinals, diagonals, and vertical movement. `Dir::delta_2d` returns `None` for up/down because minimap is flat.
-- `World::minimap` BFSes visited rooms around the current room, draws visited/current/frontier/corridor cells, and separately flags vertical exits.
+- `World::minimap` BFSes visited rooms around the current room, draws visited/current/frontier/corridor cells, highlights the previous room plus connector when available, and separately flags vertical exits.
 
 ### Authored and generated areas
 

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -147,6 +147,8 @@ Before class choice:
 
 UI uses a two-column layout with compact fallback for terminals narrower than 50 columns or shorter than 9 rows. The left column splits current room context (`Now`) from newest-first action scrollback (`Recent`); service room-description lines use `LogKind::Room` and are filtered out of `Recent` so movement does not bury combat, loot, chat, and system events. Arrivals use compact `LogKind::Travel` breadcrumbs so Recent still shows where the player has just been.
 In the Room panel, the minimap is rendered in a separate bottom-aligned side-panel region, not appended to the room detail lines; keep it anchored so changing foes/features/hints does not make the map jump vertically.
+Room-panel variable text rows (zone, exits, features, foes, occupants, wildlife) should use the side wrapping helpers in `ui.rs` so long labels wrap within the side column instead of clipping against the border.
+Non-Room side panels are rendered through `side_paragraph`, which enables Ratatui wrapping for long quest, inventory, shop, title, and ability rows.
 
 ---
 

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -146,6 +146,7 @@ Before class choice:
 - `Follow`: current occupants, follow target tag, stop-follow action.
 
 UI uses a two-column log plus side panel layout, with compact fallback for terminals narrower than 50 columns or shorter than 9 rows.
+In the Room panel, the minimap is rendered in a separate bottom-aligned side-panel region, not appended to the room detail lines; keep it anchored so changing foes/features/hints does not make the map jump vertically.
 
 ---
 

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -2658,16 +2658,22 @@ impl WorldState {
             }
             // Auto-attack is physical and runs through the mob's resistances,
             // so a physical-resistant foe rewards switching to spells.
-            let dead = {
+            let (mob_name, dealt, defense, dead) = {
                 let Some(mob) = self.mobs.get_mut(&mob_id) else {
                     continue;
                 };
-                let (dealt, _) = mob.spawn.profile.apply(player_atk, DamageType::Physical);
+                let (dealt, defense) = mob.spawn.profile.apply(player_atk, DamageType::Physical);
                 mob.hp -= dealt;
                 self.dirty = true;
-                mob.hp <= 0
+                (mob.spawn.name.to_string(), dealt, defense, mob.hp <= 0)
             };
             self.mark_world_dirty();
+            let tag = defense_tag(defense, DamageType::Physical);
+            self.log_to(
+                user_id,
+                LogKind::Combat,
+                format!("You strike {mob_name} for {dealt} physical{tag}."),
+            );
             if dead {
                 self.kill_mob(user_id, mob_id);
                 continue;
@@ -3282,6 +3288,26 @@ mod tests {
         // One tick resolves the auto-attack and consumes the opening strike.
         s.tick();
         assert!(!s.players[&uid(1)].opening_strike, "opening crit is spent");
+    }
+
+    #[test]
+    fn combat_tick_logs_player_auto_attack() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+        // Move to a combat room with a mob (room 6, goblin) and engage.
+        s.move_player(uid(1), Dir::South);
+        s.move_player(uid(1), Dir::South);
+        s.engage(uid(1));
+
+        s.tick();
+
+        let log = &s.players[&uid(1)].log;
+        assert!(
+            log.iter()
+                .any(|line| line.kind == LogKind::Combat && line.text.starts_with("You strike ")),
+            "auto-attacks should be visible in the combat log"
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -88,6 +88,8 @@ pub struct LogLine {
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum LogKind {
+    Room,
+    Travel,
     Normal,
     Combat,
     System,
@@ -927,6 +929,8 @@ struct PlayerState {
     level: i32,
     gold: i64,
     room: RoomId,
+    /// Previous room entered from, for the highlighted minimap trail.
+    previous_room: Option<RoomId>,
     /// Every room this character has stood in, for the overhead map.
     visited: HashSet<RoomId>,
     target: Option<u32>,
@@ -1087,6 +1091,7 @@ impl WorldState {
             level: 1,
             gold: STARTING_GOLD,
             room: start,
+            previous_room: None,
             visited: HashSet::from([start]),
             target: None,
             following: None,
@@ -1236,6 +1241,7 @@ impl WorldState {
             p.resource_regen = stats.resource_regen;
             p.base_attack = stats.attack;
             p.room = room;
+            p.previous_room = None;
             p.visited = saved.visited.iter().copied().collect();
             p.visited.insert(room);
             p.inventory = saved
@@ -1450,6 +1456,7 @@ impl WorldState {
         };
         let from = self.players.get(&user_id).map(|p| p.room).unwrap_or(dest);
         if let Some(player) = self.players.get_mut(&user_id) {
+            player.previous_room = Some(from);
             player.room = dest;
             player.visited.insert(dest);
         }
@@ -1479,6 +1486,7 @@ impl WorldState {
                 .collect();
             for f in followers {
                 if let Some(p) = self.players.get_mut(&f) {
+                    p.previous_room = Some(from);
                     p.room = dest;
                     p.visited.insert(dest);
                 }
@@ -1527,6 +1535,7 @@ impl WorldState {
             return;
         }
         if let Some(p) = self.players.get_mut(&user_id) {
+            p.previous_room = Some(p.room);
             p.room = home;
             p.visited.insert(home);
         }
@@ -1710,10 +1719,14 @@ impl WorldState {
     }
 
     fn look(&mut self, user_id: Uuid) {
-        self.describe_room(user_id);
+        self.describe_room_context(user_id, false);
     }
 
     fn describe_room(&mut self, user_id: Uuid) {
+        self.describe_room_context(user_id, true);
+    }
+
+    fn describe_room_context(&mut self, user_id: Uuid, announce_travel: bool) {
         let Some(player) = self.players.get(&user_id) else {
             return;
         };
@@ -1737,13 +1750,16 @@ impl WorldState {
             .map(|m| m.spawn.name.to_string())
             .collect();
         let shop = shop_at(room_id);
-        self.log_to(user_id, LogKind::Normal, format!("== {name} =="));
-        self.log_to(user_id, LogKind::Normal, desc);
-        self.log_to(user_id, LogKind::System, format!("Exits: {exit_text}"));
+        if announce_travel {
+            self.log_to(user_id, LogKind::Travel, format!("Arrived at {name}."));
+        }
+        self.log_to(user_id, LogKind::Room, format!("== {name} =="));
+        self.log_to(user_id, LogKind::Room, desc);
+        self.log_to(user_id, LogKind::Room, format!("Exits: {exit_text}"));
         if let Some(shop) = shop {
             self.log_to(
                 user_id,
-                LogKind::Loot,
+                LogKind::Room,
                 format!(
                     "{} tends {} here. Press b to browse.",
                     shop.npc_name, shop.shop_name
@@ -1751,7 +1767,7 @@ impl WorldState {
             );
         }
         for mob in mob_names {
-            self.log_to(user_id, LogKind::Combat, format!("{mob} is here."));
+            self.log_to(user_id, LogKind::Room, format!("{mob} is here."));
         }
         // Note lookable things without revealing them - you must look (o) to see
         // their description.
@@ -1760,7 +1776,7 @@ impl WorldState {
             let names: Vec<&str> = features.iter().map(|f| f.name).collect();
             self.log_to(
                 user_id,
-                LogKind::System,
+                LogKind::Room,
                 format!(
                     "You notice {} here. Press o to look closer.",
                     join_with_and(&names)
@@ -2323,6 +2339,7 @@ impl WorldState {
         match exit {
             Some((dir, dest)) => {
                 if let Some(player) = self.players.get_mut(&user_id) {
+                    player.previous_room = Some(room_id);
                     player.room = dest;
                     player.visited.insert(dest);
                 }
@@ -2566,6 +2583,7 @@ impl WorldState {
             if let Some(player) = self.players.get_mut(&user_id) {
                 player.hp = player.max_hp();
                 player.resource = player.max_resource;
+                player.previous_room = Some(player.room);
                 player.room = TEMPLE_ROOM;
                 player.target = None;
                 player.respawn_at = None;
@@ -3002,7 +3020,9 @@ impl WorldState {
                 })
                 .collect();
 
-            let minimap = self.world.minimap(player.room, &player.visited, 3, 2);
+            let minimap =
+                self.world
+                    .minimap(player.room, player.previous_room, &player.visited, 3, 2);
             let quests: Vec<QuestView> = (0..super::world::frontier_zone_count())
                 .filter_map(|z| {
                     super::world::frontier_zone_info(z).map(|(zname, boss)| QuestView {
@@ -3307,6 +3327,23 @@ mod tests {
             log.iter()
                 .any(|line| line.kind == LogKind::Combat && line.text.starts_with("You strike ")),
             "auto-attacks should be visible in the combat log"
+        );
+    }
+
+    #[test]
+    fn movement_keeps_a_compact_travel_line_in_recent_log() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Mage);
+        s.move_player(uid(1), Dir::North);
+
+        assert!(
+            s.players[&uid(1)]
+                .log
+                .iter()
+                .any(|line| line.kind == LogKind::Travel
+                    && line.text == "Arrived at Embergate - Gilded Flagon."),
+            "movement should leave a compact room-visit breadcrumb"
         );
     }
 

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -186,8 +186,13 @@ fn draw_side(
     view: &PlayerView,
     usernames: &UsernameLookup<'_>,
 ) {
+    if state.panel() == Panel::Room {
+        draw_room_side(frame, area, view, usernames);
+        return;
+    }
+
     let lines = match state.panel() {
-        Panel::Room => room_panel(view, usernames),
+        Panel::Room => unreachable!("room panel is rendered by draw_room_side"),
         Panel::Character => character_panel(view),
         Panel::Abilities => abilities_panel(view),
         Panel::Inventory => inventory_panel(view, state.cursor()),
@@ -198,6 +203,24 @@ fn draw_side(
         Panel::Follow => follow_panel(view, state.cursor(), usernames),
     };
     frame.render_widget(Paragraph::new(lines), area);
+}
+
+fn draw_room_side(
+    frame: &mut Frame,
+    area: Rect,
+    view: &PlayerView,
+    usernames: &UsernameLookup<'_>,
+) {
+    let map = minimap_lines(&view.minimap);
+    if map.is_empty() {
+        frame.render_widget(Paragraph::new(room_panel(view, usernames)), area);
+        return;
+    }
+
+    let map_h = map.len().min(area.height as usize) as u16;
+    let rows = Layout::vertical([Constraint::Min(0), Constraint::Length(map_h)]).split(area);
+    frame.render_widget(Paragraph::new(room_panel(view, usernames)), rows[0]);
+    frame.render_widget(Paragraph::new(map), rows[1]);
 }
 
 /// Titles panel: a selectable list of earned titles with their levels. Enter
@@ -422,8 +445,6 @@ fn room_panel(view: &PlayerView, usernames: &UsernameLookup<'_>) -> Vec<Line<'st
     }
     lines.push(Line::raw(""));
     lines.extend(footer_hints(view));
-    lines.push(Line::raw(""));
-    lines.extend(minimap_lines(&view.minimap));
     lines
 }
 
@@ -753,7 +774,8 @@ fn footer_hints(view: &PlayerView) -> Vec<Line<'static>> {
             (false, true) => lines.push(hint(">", "go down")),
             (false, false) => {}
         }
-        lines.push(hint("space", "attack  o look at things"));
+        lines.push(hint("space", "attack"));
+        lines.push(hint("o", "look at things"));
     }
     lines.push(hint("c v t", "sheet abilities bag"));
     lines.push(hint("j k", "quests titles"));

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -175,8 +175,29 @@ fn draw_compact(frame: &mut Frame, area: Rect, view: &PlayerView) {
 }
 
 fn draw_log(frame: &mut Frame, area: Rect, view: &PlayerView) {
-    let lines = wrapped_log_tail(view, area.width as usize, area.height as usize);
-    frame.render_widget(Paragraph::new(lines), area);
+    if area.height < 12 {
+        let lines = recent_log_tail(view, area.width as usize, area.height as usize);
+        frame.render_widget(Paragraph::new(lines), area);
+        return;
+    }
+
+    let context_lines = current_room_context(view, area.width as usize);
+    let context_h = (context_lines.len() as u16)
+        .min(if area.height < 18 { 7 } else { 10 })
+        .min(area.height.saturating_sub(4));
+    let rows = Layout::vertical([Constraint::Length(context_h), Constraint::Min(1)]).split(area);
+    frame.render_widget(
+        Paragraph::new(
+            context_lines
+                .into_iter()
+                .take(context_h as usize)
+                .collect::<Vec<_>>(),
+        ),
+        rows[0],
+    );
+
+    let events = recent_log_tail(view, rows[1].width as usize, rows[1].height as usize);
+    frame.render_widget(Paragraph::new(events), rows[1]);
 }
 
 fn draw_side(
@@ -328,7 +349,7 @@ fn vitals(view: &PlayerView) -> Vec<Line<'static>> {
         ]),
         Line::from(vec![
             Span::styled(
-                format!("{:<4}", short_res(&view.resource_name)),
+                format!("{:<5}", short_res(&view.resource_name)),
                 Style::default().fg(theme::TEXT_DIM()),
             ),
             Span::styled(
@@ -468,14 +489,17 @@ fn minimap_lines(map: &MiniMap) -> Vec<Line<'static>> {
     if map.down {
         stairs.push("down");
     }
-    if !stairs.is_empty() {
-        lines.push(Line::from(Span::styled(
-            format!("  stairs: {}", stairs.join(", ")),
-            Style::default().fg(theme::TEXT_DIM()),
-        )));
-    }
+    let stairs_text = if stairs.is_empty() {
+        String::new()
+    } else {
+        format!("stairs: {}", stairs.join(", "))
+    };
     lines.push(Line::from(Span::styled(
-        "  @=you o=seen .=new",
+        format!("  {stairs_text:<18}"),
+        Style::default().fg(theme::TEXT_DIM()),
+    )));
+    lines.push(Line::from(Span::styled(
+        "  @=you *=last o=seen .=new",
         Style::default().fg(theme::TEXT_FAINT()),
     )));
     lines
@@ -486,6 +510,7 @@ fn map_cell_span(cell: MapCell) -> Span<'static> {
     let (glyph, color) = match cell {
         MapCell::Empty => (' ', theme::TEXT_FAINT()),
         MapCell::Current => ('@', theme::AMBER_GLOW()),
+        MapCell::Previous => ('*', theme::AMBER()),
         MapCell::Visited => ('o', theme::AMBER_DIM()),
         MapCell::Frontier => ('.', theme::TEXT_FAINT()),
         MapCell::ConnH => ('-', theme::BORDER()),
@@ -493,9 +518,14 @@ fn map_cell_span(cell: MapCell) -> Span<'static> {
         MapCell::ConnSlash => ('/', theme::BORDER()),
         MapCell::ConnBack => ('\\', theme::BORDER()),
         MapCell::ConnCross => ('X', theme::BORDER()),
+        MapCell::TrailH => ('-', theme::AMBER_GLOW()),
+        MapCell::TrailV => ('|', theme::AMBER_GLOW()),
+        MapCell::TrailSlash => ('/', theme::AMBER_GLOW()),
+        MapCell::TrailBack => ('\\', theme::AMBER_GLOW()),
+        MapCell::TrailCross => ('X', theme::AMBER_GLOW()),
     };
     let mut style = Style::default().fg(color);
-    if cell == MapCell::Current {
+    if matches!(cell, MapCell::Current | MapCell::Previous) {
         style = style.add_modifier(Modifier::BOLD);
     }
     Span::styled(glyph.to_string(), style)
@@ -803,8 +833,131 @@ fn wrapped_log_tail(view: &PlayerView, width: usize, height: usize) -> Vec<Line<
     lines.split_off(start)
 }
 
+fn recent_log_tail(view: &PlayerView, width: usize, height: usize) -> Vec<Line<'static>> {
+    if width == 0 || height == 0 {
+        return Vec::new();
+    }
+
+    let mut events: Vec<Line<'static>> = view
+        .log
+        .iter()
+        .filter(|line| line.kind != LogKind::Room)
+        .flat_map(|line| wrapped_log_line(line.kind, &line.text, width))
+        .collect();
+    if events.is_empty() {
+        events.push(Line::from(Span::styled(
+            "  no recent events",
+            Style::default().fg(theme::TEXT_FAINT()),
+        )));
+    }
+
+    events.reverse();
+    let event_h = height.saturating_sub(1);
+    let mut lines = vec![section("Recent")];
+    lines.extend(events.into_iter().take(event_h));
+    lines.truncate(height);
+    lines
+}
+
+fn current_room_context(view: &PlayerView, width: usize) -> Vec<Line<'static>> {
+    let mut lines = vec![
+        section("Now"),
+        Line::from(vec![
+            Span::styled(
+                view.room_name.clone(),
+                Style::default()
+                    .fg(theme::AMBER())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("  {}", view.zone),
+                Style::default().fg(theme::TEXT_DIM()),
+            ),
+        ]),
+    ];
+    lines.extend(limited_wrap(&view.room_desc, width, 4));
+
+    let exits = if view.exits.is_empty() {
+        "none".to_string()
+    } else {
+        view.exits
+            .iter()
+            .map(|(_, n)| n.as_str())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
+    lines.push(Line::from(vec![
+        Span::styled("  exits ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled(exits, Style::default().fg(theme::AMBER_DIM())),
+    ]));
+
+    if !view.mobs.is_empty() {
+        lines.push(context_list(
+            "foes",
+            summarize_names(view.mobs.iter().map(|m| m.name.as_str()), 2),
+            theme::ERROR(),
+        ));
+    }
+    if !view.features.is_empty() {
+        lines.push(context_list(
+            "note",
+            summarize_names(view.features.iter().map(|f| f.name.as_str()), 2),
+            theme::TEXT_DIM(),
+        ));
+    }
+    if let Some(shop) = &view.shop {
+        lines.push(context_list(
+            "shop",
+            shop.shop_name.clone(),
+            theme::SUCCESS(),
+        ));
+    }
+    lines
+}
+
+fn limited_wrap(text: &str, width: usize, max_lines: usize) -> Vec<Line<'static>> {
+    let mut lines = wrap(text, width);
+    if lines.len() > max_lines {
+        lines.truncate(max_lines);
+        if let Some(last) = lines.last_mut() {
+            *last = Line::from(Span::styled(
+                "  ...",
+                Style::default().fg(theme::TEXT_FAINT()),
+            ));
+        }
+    }
+    lines
+}
+
+fn context_list(label: &str, value: String, color: ratatui::style::Color) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(
+            format!("  {label:<5}"),
+            Style::default().fg(theme::TEXT_DIM()),
+        ),
+        Span::styled(value, Style::default().fg(color)),
+    ])
+}
+
+fn summarize_names<'a>(names: impl Iterator<Item = &'a str>, visible: usize) -> String {
+    let names: Vec<&str> = names.collect();
+    let mut text = names
+        .iter()
+        .take(visible)
+        .copied()
+        .collect::<Vec<_>>()
+        .join(", ");
+    let hidden = names.len().saturating_sub(visible);
+    if hidden > 0 {
+        text.push_str(&format!(" +{hidden} more"));
+    }
+    text
+}
+
 fn wrapped_log_line(kind: LogKind, text: &str, width: usize) -> Vec<Line<'static>> {
     let color = match kind {
+        LogKind::Room => theme::TEXT_DIM(),
+        LogKind::Travel => theme::AMBER_DIM(),
         LogKind::Normal => theme::TEXT(),
         LogKind::Combat => theme::ERROR(),
         LogKind::System => theme::AMBER_DIM(),

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -8,7 +8,7 @@ use ratatui::{
     layout::{Constraint, Layout, Rect},
     style::{Modifier, Style},
     text::{Line, Span},
-    widgets::Paragraph,
+    widgets::{Paragraph, Wrap},
 };
 use unicode_width::{UnicodeWidthChar, UnicodeWidthStr};
 
@@ -153,6 +153,10 @@ fn draw_class_select(frame: &mut Frame, area: Rect, view: &PlayerView) {
     frame.render_widget(Paragraph::new(lines), area);
 }
 
+fn side_paragraph(lines: Vec<Line<'static>>) -> Paragraph<'static> {
+    Paragraph::new(lines).wrap(Wrap { trim: false })
+}
+
 fn draw_compact(frame: &mut Frame, area: Rect, view: &PlayerView) {
     let mut lines = vec![Line::from(vec![
         Span::styled(
@@ -171,7 +175,7 @@ fn draw_compact(frame: &mut Frame, area: Rect, view: &PlayerView) {
         area.width as usize,
         area.height.saturating_sub(1) as usize,
     ));
-    frame.render_widget(Paragraph::new(lines), area);
+    frame.render_widget(side_paragraph(lines), area);
 }
 
 fn draw_log(frame: &mut Frame, area: Rect, view: &PlayerView) {
@@ -223,7 +227,7 @@ fn draw_side(
         Panel::Quests => quests_panel(view),
         Panel::Follow => follow_panel(view, state.cursor(), usernames),
     };
-    frame.render_widget(Paragraph::new(lines), area);
+    frame.render_widget(side_paragraph(lines), area);
 }
 
 fn draw_room_side(
@@ -234,13 +238,19 @@ fn draw_room_side(
 ) {
     let map = minimap_lines(&view.minimap);
     if map.is_empty() {
-        frame.render_widget(Paragraph::new(room_panel(view, usernames)), area);
+        frame.render_widget(
+            Paragraph::new(room_panel(view, usernames, area.width as usize)),
+            area,
+        );
         return;
     }
 
     let map_h = map.len().min(area.height as usize) as u16;
     let rows = Layout::vertical([Constraint::Min(0), Constraint::Length(map_h)]).split(area);
-    frame.render_widget(Paragraph::new(room_panel(view, usernames)), rows[0]);
+    frame.render_widget(
+        Paragraph::new(room_panel(view, usernames, rows[0].width as usize)),
+        rows[0],
+    );
     frame.render_widget(Paragraph::new(map), rows[1]);
 }
 
@@ -367,14 +377,15 @@ fn vitals(view: &PlayerView) -> Vec<Line<'static>> {
     ]
 }
 
-fn room_panel(view: &PlayerView, usernames: &UsernameLookup<'_>) -> Vec<Line<'static>> {
+fn room_panel(
+    view: &PlayerView,
+    usernames: &UsernameLookup<'_>,
+    width: usize,
+) -> Vec<Line<'static>> {
     let mut lines = vitals(view);
     lines.push(Line::raw(""));
     lines.push(section("Here"));
-    lines.push(Line::from(Span::styled(
-        format!("  {}", view.zone),
-        Style::default().fg(theme::TEXT()),
-    )));
+    lines.extend(side_text_wrap(&view.zone, theme::TEXT(), width));
     let exits = if view.exits.is_empty() {
         "none".to_string()
     } else {
@@ -384,17 +395,15 @@ fn room_panel(view: &PlayerView, usernames: &UsernameLookup<'_>) -> Vec<Line<'st
             .collect::<Vec<_>>()
             .join(", ")
     };
-    lines.push(Line::from(vec![
-        Span::styled("  exits ", Style::default().fg(theme::TEXT_DIM())),
-        Span::styled(exits, Style::default().fg(theme::AMBER_DIM())),
-    ]));
+    lines.extend(side_kv_wrap("exits", &exits, theme::AMBER_DIM(), width));
     if !view.features.is_empty() {
         lines.push(section("Of note"));
         for feat in &view.features {
-            lines.push(Line::from(Span::styled(
-                format!("  {}", feat.name),
-                Style::default().fg(interactable_color(&feat.kind)),
-            )));
+            lines.extend(side_text_wrap(
+                feat.name.as_str(),
+                interactable_color(&feat.kind),
+                width,
+            ));
         }
         lines.push(hint("o", "look / interact"));
     }
@@ -408,13 +417,11 @@ fn room_panel(view: &PlayerView, usernames: &UsernameLookup<'_>) -> Vec<Line<'st
             } else {
                 "  "
             };
-            lines.push(Line::from(vec![
-                Span::styled(format!("{marker}Lv{} {} ", mob.level, mob.name), name_style),
-                Span::styled(
-                    format!("{}/{}", mob.hp, mob.max_hp),
-                    Style::default().fg(theme::TEXT_DIM()),
-                ),
-            ]));
+            let text = format!(
+                "{marker}Lv{} {} {}/{}",
+                mob.level, mob.name, mob.hp, mob.max_hp
+            );
+            lines.extend(side_text_wrap_styled(&text, name_style, width));
         }
     }
     if !view.occupants.is_empty() {
@@ -437,10 +444,7 @@ fn room_panel(view: &PlayerView, usernames: &UsernameLookup<'_>) -> Vec<Line<'st
             } else {
                 theme::SUCCESS()
             };
-            lines.push(Line::from(Span::styled(
-                format!("  {name}{tag}"),
-                Style::default().fg(color),
-            )));
+            lines.extend(side_text_wrap(&format!("{name}{tag}"), color, width));
         }
     }
     if !view.wildlife.is_empty() {
@@ -458,10 +462,11 @@ fn room_panel(view: &PlayerView, usernames: &UsernameLookup<'_>) -> Vec<Line<'st
             } else {
                 String::new()
             };
-            lines.push(Line::from(Span::styled(
-                format!("  {marker}{}{detail}", w.name),
-                Style::default().fg(color),
-            )));
+            lines.extend(side_text_wrap(
+                &format!("{marker}{}{detail}", w.name),
+                color,
+                width,
+            ));
         }
     }
     lines.push(Line::raw(""));
@@ -937,6 +942,54 @@ fn context_list(label: &str, value: String, color: ratatui::style::Color) -> Lin
         ),
         Span::styled(value, Style::default().fg(color)),
     ])
+}
+
+fn side_kv_wrap(
+    label: &str,
+    value: &str,
+    value_color: ratatui::style::Color,
+    width: usize,
+) -> Vec<Line<'static>> {
+    let label_text = format!("  {label} ");
+    let label_width = UnicodeWidthStr::width(label_text.as_str());
+    let value_width = width.saturating_sub(label_width).max(1);
+    let mut wrapped = wrap_log_text(value, value_width);
+    if wrapped.is_empty() {
+        wrapped.push(String::new());
+    }
+
+    let mut lines = Vec::with_capacity(wrapped.len());
+    if let Some(first) = wrapped.first() {
+        lines.push(Line::from(vec![
+            Span::styled(label_text.clone(), Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(
+                first.trim_start().to_string(),
+                Style::default().fg(value_color),
+            ),
+        ]));
+    }
+    for line in wrapped.into_iter().skip(1) {
+        lines.push(Line::from(vec![
+            Span::raw(" ".repeat(label_width)),
+            Span::styled(
+                line.trim_start().to_string(),
+                Style::default().fg(value_color),
+            ),
+        ]));
+    }
+    lines
+}
+
+fn side_text_wrap(text: &str, color: ratatui::style::Color, width: usize) -> Vec<Line<'static>> {
+    side_text_wrap_styled(text, Style::default().fg(color), width)
+}
+
+fn side_text_wrap_styled(text: &str, style: Style, width: usize) -> Vec<Line<'static>> {
+    let text_width = width.saturating_sub(2).max(1);
+    wrap_log_text(text, text_width)
+        .into_iter()
+        .map(|line| Line::from(Span::styled(format!("  {line}"), style)))
+        .collect()
 }
 
 fn summarize_names<'a>(names: impl Iterator<Item = &'a str>, visible: usize) -> String {

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -339,7 +339,7 @@ fn vitals(view: &PlayerView) -> Vec<Line<'static>> {
             ),
         ]),
         Line::from(vec![
-            Span::styled("HP  ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(vital_label("HP"), Style::default().fg(theme::TEXT_DIM())),
             Span::styled(
                 format!("{}/{}", view.hp, view.max_hp),
                 Style::default()
@@ -349,7 +349,7 @@ fn vitals(view: &PlayerView) -> Vec<Line<'static>> {
         ]),
         Line::from(vec![
             Span::styled(
-                format!("{:<5}", short_res(&view.resource_name)),
+                vital_label(&short_res(&view.resource_name)),
                 Style::default().fg(theme::TEXT_DIM()),
             ),
             Span::styled(
@@ -358,7 +358,7 @@ fn vitals(view: &PlayerView) -> Vec<Line<'static>> {
             ),
         ]),
         Line::from(vec![
-            Span::styled("gold ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(vital_label("gold"), Style::default().fg(theme::TEXT_DIM())),
             Span::styled(
                 format!("{}", view.gold),
                 Style::default().fg(theme::BADGE_GOLD()),
@@ -1082,6 +1082,10 @@ fn wrap(text: &str, width: usize) -> Vec<Line<'static>> {
 
 fn short_res(name: &str) -> String {
     name.chars().take(4).collect()
+}
+
+fn vital_label(label: &str) -> String {
+    format!("{label:<5}")
 }
 
 fn hp_color(hp: i32, max_hp: i32) -> ratatui::style::Color {

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -176,7 +176,14 @@ impl World {
     /// an unvisited room one step from a drawn room becomes a faint frontier
     /// marker so the player can see where there is still to explore. Up/down
     /// exits can't be placed on a flat plane, so they're reported as flags.
-    pub fn minimap(&self, current: RoomId, visited: &HashSet<RoomId>, hr: i32, vr: i32) -> MiniMap {
+    pub fn minimap(
+        &self,
+        current: RoomId,
+        previous: Option<RoomId>,
+        visited: &HashSet<RoomId>,
+        hr: i32,
+        vr: i32,
+    ) -> MiniMap {
         // 1. Lay visited rooms onto an integer grid by walking exits out from the
         //    current room. BFS, so the shortest path to each room wins any clash
         //    that the world's non-Euclidean geometry might otherwise create.
@@ -214,6 +221,8 @@ impl World {
             let (r, c) = to_cell(x, y);
             grid[r][c] = if rid == current {
                 MapCell::Current
+            } else if Some(rid) == previous {
+                MapCell::Previous
             } else {
                 MapCell::Visited
             };
@@ -239,6 +248,17 @@ impl World {
             }
         }
 
+        if let Some(previous) = previous
+            && let Some(&(px, py)) = coords.get(&previous)
+            && (px, py) != (0, 0)
+            && px.abs() <= 1
+            && py.abs() <= 1
+        {
+            let (pr, pc) = to_cell(px, py);
+            let (cr, cc) = to_cell(0, 0);
+            draw_trail_connector(&mut grid[(pr + cr) / 2][(pc + cc) / 2], -px, -py);
+        }
+
         let exits = self.room(current).map(|room| &room.exits);
         MiniMap {
             grid,
@@ -257,6 +277,8 @@ pub enum MapCell {
     Current,
     /// A room the player has already visited.
     Visited,
+    /// The room the player just came from.
+    Previous,
     /// An unvisited room one step from somewhere visited - left to explore.
     Frontier,
     /// A horizontal corridor (`-`).
@@ -269,6 +291,12 @@ pub enum MapCell {
     ConnBack,
     /// Where two diagonal corridors cross (`X`).
     ConnCross,
+    /// Highlighted connector from the previous room to the current room.
+    TrailH,
+    TrailV,
+    TrailSlash,
+    TrailBack,
+    TrailCross,
 }
 
 /// A small overhead map of the explored neighbourhood, ready to paint in the
@@ -299,6 +327,27 @@ fn draw_connector(cell: &mut MapCell, dx: i32, dy: i32) {
             MapCell::ConnCross
         }
         (existing, _) => existing,
+    };
+}
+
+fn draw_trail_connector(cell: &mut MapCell, dx: i32, dy: i32) {
+    let drawn = if dx == 0 {
+        MapCell::TrailV
+    } else if dy == 0 {
+        MapCell::TrailH
+    } else if dx == dy {
+        MapCell::TrailBack
+    } else {
+        MapCell::TrailSlash
+    };
+    *cell = match (*cell, drawn) {
+        (_, glyph @ (MapCell::TrailH | MapCell::TrailV)) => glyph,
+        (MapCell::TrailSlash, MapCell::TrailBack)
+        | (MapCell::TrailBack, MapCell::TrailSlash)
+        | (MapCell::ConnSlash, MapCell::TrailBack)
+        | (MapCell::ConnBack, MapCell::TrailSlash)
+        | (MapCell::ConnCross, _) => MapCell::TrailCross,
+        (_, glyph) => glyph,
     };
 }
 
@@ -5119,7 +5168,7 @@ mod tests {
         // Only the start room is visited: it sits dead centre, and at least one
         // unexplored exit shows up as a frontier marker.
         let visited = HashSet::from([start]);
-        let map = world.minimap(start, &visited, 3, 2);
+        let map = world.minimap(start, None, &visited, 3, 2);
         let centre = (map.grid.len() / 2, map.grid[0].len() / 2);
         assert_eq!(map.grid[centre.0][centre.1], MapCell::Current);
         let frontiers = map
@@ -5148,7 +5197,7 @@ mod tests {
             .next()
             .expect("start has a planar exit");
         let visited = HashSet::from([start, neighbour]);
-        let map = world.minimap(start, &visited, 3, 2);
+        let map = world.minimap(start, None, &visited, 3, 2);
         let visited_cells = map
             .grid
             .iter()
@@ -5162,11 +5211,45 @@ mod tests {
             .flatten()
             .filter(|c| {
                 matches!(
-                    c,
+                    **c,
                     MapCell::ConnH | MapCell::ConnV | MapCell::ConnSlash | MapCell::ConnBack
                 )
             })
             .count();
         assert!(corridors >= 1, "a corridor should join the two rooms");
+    }
+
+    #[test]
+    fn minimap_marks_previous_room_and_trail() {
+        let world = seed_world();
+        let start = world.start_room;
+        let previous = world
+            .room(start)
+            .unwrap()
+            .exits
+            .iter()
+            .filter(|(dir, _)| dir.delta_2d().is_some())
+            .map(|(_, dest)| *dest)
+            .next()
+            .expect("start has a planar exit");
+        let visited = HashSet::from([start, previous]);
+
+        let map = world.minimap(start, Some(previous), &visited, 3, 2);
+
+        assert!(
+            map.grid.iter().flatten().any(|c| *c == MapCell::Previous),
+            "the room just left should be marked"
+        );
+        assert!(
+            map.grid.iter().flatten().any(|c| matches!(
+                *c,
+                MapCell::TrailH
+                    | MapCell::TrailV
+                    | MapCell::TrailSlash
+                    | MapCell::TrailBack
+                    | MapCell::TrailCross
+            )),
+            "the route from previous room to current room should be highlighted"
+        );
     }
 }

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -349,9 +349,9 @@ pub fn chat_help_lines(keep_composer_focused: bool) -> Vec<String> {
         "  Ctrl+N / Ctrl+P    next / previous room while preserving draft",
         "",
         "Polls",
-        "  /poll              create a 10-minute poll in the selected Home room",
+        "  /poll              create a 10/20/30-minute poll in the selected Home room",
         "  v1 / v2 / v3       vote while a poll is visible; otherwise music votes",
-        "  cooldown           one active poll / one started poll per room every 30m",
+        "  limit              one active poll per room",
         "",
         "Compose",
         // `<<COMPOSE_SEND_LINES>>` marker is replaced after collection so the


### PR DESCRIPTION
## Summary
- Adds selectable 10, 20, and 30 minute chat polls, and removes the old per-room started-poll cooldown.
- Makes Lateania easier to scan by separating current room context from recent events and improving minimap orientation.

## Changes
- `/poll` now includes a Duration field with 10m, 20m, and 30m options; 10m remains the default.
- Poll validation now accepts only configured durations and limits rooms to one active poll at a time.
- Lateania room descriptions are filtered out of Recent activity, with travel breadcrumbs and auto-attack combat lines kept visible.
- Lateania side panels now wrap long rows, anchor the minimap at the bottom, and highlight the previous room plus trail.
- Help text and domain context were updated for the new poll and Lateania behavior.

## Behavior notes
- Includes a migration that drops the obsolete `chat_polls_room_created_idx` index if present.
- Poll cooldown messaging now only reports active-poll conflicts, since the 30-minute started-poll cooldown was removed.

## Feature flags
- None

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Added unit coverage for poll duration validation, Lateania combat tick logging, movement breadcrumbs, and minimap previous-room trail behavior. Not run locally per repo policy for LLM agents.
- Manual: Not run.