### PR TITLE
Add Lateania banking and rebalance progression

### DIFF
--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -4,7 +4,7 @@
 - Scope: `late-ssh/src/app/door/lateania` plus Lateania screen lifecycle in `late-ssh/src/app/door`
 - Domain: Lateania, the persistent D&D-style MUD inside late.sh
 - Primary audience: LLM agents changing the Lateania game runtime, content, UI, combat, or persistence
-- Last updated: 2026-06-16
+- Last updated: 2026-06-17
 - Status: Active
 - Parent context: `../../../../../CONTEXT.md`
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change when gameplay/content changes.
@@ -125,6 +125,7 @@ Before class choice:
 ### Active game keys
 
 - Movement: `w/a/s/d` and arrow keys for cardinal directions; `y/u/n/m` for diagonals; `<` or `,` for up; `>` or `.` for down.
+- The Town Square Frontier descent is deliberately reachable from the start but guarded by a transient two-step warning: the first `>` logs that the Frontier is older, meaner country for seasoned adventurers, and the next `>` confirms descent. Service-backed non-movement actions clear the pending warning.
 - Combat: `space`, `x`, or Enter attacks when not in a list panel; `z` flees.
 - Abilities: `1-9` use unlocked ability slots unless a list panel is open.
 - World actions: `r` recalls to Embergate's Town Square when out of combat; `f` toggles the Follow panel.
@@ -170,11 +171,13 @@ Non-Room side panels are rendered through `side_paragraph`, which enables Ratatu
 - `extend_overworld` adds 100 rooms including Greatroad, Tasmania, Melvanala, Matlatesh, Sapphire Coast, Verdant Highlands, Mistfen, Fungal Hollow, Sahra Wastes, Amber Savanna, and Skyreach Mesas.
 - Safe capital squares are `TASMANIA_SQUARE = 620`, `MELVANALA_SQUARE = 660`, and `MATLATESH_SQUARE = 720`. Each must remain safe and carry a fountain plus dedication plaque.
 - `extend_frontier` adds 20 Frontier zones. Each zone is a 10 by 5 grid with a safe entrance cell, regular mobs on even-indexed cells, a boss in the last cell, generated names/descriptions, and down/up links between zones.
+- Frontier remains hung off Embergate's Town Square for reachability, but its exit label renders as `down (dangerous Frontier)` and the Town Square/class-choice guidance points new players toward the South Gate first.
 
 ### Features
 
 - `FEATURES` contains lookable room features.
 - `FeatureKind::Fountain` restores HP/resource and refreshes veteran resurrection charges only when examined in a safe room.
+- `FeatureKind::Bank` toggles deposit/withdraw of all carried gold at the Embergate banker's grille. Banked gold is safe from death loss but must be withdrawn before shopping.
 - Plaques and vistas are descriptive.
 - Room descriptions intentionally mention only feature names; the detailed text is revealed by `o` / Examine.
 
@@ -191,7 +194,7 @@ Non-Room side panels are rendered through `side_paragraph`, which enables Ratatu
 - `items::FRONTIER_TIERS = 20`, one tier per Frontier zone.
 - Generated Frontier item IDs are `3000..3200`, 20 tiers times 10 slots.
 - `item(id)` searches both authored `ITEMS` and generated Frontier catalog.
-- Frontier mob and boss loot tables use `frontier_loot(zone)`.
+- Frontier mob and boss loot tables use `frontier_loot(zone)`, which includes representative weapon, head, chest, hands, ring, draught, and relic entries for the zone tier.
 
 ---
 
@@ -208,7 +211,7 @@ Playable classes:
 
 Progression:
 - Level cap is `Class::MAX_LEVEL = 50`.
-- `xp_for_level` is cubic-ish; `level_for_xp` caps at 50.
+- `xp_for_level` keeps early levels quick, then adds a steeper post-level-8 term so midgame and Frontier progress take longer; `level_for_xp` caps at 50.
 - `Class::stats_at(level)` computes HP/resource/attack/resource regen.
 - Ability scores are rolled before class selection and persist after class choice.
 - Constitution adjusts max HP by level; class primary score adjusts attack.
@@ -233,7 +236,8 @@ Progression:
 - Ranger damage is boosted against wounded targets below half health.
 - Warrior survives the first lethal blow of each life at 1 HP.
 - Veteran accounts, checked on join by account age, can resurrect in place while charges remain; fountains refresh charges.
-- Normal death clears target, sets `respawn_at`, and later respawns the player at the temple.
+- Normal death clears target, removes 20% of carried gold, sets `respawn_at`, and later respawns the player at the temple. Banked gold is protected.
+- `seed_world()` applies a balance scaler after all authored/overworld/Frontier spawns are generated: authored regular mobs are modestly tougher with a small XP bump and faster respawns, authored bosses gain larger HP/damage bumps with lower XP, and Frontier mobs/bosses scale harder than story content while Frontier regulars remain rewarding enough to grind.
 
 ### Items, shops, and rewards
 
@@ -242,8 +246,11 @@ Progression:
 - Item kinds: Equipment, Consumable, Valuable.
 - Starter inventory is a Rusty Shortsword and two Minor Healing Draughts. Starting gold is 120.
 - Shops are in Embergate: Ember Forge, Outfitter, Apothecary, and Curio Cart.
+- Shop economy intentionally includes expensive late-game gold sinks: masterwork weapon/armor/head/hands, premium curio gear, and the repeatable Phoenix Tonic. The masterwork shop pieces are shop-stock, not boss drops, so gold remains useful after normal boss clears.
+- Apothecary consumables are tuned as the pressure valve for harder combat: early draughts are affordable recovery, Elixir of Renewal covers mid/late mixed HP/resource recovery, and Phoenix Tonic is a repeatable expensive late-game recovery sink.
+- Authored boss loot tables include head and hand upgrades across tiers, while regular mobs keep modest low-tier drop pools.
 - Bosses always drop one item from their loot table. Regular mobs have a modest chance if their table is non-empty.
-- Mob kills grant XP, gold, possible loot, and titles.
+- Mob kills grant XP, reduced gold, possible loot, and titles. Boss XP and Frontier quest XP/gold bounties are intentionally damped so boss chains do not skip too much of the level curve.
 - Boss title format is `Bane of ...`; lesser foes grant a derived `...bane` title.
 - Frontier boss kills complete their zone quest, award XP/gold, and grant `Champion of the <zone>`.
 - Defeating the authored final boss, the Archdemon Mal'gareth, pays a once-per-account 10,000 chip lifetime payout and grants the `LAD` profile-award badge.
@@ -258,10 +265,10 @@ Progression:
 
 Character persistence uses `late_core::models::mud_character` / `mud_characters`.
 
-Saved character schema version: `4`.
+Saved character schema version: `5`.
 
 Durable fields:
-- class key, XP, level, gold, current HP;
+- class key, XP, level, carried gold, banked gold, current HP;
 - saved room, but hydration only restores it if the room still exists and is safe;
 - visited rooms for minimap;
 - inventory and equipped `(slot-key, item-id)` pairs;

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -211,7 +211,7 @@ Playable classes:
 
 Progression:
 - Level cap is `Class::MAX_LEVEL = 50`.
-- `xp_for_level` keeps early levels quick, then adds a steeper post-level-8 term so midgame and Frontier progress take longer; `level_for_xp` caps at 50.
+- `xp_for_level` keeps early levels quick, then adds a much steeper post-level-8 term so midgame and Frontier progress target roughly week-scale casual play instead of a 1-2 sitting clear; `level_for_xp` caps at 50.
 - `Class::stats_at(level)` computes HP/resource/attack/resource regen.
 - Ability scores are rolled before class selection and persist after class choice.
 - Constitution adjusts max HP by level; class primary score adjusts attack.

--- a/late-ssh/src/app/door/lateania/classes.rs
+++ b/late-ssh/src/app/door/lateania/classes.rs
@@ -249,7 +249,7 @@ pub fn xp_for_level(level: i32) -> i64 {
         base
     } else {
         let late = d - 7;
-        base + 70 * late * late + 3 * late * late * late
+        base + 220 * late * late + 8 * late * late * late
     }
 }
 
