### PR TITLE
Lateania: living world — day/night, weather, and a wandering world boss

### DIFF
--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -98,11 +98,14 @@ Input capture contract:
 ### Tick loop
 
 Every `TICK_SECS = 2`, `WorldState::tick`:
-- respawns dead mobs whose timers have elapsed;
+- advances the world clock (`world_ticks`), which derives `TimeOfDay` (Dawn/Day/Dusk/Night, `PHASE_TICKS`) and `Weather` (Clear/Rain/Fog/Storm, `WEATHER_TICKS`), surfaced on `PlayerView` and shown in the room panel;
+- runs the wandering world-boss lifecycle: notes when the reigning boss has died (clearing `world_boss`, scheduling the next at `+WORLD_BOSS_INTERVAL`) and raises a new one (fixed id `WORLD_BOSS_ID`, a roaming Hunter boss) when due, announced server-wide via `log_all`;
+- reaps runtime-only mobs (`id >= SUMMON_ID_START`: summoner adds and the dead world boss) and respawns authored mobs (resetting roamers to `leash_home` and re-hiding Ambushers);
+- moves roamers (`move_roamers`): Wanderers/Patrollers drift in-zone, Hunters prowl only after dark (the world boss roams any zone, any hour);
 - applies mob damage-over-time stacks and kills mobs if DoTs finish them;
 - respawns downed players at `TEMPLE_ROOM = 4` after `PLAYER_RESPAWN_SECS = 8`;
 - regenerates class resources and decrements buffs, shields, HoTs, stuns, and cooldowns;
-- resolves one combat round for each engaged player;
+- resolves one combat round for each engaged player, then per-mob behavior (`resolve_mob_behavior`): Caster bolts (storm-boosted), PackHunter gang-ups, Summoner adds, Brute enrage, Thief steal-and-flee, Skirmisher flee; all mob damage is scaled by `TimeOfDay::mob_damage_pct` (the dark hits harder) and Ambush reveals are fog-boosted;
 - removes idle players after `PLAYER_IDLE_TIMEOUT_SECS = 10 * 60`, exporting their save;
 - increments snapshot generation when dirty and drains kill outcomes for `ActivityGame::Mud`.
 

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -37,8 +37,9 @@ Core shape:
 
 Current game scale:
 - `seed_world()` starts at Embergate room `1`.
-- Tests currently assert `1298` rooms: 198 base/extension rooms, 100 overworld rooms, and 1000 Frontier rooms.
+- Tests currently assert `1394` rooms: 198 base/extension rooms, 100 overworld rooms, 1000 Frontier rooms, and the 96-room Sunken Catacombs maze.
 - Frontier has 20 zones, each 10 by 5 rooms, starting at room `2000`.
+- The Sunken Catacombs (rooms `5000+`, hung off `TASMANIA_SQUARE`) is a deterministically-carved braided maze (`carve_maze` + `extend_catacombs` in `world.rs`), not a grid: winding corridors, dead-ends, junctions, loops, and a central vault. Generation uses a fixed-seed xorshift (`MazeRng`) so the world is identical every boot.
 
 ---
 

--- a/late-ssh/src/app/door/lateania/screen.rs
+++ b/late-ssh/src/app/door/lateania/screen.rs
@@ -339,7 +339,7 @@ fn draw_frontier_art(
         )),
         Line::raw(""),
         fact_line("20", "frontier zones"),
-        fact_line("1,298", "rooms in the world"),
+        fact_line("1,394", "rooms in the world"),
         fact_line("100", "generated frontier items"),
         fact_line("5", "classes with unlockable abilities"),
         fact_line("30k", "one-time chips across final boss achievements"),
@@ -420,7 +420,10 @@ fn world_stats() -> Vec<Line<'static>> {
             "boss quests, titles, and bounty rewards",
         ),
         stat_line("LAD / LFK", "profile badges for the two final clears"),
-        stat_line("1,298 rooms", "towns, shops, capitals, dungeons, and wilds"),
+        stat_line(
+            "1,394 rooms",
+            "towns, shops, capitals, wilds, and a maze crypt",
+        ),
         stat_line("5 classes", "Warrior, Mage, Cleric, Rogue, Ranger"),
         stat_line("shared runtime", "mob state and combat persist server-side"),
     ]

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -50,12 +50,17 @@ use super::persist::{
 };
 use super::stats::AbilityScores;
 use super::world::{
-    CritterKind, Dir, FeatureKind, MiniMap, MobSpawn, Perk, RoomId, World, critter_index,
-    critters_at, features_at, frontier_entrance_room, seed_world,
+    CritterKind, Dir, FeatureKind, MiniMap, MobBehavior, MobSpawn, Perk, RoomId, World,
+    critter_index, critters_at, features_at, frontier_entrance_room, seed_world,
 };
 
 /// World heartbeat. One combat round resolves per tick.
 const TICK_SECS: u64 = 2;
+/// First id handed out to runtime-only summoned adds, kept far clear of the
+/// authored spawn-id ranges (base game, Catacombs 800k+, Frontier 900k+).
+const SUMMON_ID_START: u32 = 990_000_000;
+/// A roamer takes a step at most this often (in ticks); at 2s/tick that is ~8s.
+const MOB_MOVE_COOLDOWN: u8 = 4;
 /// A player who sends no command for this long is dropped from the world.
 const PLAYER_IDLE_TIMEOUT_SECS: u64 = 10 * 60;
 /// How long a defeated player rests before respawning at the temple.