@@ -286,8 +286,9 @@ mod tests {
     #[test]
     fn xp_curve_slows_after_early_story_levels() {
         assert_eq!(xp_for_level(8), 25 * 7 * 7 + (15 * 7 * 7 * 7) / 10);
-        assert!(xp_for_level(15) > 12_000);
-        assert!(xp_for_level(50) > 500_000);
+        assert!(xp_for_level(15) > 22_000);
+        assert!(xp_for_level(30) > 240_000);
+        assert!(xp_for_level(50) > 1_200_000);
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/classes.rs
+++ b/late-ssh/src/app/door/lateania/classes.rs
@@ -236,15 +236,21 @@ impl Class {
 }
 
 /// Total experience required to reach a given level. Smoothly rising curve so
-/// the climb to 50 is a real journey: ~50 xp for level 2, tens of thousands by 50.
+/// early levels arrive quickly, then the climb past the first story bosses
+/// stretches into a longer campaign.
 pub fn xp_for_level(level: i32) -> i64 {
     if level <= 1 {
         return 0;
     }
     let l = level as i64;
-    // Cubic-ish curve: 25*(l-1)^2 + 15*(l-1)^3/10, tuned for a long grind.
     let d = l - 1;
-    25 * d * d + (15 * d * d * d) / 10
+    let base = 25 * d * d + (15 * d * d * d) / 10;
+    if level <= 8 {
+        base
+    } else {
+        let late = d - 7;
+        base + 70 * late * late + 3 * late * late * late
+    }
 }
 
 /// The level a given total xp corresponds to (1..=MAX_LEVEL).
@@ -275,6 +281,13 @@ mod tests {
                 "xp curve must rise at level {l}"
             );
         }
+    }
+
+    #[test]
+    fn xp_curve_slows_after_early_story_levels() {
+        assert_eq!(xp_for_level(8), 25 * 7 * 7 + (15 * 7 * 7 * 7) / 10);
+        assert!(xp_for_level(15) > 12_000);
+        assert!(xp_for_level(50) > 500_000);
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/items.rs
+++ b/late-ssh/src/app/door/lateania/items.rs
@@ -1001,8 +1001,8 @@ pub const SHOPS: &[Shop] = &[
         shop_name: "The Outfitter's Stall",
         greeting: "A wiry man peers over a counter heaped with hide and mail. \"Armor keeps a body breathing. Browse, browse.\"",
         stock: &[
-            1100, 1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108, 1109, 1110, 1111, 1112,
-            1113, 1120, 1121, 1122,
+            1100, 1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108, 1109, 1110, 1111, 1112, 1113,
+            1120, 1121, 1122,
         ],
     },
     Shop {
@@ -1060,7 +1060,9 @@ mod tests {
             "shops should offer enough expensive late-game stock"
         );
         assert!(
-            costly.iter().any(|it| matches!(it.kind, ItemKind::Consumable { .. })),
+            costly
+                .iter()
+                .any(|it| matches!(it.kind, ItemKind::Consumable { .. })),
             "shops should include a repeatable expensive consumable"
         );
     }
@@ -1090,11 +1092,7 @@ mod tests {
             .iter()
             .find(|shop| shop.shop_name == "The Outfitter's Stall")
             .expect("outfitter shop exists");
-        let stock: Vec<_> = outfitter
-            .stock
-            .iter()
-            .filter_map(|id| item(*id))
-            .collect();
+        let stock: Vec<_> = outfitter.stock.iter().filter_map(|id| item(*id)).collect();
 
         assert!(
             stock

--- a/late-ssh/src/app/door/lateania/items.rs
+++ b/late-ssh/src/app/door/lateania/items.rs
@@ -325,6 +325,18 @@ pub const ITEMS: &[Item] = &[
         900,
         None,
     ),
+    eq(
+        1010,
+        "Mythril Arming Sword",
+        "A masterwork blade commissioned for adventurers with more gold than caution.",
+        Slot::Weapon,
+        Rarity::Legendary,
+        34,
+        16,
+        0,
+        2600,
+        None,
+    ),
     // ---- Armor (the Outfitter) ------------------------------------------
     eq(
         1100,
@@ -446,6 +458,162 @@ pub const ITEMS: &[Item] = &[
         880,
         Some(Class::Cleric),
     ),
+    eq(
+        1110,
+        "Scout's Hood",
+        "Weatherproof cloth with a narrow shadowing brim.",
+        Slot::Head,
+        Rarity::Uncommon,
+        2,
+        10,
+        1,
+        115,
+        Some(Class::Ranger),
+    ),
+    eq(
+        1111,
+        "Reinforced Gauntlets",
+        "Layered leather and steel plates over the knuckles.",
+        Slot::Hands,
+        Rarity::Uncommon,
+        2,
+        9,
+        2,
+        125,
+        Some(Class::Warrior),
+    ),
+    eq(
+        1112,
+        "Steel Sallet",
+        "A close helm with a narrow, practical visor.",
+        Slot::Head,
+        Rarity::Rare,
+        1,
+        24,
+        5,
+        310,
+        None,
+    ),
+    eq(
+        1113,
+        "Spellwoven Gloves",
+        "Fine gloves stitched with conductive silver thread.",
+        Slot::Hands,
+        Rarity::Rare,
+        5,
+        12,
+        2,
+        320,
+        Some(Class::Mage),
+    ),
+    eq(
+        1114,
+        "Barrow Crown",
+        "A tarnished war-crown taken from a king who refused the grave.",
+        Slot::Head,
+        Rarity::Rare,
+        3,
+        28,
+        5,
+        420,
+        None,
+    ),
+    eq(
+        1115,
+        "Tidecaller's Grips",
+        "Brine-dark gloves that never quite dry.",
+        Slot::Hands,
+        Rarity::Rare,
+        6,
+        16,
+        2,
+        430,
+        None,
+    ),
+    eq(
+        1116,
+        "Emberguard Helm",
+        "Blackened plate with a coal-red glow behind the visor.",
+        Slot::Head,
+        Rarity::Epic,
+        4,
+        36,
+        7,
+        780,
+        None,
+    ),
+    eq(
+        1117,
+        "Rimeforged Gloves",
+        "Gauntlets rimed with frost that hardens around every blow.",
+        Slot::Hands,
+        Rarity::Epic,
+        7,
+        22,
+        4,
+        760,
+        None,
+    ),
+    eq(
+        1118,
+        "Saintguard Visor",
+        "A citadel helm engraved with prayers almost worn smooth.",
+        Slot::Head,
+        Rarity::Epic,
+        5,
+        42,
+        8,
+        920,
+        Some(Class::Cleric),
+    ),
+    eq(
+        1119,
+        "Abyssal Talons",
+        "Demon-forged clawed gauntlets that drink torchlight.",
+        Slot::Hands,
+        Rarity::Legendary,
+        10,
+        28,
+        5,
+        1300,
+        None,
+    ),
+    eq(
+        1120,
+        "Masterwork Greathelm",
+        "A custom-fitted helm from Tomas's locked display case.",
+        Slot::Head,
+        Rarity::Legendary,
+        6,
+        52,
+        10,
+        2400,
+        None,
+    ),
+    eq(
+        1121,
+        "Masterwork Gauntlets",
+        "Perfectly weighted steel, lined with grip-leather and quiet runes.",
+        Slot::Hands,
+        Rarity::Legendary,
+        11,
+        30,
+        6,
+        2400,
+        None,
+    ),
+    eq(
+        1122,
+        "Runic Warplate",
+        "Expensive plate reinforced with every ward the outfitter trusts.",
+        Slot::Chest,
+        Rarity::Legendary,
+        7,
+        66,
+        13,
+        3400,
+        None,
+    ),
     // ---- Trinkets and rings (the Curio Cart) ----------------------------
     eq(
         1200,
@@ -519,33 +687,57 @@ pub const ITEMS: &[Item] = &[
         820,
         None,
     ),
+    eq(
+        1206,
+        "Vaultkeeper's Band",
+        "A heavy ring sold only to adventurers who can afford to lose it.",
+        Slot::Ring,
+        Rarity::Epic,
+        8,
+        26,
+        3,
+        1750,
+        None,
+    ),
+    eq(
+        1207,
+        "Dragonbone Reliquary",
+        "A polished dragonbone charm set in a frame of soft gold.",
+        Slot::Trinket,
+        Rarity::Legendary,
+        11,
+        34,
+        5,
+        2700,
+        None,
+    ),
     // ---- Consumables (the Apothecary) -----------------------------------
     consumable(
         1300,
         "Minor Healing Draught",
         "A bitter red tonic that closes small wounds.",
         Rarity::Common,
-        30,
+        40,
         0,
-        20,
+        25,
     ),
     consumable(
         1301,
         "Healing Potion",
         "The reliable choice of every sensible adventurer.",
         Rarity::Uncommon,
-        70,
+        90,
         0,
-        55,
+        75,
     ),
     consumable(
         1302,
         "Greater Healing Elixir",
         "Mends even grievous hurts in moments.",
         Rarity::Rare,
-        150,
+        210,
         0,
-        140,
+        165,
     ),
     consumable(
         1303,
@@ -553,17 +745,26 @@ pub const ITEMS: &[Item] = &[
         "Restores the fire that fuels your craft.",
         Rarity::Uncommon,
         0,
-        60,
-        50,
+        80,
+        65,
     ),
     consumable(
         1304,
         "Elixir of Renewal",
         "Restores both flesh and will at once.",
         Rarity::Epic,
+        180,
         120,
-        80,
+        280,
+    ),
+    consumable(
+        1305,
+        "Phoenix Tonic",
+        "A bright, expensive cordial for adventurers deep past prudence.",
+        Rarity::Legendary,
+        420,
         220,
+        1500,
     ),
     // ---- Valuables (sold to any merchant) -------------------------------
     Item {
@@ -620,16 +821,24 @@ pub fn frontier_items() -> &'static [Item] {
     CATALOG.get_or_init(build_frontier_items)
 }
 
-/// The drop table for a frontier zone (tier 0..FRONTIER_TIERS): a representative
-/// weapon, chest, ring, draught, and relic from that tier. Tiers past the last
-/// clamp to the deepest table.
+/// The drop table for a frontier zone (tier 0..FRONTIER_TIERS): representative
+/// weapon, head, chest, hands, ring, draught, and relic entries from that tier.
+/// Tiers past the last clamp to the deepest table.
 pub fn frontier_loot(tier: usize) -> &'static [u32] {
     static TABLES: OnceLock<Vec<Vec<u32>>> = OnceLock::new();
     let tables = TABLES.get_or_init(|| {
         (0..FRONTIER_TIERS as u32)
             .map(|t| {
                 let base = 3000 + t * 10;
-                vec![base, base + 2, base + 6, base + 8, base + 9]
+                vec![
+                    base,
+                    base + 1,
+                    base + 2,
+                    base + 4,
+                    base + 6,
+                    base + 8,
+                    base + 9,
+                ]
             })
             .collect()
     });
@@ -782,28 +991,33 @@ pub const SHOPS: &[Shop] = &[
         npc_name: "Bruna Ironhand",
         shop_name: "The Ember Forge",
         greeting: "Bruna looks up from the anvil, soot on her brow. \"Steel for steel's work. What'll it be?\"",
-        stock: &[1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009],
+        stock: &[
+            1000, 1001, 1002, 1003, 1004, 1005, 1006, 1007, 1008, 1009, 1010,
+        ],
     },
     Shop {
         room: 201,
         npc_name: "Tomas Threadneedle",
         shop_name: "The Outfitter's Stall",
         greeting: "A wiry man peers over a counter heaped with hide and mail. \"Armor keeps a body breathing. Browse, browse.\"",
-        stock: &[1100, 1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108, 1109],
+        stock: &[
+            1100, 1101, 1102, 1103, 1104, 1105, 1106, 1107, 1108, 1109, 1110, 1111, 1112,
+            1113, 1120, 1121, 1122,
+        ],
     },
     Shop {
         room: 202,
         npc_name: "Old Mirela",
         shop_name: "The Apothecary",
         greeting: "Shelves of bottles glint behind a stooped woman who smells of crushed herbs. \"Hurt, are you? I have just the thing.\"",
-        stock: &[1300, 1301, 1302, 1303, 1304],
+        stock: &[1300, 1301, 1302, 1303, 1304, 1305],
     },
     Shop {
         room: 203,
         npc_name: "Pell the Magpie",
         shop_name: "The Curio Cart",
         greeting: "A grinning fellow guards a cart of glittering oddments. \"Rings, charms, lucky bits and bobs! All genuine, mostly.\"",
-        stock: &[1200, 1201, 1202, 1203, 1204, 1205],
+        stock: &[1200, 1201, 1202, 1203, 1204, 1205, 1206, 1207],
     },
 ];
 
@@ -832,6 +1046,81 @@ mod tests {
                 assert!(item(*id).is_some(), "shop sells missing item {id}");
             }
         }
+    }
+
+    #[test]
+    fn shops_offer_late_gold_sinks() {
+        let costly: Vec<_> = SHOPS
+            .iter()
+            .flat_map(|shop| shop.stock.iter().filter_map(|id| item(*id)))
+            .filter(|it| it.price >= 1_500)
+            .collect();
+        assert!(
+            costly.len() >= 6,
+            "shops should offer enough expensive late-game stock"
+        );
+        assert!(
+            costly.iter().any(|it| matches!(it.kind, ItemKind::Consumable { .. })),
+            "shops should include a repeatable expensive consumable"
+        );
+    }
+
+    #[test]
+    fn apothecary_consumables_scale_into_late_recovery() {
+        let minor = item(1300).expect("minor draught exists");
+        let potion = item(1301).expect("healing potion exists");
+        let greater = item(1302).expect("greater elixir exists");
+        let renewal = item(1304).expect("renewal elixir exists");
+        let phoenix = item(1305).expect("phoenix tonic exists");
+
+        let healing = |it: &Item| match it.kind {
+            ItemKind::Consumable { heal, restore } => (heal, restore),
+            _ => panic!("expected consumable"),
+        };
+
+        assert!(healing(minor).0 < healing(potion).0);
+        assert!(healing(potion).0 < healing(greater).0);
+        assert!(healing(renewal).0 >= 180 && healing(renewal).1 >= 120);
+        assert!(healing(phoenix).0 >= 400 && healing(phoenix).1 >= 200);
+    }
+
+    #[test]
+    fn outfitter_sells_real_head_and_hand_upgrades() {
+        let outfitter = SHOPS
+            .iter()
+            .find(|shop| shop.shop_name == "The Outfitter's Stall")
+            .expect("outfitter shop exists");
+        let stock: Vec<_> = outfitter
+            .stock
+            .iter()
+            .filter_map(|id| item(*id))
+            .collect();
+
+        assert!(
+            stock
+                .iter()
+                .any(|it| it.slot() == Some(Slot::Head) && it.price >= 2_000),
+            "outfitter should sell a late-game helm"
+        );
+        assert!(
+            stock
+                .iter()
+                .any(|it| it.slot() == Some(Slot::Hands) && it.price >= 2_000),
+            "outfitter should sell late-game gloves"
+        );
+    }
+
+    #[test]
+    fn frontier_loot_includes_head_and_hands() {
+        let slots: Vec<_> = frontier_loot(0)
+            .iter()
+            .filter_map(|id| item(*id).and_then(Item::slot))
+            .collect();
+        assert!(slots.contains(&Slot::Head), "frontier should drop helms");
+        assert!(
+            slots.contains(&Slot::Hands),
+            "frontier should drop gauntlets"
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/persist.rs
+++ b/late-ssh/src/app/door/lateania/persist.rs
@@ -1,10 +1,11 @@
 // Character persistence for Lateania.
 //
-// A `SavedCharacter` is the durable slice of a player: class, progression, gold,
-// vitals, and gear. It serializes to the JSON blob stored in the mud_characters
-// table (see late_core::models::mud_character). Transient combat state (current
-// target, active effects, cooldowns, respawn timers) is deliberately NOT saved -
-// a character reloads at full readiness in a safe room.
+// A `SavedCharacter` is the durable slice of a player: class, progression,
+// carried and banked gold, vitals, and gear. It serializes to the JSON blob
+// stored in the mud_characters table (see late_core::models::mud_character).
+// Transient combat state (current target, active effects, cooldowns, respawn
+// timers) is deliberately NOT saved - a character reloads at full readiness in
+// a safe room.
 //
 // The struct is versioned. Unknown/missing fields fall back to defaults via
 // serde, so adding fields later never breaks an old save.
@@ -16,7 +17,7 @@ use super::classes::Class;
 use super::stats::AbilityScores;
 use super::world::RoomId;
 
-const SCHEMA_VERSION: u32 = 4;
+const SCHEMA_VERSION: u32 = 5;
 const WORLD_SCHEMA_VERSION: u32 = 1;
 
 pub struct SavedCharacterInit {
@@ -24,6 +25,7 @@ pub struct SavedCharacterInit {
     pub xp: i64,
     pub level: i32,
     pub gold: i64,
+    pub banked_gold: i64,
     pub hp: i32,
     pub room: RoomId,
     pub visited: Vec<RoomId>,
@@ -49,6 +51,8 @@ pub struct SavedCharacter {
     pub level: i32,
     #[serde(default)]
     pub gold: i64,
+    #[serde(default)]
+    pub banked_gold: i64,
     /// Saved current HP (clamped to max on load).
     #[serde(default)]
     pub hp: i32,
@@ -138,6 +142,7 @@ impl SavedCharacter {
             xp: init.xp,
             level: init.level,
             gold: init.gold,
+            banked_gold: init.banked_gold,
             hp: init.hp,
             room: init.room,
             visited: init.visited,
@@ -211,6 +216,7 @@ mod tests {
             xp: 1234,
             level: 7,
             gold: 560,
+            banked_gold: 1400,
             hp: 42,
             room: 18,
             visited: vec![1, 5, 18],
@@ -228,6 +234,7 @@ mod tests {
         assert_eq!(back.xp, 1234);
         assert_eq!(back.level, 7);
         assert_eq!(back.gold, 560);
+        assert_eq!(back.banked_gold, 1400);
         assert_eq!(back.visited, vec![1, 5, 18]);
         assert_eq!(back.inventory, vec![1300, 1301]);
         assert_eq!(back.equipped, vec![("weapon".to_string(), 1004)]);
@@ -248,6 +255,8 @@ mod tests {
         let c = SavedCharacter::from_json(&json).expect("parses partial");
         assert_eq!(c.class(), Some(Class::Mage));
         assert_eq!(c.level, 1);
+        assert_eq!(c.gold, 0);
+        assert_eq!(c.banked_gold, 0);
         assert_eq!(c.room, 1);
         assert!(c.visited.is_empty());
         assert!(c.inventory.is_empty());

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -806,9 +806,7 @@ impl LateaniaService {
     }
 
     pub fn move_task(&self, user_id: Uuid, dir: Dir) {
-        self.mutate_preserving_frontier_warning(user_id, move |s| {
-            s.move_player(user_id, dir)
-        });
+        self.mutate_preserving_frontier_warning(user_id, move |s| s.move_player(user_id, dir));
     }
 
     pub fn recall_task(&self, user_id: Uuid) {
@@ -3486,7 +3484,8 @@ mod tests {
 
         s.move_player(uid(1), Dir::Down);
         assert_eq!(
-            s.players[&uid(1)].room, home,
+            s.players[&uid(1)].room,
+            home,
             "first descent should warn without moving"
         );
         assert!(s.players[&uid(1)].frontier_descent_pending);
@@ -3525,11 +3524,9 @@ mod tests {
         let snap = s.snapshot();
         let view = snap.players.get(&uid(1)).expect("player view");
         assert!(
-            view.exits
-                .iter()
-                .any(|(dir, label)| {
-                    *dir == Dir::Down && label.as_str() == "down (dangerous Frontier)"
-                }),
+            view.exits.iter().any(|(dir, label)| {
+                *dir == Dir::Down && label.as_str() == "down (dangerous Frontier)"
+            }),
             "Town Square should visibly mark the Frontier exit"
         );
     }

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -51,7 +51,7 @@ use super::persist::{
 use super::stats::AbilityScores;
 use super::world::{
     CritterKind, Dir, FeatureKind, MiniMap, MobSpawn, Perk, RoomId, World, critter_index,
-    critters_at, features_at, seed_world,
+    critters_at, features_at, frontier_entrance_room, seed_world,
 };
 
 /// World heartbeat. One combat round resolves per tick.
@@ -62,6 +62,8 @@ const PLAYER_IDLE_TIMEOUT_SECS: u64 = 10 * 60;
 const PLAYER_RESPAWN_SECS: u64 = 8;
 /// Gold every new adventurer starts with.
 const STARTING_GOLD: i64 = 120;
+/// Normal death removes this share of carried gold; banked gold is protected.
+const DEATH_GOLD_LOSS_PERCENT: i64 = 20;
 
 /// How often the world autosaves every present character's progress.
 const AUTOSAVE_SECS: u64 = 60;
@@ -252,6 +254,7 @@ pub struct PlayerView {
     pub xp_for_next: i64,
     pub level: i32,
     pub gold: i64,
+    pub banked_gold: i64,
     pub room_name: String,
     pub room_desc: String,
     pub zone: String,
@@ -309,6 +312,7 @@ impl PlayerView {
             xp_for_next: 0,
             level: 1,
             gold: 0,
+            banked_gold: 0,
             room_name: String::new(),
             room_desc: String::new(),
             zone: String::new(),
@@ -395,9 +399,29 @@ impl LateaniaService {
     // ---- Commands (fire-and-forget, *_task convention) -------------------
 
     fn mutate<F: FnOnce(&mut WorldState) + Send + 'static>(&self, user_id: Uuid, f: F) {
+        self.mutate_with_frontier_warning_clear(user_id, true, f);
+    }
+
+    fn mutate_preserving_frontier_warning<F: FnOnce(&mut WorldState) + Send + 'static>(
+        &self,
+        user_id: Uuid,
+        f: F,
+    ) {
+        self.mutate_with_frontier_warning_clear(user_id, false, f);
+    }
+
+    fn mutate_with_frontier_warning_clear<F: FnOnce(&mut WorldState) + Send + 'static>(
+        &self,
+        user_id: Uuid,
+        clear_frontier_warning: bool,
+        f: F,
+    ) {
         let svc = self.clone();
         tokio::spawn(async move {
             let mut state = svc.state.lock().await;
+            if clear_frontier_warning {
+                state.clear_frontier_descent_pending(user_id);
+            }
             f(&mut state);
             state.touch(user_id);
             svc.publish(&state);
@@ -782,7 +806,9 @@ impl LateaniaService {
     }
 
     pub fn move_task(&self, user_id: Uuid, dir: Dir) {
-        self.mutate(user_id, move |s| s.move_player(user_id, dir));
+        self.mutate_preserving_frontier_warning(user_id, move |s| {
+            s.move_player(user_id, dir)
+        });
     }
 
     pub fn recall_task(&self, user_id: Uuid) {
@@ -1046,6 +1072,7 @@ struct PlayerState {
     xp: i64,
     level: i32,
     gold: i64,
+    banked_gold: i64,
     room: RoomId,
     /// Previous room entered from, for the highlighted minimap trail.
     previous_room: Option<RoomId>,
@@ -1082,6 +1109,8 @@ struct PlayerState {
     active_title: Option<usize>,
     /// Frontier zone indices whose quest (slay the boss) the player has cleared.
     completed_quests: Vec<usize>,
+    /// Transient warning gate for the start-room Frontier entrance.
+    frontier_descent_pending: bool,
     /// Veteran in-place resurrections: total this adventure and how many remain.
     resurrection_cap: u8,
     resurrections_left: u8,
@@ -1208,6 +1237,7 @@ impl WorldState {
             xp: 0,
             level: 1,
             gold: STARTING_GOLD,
+            banked_gold: 0,
             room: start,
             previous_room: None,
             visited: HashSet::from([start]),
@@ -1229,6 +1259,7 @@ impl WorldState {
             title_levels: Vec::new(),
             active_title: None,
             completed_quests: Vec::new(),
+            frontier_descent_pending: false,
             resurrection_cap: 0,
             resurrections_left: 0,
             last_activity: Instant::now(),
@@ -1270,6 +1301,12 @@ impl WorldState {
             user_id,
             LogKind::System,
             format!("You are now a {name}. Your trait: {trait_name}."),
+        );
+        self.log_to(
+            user_id,
+            LogKind::System,
+            "New adventurers usually leave by the South Gate. Stranger paths from the square lead into much older danger."
+                .to_string(),
         );
         self.describe_room(user_id);
     }
@@ -1353,6 +1390,7 @@ impl WorldState {
             p.level = level;
             p.xp = saved.xp.max(0);
             p.gold = saved.gold.max(0);
+            p.banked_gold = saved.banked_gold.max(0);
             p.base_max_hp = stats.max_hp;
             p.max_resource = stats.max_resource;
             p.resource = stats.max_resource;
@@ -1412,6 +1450,7 @@ impl WorldState {
             xp: p.xp,
             level: p.level,
             gold: p.gold,
+            banked_gold: p.banked_gold,
             hp: p.hp.max(1),
             room: p.room,
             visited: {
@@ -1542,6 +1581,12 @@ impl WorldState {
             .unwrap_or(false)
     }
 
+    fn clear_frontier_descent_pending(&mut self, user_id: Uuid) {
+        if let Some(player) = self.players.get_mut(&user_id) {
+            player.frontier_descent_pending = false;
+        }
+    }
+
     fn move_player(&mut self, user_id: Uuid, dir: Dir) {
         if !self.is_classed(user_id) {
             return;
@@ -1565,6 +1610,9 @@ impl WorldState {
             return;
         };
         let Some(&dest) = room.exits.get(&dir) else {
+            if let Some(player) = self.players.get_mut(&user_id) {
+                player.frontier_descent_pending = false;
+            }
             self.log_to(
                 user_id,
                 LogKind::Normal,
@@ -1573,7 +1621,31 @@ impl WorldState {
             return;
         };
         let from = self.players.get(&user_id).map(|p| p.room).unwrap_or(dest);
+        if self.is_frontier_gateway(from, dest) {
+            let confirmed = self
+                .players
+                .get(&user_id)
+                .is_some_and(|p| p.frontier_descent_pending);
+            if !confirmed {
+                if let Some(player) = self.players.get_mut(&user_id) {
+                    player.frontier_descent_pending = true;
+                }
+                self.log_to(
+                    user_id,
+                    LogKind::System,
+                    format!(
+                        "The way {} opens into the Frontier: older, meaner country meant for seasoned adventurers. Press {} again if you truly want to go.",
+                        dir.label(),
+                        dir_input_hint(dir)
+                    ),
+                );
+                return;
+            }
+        } else if let Some(player) = self.players.get_mut(&user_id) {
+            player.frontier_descent_pending = false;
+        }
         if let Some(player) = self.players.get_mut(&user_id) {
+            player.frontier_descent_pending = false;
             player.previous_room = Some(from);
             player.room = dest;
             player.visited.insert(dest);
@@ -1581,6 +1653,18 @@ impl WorldState {
         self.describe_room(user_id);
         self.apply_critter_perks(user_id);
         self.move_followers(user_id, from, dest, dir);
+    }
+
+    fn is_frontier_gateway(&self, from: RoomId, dest: RoomId) -> bool {
+        from == self.world.start_room && dest == frontier_entrance_room()
+    }
+
+    fn exit_label(&self, from: RoomId, dir: Dir, dest: RoomId) -> String {
+        if self.is_frontier_gateway(from, dest) {
+            format!("{} (dangerous Frontier)", dir.label())
+        } else {
+            dir.label().to_string()
+        }
     }
 
     /// Drag everyone following the mover from `from` into `dest`, walking the
@@ -1854,7 +1938,11 @@ impl WorldState {
         };
         let name = room.name.to_string();
         let desc = room.desc.to_string();
-        let mut exits: Vec<&'static str> = room.exits.keys().map(|d| d.label()).collect();
+        let mut exits: Vec<String> = room
+            .exits
+            .iter()
+            .map(|(dir, dest)| self.exit_label(room_id, *dir, *dest))
+            .collect();
         exits.sort_unstable();
         let exit_text = if exits.is_empty() {
             "none".to_string()
@@ -1937,8 +2025,36 @@ impl WorldState {
                         .to_string(),
                 );
             }
+        } else if feat.kind == FeatureKind::Bank {
+            let safe = self.world.room(room_id).is_some_and(|r| r.safe);
+            if safe {
+                self.use_bank(user_id);
+            }
         }
         self.dirty = true;
+    }
+
+    fn use_bank(&mut self, user_id: Uuid) {
+        let Some(p) = self.players.get_mut(&user_id) else {
+            return;
+        };
+        let message = if p.gold > 0 {
+            let amount = p.gold;
+            p.gold = 0;
+            p.banked_gold += amount;
+            format!(
+                "You deposit {amount} carried gold. The bank now holds {} gold for you.",
+                p.banked_gold
+            )
+        } else if p.banked_gold > 0 {
+            let amount = p.banked_gold;
+            p.banked_gold = 0;
+            p.gold += amount;
+            format!("You withdraw {amount} gold. Keep it close, or spend it quickly.")
+        } else {
+            "The clerk taps the empty ledger. You have no gold to bank.".to_string()
+        };
+        self.log_to(user_id, LogKind::Loot, message);
     }
 
     fn engage(&mut self, user_id: Uuid) {
@@ -2265,7 +2381,7 @@ impl WorldState {
             }
             None => return,
         };
-        let gold = 3 + xp / 4;
+        let gold = gold_for_kill(xp, boss);
         self.log_to(
             user_id,
             LogKind::Loot,
@@ -2360,8 +2476,8 @@ impl WorldState {
         let Some((zname, _boss)) = super::world::frontier_zone_info(zone) else {
             return;
         };
-        let bonus_xp = (100 + boss_level * 40) as i64;
-        let bonus_gold = (50 + boss_level * 10) as i64;
+        let bonus_xp = (80 + boss_level * 24) as i64;
+        let bonus_gold = (35 + boss_level * 6) as i64;
         if let Some(p) = self.players.get_mut(&user_id) {
             p.completed_quests.push(zone);
             p.xp += bonus_xp;
@@ -2951,11 +3067,16 @@ impl WorldState {
             p.hp = 0;
             p.target = None;
             p.respawn_at = Some(now + Duration::from_secs(PLAYER_RESPAWN_SECS));
-            self.log_to(
-                user_id,
-                LogKind::System,
-                "You have fallen! Darkness takes you...".to_string(),
-            );
+            let lost_gold = carried_gold_death_loss(p.gold);
+            if lost_gold > 0 {
+                p.gold -= lost_gold;
+            }
+            let death_message = if lost_gold > 0 {
+                format!("You have fallen! Darkness takes you... You lose {lost_gold} carried gold.")
+            } else {
+                "You have fallen! Darkness takes you...".to_string()
+            };
+            self.log_to(user_id, LogKind::System, death_message);
         } else {
             self.log_to(
                 user_id,
@@ -2980,8 +3101,8 @@ impl WorldState {
                 Some(room) => {
                     let mut exits: Vec<(Dir, String)> = room
                         .exits
-                        .keys()
-                        .map(|d| (*d, d.label().to_string()))
+                        .iter()
+                        .map(|(dir, dest)| (*dir, self.exit_label(player.room, *dir, *dest)))
                         .collect();
                     exits.sort_by(|a, b| a.1.cmp(&b.1));
                     (
@@ -3188,6 +3309,7 @@ impl WorldState {
                     xp_for_next: xp_next,
                     level: player.level,
                     gold: player.gold,
+                    banked_gold: player.banked_gold,
                     room_name,
                     room_desc,
                     zone,
@@ -3232,6 +3354,21 @@ fn defense_tag(defense: Defense, _dtype: DamageType) -> &'static str {
     }
 }
 
+fn dir_input_hint(dir: Dir) -> &'static str {
+    match dir {
+        Dir::North => "w",
+        Dir::South => "s",
+        Dir::East => "d",
+        Dir::West => "a",
+        Dir::Northeast => "u",
+        Dir::Northwest => "y",
+        Dir::Southeast => "n",
+        Dir::Southwest => "m",
+        Dir::Up => "<",
+        Dir::Down => ">",
+    }
+}
+
 /// Derive a title from a slain foe. Bosses already read as proper names ("the
 /// Barrow King") and become "Bane of ..."; lesser foes ("a frost-bound wretch")
 /// lend their creature word to a "...bane" epithet ("Wretchbane").
@@ -3273,6 +3410,22 @@ fn join_with_and(items: &[&str]) -> String {
         [a, b] => format!("{a} and {b}"),
         [rest @ .., last] => format!("{}, and {last}", rest.join(", ")),
     }
+}
+
+fn gold_for_kill(xp: i32, boss: bool) -> i32 {
+    let base = if boss { 10 } else { 3 };
+    base + xp.max(0) / 5
+}
+
+fn carried_gold_death_loss(gold: i64) -> i64 {
+    if gold <= 0 {
+        return 0;
+    }
+    let loss = gold
+        .saturating_mul(DEATH_GOLD_LOSS_PERCENT)
+        .saturating_add(99)
+        / 100;
+    loss.min(gold)
 }
 
 fn push_log(log: &mut Vec<LogLine>, kind: LogKind, text: String) {
@@ -3321,6 +3474,63 @@ mod tests {
             s.players[&uid(1)].room,
             home,
             "recall returns to the square"
+        );
+    }
+
+    #[test]
+    fn frontier_entrance_requires_a_second_confirming_move() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+        let home = s.world.start_room;
+
+        s.move_player(uid(1), Dir::Down);
+        assert_eq!(
+            s.players[&uid(1)].room, home,
+            "first descent should warn without moving"
+        );
+        assert!(s.players[&uid(1)].frontier_descent_pending);
+        assert!(
+            s.players[&uid(1)]
+                .log
+                .iter()
+                .any(|line| line.text.contains("older, meaner country")),
+            "warning should explain the Frontier danger"
+        );
+
+        s.move_player(uid(1), Dir::Down);
+        assert_eq!(s.players[&uid(1)].room, frontier_entrance_room());
+        assert!(!s.players[&uid(1)].frontier_descent_pending);
+    }
+
+    #[test]
+    fn frontier_warning_clears_when_moving_elsewhere() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+
+        s.move_player(uid(1), Dir::Down);
+        assert!(s.players[&uid(1)].frontier_descent_pending);
+        s.move_player(uid(1), Dir::South);
+        assert_eq!(s.players[&uid(1)].room, 5);
+        assert!(!s.players[&uid(1)].frontier_descent_pending);
+    }
+
+    #[test]
+    fn town_square_exit_labels_mark_frontier_as_dangerous() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+
+        let snap = s.snapshot();
+        let view = snap.players.get(&uid(1)).expect("player view");
+        assert!(
+            view.exits
+                .iter()
+                .any(|(dir, label)| {
+                    *dir == Dir::Down && label.as_str() == "down (dangerous Frontier)"
+                }),
+            "Town Square should visibly mark the Frontier exit"
         );
     }
 
@@ -3424,6 +3634,47 @@ mod tests {
         let p = &s.players[&uid(1)];
         assert_eq!(p.gold, before - 80);
         assert!(p.inventory.contains(&1001));
+    }
+
+    #[test]
+    fn bank_toggles_between_deposit_and_withdraw_all_gold() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+
+        s.interact(uid(1), 1); // feature 1 in the square is the banker's grille
+        let p = &s.players[&uid(1)];
+        assert_eq!(p.gold, 0);
+        assert_eq!(p.banked_gold, STARTING_GOLD);
+
+        s.interact(uid(1), 1);
+        let p = &s.players[&uid(1)];
+        assert_eq!(p.gold, STARTING_GOLD);
+        assert_eq!(p.banked_gold, 0);
+    }
+
+    #[test]
+    fn normal_death_loses_carried_gold_but_not_banked_gold() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Mage);
+        if let Some(p) = s.players.get_mut(&uid(1)) {
+            p.gold = 1000;
+            p.banked_gold = 500;
+        }
+
+        s.strike_player(uid(1), 9999, DamageType::Physical, "a test foe");
+
+        let p = &s.players[&uid(1)];
+        assert_eq!(p.gold, 800);
+        assert_eq!(p.banked_gold, 500);
+        assert!(p.respawn_at.is_some());
+        assert!(
+            p.log
+                .iter()
+                .any(|line| line.text.contains("lose 200 carried gold")),
+            "death log should explain the gold loss"
+        );
     }
 
     #[test]
@@ -3555,6 +3806,15 @@ mod tests {
         );
 
         assert!(boss_achievement_for("the Elder Treant").is_none());
+    }
+
+    #[test]
+    fn gold_math_keeps_rewards_and_death_loss_predictable() {
+        assert_eq!(gold_for_kill(80, false), 19);
+        assert_eq!(gold_for_kill(352, true), 80);
+        assert_eq!(carried_gold_death_loss(0), 0);
+        assert_eq!(carried_gold_death_loss(1), 1);
+        assert_eq!(carried_gold_death_loss(1000), 200);
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -1119,7 +1119,10 @@ fn shop_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
                 .fg(theme::AMBER_GLOW())
                 .add_modifier(Modifier::BOLD),
         )),
-        Line::from(Span::styled(gold_line, Style::default().fg(theme::TEXT_DIM()))),
+        Line::from(Span::styled(
+            gold_line,
+            Style::default().fg(theme::TEXT_DIM()),
+        )),
         Line::raw(""),
     ];
     for (i, e) in shop.entries.iter().enumerate() {

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -336,7 +336,7 @@ fn quests_panel(view: &PlayerView) -> Vec<Line<'static>> {
 }
 
 fn vitals(view: &PlayerView) -> Vec<Line<'static>> {
-    vec![
+    let mut lines = vec![
         Line::from(vec![
             Span::styled(
                 format!("{} ", view.class_name),
@@ -382,7 +382,17 @@ fn vitals(view: &PlayerView) -> Vec<Line<'static>> {
                 Style::default().fg(theme::BADGE_GOLD()),
             ),
         ]),
-    ]
+    ];
+    if view.banked_gold > 0 {
+        lines.push(Line::from(vec![
+            Span::styled(vital_label("bank"), Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(
+                format!("{}", view.banked_gold),
+                Style::default().fg(theme::TEXT_BRIGHT()),
+            ),
+        ]));
+    }
+    lines
 }
 
 fn room_panel(
@@ -632,6 +642,15 @@ fn sheet_identity(view: &PlayerView, accent: Color) -> Vec<Line<'static>> {
             Style::default().fg(theme::BADGE_GOLD()),
         ),
     ]));
+    if view.banked_gold > 0 {
+        lines.push(Line::from(vec![
+            Span::styled("bank ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(
+                view.banked_gold.to_string(),
+                Style::default().fg(theme::TEXT_BRIGHT()),
+            ),
+        ]));
+    }
     lines
 }
 
@@ -1033,6 +1052,12 @@ fn inventory_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
             Style::default().fg(theme::BADGE_GOLD()),
         )),
     ];
+    if view.banked_gold > 0 {
+        lines.push(Line::from(Span::styled(
+            format!("  {} banked", view.banked_gold),
+            Style::default().fg(theme::TEXT_DIM()),
+        )));
+    }
     if view.inventory.is_empty() {
         lines.push(Line::from(Span::styled(
             "  (empty)",
@@ -1079,6 +1104,14 @@ fn shop_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
             Style::default().fg(theme::TEXT_DIM()),
         ))];
     };
+    let gold_line = if view.banked_gold > 0 {
+        format!(
+            "{} - your gold: {} (bank: {})",
+            shop.npc_name, view.gold, view.banked_gold
+        )
+    } else {
+        format!("{} - your gold: {}", shop.npc_name, view.gold)
+    };
     let mut lines = vec![
         Line::from(Span::styled(
             shop.shop_name.clone(),
@@ -1086,10 +1119,7 @@ fn shop_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
                 .fg(theme::AMBER_GLOW())
                 .add_modifier(Modifier::BOLD),
         )),
-        Line::from(Span::styled(
-            format!("{} - your gold: {}", shop.npc_name, view.gold),
-            Style::default().fg(theme::TEXT_DIM()),
-        )),
+        Line::from(Span::styled(gold_line, Style::default().fg(theme::TEXT_DIM()))),
         Line::raw(""),
     ];
     for (i, e) in shop.entries.iter().enumerate() {
@@ -1143,14 +1173,23 @@ fn footer_hints(view: &PlayerView) -> Vec<Line<'static>> {
     } else {
         lines.push(hint("wasd/arrows", "move"));
         lines.push(hint("yunm", "diagonals"));
+        let at_town_square = view.room_name == "Embergate - Town Square";
+        if at_town_square && view.exits.iter().any(|(dir, _)| *dir == Dir::South) {
+            lines.push(hint("s", "King's Road"));
+        }
         // Vertical exits aren't on the wasd/diagonal keys, so spell out the
         // stair keys - but only when this room actually has a way up or down,
         // so the hint appears exactly when the player needs it.
         let has_up = view.exits.iter().any(|(dir, _)| *dir == Dir::Up);
         let has_down = view.exits.iter().any(|(dir, _)| *dir == Dir::Down);
+        let has_danger_down = view
+            .exits
+            .iter()
+            .any(|(dir, label)| *dir == Dir::Down && label.contains("dangerous Frontier"));
         match (has_up, has_down) {
             (true, true) => lines.push(hint("< >", "climb up / go down")),
             (true, false) => lines.push(hint("<", "climb up")),
+            (false, true) if has_danger_down => lines.push(hint(">", "dangerous Frontier")),
             (false, true) => lines.push(hint(">", "go down")),
             (false, false) => {}
         }

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -2506,13 +2506,12 @@ pub fn seed_world() -> World {
 }
 
 fn scale_i32(value: i32, numerator: i32, denominator: i32) -> i32 {
-    (((value as i64) * (numerator as i64) + (denominator as i64 - 1))
-        / denominator as i64)
-        .max(1) as i32
+    (((value as i64) * (numerator as i64) + (denominator as i64 - 1)) / denominator as i64).max(1)
+        as i32
 }
 
 fn scale_u64(value: u64, numerator: u64, denominator: u64) -> u64 {
-    ((value * numerator + (denominator - 1)) / denominator).max(1)
+    (value * numerator).div_ceil(denominator).max(1)
 }
 
 fn tune_spawn_balance(spawns: &mut [MobSpawn]) {
@@ -5182,7 +5181,10 @@ mod tests {
             .iter()
             .find(|spawn| spawn.home == 6 && !spawn.boss)
             .expect("first road mob exists");
-        assert!(first_road_mob.xp >= 14, "early mobs should still be worth killing");
+        assert!(
+            first_road_mob.xp >= 14,
+            "early mobs should still be worth killing"
+        );
 
         let frontier_regular = world
             .spawns

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -366,11 +366,12 @@ pub const MELVANALA_SQUARE: RoomId = 660;
 pub const MATLATESH_SQUARE: RoomId = 720;
 
 /// What kind of lookable thing a feature is. Fountains restore vitals in a safe
-/// capital; the rest are pure description revealed on look.
+/// capital, banks protect gold, and the rest are pure description revealed on look.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum FeatureKind {
     Scenery,
     Fountain,
+    Bank,
     Plaque,
     Vista,
 }
@@ -381,6 +382,7 @@ impl FeatureKind {
         match self {
             Self::Scenery => "",
             Self::Fountain => "fountain",
+            Self::Bank => "bank",
             Self::Plaque => "plaque",
             Self::Vista => "vista",
         }
@@ -431,6 +433,13 @@ const EMBERGATE_WELL_DESC: &str = "The old well stands at the square's edge bene
     the day you come back to Embergate sets even the deepest weariness to rights and closes \
     whatever the frontier opened in you.";
 
+/// The bank is deliberately in the first safe room so death-risked gold can be
+/// protected before pushing into harder regions.
+const EMBERGATE_BANK_DESC: &str = "A narrow counting-house window has been built into the \
+    old guildhall wall, guarded by iron scrollwork and a sleepy clerk with sharper eyes \
+    than their posture suggests. Adventurers slide coin through the grille before heading \
+    out beyond the lamps; coin left here survives whatever the road does to its owner.";
+
 /// Every lookable feature in the world, keyed to the room it stands in.
 pub const FEATURES: &[Feature] = &[
     // ---- Embergate (the town square: recall point + safe haven) ---------
@@ -439,6 +448,12 @@ pub const FEATURES: &[Feature] = &[
         "the town well",
         FeatureKind::Fountain,
         EMBERGATE_WELL_DESC,
+    ),
+    feat(
+        1,
+        "the banker's grille",
+        FeatureKind::Bank,
+        EMBERGATE_BANK_DESC,
     ),
     // ---- Tasmania (harbor capital) --------------------------------------
     feat(
@@ -734,9 +749,10 @@ pub fn seed_world() -> World {
              name from it. Embergate hums with evening trade: a fiddler saws by the \
              well, children chase a dog between the legs of off-duty guardsmen, and \
              the smell of the baker's last loaves hangs warm in the air. A notice \
-             board leans by the well, thick with bounties and lost-cat pleas alike. \
-             The Gilded Flagon glows north, the temple west, Market Row east, and the \
-             South Gate and open road lie south.",
+             board leans by the well, thick with bounties and lost-cat pleas alike. Near \
+             the brazier, old stone steps vanish below the square behind warning plaques \
+             no one has bothered to repaint. The Gilded Flagon glows north, the temple \
+             west, Market Row east, and the South Gate and open road lie south.",
             &[
                 (Dir::North, 2),
                 (Dir::East, 3),
@@ -2064,7 +2080,7 @@ pub fn seed_world() -> World {
             damage: 12,
             xp: 150,
             respawn_secs: 300,
-            loot: &[1006, 1201, 1301],
+            loot: &[1006, 1110, 1111, 1201, 1301],
             boss: true,
             profile: DamageProfile::new(
                 DamageType::Physical,
@@ -2126,7 +2142,7 @@ pub fn seed_world() -> World {
             damage: 16,
             xp: 220,
             respawn_secs: 300,
-            loot: &[1105, 1202, 1302],
+            loot: &[1105, 1112, 1113, 1202, 1302],
             boss: true,
             profile: DamageProfile::new(
                 DamageType::Shadow,
@@ -2192,7 +2208,7 @@ pub fn seed_world() -> World {
             damage: 20,
             xp: 320,
             respawn_secs: 360,
-            loot: &[1008, 1204, 1302],
+            loot: &[1008, 1115, 1204, 1302],
             boss: true,
             profile: DamageProfile::new(
                 DamageType::Shadow,
@@ -2258,7 +2274,7 @@ pub fn seed_world() -> World {
             damage: 26,
             xp: 440,
             respawn_secs: 360,
-            loot: &[1009, 1205, 1304],
+            loot: &[1009, 1116, 1117, 1205, 1304],
             boss: true,
             profile: DamageProfile::new(
                 DamageType::Fire,
@@ -2324,7 +2340,7 @@ pub fn seed_world() -> World {
             damage: 32,
             xp: 600,
             respawn_secs: 420,
-            loot: &[1007, 1205, 1304],
+            loot: &[1007, 1117, 1205, 1304],
             boss: true,
             profile: DamageProfile::new(
                 DamageType::Frost,
@@ -2390,7 +2406,7 @@ pub fn seed_world() -> World {
             damage: 38,
             xp: 820,
             respawn_secs: 420,
-            loot: &[1109, 1202, 1304],
+            loot: &[1109, 1118, 1202, 1304],
             boss: true,
             profile: DamageProfile::new(
                 DamageType::Holy,
@@ -2456,7 +2472,7 @@ pub fn seed_world() -> World {
             damage: 48,
             xp: 1500,
             respawn_secs: 600,
-            loot: &[1009, 1205, 1401],
+            loot: &[1009, 1119, 1205, 1401],
             boss: true,
             profile: DamageProfile::new(
                 DamageType::Shadow,
@@ -2476,10 +2492,11 @@ pub fn seed_world() -> World {
     // (rooms 600+), reachable from Embergate's South Gate.
     extend_overworld(&mut rooms, &mut spawns);
 
-    // Append the Frontier: 500 procedurally-composed rooms across ten themed
+    // Append the Frontier: 1000 procedurally-composed rooms across twenty themed
     // zones (rooms 2000+), hung off Embergate and populated with the 40-type
     // frontier roster and generated loot.
     extend_frontier(&mut rooms, &mut spawns);
+    tune_spawn_balance(&mut spawns);
 
     World {
         rooms,
@@ -2488,18 +2505,57 @@ pub fn seed_world() -> World {
     }
 }
 
+fn scale_i32(value: i32, numerator: i32, denominator: i32) -> i32 {
+    (((value as i64) * (numerator as i64) + (denominator as i64 - 1))
+        / denominator as i64)
+        .max(1) as i32
+}
+
+fn scale_u64(value: u64, numerator: u64, denominator: u64) -> u64 {
+    ((value * numerator + (denominator - 1)) / denominator).max(1)
+}
+
+fn tune_spawn_balance(spawns: &mut [MobSpawn]) {
+    for spawn in spawns {
+        let frontier = spawn.id >= FRONTIER_SPAWN_ID_START;
+        let (hp_num, hp_den, dmg_num, dmg_den, xp_num, xp_den) = match (frontier, spawn.boss) {
+            (true, true) => (9, 5, 7, 5, 4, 5),
+            (true, false) => (3, 2, 4, 3, 5, 4),
+            (false, true) => (3, 2, 5, 4, 4, 5),
+            (false, false) => (6, 5, 6, 5, 9, 8),
+        };
+        spawn.max_hp = scale_i32(spawn.max_hp, hp_num, hp_den);
+        spawn.damage = scale_i32(spawn.damage, dmg_num, dmg_den);
+        spawn.xp = scale_i32(spawn.xp, xp_num, xp_den);
+        if !spawn.boss {
+            spawn.respawn_secs = if frontier {
+                scale_u64(spawn.respawn_secs, 3, 4).max(60)
+            } else {
+                scale_u64(spawn.respawn_secs, 4, 5).max(25)
+            };
+        }
+    }
+}
+
 // ---- The Frontier (procedural expansion) --------------------------------
 //
-// Ten themed zones, each a 10x5 grid of 50 rooms, chained one below the next and
+// Twenty themed zones, each a 10x5 grid of 50 rooms, chained one below the next and
 // hung off Embergate's square. Rooms, names and descriptions are composed
 // deterministically from per-zone flavour and leaked to 'static (the world is
-// built once at startup). Each zone fields three regular mob types and a boss
-// (40 types total); loot is the generated frontier catalog for that tier.
+// built once at startup). Each zone fields three regular mob types and a boss;
+// loot is the generated frontier catalog for that tier.
 
 const FRONTIER_BASE: RoomId = 2000;
 const FRONTIER_W: u32 = 10;
 const FRONTIER_H: u32 = 5;
 const FRONTIER_ZONES: usize = FRONTIER_ZONES_DATA.len();
+const FRONTIER_SPAWN_ID_START: u32 = 900_000;
+
+/// The first Frontier room, reached from Embergate's square through the old
+/// gateway stair.
+pub fn frontier_entrance_room() -> RoomId {
+    FRONTIER_BASE
+}
 
 /// Per-zone flavour: name, adjective, ground noun, a landmark feature, the
 /// creatures that haunt it, three regular mob names, and the zone boss.
@@ -2751,7 +2807,7 @@ fn frontier_desc(adj: &str, ground: &str, feature: &str, creature: &str, idx: u3
 
 fn extend_frontier(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
     let per_zone = FRONTIER_W * FRONTIER_H;
-    let mut spawn_id: u32 = 900_000;
+    let mut spawn_id: u32 = FRONTIER_SPAWN_ID_START;
 
     // Pass 1: create every room and its mobs.
     for (z, &(zname, adj, ground, feature, creature, mob_names, boss)) in
@@ -3085,7 +3141,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         13,
         165,
         true,
-        &[1006, 1201, 1302],
+        &[1006, 1110, 1111, 1201, 1302],
         p(D::Shadow, Some(D::Shadow), Some(D::Holy)),
     );
 
@@ -3203,7 +3259,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         17,
         235,
         true,
-        &[1105, 1202, 1302],
+        &[1105, 1114, 1113, 1202, 1302],
         p(D::Shadow, Some(D::Shadow), Some(D::Holy)),
     );
 
@@ -3321,7 +3377,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         21,
         340,
         true,
-        &[1008, 1204, 1302],
+        &[1008, 1115, 1204, 1302],
         p(D::Frost, Some(D::Frost), Some(D::Lightning)),
     );
 
@@ -3439,7 +3495,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         27,
         460,
         true,
-        &[1009, 1205, 1304],
+        &[1009, 1116, 1117, 1205, 1304],
         p(D::Fire, Some(D::Fire), Some(D::Frost)),
     );
 
@@ -3557,7 +3613,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         33,
         620,
         true,
-        &[1007, 1205, 1304],
+        &[1007, 1117, 1205, 1304],
         p(D::Frost, Some(D::Frost), Some(D::Fire)),
     );
 
@@ -3669,7 +3725,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         39,
         840,
         true,
-        &[1109, 1202, 1304],
+        &[1109, 1118, 1202, 1304],
         p(D::Shadow, Some(D::Shadow), Some(D::Holy)),
     );
 
@@ -3781,7 +3837,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         43,
         1100,
         true,
-        &[1009, 1205, 1401],
+        &[1009, 1119, 1205, 1401],
         p(D::Shadow, Some(D::Fire), Some(D::Holy)),
     );
 
@@ -3883,7 +3939,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         12,
         130,
         true,
-        &[1006, 1201, 1301],
+        &[1006, 1110, 1111, 1201, 1301],
         DamageProfile::physical(),
     );
 }
@@ -4187,7 +4243,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         22,
         380,
         true,
-        &[1008, 1205, 1302],
+        &[1008, 1115, 1205, 1302],
         p(D::Frost, Some(D::Frost), Some(D::Lightning)),
     );
 
@@ -4350,7 +4406,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         24,
         420,
         true,
-        &[1007, 1202, 1304],
+        &[1007, 1117, 1202, 1304],
         p(D::Physical, Some(D::Frost), Some(D::Fire)),
     );
 
@@ -4451,7 +4507,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         21,
         360,
         true,
-        &[1109, 1204, 1302],
+        &[1109, 1118, 1204, 1302],
         p(D::Poison, Some(D::Poison), Some(D::Fire)),
     );
 
@@ -4547,7 +4603,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         22,
         400,
         true,
-        &[1008, 1205, 1304],
+        &[1008, 1115, 1205, 1304],
         p(D::Poison, Some(D::Poison), Some(D::Fire)),
     );
 
@@ -4710,7 +4766,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         25,
         460,
         true,
-        &[1009, 1205, 1401],
+        &[1009, 1116, 1119, 1205, 1401],
         p(D::Physical, Some(D::Fire), Some(D::Frost)),
     );
 
@@ -4811,7 +4867,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         24,
         430,
         true,
-        &[1007, 1202, 1304],
+        &[1007, 1117, 1202, 1304],
         p(D::Physical, None, Some(D::Fire)),
     );
 
@@ -4907,7 +4963,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         25,
         450,
         true,
-        &[1008, 1205, 1304],
+        &[1008, 1118, 1205, 1304],
         p(D::Lightning, Some(D::Lightning), Some(D::Frost)),
     );
 }
@@ -5103,6 +5159,43 @@ mod tests {
     }
 
     #[test]
+    fn regular_mobs_respawn_fast_enough_for_grinding() {
+        let world = seed_world();
+        let slow: Vec<_> = world
+            .spawns
+            .iter()
+            .filter(|spawn| !spawn.boss && spawn.respawn_secs > 76)
+            .map(|spawn| (spawn.name, spawn.respawn_secs))
+            .collect();
+
+        assert!(
+            slow.is_empty(),
+            "regular grind mobs should not have long respawns: {slow:?}"
+        );
+    }
+
+    #[test]
+    fn regular_mobs_keep_grind_rewards_after_boss_tuning() {
+        let world = seed_world();
+        let first_road_mob = world
+            .spawns
+            .iter()
+            .find(|spawn| spawn.home == 6 && !spawn.boss)
+            .expect("first road mob exists");
+        assert!(first_road_mob.xp >= 14, "early mobs should still be worth killing");
+
+        let frontier_regular = world
+            .spawns
+            .iter()
+            .find(|spawn| spawn.id >= FRONTIER_SPAWN_ID_START && !spawn.boss)
+            .expect("frontier regular mob exists");
+        assert!(
+            frontier_regular.xp >= 60,
+            "frontier regulars should reward deliberate grinding"
+        );
+    }
+
+    #[test]
     fn town_and_capitals_have_wildlife() {
         assert!(!critters_at(1).is_empty(), "the town square has wildlife");
         assert!(
@@ -5118,14 +5211,18 @@ mod tests {
     }
 
     #[test]
-    fn town_square_has_a_recall_fountain() {
+    fn town_square_has_a_recall_fountain_and_bank() {
         // The recall destination carries a healing fountain, and room 1 is safe
-        // so the fountain actually restores vitals.
+        // so the fountain actually restores vitals. It also carries the bank
+        // that protects gold from death loss.
+        let features = features_at(1);
         assert!(
-            features_at(1)
-                .iter()
-                .any(|f| f.kind == FeatureKind::Fountain),
+            features.iter().any(|f| f.kind == FeatureKind::Fountain),
             "the town square needs a fountain"
+        );
+        assert!(
+            features.iter().any(|f| f.kind == FeatureKind::Bank),
+            "the town square needs a bank"
         );
         assert!(seed_world().room(1).expect("town square exists").safe);
     }


### PR DESCRIPTION
## Summary
- Adds a Lateania bank so players can protect gold from death loss, while retuning progression, loot, shops, and Frontier access for a longer campaign curve.

## Changes
- Adds banked gold to character persistence, snapshots, and UI panels.
- Adds the Embergate banker's grille: examining it deposits all carried gold or withdraws all banked gold.
- Normal death now removes 20% of carried gold while leaving banked gold untouched.
- Slows post-early-game XP progression and reduces some boss/frontier bounty acceleration.
- Expands shops and boss/frontier loot with head, hand, late-game, and repeatable consumable gold sinks.
- Marks the Town Square Frontier descent as dangerous and requires a second confirming `>` move.

## Behavior notes
- Saved character schema is bumped to version 5; old saves default `banked_gold` to `0`.
- Banked gold is protected from death, but must be withdrawn before shopping.

## Feature flags
- None.

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Not run per repo policy for LLM agents. Added/updated pure unit coverage for XP curve, shop stock/recovery scaling, Frontier loot slots, bank deposit/withdraw, death gold loss, Frontier confirmation, exit labeling, gold math, and spawn balance.
- Manual: Not run.