@@ -1158,6 +1163,20 @@ struct MobInstance {
     hp: i32,
     alive: bool,
     respawn_at: Option<Instant>,
+    /// What this mob does beyond standing and fighting (from `World::behaviors`).
+    behavior: MobBehavior,
+    /// Where the mob actually is right now. Roamers move; this drives which room
+    /// shows the mob and which mob a player in a room can engage. Starts at home.
+    current_room: RoomId,
+    /// The mob's home; roamers tether to it and return here on respawn.
+    leash_home: RoomId,
+    /// Ticks until this mob may take another roaming step.
+    move_cooldown: u8,
+    /// Ambushers are hidden from the room view until a player enters (then they
+    /// reveal and strike first). Always true for every other behavior.
+    revealed: bool,
+    /// Ticks until a Summoner may call another add.
+    summon_cooldown: u8,
 }
 
 struct WorldState {
@@ -1177,6 +1196,9 @@ struct WorldState {
     world_revision: u64,
     /// Hunt cooldowns for `Game` critters, keyed by global WILDLIFE index.
     hunted: HashMap<usize, Instant>,
+    /// Next id for a runtime-only summoned add (Summoner behavior). Kept well
+    /// clear of authored spawn ids so the two never collide.
+    next_summon_id: u32,
 }
 
 const LOG_CAP: usize = 60;
@@ -1190,13 +1212,20 @@ impl WorldState {
             .spawns
             .iter()
             .map(|spawn| {
+                let behavior = world.behavior_of(spawn.id);
                 (
                     spawn.id,
                     MobInstance {
-                        spawn: spawn.clone(),
                         hp: spawn.max_hp,
                         alive: true,
                         respawn_at: None,
+                        behavior,
+                        current_room: spawn.home,
+                        leash_home: spawn.home,
+                        move_cooldown: 0,
+                        revealed: !matches!(behavior, MobBehavior::Ambusher),
+                        summon_cooldown: 0,
+                        spawn: spawn.clone(),
                     },
                 )
             })
@@ -1214,6 +1243,7 @@ impl WorldState {
             world_dirty: false,
             world_revision: 0,
             hunted: HashMap::new(),
+            next_summon_id: SUMMON_ID_START,
         }
     }
 
@@ -1966,11 +1996,55 @@ impl WorldState {
         self.describe_room_context(user_id, false);
     }
 
+    /// Reveal any Ambushers lurking in the player's room: they spring out and
+    /// land a free first strike. Once revealed they behave like any other foe.
+    fn reveal_ambushers(&mut self, user_id: Uuid) {
+        let room = match self.players.get(&user_id) {
+            Some(p) if p.respawn_at.is_none() => p.room,
+            _ => return,
+        };
+        let lurkers: Vec<(u32, i32, DamageType, String)> = self
+            .mobs
+            .values()
+            .filter(|m| {
+                m.alive
+                    && !m.revealed
+                    && matches!(m.behavior, MobBehavior::Ambusher)
+                    && m.current_room == room
+            })
+            .map(|m| {
+                (
+                    m.spawn.id,
+                    m.spawn.damage,
+                    m.spawn.profile.attack_type,
+                    m.spawn.name.to_string(),
+                )
+            })
+            .collect();
+        if lurkers.is_empty() {
+            return;
+        }
+        for (id, dmg, dt, name) in lurkers {
+            if let Some(m) = self.mobs.get_mut(&id) {
+                m.revealed = true;
+            }
+            self.log_to(
+                user_id,
+                LogKind::Combat,
+                format!("{name} lunges from the shadows and strikes first!"),
+            );
+            self.strike_player(user_id, dmg, dt, &name);
+        }
+        self.dirty = true;
+        self.mark_world_dirty();
+    }
+
     fn describe_room(&mut self, user_id: Uuid) {
         self.describe_room_context(user_id, true);
     }
 
     fn describe_room_context(&mut self, user_id: Uuid, announce_travel: bool) {
+        self.reveal_ambushers(user_id);
         let Some(player) = self.players.get(&user_id) else {
             return;
         };
@@ -1994,7 +2068,7 @@ impl WorldState {
         let mob_names: Vec<String> = self
             .mobs
             .values()
-            .filter(|m| m.alive && m.spawn.home == room_id)
+            .filter(|m| m.alive && m.revealed && m.current_room == room_id)
             .map(|m| m.spawn.name.to_string())
             .collect();
         let shop = shop_at(room_id);
@@ -2121,7 +2195,7 @@ impl WorldState {
         let target = self
             .mobs
             .values()
-            .find(|m| m.alive && m.spawn.home == room_id)
+            .find(|m| m.alive && m.revealed && m.current_room == room_id)
             .map(|m| m.spawn.id);
         match target {
             Some(mob_id) => {
@@ -2814,6 +2888,13 @@ impl WorldState {
         self.pending_kills.clear();
         let now = Instant::now();
 
+        // Reap runtime-only summoned adds once dead so they don't pile up.
+        let before = self.mobs.len();
+        self.mobs.retain(|id, m| *id < SUMMON_ID_START || m.alive);
+        if self.mobs.len() != before {
+            self.mark_world_dirty();
+        }
+
         let mut world_changed = false;
         for mob in self.mobs.values_mut() {
             if !mob.alive
@@ -2823,6 +2904,11 @@ impl WorldState {
                 mob.alive = true;
                 mob.hp = mob.spawn.max_hp;
                 mob.respawn_at = None;
+                // A respawned roamer returns home and re-hides if it ambushes.
+                mob.current_room = mob.leash_home;
+                mob.move_cooldown = 0;
+                mob.summon_cooldown = 0;
+                mob.revealed = !matches!(mob.behavior, MobBehavior::Ambusher);
                 self.dirty = true;
                 world_changed = true;
             }
@@ -2830,6 +2916,9 @@ impl WorldState {
         if world_changed {
             self.mark_world_dirty();
         }
+
+        // Roaming: move wanderers/patrollers/hunters that no one is fighting.
+        self.move_roamers();
 
         // Mob damage-over-time from player abilities.
         let dot_ids: Vec<u32> = self.mob_dots.keys().copied().collect();
@@ -3008,14 +3097,21 @@ impl WorldState {
                 .mobs
                 .get(&mob_id)
                 .map(|m| {
-                    (
-                        m.spawn.damage,
-                        m.spawn.profile.attack_type,
-                        m.spawn.name.to_string(),
-                    )
+                    // Brute: the closer to death, the harder it swings.
+                    let enraged =
+                        matches!(m.behavior, MobBehavior::Brute) && m.hp * 3 < m.spawn.max_hp;
+                    let dmg = if enraged {
+                        m.spawn.damage * 3 / 2
+                    } else {
+                        m.spawn.damage
+                    };
+                    (dmg, m.spawn.profile.attack_type, m.spawn.name.to_string())
                 })
                 .unwrap_or((0, DamageType::Physical, String::new()));
             self.strike_player(user_id, mob_damage, mob_dtype, &mob_name);
+            // Resolve the rest of the mob's behavior this round (cast/pack/
+            // summon/steal/flee). No-op for plain Sentinels.
+            self.resolve_mob_behavior(user_id, mob_id);
         }
 
         // Drop idle players.
@@ -3043,6 +3139,277 @@ impl WorldState {
             kills: std::mem::take(&mut self.pending_kills),
             idle_saves,
         }
+    }
+
+    /// Step roaming mobs (Wanderer/Patroller/Hunter) that no player is fighting,
+    /// keeping them inside their own zone and out of safe rooms. Hunters prefer a
+    /// neighbour that holds a player so they close the distance.
+    fn move_roamers(&mut self) {
+        let engaged: Vec<u32> = self.players.values().filter_map(|p| p.target).collect();
+        let player_rooms: Vec<RoomId> = self
+            .players
+            .values()
+            .filter(|p| p.respawn_at.is_none())
+            .map(|p| p.room)
+            .collect();
+
+        let mut plan: Vec<(u32, RoomId)> = Vec::new();
+        let mut ticking: Vec<u32> = Vec::new();
+        for (id, m) in self.mobs.iter() {
+            if !m.alive
+                || !m.revealed
+                || engaged.contains(id)
+                || !matches!(
+                    m.behavior,
+                    MobBehavior::Wanderer | MobBehavior::Patroller | MobBehavior::Hunter
+                )
+            {
+                continue;
+            }
+            if m.move_cooldown > 0 {
+                ticking.push(*id);
+                continue;
+            }
+            let Some(room) = self.world.room(m.current_room) else {
+                continue;
+            };
+            let zone = room.zone;
+            let dests: Vec<RoomId> = room
+                .exits
+                .values()
+                .copied()
+                .filter(|to| {
+                    self.world
+                        .room(*to)
+                        .is_some_and(|d| d.zone == zone && !d.safe)
+                })
+                .collect();
+            if dests.is_empty() {
+                ticking.push(*id);
+                continue;
+            }
+            let pick = (m.spawn.id as usize).wrapping_add(self.generation as usize) % dests.len();
+            let dest = if matches!(m.behavior, MobBehavior::Hunter) {
+                dests
+                    .iter()
+                    .copied()
+                    .find(|d| player_rooms.contains(d))
+                    .unwrap_or(dests[pick])
+            } else {
+                dests[pick]
+            };
+            plan.push((*id, dest));
+        }
+
+        for id in ticking {
+            if let Some(m) = self.mobs.get_mut(&id) {
+                m.move_cooldown = m.move_cooldown.saturating_sub(1);
+            }
+        }
+        let mut moved = false;
+        for (id, dest) in plan {
+            if let Some(m) = self.mobs.get_mut(&id) {
+                m.current_room = dest;
+                m.move_cooldown = MOB_MOVE_COOLDOWN;
+                moved = true;
+            }
+        }
+        if moved {
+            self.dirty = true;
+            self.mark_world_dirty();
+        }
+    }
+
+    /// Behaviors that fire during a mob's combat turn: casters bolt, pack hunters
+    /// gang up, summoners call adds, thieves rob and run, skirmishers flee when
+    /// hurt. Called right after the mob's normal strike; a no-op for Sentinels,
+    /// Brutes (handled in the strike), and roamers.
+    fn resolve_mob_behavior(&mut self, user_id: Uuid, mob_id: u32) {
+        let (behavior, room, name, bite, hp, max_hp, summon_ready) = {
+            let Some(m) = self.mobs.get(&mob_id) else {
+                return;
+            };
+            if !m.alive {
+                return;
+            }
+            (
+                m.behavior,
+                m.current_room,
+                m.spawn.name.to_string(),
+                m.spawn.damage,
+                m.hp,
+                m.spawn.max_hp,
+                m.summon_cooldown == 0,
+            )
+        };
+        // A cheap per-round roll without threading RNG state through combat.
+        let roll = (self.generation as usize).wrapping_add(mob_id as usize) % 100;
+
+        match behavior {
+            MobBehavior::Caster(school) if roll < 40 => {
+                self.log_to(
+                    user_id,
+                    LogKind::Combat,
+                    format!("{name} channels a bolt of {}!", school.label()),
+                );
+                self.strike_player(user_id, bite + bite / 2, school, &name);
+            }
+            MobBehavior::PackHunter => {
+                let allies: Vec<(i32, DamageType, String)> = self
+                    .mobs
+                    .values()
+                    .filter(|o| {
+                        o.alive && o.revealed && o.current_room == room && o.spawn.id != mob_id
+                    })
+                    .map(|o| {
+                        (
+                            o.spawn.damage,
+                            o.spawn.profile.attack_type,
+                            o.spawn.name.to_string(),
+                        )
+                    })
+                    .collect();
+                if !allies.is_empty() {
+                    self.log_to(
+                        user_id,
+                        LogKind::Combat,
+                        format!("{name} howls - the pack closes in!"),
+                    );
+                    for (dmg, dt, an) in allies {
+                        self.strike_player(user_id, dmg, dt, &an);
+                    }
+                }
+            }
+            MobBehavior::Summoner => {
+                if summon_ready {
+                    self.summon_add(mob_id, room);
+                    self.log_to(
+                        user_id,
+                        LogKind::Combat,
+                        format!("{name} calls a servant from the dark!"),
+                    );
+                    if let Some(mm) = self.mobs.get_mut(&mob_id) {
+                        mm.summon_cooldown = 6;
+                    }
+                } else if let Some(mm) = self.mobs.get_mut(&mob_id) {
+                    mm.summon_cooldown = mm.summon_cooldown.saturating_sub(1);
+                }
+            }
+            MobBehavior::Thief if roll < 35 => {
+                let stolen = self
+                    .players
+                    .get(&user_id)
+                    .map(|p| (p.gold / 10).clamp(5, 50).min(p.gold))
+                    .unwrap_or(0);
+                if stolen > 0 {
+                    if let Some(p) = self.players.get_mut(&user_id) {
+                        p.gold -= stolen;
+                    }
+                    self.log_to(
+                        user_id,
+                        LogKind::Combat,
+                        format!("{name} snatches {stolen} gold and bolts!"),
+                    );
+                    self.flee_mob(user_id, mob_id);
+                }
+            }
+            MobBehavior::Skirmisher if hp * 3 < max_hp => {
+                self.log_to(
+                    user_id,
+                    LogKind::Combat,
+                    format!("{name} breaks away and flees into the dark!"),
+                );
+                self.flee_mob(user_id, mob_id);
+            }
+            _ => {}
+        }
+    }
+
+    /// Spawn a short-lived add for a Summoner. The add is a runtime-only mob
+    /// (id >= `SUMMON_ID_START`) that simply dies for good when killed.
+    fn summon_add(&mut self, parent_id: u32, room: RoomId) {
+        let (max_hp, damage, profile) = {
+            let Some(parent) = self.mobs.get(&parent_id) else {
+                return;
+            };
+            (
+                parent.spawn.max_hp / 3 + 20,
+                (parent.spawn.damage / 2).max(3),
+                parent.spawn.profile,
+            )
+        };
+        let id = self.next_summon_id;
+        self.next_summon_id = self.next_summon_id.wrapping_add(1);
+        let spawn = MobSpawn {
+            id,
+            name: "a Risen Servant",
+            home: room,
+            max_hp,
+            damage,
+            xp: 5,
+            respawn_secs: 0,
+            loot: &[],
+            boss: false,
+            profile,
+        };
+        self.mobs.insert(
+            id,
+            MobInstance {
+                hp: spawn.max_hp,
+                alive: true,
+                respawn_at: None,
+                behavior: MobBehavior::Sentinel,
+                current_room: room,
+                leash_home: room,
+                move_cooldown: 0,
+                revealed: true,
+                summon_cooldown: 0,
+                spawn,
+            },
+        );
+        self.dirty = true;
+        self.mark_world_dirty();
+    }
+
+    /// Move a mob to a random same-zone, non-safe neighbour and drop the player's
+    /// lock on it (Skirmisher/Thief flight). No-op if there is nowhere to run.
+    fn flee_mob(&mut self, user_id: Uuid, mob_id: u32) {
+        let dest = {
+            let Some(m) = self.mobs.get(&mob_id) else {
+                return;
+            };
+            let Some(room) = self.world.room(m.current_room) else {
+                return;
+            };
+            let zone = room.zone;
+            let dests: Vec<RoomId> = room
+                .exits
+                .values()
+                .copied()
+                .filter(|to| {
+                    self.world
+                        .room(*to)
+                        .is_some_and(|d| d.zone == zone && !d.safe)
+                })
+                .collect();
+            if dests.is_empty() {
+                None
+            } else {
+                Some(dests[(self.generation as usize).wrapping_add(mob_id as usize) % dests.len()])
+            }
+        };
+        let Some(to) = dest else { return };
+        if let Some(m) = self.mobs.get_mut(&mob_id) {
+            m.current_room = to;
+            m.move_cooldown = MOB_MOVE_COOLDOWN;
+        }
+        if let Some(p) = self.players.get_mut(&user_id)
+            && p.target == Some(mob_id)
+        {
+            p.target = None;
+        }
+        self.dirty = true;
+        self.mark_world_dirty();
     }
 
     fn strike_player(&mut self, user_id: Uuid, raw: i32, dtype: DamageType, mob_name: &str) {
@@ -3166,7 +3533,7 @@ impl WorldState {
             let mobs: Vec<MobView> = self
                 .mobs
                 .values()
-                .filter(|m| m.alive && m.spawn.home == player.room)
+                .filter(|m| m.alive && m.revealed && m.current_room == player.room)
                 .map(|m| MobView {
                     name: m.spawn.name.to_string(),
                     hp: m.hp,
@@ -3484,6 +3851,63 @@ mod tests {
 
     fn world() -> WorldState {
         WorldState::new(uid(999), seed_world())
+    }
+
+    /// Put a classed player and a single controlled mob (with `behavior`) into a
+    /// non-safe Frontier room that has same-zone neighbours to flee to, engage
+    /// it, and return (state, mob_id). The mob is given a big HP pool so the
+    /// player's opening strike can't kill it before its behavior resolves.
+    fn engaged_with(behavior: MobBehavior) -> (WorldState, u32) {
+        const ROOM: RoomId = 2001; // Frontier zone 0, interior (non-safe, has exits)
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+        let mob_id = *s.mobs.keys().next().expect("world has mobs");
+        {
+            let m = s.mobs.get_mut(&mob_id).unwrap();
+            m.behavior = behavior;
+            m.alive = true;
+            m.revealed = true;
+            m.current_room = ROOM;
+            m.leash_home = ROOM;
+            m.hp = 200;
+            m.spawn.max_hp = 1000;
+            m.spawn.damage = 1; // can't kill the player while we observe
+        }
+        s.players.get_mut(&uid(1)).unwrap().room = ROOM;
+        s.engage(uid(1));
+        assert_eq!(s.players[&uid(1)].target, Some(mob_id), "engaged the mob");
+        (s, mob_id)
+    }
+
+    #[test]
+    fn skirmisher_flees_when_wounded_and_breaks_the_lock() {
+        let (mut s, mob_id) = engaged_with(MobBehavior::Skirmisher);
+        let start = s.mobs[&mob_id].current_room;
+        // Wound it below a third so the flee condition trips.
+        s.mobs.get_mut(&mob_id).unwrap().hp = 100; // < 1000/3
+        s.tick();
+        assert_ne!(
+            s.mobs[&mob_id].current_room, start,
+            "a wounded skirmisher should flee to another room"
+        );
+        assert_eq!(
+            s.players[&uid(1)].target,
+            None,
+            "fleeing breaks the player's target lock"
+        );
+    }
+
+    #[test]
+    fn summoner_calls_an_add_into_the_fight() {
+        let (mut s, _mob_id) = engaged_with(MobBehavior::Summoner);
+        let before = s.mobs.len();
+        s.tick();
+        assert!(
+            s.mobs.keys().any(|id| *id >= SUMMON_ID_START),
+            "summoner should have spawned a runtime add"
+        );
+        assert!(s.mobs.len() > before, "the add joins the mob roster");
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -43,7 +43,7 @@ use crate::app::{
 
 use super::abilities::{Ability, AbilityEffect, learned_at, unlocked_for};
 use super::classes::{Class, level_for_xp, xp_for_level};
-use super::damage::{DamageType, Defense};
+use super::damage::{DamageProfile, DamageType, Defense};
 use super::items::{ItemKind, Slot, item, shop_at};
 use super::persist::{
     SavedCharacter, SavedCharacterInit, SavedMob, SavedMobDot, SavedMobStun, SavedWorld,
@@ -61,6 +61,82 @@ const TICK_SECS: u64 = 2;
 const SUMMON_ID_START: u32 = 990_000_000;
 /// A roamer takes a step at most this often (in ticks); at 2s/tick that is ~8s.
 const MOB_MOVE_COOLDOWN: u8 = 4;
+/// Ticks per time-of-day phase. Four phases => a ~16-minute day at 2s/tick.
+const PHASE_TICKS: u64 = 120;
+/// Ticks the weather holds before it rolls over (~3 minutes).
+const WEATHER_TICKS: u64 = 90;
+/// Fixed id for the lone wandering world boss (reaped like a summon on death).
+const WORLD_BOSS_ID: u32 = 999_000_000;
+/// The first world boss stirs this many ticks after boot (~2 minutes).
+const WORLD_BOSS_FIRST_TICK: u64 = 60;
+/// Ticks between one world boss falling and the next rising (~10 minutes).
+const WORLD_BOSS_INTERVAL: u64 = 300;
+
+/// The world clock's coarse phase, derived from the tick count. Dusk and Night
+/// count as "dark", when the dead grow bolder and stronger.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum TimeOfDay {
+    Dawn,
+    Day,
+    Dusk,
+    Night,
+}
+
+impl TimeOfDay {
+    fn from_ticks(t: u64) -> Self {
+        match (t / PHASE_TICKS) % 4 {
+            0 => Self::Dawn,
+            1 => Self::Day,
+            2 => Self::Dusk,
+            _ => Self::Night,
+        }
+    }
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Dawn => "dawn",
+            Self::Day => "day",
+            Self::Dusk => "dusk",
+            Self::Night => "night",
+        }
+    }
+    fn is_dark(self) -> bool {
+        matches!(self, Self::Dusk | Self::Night)
+    }
+    /// Multiplier (percent) applied to mob damage; the dark hits harder.
+    fn mob_damage_pct(self) -> i32 {
+        if self.is_dark() { 125 } else { 100 }
+    }
+}
+
+/// The current weather, derived from the tick count. Beyond flavor, fog feeds
+/// ambushers and storms charge spellcasters.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Weather {
+    Clear,
+    Rain,
+    Fog,
+    Storm,
+}
+
+impl Weather {
+    fn from_ticks(t: u64) -> Self {
+        // Offset from the day phase so weather and time drift independently.
+        match (t / WEATHER_TICKS + 1) % 4 {
+            0 => Self::Clear,
+            1 => Self::Rain,
+            2 => Self::Fog,
+            _ => Self::Storm,
+        }
+    }
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Clear => "clear",
+            Self::Rain => "rain",
+            Self::Fog => "fog",
+            Self::Storm => "storm",
+        }
+    }
+}
 /// A player who sends no command for this long is dropped from the world.
 const PLAYER_IDLE_TIMEOUT_SECS: u64 = 10 * 60;
 /// How long a defeated player rests before respawning at the temple.
@@ -298,6 +374,10 @@ pub struct PlayerView {
     pub features: Vec<FeatureView>,
     /// Overhead map of the explored neighbourhood around the player.
     pub minimap: MiniMap,
+    /// The world clock phase, e.g. "dawn"/"day"/"dusk"/"night".
+    pub time_of_day: &'static str,
+    /// The current weather, e.g. "clear"/"rain"/"fog"/"storm".
+    pub weather: &'static str,
 }
 
 impl PlayerView {
@@ -346,6 +426,8 @@ impl PlayerView {
             resurrection_cap: 0,
             features: Vec::new(),
             minimap: MiniMap::default(),
+            time_of_day: "day",
+            weather: "clear",
         }
     }
 }
@@ -1199,6 +1281,12 @@ struct WorldState {
     /// Next id for a runtime-only summoned add (Summoner behavior). Kept well
     /// clear of authored spawn ids so the two never collide.
     next_summon_id: u32,
+    /// The world heartbeat, in ticks. Drives time-of-day and weather.
+    world_ticks: u64,
+    /// The active wandering world boss, if one currently roams.
+    world_boss: Option<u32>,
+    /// Tick at which the next world boss may rise.
+    next_world_boss_tick: u64,
 }
 
 const LOG_CAP: usize = 60;
@@ -1244,6 +1332,28 @@ impl WorldState {
             world_revision: 0,
             hunted: HashMap::new(),
             next_summon_id: SUMMON_ID_START,
+            world_ticks: 0,
+            world_boss: None,
+            next_world_boss_tick: WORLD_BOSS_FIRST_TICK,
+        }
+    }
+
+    /// The current world clock phase.
+    fn time_of_day(&self) -> TimeOfDay {
+        TimeOfDay::from_ticks(self.world_ticks)
+    }
+
+    /// The current weather.
+    fn weather(&self) -> Weather {
+        Weather::from_ticks(self.world_ticks)
+    }
+
+    /// Push a system line to every player currently in the world (server-wide
+    /// announcements like a world boss rising or falling).
+    fn log_all(&mut self, text: String) {
+        let ids: Vec<Uuid> = self.players.keys().copied().collect();
+        for id in ids {
+            self.log_to(id, LogKind::System, text.clone());
         }
     }
 
@@ -2024,6 +2134,8 @@ impl WorldState {
         if lurkers.is_empty() {
             return;
         }
+        // Fog hides them better: the ambush lands half again as hard.
+        let fog = self.weather() == Weather::Fog;
         for (id, dmg, dt, name) in lurkers {
             if let Some(m) = self.mobs.get_mut(&id) {
                 m.revealed = true;
@@ -2033,6 +2145,7 @@ impl WorldState {
                 LogKind::Combat,
                 format!("{name} lunges from the shadows and strikes first!"),
             );
+            let dmg = if fog { dmg * 3 / 2 } else { dmg };
             self.strike_player(user_id, dmg, dt, &name);
         }
         self.dirty = true;
@@ -2888,11 +3001,27 @@ impl WorldState {
         self.pending_kills.clear();
         let now = Instant::now();
 
-        // Reap runtime-only summoned adds once dead so they don't pile up.
+        // Advance the world clock (drives time-of-day and weather).
+        self.world_ticks = self.world_ticks.wrapping_add(1);
+
+        // World boss lifecycle: note when the reigning boss has fallen (before
+        // the reaper sweeps its corpse), then raise a new one when due.
+        if let Some(id) = self.world_boss
+            && !self.mobs.get(&id).is_some_and(|m| m.alive)
+        {
+            self.world_boss = None;
+            self.next_world_boss_tick = self.world_ticks + WORLD_BOSS_INTERVAL;
+        }
+
+        // Reap runtime-only summoned adds (and the dead world boss) once gone.
         let before = self.mobs.len();
         self.mobs.retain(|id, m| *id < SUMMON_ID_START || m.alive);
         if self.mobs.len() != before {
             self.mark_world_dirty();
+        }
+
+        if self.world_boss.is_none() && self.world_ticks >= self.next_world_boss_tick {
+            self.spawn_world_boss();
         }
 
         let mut world_changed = false;
@@ -3141,10 +3270,79 @@ impl WorldState {
         }
     }
 
+    /// Raise the lone wandering world boss in a random non-safe room and
+    /// announce it to everyone. It hunts as a roaming boss and roams the whole
+    /// world (it is not pinned to one zone like ordinary roamers).
+    fn spawn_world_boss(&mut self) {
+        let rooms: Vec<RoomId> = self
+            .world
+            .rooms
+            .values()
+            .filter(|r| !r.safe)
+            .map(|r| r.id)
+            .collect();
+        if rooms.is_empty() {
+            return;
+        }
+        let room = rooms[(self.world_ticks as usize) % rooms.len()];
+        const NAMES: [&str; 4] = [
+            "Gravelord Yorth",
+            "the Hollow Sovereign",
+            "Malrik the Unburied",
+            "Vaultwarden Sceth",
+        ];
+        let name = NAMES[(self.world_ticks / WORLD_BOSS_INTERVAL.max(1)) as usize % NAMES.len()];
+        let spawn = MobSpawn {
+            id: WORLD_BOSS_ID,
+            name,
+            home: room,
+            max_hp: 900,
+            damage: 26,
+            xp: 600,
+            respawn_secs: 0,
+            loot: super::items::frontier_loot(8),
+            boss: true,
+            profile: DamageProfile::new(
+                DamageType::Shadow,
+                Some(DamageType::Physical),
+                Some(DamageType::Holy),
+            ),
+        };
+        self.mobs.insert(
+            WORLD_BOSS_ID,
+            MobInstance {
+                hp: spawn.max_hp,
+                alive: true,
+                respawn_at: None,
+                behavior: MobBehavior::Hunter,
+                current_room: room,
+                leash_home: room,
+                move_cooldown: 0,
+                revealed: true,
+                summon_cooldown: 0,
+                spawn,
+            },
+        );
+        self.world_boss = Some(WORLD_BOSS_ID);
+        let zone = self
+            .world
+            .room(room)
+            .map(|r| r.zone)
+            .unwrap_or("the deep world");
+        self.log_all(format!(
+            "A chill grips Lateania: {name} rises in {zone} and begins to hunt."
+        ));
+        self.dirty = true;
+        self.mark_world_dirty();
+    }
+
     /// Step roaming mobs (Wanderer/Patroller/Hunter) that no player is fighting,
     /// keeping them inside their own zone and out of safe rooms. Hunters prefer a
-    /// neighbour that holds a player so they close the distance.
+    /// neighbour that holds a player so they close the distance. Ordinary Hunters
+    /// only prowl after dark; the world boss roams the whole world at any hour.
     fn move_roamers(&mut self) {
+        let dark = self.time_of_day().is_dark();
+        let world_boss = self.world_boss;
         let engaged: Vec<u32> = self.players.values().filter_map(|p| p.target).collect();
         let player_rooms: Vec<RoomId> = self
             .players
@@ -3156,6 +3354,7 @@ impl WorldState {
         let mut plan: Vec<(u32, RoomId)> = Vec::new();
         let mut ticking: Vec<u32> = Vec::new();
         for (id, m) in self.mobs.iter() {
+            let is_boss = Some(*id) == world_boss;
             if !m.alive
                 || !m.revealed
                 || engaged.contains(id)
@@ -3164,6 +3363,11 @@ impl WorldState {
                     MobBehavior::Wanderer | MobBehavior::Patroller | MobBehavior::Hunter
                 )
             {
+                continue;
+            }
+            // Ordinary Hunters keep to their lair by day and only prowl in the dark.
+            if matches!(m.behavior, MobBehavior::Hunter) && !is_boss && !dark {
+                ticking.push(*id);
                 continue;
             }
             if m.move_cooldown > 0 {
@@ -3181,7 +3385,8 @@ impl WorldState {
                 .filter(|to| {
                     self.world
                         .room(*to)
-                        .is_some_and(|d| d.zone == zone && !d.safe)
+                        // The world boss roams anywhere; others keep to their zone.
+                        .is_some_and(|d| !d.safe && (is_boss || d.zone == zone))
                 })
                 .collect();
             if dests.is_empty() {
@@ -3247,12 +3452,17 @@ impl WorldState {
 
         match behavior {
             MobBehavior::Caster(school) if roll < 40 => {
+                // A storm charges the air, so spell-bolts land half again as hard.
+                let mut bolt = bite + bite / 2;
+                if self.weather() == Weather::Storm {
+                    bolt = bolt * 3 / 2;
+                }
                 self.log_to(
                     user_id,
                     LogKind::Combat,
                     format!("{name} channels a bolt of {}!", school.label()),
                 );
-                self.strike_player(user_id, bite + bite / 2, school, &name);
+                self.strike_player(user_id, bolt, school, &name);
             }
             MobBehavior::PackHunter => {
                 let allies: Vec<(i32, DamageType, String)> = self
@@ -3414,6 +3624,8 @@ impl WorldState {
 
     fn strike_player(&mut self, user_id: Uuid, raw: i32, dtype: DamageType, mob_name: &str) {
         let now = Instant::now();
+        // The dark emboldens the dead: every mob blow hits harder after dusk.
+        let raw = raw * self.time_of_day().mob_damage_pct() / 100;
         let Some(p) = self.players.get_mut(&user_id) else {
             return;
         };
@@ -3504,6 +3716,8 @@ impl WorldState {
 
     fn snapshot(&self) -> MudSnapshot {
         let mut players = HashMap::new();
+        let time_of_day = self.time_of_day().label();
+        let weather = self.weather().label();
         for (user_id, player) in &self.players {
             let room = self.world.room(player.room);
             let (room_name, room_desc, zone, safe, exits) = match room {
@@ -3743,6 +3957,8 @@ impl WorldState {
                     resurrection_cap: player.resurrection_cap,
                     features,
                     minimap,
+                    time_of_day,
+                    weather,
                 },
             );
         }
@@ -3908,6 +4124,51 @@ mod tests {
             "summoner should have spawned a runtime add"
         );
         assert!(s.mobs.len() > before, "the add joins the mob roster");
+    }
+
+    #[test]
+    fn world_clock_cycles_through_day_phases_and_weather() {
+        assert_eq!(TimeOfDay::from_ticks(0), TimeOfDay::Dawn);
+        assert_eq!(TimeOfDay::from_ticks(PHASE_TICKS), TimeOfDay::Day);
+        assert_eq!(TimeOfDay::from_ticks(PHASE_TICKS * 2), TimeOfDay::Dusk);
+        assert_eq!(TimeOfDay::from_ticks(PHASE_TICKS * 3), TimeOfDay::Night);
+        assert_eq!(TimeOfDay::from_ticks(PHASE_TICKS * 4), TimeOfDay::Dawn);
+        // The dark hits harder than the day.
+        assert_eq!(TimeOfDay::Day.mob_damage_pct(), 100);
+        assert!(TimeOfDay::Night.mob_damage_pct() > 100);
+        // Weather rolls over as the clock advances.
+        assert_ne!(
+            Weather::from_ticks(0),
+            Weather::from_ticks(WEATHER_TICKS * 2)
+        );
+    }
+
+    #[test]
+    fn world_boss_rises_on_schedule_and_is_announced() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Ranger);
+        s.world_ticks = WORLD_BOSS_FIRST_TICK - 1;
+        s.next_world_boss_tick = WORLD_BOSS_FIRST_TICK;
+        s.tick();
+        assert_eq!(
+            s.world_boss,
+            Some(WORLD_BOSS_ID),
+            "a world boss should rise"
+        );
+        let boss = s
+            .mobs
+            .get(&WORLD_BOSS_ID)
+            .expect("world boss joins the roster");
+        assert!(boss.spawn.boss, "it is a boss");
+        assert!(matches!(boss.behavior, MobBehavior::Hunter), "it hunts");
+        assert!(
+            s.players[&uid(1)]
+                .log
+                .iter()
+                .any(|l| l.text.contains("rises")),
+            "the rising is announced server-wide"
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -404,6 +404,11 @@ fn room_panel(
     lines.push(Line::raw(""));
     lines.push(section("Here"));
     lines.extend(side_text_wrap(&view.zone, theme::TEXT(), width));
+    // The living-world clock: time of day and weather.
+    lines.push(Line::from(Span::styled(
+        format!("  {} · {}", view.time_of_day, view.weather),
+        Style::default().fg(theme::AMBER_DIM()),
+    )));
     let exits = if view.exits.is_empty() {
         "none".to_string()
     } else {

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -138,12 +138,52 @@ impl MobSpawn {
     }
 }
 
-/// The immutable world: every room plus the mob roster.
+/// What a mob *does*, beyond standing at its home and trading blows. Stored in a
+/// side map (`World::behaviors`) keyed by spawn id so the 37 hand-authored
+/// `MobSpawn` literals stay untouched — the same layering the wildlife system
+/// uses. A spawn with no entry behaves as [`MobBehavior::Sentinel`].
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum MobBehavior {
+    /// Holds its room and only fights when engaged (the legacy behavior).
+    #[default]
+    Sentinel,
+    /// Wanders to a random adjacent room on a cooldown when no one is fighting it.
+    Wanderer,
+    /// Paces between rooms, leashing back toward its home if it strays too far.
+    Patroller,
+    /// Stalks the nearest player: steps toward them and gives chase if they flee.
+    Hunter,
+    /// Hidden from the room view until a player enters, then strikes first.
+    Ambusher,
+    /// Flees to an adjacent room when its health drops below a third.
+    Skirmisher,
+    /// Hurls a damage-school attack of its own each combat round.
+    Caster(DamageType),
+    /// Calls a short-lived add into the fight when first engaged.
+    Summoner,
+    /// Drags the other mobs sharing its room into the fight when engaged.
+    PackHunter,
+    /// Hits harder the closer it is to death.
+    Brute,
+    /// Snatches some of the player's gold, then bolts.
+    Thief,
+}
+
+/// The immutable world: every room plus the mob roster and per-mob behaviors.
 #[derive(Clone, Debug)]
 pub struct World {
     pub rooms: HashMap<RoomId, Room>,
     pub spawns: Vec<MobSpawn>,
     pub start_room: RoomId,
+    /// Spawn id -> behavior. Missing entries are [`MobBehavior::Sentinel`].
+    pub behaviors: HashMap<u32, MobBehavior>,
+}
+
+impl World {
+    /// The behavior assigned to a spawn id, defaulting to `Sentinel`.
+    pub fn behavior_of(&self, spawn_id: u32) -> MobBehavior {
+        self.behaviors.get(&spawn_id).copied().unwrap_or_default()
+    }
 }
 
 impl World {
@@ -2449,12 +2489,408 @@ pub fn seed_world() -> World {
     // zones (rooms 2000+), hung off Embergate and populated with the 40-type
     // frontier roster and generated loot.
     extend_frontier(&mut rooms, &mut spawns);
+
+    // Append the Sunken Catacombs: a hand-feeling braided maze (rooms 5000+) hung
+    // off the Tasmania capital, populated with roaming, behavior-driven undead.
+    let mut behaviors: HashMap<u32, MobBehavior> = HashMap::new();
+    extend_catacombs(&mut rooms, &mut spawns, &mut behaviors);
+
     tune_spawn_balance(&mut spawns);
 
     World {
         rooms,
         spawns,
         start_room: 1,
+        behaviors,
+    }
+}
+
+// ---- The Sunken Catacombs: a braided maze region (rooms 5000+) ------------
+//
+// Unlike the Frontier's 10x5 grids (every cell wired to all four neighbours),
+// the Catacombs are carved as a maze: a recursive-backtracker passes over a
+// logical grid and only opens the walls it visits, then a braiding pass knocks
+// a few extra walls through so the result has dead-ends, winding corridors,
+// junctions, and loops rather than uniform blocks. Generation is fully
+// deterministic (fixed-seed xorshift) so the world is identical every boot and
+// the invariant tests stay stable.
+
+const CATACOMBS_BASE: RoomId = 5000;
+const CATACOMBS_W: usize = 12;
+const CATACOMBS_H: usize = 8;
+const CATACOMBS_SPAWN_ID_START: u32 = 800_000;
+const CATACOMBS_SEED: u64 = 0xCA7A_C0DE_u64;
+
+/// A tiny deterministic xorshift64 PRNG, so maze carving never depends on the
+/// global RNG (the world must build identically every time).
+struct MazeRng(u64);
+
+impl MazeRng {
+    fn new(seed: u64) -> Self {
+        Self(seed | 1)
+    }
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+    fn below(&mut self, n: usize) -> usize {
+        (self.next_u64() % n.max(1) as u64) as usize
+    }
+    fn chance(&mut self, pct: u64) -> bool {
+        self.next_u64() % 100 < pct
+    }
+}
+
+/// Open-wall flags per cell in [N, E, S, W] order, matching the deltas below.
+type Walls = [bool; 4];
+const DIRS: [Dir; 4] = [Dir::North, Dir::East, Dir::South, Dir::West];
+
+/// The in-bounds neighbour cell index in direction `d`, if any.
+fn maze_neighbor(cell: usize, d: usize, w: usize, h: usize) -> Option<usize> {
+    let (cx, cy) = (cell % w, cell / w);
+    match d {
+        0 if cy > 0 => Some(cell - w),
+        1 if cx + 1 < w => Some(cell + 1),
+        2 if cy + 1 < h => Some(cell + w),
+        3 if cx > 0 => Some(cell - 1),
+        _ => None,
+    }
+}
+
+/// Carve a braided maze over `w*h` cells: a perfect maze via randomized DFS,
+/// then ~30% of dead-ends opened to make loops. Returns the open-wall flags.
+#[allow(clippy::needless_range_loop)] // `d` indexes the [N,E,S,W] wall array AND maps to a Dir
+fn carve_maze(w: usize, h: usize, rng: &mut MazeRng) -> Vec<Walls> {
+    let n = w * h;
+    let mut open = vec![[false; 4]; n];
+    let mut visited = vec![false; n];
+    let mut stack = vec![0usize];
+    visited[0] = true;
+    while let Some(&cur) = stack.last() {
+        let mut frontier: Vec<(usize, usize)> = Vec::new();
+        for d in 0..4 {
+            if let Some(nb) = maze_neighbor(cur, d, w, h)
+                && !visited[nb]
+            {
+                frontier.push((d, nb));
+            }
+        }
+        if frontier.is_empty() {
+            stack.pop();
+            continue;
+        }
+        let (d, nb) = frontier[rng.below(frontier.len())];
+        open[cur][d] = true;
+        open[nb][(d + 2) % 4] = true;
+        visited[nb] = true;
+        stack.push(nb);
+    }
+    // Braid: relieve dead-ends so the maze has loops, not just one true path.
+    for cell in 0..n {
+        if open[cell].iter().filter(|o| **o).count() != 1 || !rng.chance(30) {
+            continue;
+        }
+        let mut cand: Vec<(usize, usize)> = Vec::new();
+        for d in 0..4 {
+            if !open[cell][d]
+                && let Some(nb) = maze_neighbor(cell, d, w, h)
+            {
+                cand.push((d, nb));
+            }
+        }
+        if !cand.is_empty() {
+            let (d, nb) = cand[rng.below(cand.len())];
+            open[cell][d] = true;
+            open[nb][(d + 2) % 4] = true;
+        }
+    }
+    open
+}
+
+/// BFS distance from `start` over the carved passages; `usize::MAX` if unreached.
+#[allow(clippy::needless_range_loop)] // `d` indexes the [N,E,S,W] wall array AND maps to a Dir
+fn maze_distances(open: &[Walls], w: usize, h: usize, start: usize) -> Vec<usize> {
+    let mut dist = vec![usize::MAX; open.len()];
+    dist[start] = 0;
+    let mut queue = VecDeque::from([start]);
+    while let Some(cell) = queue.pop_front() {
+        for d in 0..4 {
+            if open[cell][d]
+                && let Some(nb) = maze_neighbor(cell, d, w, h)
+                && dist[nb] == usize::MAX
+            {
+                dist[nb] = dist[cell] + 1;
+                queue.push_back(nb);
+            }
+        }
+    }
+    dist
+}
+
+fn leak(s: String) -> &'static str {
+    Box::leak(s.into_boxed_str())
+}
+
+/// Build the Sunken Catacombs maze, its roaming undead, and the behavior map,
+/// and hang the entrance off the Tasmania capital square.
+#[allow(clippy::needless_range_loop)] // `d` indexes the [N,E,S,W] wall array AND maps to a Dir
+fn extend_catacombs(
+    rooms: &mut HashMap<RoomId, Room>,
+    spawns: &mut Vec<MobSpawn>,
+    behaviors: &mut HashMap<u32, MobBehavior>,
+) {
+    let (w, h) = (CATACOMBS_W, CATACOMBS_H);
+    let mut rng = MazeRng::new(CATACOMBS_SEED);
+    let open = carve_maze(w, h, &mut rng);
+    let dist = maze_distances(&open, w, h, 0);
+    // The goal vault is the reachable cell farthest from the entrance.
+    let vault = (0..w * h)
+        .filter(|&c| dist[c] != usize::MAX)
+        .max_by_key(|&c| dist[c])
+        .unwrap_or(0);
+
+    const ATMOS: [&str; 6] = [
+        "Bone-dust hangs in the still air",
+        "Water seeps black between the flagstones",
+        "Niche after niche gapes empty in the walls",
+        "Cold breathes up from somewhere below",
+        "Guttering grave-lamps throw long shadows",
+        "Roots have prised the old masonry apart",
+    ];
+    const SHAPE: [&str; 6] = [
+        "a low barrel-vaulted passage",
+        "a cramped ossuary gallery",
+        "a junction of slumping arches",
+        "a collapsed burial chamber",
+        "a winding stair-cut tunnel",
+        "a pillared crypt-hall",
+    ];
+    const SOUND: [&str; 6] = [
+        "water drips somewhere out of sight",
+        "your own breath sounds too loud",
+        "something skitters away unseen",
+        "the dark swallows every echo",
+        "a draught moans through unseen cracks",
+        "loose grit shifts underfoot",
+    ];
+    const DETAIL: [&str; 6] = [
+        "Centuries of grave-goods have long since been looted",
+        "Faded sigils ward the lintels against whatever sleeps below",
+        "Stacked skulls watch from the shadowed niches",
+        "The flagstones are worn smooth by older feet than yours",
+        "Damp has bloomed the walls with pale, patient fungus",
+        "A cold current tugs steadily on toward the deep",
+    ];
+
+    let zone: &'static str = "The Sunken Catacombs";
+    let mut spawn_id = CATACOMBS_SPAWN_ID_START;
+    // Undead resist shadow and decay, but holy light withers them.
+    let undead = DamageProfile::new(
+        DamageType::Physical,
+        Some(DamageType::Shadow),
+        Some(DamageType::Holy),
+    );
+
+    for cell in 0..w * h {
+        if dist[cell] == usize::MAX {
+            continue; // unreachable pocket (shouldn't happen post-braid, but be safe)
+        }
+        let id = CATACOMBS_BASE + cell as u32;
+        let degree = open[cell].iter().filter(|o| **o).count();
+        let is_entrance = cell == 0;
+        let is_vault = cell == vault;
+
+        let mut exits: HashMap<Dir, RoomId> = HashMap::new();
+        for d in 0..4 {
+            if open[cell][d]
+                && let Some(nb) = maze_neighbor(cell, d, w, h)
+            {
+                exits.insert(DIRS[d], CATACOMBS_BASE + nb as u32);
+            }
+        }
+
+        let name: &'static str = if is_entrance {
+            "Catacombs - Mouth of the Crypt"
+        } else if is_vault {
+            "Catacombs - The Drowned Reliquary"
+        } else {
+            leak(format!(
+                "Catacombs - {}",
+                SHAPE[(cell.wrapping_mul(7)) % SHAPE.len()]
+            ))
+        };
+        let desc: &'static str = if is_entrance {
+            "A stair descends from the Tasmania boneyard into still, lamp-lit dark. \
+             This threshold is hallowed ground - nothing dead will cross it. The \
+             passages beyond branch and double back into the deep."
+        } else if is_vault {
+            leak(format!(
+                "The maze gives onto a flooded reliquary, its black water mirroring \
+                 a vaulted ceiling lost in dark. {}. Whatever the Catacombs were \
+                 built to keep, it waits here.",
+                ATMOS[(cell.wrapping_mul(5)) % ATMOS.len()]
+            ))
+        } else {
+            leak(format!(
+                "You stand in {}, its stones slick and cold. {}, and {}. {}. {}.",
+                SHAPE[(cell.wrapping_mul(7)) % SHAPE.len()],
+                ATMOS[(cell.wrapping_mul(3)) % ATMOS.len()],
+                SOUND[(cell.wrapping_mul(11)) % SOUND.len()],
+                DETAIL[(cell.wrapping_mul(13)) % DETAIL.len()],
+                if degree >= 3 {
+                    "Several passages meet here"
+                } else if degree == 1 {
+                    "The way ends in a sealed burial cell"
+                } else {
+                    "The corridor presses on into the dark"
+                }
+            ))
+        };
+
+        rooms.insert(
+            id,
+            Room {
+                id,
+                name,
+                desc,
+                zone,
+                safe: is_entrance,
+                exits,
+            },
+        );
+
+        if is_entrance {
+            continue;
+        }
+
+        // Place a behavior-driven undead based on the room's role in the maze.
+        let depth = dist[cell] as i32;
+        let (mob_name, behavior, boss, hp, dmg) = if is_vault {
+            ("The Bonewright Lich", MobBehavior::Summoner, true, 360, 22)
+        } else if degree == 1 {
+            // Dead-end lairs: things that lie in wait.
+            if rng.chance(50) {
+                (
+                    "a Tomb Lurker",
+                    MobBehavior::Ambusher,
+                    false,
+                    90 + depth * 6,
+                    12 + depth,
+                )
+            } else {
+                (
+                    "a Grave Rat",
+                    MobBehavior::Thief,
+                    false,
+                    60 + depth * 4,
+                    8 + depth,
+                )
+            }
+        } else if degree >= 3 {
+            // Junctions: things that bring friends.
+            if rng.chance(55) {
+                (
+                    "a Ghoul Packmaster",
+                    MobBehavior::PackHunter,
+                    false,
+                    110 + depth * 6,
+                    13 + depth,
+                )
+            } else {
+                (
+                    "a Bone Broodmother",
+                    MobBehavior::Summoner,
+                    false,
+                    120 + depth * 6,
+                    12 + depth,
+                )
+            }
+        } else {
+            // Corridors: things that move.
+            match rng.below(5) {
+                0 => (
+                    "a Shambling Skeleton",
+                    MobBehavior::Wanderer,
+                    false,
+                    80 + depth * 5,
+                    10 + depth,
+                ),
+                1 => (
+                    "a Crypt Wight",
+                    MobBehavior::Patroller,
+                    false,
+                    95 + depth * 5,
+                    11 + depth,
+                ),
+                2 => (
+                    "a Barrow Wraith",
+                    MobBehavior::Hunter,
+                    false,
+                    90 + depth * 5,
+                    12 + depth,
+                ),
+                3 => (
+                    "a Pale Acolyte",
+                    MobBehavior::Caster(DamageType::Shadow),
+                    false,
+                    85 + depth * 5,
+                    10 + depth,
+                ),
+                _ => (
+                    "a Cinder Shade",
+                    MobBehavior::Caster(DamageType::Fire),
+                    false,
+                    85 + depth * 5,
+                    10 + depth,
+                ),
+            }
+        };
+        // Leave some corridors quiet so the maze breathes.
+        if !is_vault && degree == 2 && rng.chance(35) {
+            continue;
+        }
+
+        let profile = match behavior {
+            MobBehavior::Caster(school) => {
+                DamageProfile::new(school, Some(DamageType::Shadow), Some(DamageType::Holy))
+            }
+            _ => undead,
+        };
+        spawns.push(MobSpawn {
+            id: spawn_id,
+            name: mob_name,
+            home: id,
+            max_hp: hp,
+            damage: dmg,
+            xp: 30 + depth * 8 + if boss { 400 } else { 0 },
+            respawn_secs: if boss { 600 } else { 75 },
+            loot: super::items::frontier_loot(if boss { 6 } else { 2 }),
+            boss,
+            profile,
+        });
+        behaviors.insert(spawn_id, behavior);
+        spawn_id += 1;
+    }
+
+    // Hang the crypt mouth off the Tasmania capital square via a free direction.
+    let entrance = CATACOMBS_BASE;
+    let portal = [Dir::Down, Dir::East, Dir::West, Dir::North]
+        .into_iter()
+        .find(|d| {
+            rooms
+                .get(&TASMANIA_SQUARE)
+                .is_some_and(|r| !r.exits.contains_key(d))
+        })
+        .unwrap_or(Dir::Down);
+    if let Some(sq) = rooms.get_mut(&TASMANIA_SQUARE) {
+        sq.exits.insert(portal, entrance);
+    }
+    if let Some(r) = rooms.get_mut(&entrance) {
+        r.exits.insert(portal.opposite(), TASMANIA_SQUARE);
     }
 }
 
@@ -4957,9 +5393,14 @@ mod tests {
     #[test]
     fn world_has_expected_size_and_every_mob_homes_to_a_real_room() {
         let world = seed_world();
-        // 198 base + extension rooms, the 100 overworld rooms, and the 1000
-        // procedural Frontier rooms (20 zones × 50, rooms 2000+).
-        assert_eq!(world.rooms.len(), 1298, "expected 1298 rooms");
+        // 198 base + extension rooms, the 100 overworld rooms, the 1000
+        // procedural Frontier rooms (20 zones × 50, rooms 2000+), and the
+        // 96-room Sunken Catacombs maze (12×8, rooms 5000+).
+        assert_eq!(
+            world.rooms.len(),
+            1298 + CATACOMBS_W * CATACOMBS_H,
+            "expected 1394 rooms"
+        );
         for spawn in &world.spawns {
             assert!(
                 world.rooms.contains_key(&spawn.home),
@@ -4969,6 +5410,76 @@ mod tests {
                 spawn.home
             );
         }
+    }
+
+    #[test]
+    fn catacombs_are_a_braided_maze_not_a_grid() {
+        let world = seed_world();
+        let catacomb_rooms: Vec<&Room> = world
+            .rooms
+            .values()
+            .filter(|r| {
+                r.id >= CATACOMBS_BASE
+                    && (r.id as usize) < CATACOMBS_BASE as usize + CATACOMBS_W * CATACOMBS_H
+            })
+            .collect();
+        assert_eq!(catacomb_rooms.len(), CATACOMBS_W * CATACOMBS_H);
+        // A maze has dead-ends (one exit, ignoring the safe entrance's portal)
+        // and junctions (3+ exits) — a uniform grid would have neither in the
+        // interior. Confirm both shapes exist.
+        let dead_ends = catacomb_rooms
+            .iter()
+            .filter(|r| !r.safe && r.exits.len() == 1)
+            .count();
+        let junctions = catacomb_rooms.iter().filter(|r| r.exits.len() >= 3).count();
+        assert!(dead_ends > 0, "a maze should have dead-ends, found none");
+        assert!(junctions > 0, "a maze should have junctions, found none");
+        // Reachable from the start, and reciprocal: every exit's target links back.
+        for r in &catacomb_rooms {
+            for to in r.exits.values() {
+                let dest = world.room(*to).expect("catacomb exit resolves");
+                assert!(
+                    dest.exits.values().any(|back| *back == r.id),
+                    "room {} -> {} is one-way",
+                    r.id,
+                    to
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn catacombs_have_behavior_driven_mobs() {
+        let world = seed_world();
+        let catacomb_spawns: Vec<&MobSpawn> = world
+            .spawns
+            .iter()
+            .filter(|s| {
+                s.id >= CATACOMBS_SPAWN_ID_START && s.id < CATACOMBS_SPAWN_ID_START + 10_000
+            })
+            .collect();
+        assert!(
+            !catacomb_spawns.is_empty(),
+            "the catacombs should be populated"
+        );
+        // Every catacomb mob has a non-Sentinel behavior, and several distinct
+        // behaviors appear across the region.
+        let mut kinds = std::collections::HashSet::new();
+        for s in &catacomb_spawns {
+            let b = world.behavior_of(s.id);
+            assert_ne!(
+                b,
+                MobBehavior::Sentinel,
+                "{} should have a behavior",
+                s.name
+            );
+            kinds.insert(std::mem::discriminant(&b));
+        }
+        assert!(
+            kinds.len() >= 4,
+            "expected several distinct mob behaviors, found {}",
+            kinds.len()
+        );
     }
 
     #[test]


### PR DESCRIPTION
Thanks @mpiorowski! Second slice of the living-world update for Lateania.

> **Stacked on #354** (the Sunken Catacombs maze + roaming mobs). Until #354 merges, this PR's diff includes those commits too; once #354 lands, it narrows to just the changes below. Happy to hold this for review until #354 is in.

## World clock
- `WorldState` gains `world_ticks`, advanced each tick, deriving **TimeOfDay** (Dawn/Day/Dusk/Night) and **Weather** (Clear/Rain/Fog/Storm). Both ride on `PlayerView` and show in the room panel (e.g. `dusk · fog`).
- **The dark has teeth:** all mob damage scales up after dusk, and ordinary Hunters only prowl at night — by day they hold their lair.
- **Weather matters, not just flavour:** fog makes ambushes land harder; storms charge spellcasters' bolts.

## Wandering world boss
- A lone roaming boss **rises on a schedule** (first after `WORLD_BOSS_FIRST_TICK`, then `WORLD_BOSS_INTERVAL` after each falls), in a random non-safe room, **announced to everyone** via a new `log_all`. Unlike ordinary roamers it wanders the **whole world**, not one zone, hunting players. It's a runtime-only mob, reaped on death, after which the next is scheduled.

Lock-free / snapshot-only, no persistence or service-contract changes.

## Tests
```
cargo test -p late-ssh --lib door::lateania   # 88 pass, incl. new tests
cargo clippy -p late-ssh --lib                # clean
cargo fmt --check                             # clean
```
New tests cover the clock phase + weather math and the world boss rising on schedule and being announced server-wide.

## Next on this line
PR 3: varied quests (bounty / collection / exploration / escort + dailies keyed off the world clock) and the Thornwood Hollows + Drowned Caverns regions on the PR 1 maze generator.