### PR TITLE
Improve Rubik's Cube Arcade View

### DIFF
--- a/late-ssh/src/app/arcade/rubiks_cube/state.rs
+++ b/late-ssh/src/app/arcade/rubiks_cube/state.rs
@@ -414,7 +414,6 @@ pub fn oriented_face(
     view: CubeView,
 ) -> [[Sticker; 3]; 3] {
     let (top, front, right) = face_for_view(view);
-    let normal = face_normal(face);
     let top_normal = face_normal(top);
     let front_normal = face_normal(front);
     let right_normal = face_normal(right);
@@ -427,7 +426,16 @@ pub fn oriented_face(
     } else {
         (right_normal, top_normal)
     };
+    oriented_grid(stickers, face, screen_right, screen_up)
+}
 
+fn oriented_grid(
+    stickers: &[[Sticker; 9]; 6],
+    face: Face,
+    screen_right: Coord,
+    screen_up: Coord,
+) -> [[Sticker; 3]; 3] {
+    let normal = face_normal(face);
     let mut grid = [[Sticker::White; 3]; 3];
     for row in 0..3 {
         for col in 0..3 {
@@ -441,6 +449,46 @@ pub fn oriented_face(
         }
     }
     grid
+}
+
+/// One face as it appears unfolded from the current viewpoint: the absolute
+/// face sitting in a viewer-relative slot, plus its stickers oriented to match
+/// what you would see if you turned that face toward you.
+#[derive(Clone, Copy)]
+pub struct NetTile {
+    pub face: Face,
+    pub grid: [[Sticker; 3]; 3],
+}
+
+/// The whole cube unfolded relative to the current view: `up` is what is above
+/// you, `left` is your actual left, `down` is your bottom, and so on. Each tile
+/// is oriented so no mental rotation is needed to read a hidden side.
+pub struct NetView {
+    pub up: NetTile,
+    pub left: NetTile,
+    pub front: NetTile,
+    pub right: NetTile,
+    pub back: NetTile,
+    pub down: NetTile,
+}
+
+pub fn net_view(stickers: &[[Sticker; 9]; 6], view: CubeView) -> NetView {
+    let (top, front, right) = view.visible_faces();
+    let top_normal = face_normal(top);
+    let front_normal = face_normal(front);
+    let right_normal = face_normal(right);
+    let tile = |face: Face, screen_right: Coord, screen_up: Coord| NetTile {
+        face,
+        grid: oriented_grid(stickers, face, screen_right, screen_up),
+    };
+    NetView {
+        up: tile(top, right_normal, negate(front_normal)),
+        left: tile(opposite(right), front_normal, top_normal),
+        front: tile(front, right_normal, top_normal),
+        right: tile(right, negate(front_normal), top_normal),
+        back: tile(opposite(front), negate(right_normal), top_normal),
+        down: tile(opposite(top), right_normal, front_normal),
+    }
 }
 
 fn sticker_coord(face: Face, row: usize, col: usize) -> (Coord, Coord) {

--- a/late-ssh/src/app/arcade/rubiks_cube/ui.rs
+++ b/late-ssh/src/app/arcade/rubiks_cube/ui.rs
@@ -62,11 +62,11 @@ pub fn draw_game(frame: &mut Frame, area: Rect, state: &State, show_bottom_bar: 
     );
     let columns = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(40), Constraint::Length(37)])
+        .constraints([Constraint::Length(37), Constraint::Min(40)])
         .split(content);
 
-    draw_cube(frame, columns[0], state);
-    draw_net(frame, columns[1], state);
+    draw_net(frame, columns[0], state);
+    draw_cube(frame, columns[1], state);
 
     if state.is_solved() && state.has_started() {
         draw_game_overlay(
@@ -86,31 +86,92 @@ fn draw_cube(frame: &mut Frame, area: Rect, state: &State) {
     let front = oriented_face(state.stickers(), front_face, view);
     let right = oriented_face(state.stickers(), right_face, view);
 
-    let mut lines = Vec::new();
-    lines.push(Line::from(Span::styled(
-        format!(
-            "Visible: {} top / {} front / {} right",
-            top_face.label(),
-            front_face.label(),
-            right_face.label()
-        ),
-        Style::default().fg(theme::TEXT_DIM()),
-    )));
-    lines.push(Line::from(""));
+    // Filled isometric: front face straight, top as a parallelogram lid on the
+    // front's top edge, right face receding off the front's right edge. Painted
+    // into a pixel canvas, then emitted as runs of background-colored spans so
+    // the faces read as one solid block instead of detached stickers.
+    const SW: i32 = 4; // sticker width in cells
+    const SH: i32 = 2; // sticker height in cells
+    const DX: i32 = 2; // depth step right per layer
+    const DY: i32 = 2; // depth step up per layer
+    const GAP: i32 = 1; // free channel between faces
+    let lid_h = 3 * DY;
+    let front_y = lid_h + GAP;
+    let right_x = 3 * SW + GAP;
+    let width = (right_x + 3 * DX) as usize;
+    let height = (front_y + 3 * SH) as usize;
+    let mut canvas: Vec<Vec<Option<Color>>> = vec![vec![None; width]; height];
+    let mut paint = |x0: i32, y0: i32, w: i32, h: i32, color: Color| {
+        for y in y0..y0 + h {
+            for x in x0..x0 + w {
+                if y >= 0 && (y as usize) < height && x >= 0 && (x as usize) < width {
+                    canvas[y as usize][x as usize] = Some(color);
+                }
+            }
+        }
+    };
 
-    for (row, stickers) in top.iter().enumerate() {
-        let mut spans = Vec::new();
-        spans.push(Span::raw(" ".repeat(12 - row * 2)));
-        push_face_row(&mut spans, *stickers, 4, true);
-        lines.push(Line::from(spans));
+    for r in 0..3 {
+        for c in 0..3 {
+            paint(
+                c as i32 * SW,
+                front_y + r as i32 * SH,
+                SW,
+                SH,
+                sticker_color(front[r][c]),
+            );
+        }
+    }
+    for r in 0..3 {
+        for d in 0..3 {
+            paint(
+                right_x + d as i32 * DX,
+                front_y + r as i32 * SH - d as i32 * DY,
+                DX,
+                SH,
+                sticker_color(right[r][d]),
+            );
+        }
+    }
+    for d in 0..3 {
+        for c in 0..3 {
+            paint(
+                c as i32 * SW + d as i32 * DX,
+                lid_h - DY - d as i32 * DY,
+                SW,
+                DY,
+                sticker_color(top[2 - d][c]),
+            );
+        }
     }
 
-    for (row, stickers) in front.iter().enumerate() {
+    let mut lines = vec![
+        Line::from(Span::styled(
+            format!(
+                "Visible: {} top / {} front / {} right",
+                top_face.label(),
+                front_face.label(),
+                right_face.label()
+            ),
+            Style::default().fg(theme::TEXT_DIM()),
+        )),
+        Line::from(""),
+    ];
+    for row in canvas {
         let mut spans = Vec::new();
-        spans.push(Span::raw("      "));
-        push_face_row(&mut spans, *stickers, 4, false);
-        spans.push(Span::raw(" ".repeat(row * 2)));
-        push_face_row(&mut spans, right[row], 4, false);
+        let mut x = 0;
+        while x < width {
+            let cell = row[x];
+            let start = x;
+            while x < width && row[x] == cell {
+                x += 1;
+            }
+            let text = " ".repeat(x - start);
+            match cell {
+                Some(color) => spans.push(Span::styled(text, Style::default().bg(color))),
+                None => spans.push(Span::raw(text)),
+            }
+        }
         lines.push(Line::from(spans));
     }
 
@@ -210,20 +271,6 @@ fn push_net_box(
         bottom.push(Span::styled("└──────┘", net_border_style(tile.face, front)));
     }
     lines.push(Line::from(bottom));
-}
-
-fn push_face_row(
-    spans: &mut Vec<Span<'static>>,
-    row: [Sticker; 3],
-    width: usize,
-    trailing_gap: bool,
-) {
-    for (idx, sticker) in row.into_iter().enumerate() {
-        spans.push(sticker_span(sticker, width));
-        if trailing_gap || idx < 2 {
-            spans.push(Span::raw(" "));
-        }
-    }
 }
 
 fn sticker_span(sticker: Sticker, width: usize) -> Span<'static> {

--- a/late-ssh/src/app/arcade/rubiks_cube/ui.rs
+++ b/late-ssh/src/app/arcade/rubiks_cube/ui.rs
@@ -6,7 +6,9 @@ use ratatui::{
     widgets::Paragraph,
 };
 
-use super::state::{DAILY_WIN_REWARD_CHIPS, Face, State, Sticker, face_for_view, oriented_face};
+use super::state::{
+    DAILY_WIN_REWARD_CHIPS, Face, NetTile, State, Sticker, face_for_view, net_view, oriented_face,
+};
 use crate::app::arcade::ui::{
     GameBottomBar, centered_rect, draw_game_frame, draw_game_overlay, keys_line, status_line,
     tip_line,
@@ -14,10 +16,10 @@ use crate::app::arcade::ui::{
 use crate::app::common::theme;
 
 const MINI_STICKER_WIDTH: usize = 2;
-const MINI_FACE_WIDTH: usize = MINI_STICKER_WIDTH * 3;
-const MINI_FACE_GAP: usize = 1;
-const MINI_FACE_STRIDE: usize = MINI_FACE_WIDTH + MINI_FACE_GAP;
-const NET_MIDDLE_FACE_INDENT: usize = MINI_FACE_STRIDE;
+const NET_FACE_INTERIOR: usize = MINI_STICKER_WIDTH * 3;
+const NET_BOX_WIDTH: usize = NET_FACE_INTERIOR + 2;
+const NET_FACE_GAP: usize = 1;
+const NET_MIDDLE_INDENT: usize = NET_BOX_WIDTH + NET_FACE_GAP;
 
 pub fn draw_game(frame: &mut Frame, area: Rect, state: &State, show_bottom_bar: bool) {
     let bottom = GameBottomBar {
@@ -60,7 +62,7 @@ pub fn draw_game(frame: &mut Frame, area: Rect, state: &State, show_bottom_bar: 
     );
     let columns = Layout::default()
         .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(44), Constraint::Length(30)])
+        .constraints([Constraint::Min(40), Constraint::Length(37)])
         .split(content);
 
     draw_cube(frame, columns[0], state);
@@ -116,95 +118,98 @@ fn draw_cube(frame: &mut Frame, area: Rect, state: &State) {
 }
 
 fn draw_net(frame: &mut Frame, area: Rect, state: &State) {
-    let stickers = state.stickers();
+    let net = net_view(state.stickers(), state.view());
+    let front = net.front.face;
     let mut lines = vec![Line::from(Span::styled(
-        "Net",
+        "All sides",
         Style::default()
             .fg(theme::TEXT_BRIGHT())
             .add_modifier(Modifier::BOLD),
     ))];
     lines.push(Line::from(""));
 
-    push_net_label_line(&mut lines, &[(NET_MIDDLE_FACE_INDENT, Face::Up)]);
-    push_net_face(&mut lines, Face::Up, stickers, NET_MIDDLE_FACE_INDENT);
-    push_net_label_line(
+    push_net_box(&mut lines, &[&net.up], front, NET_MIDDLE_INDENT);
+    push_net_box(
         &mut lines,
-        &[
-            (0, Face::Left),
-            (MINI_FACE_STRIDE, Face::Front),
-            (MINI_FACE_STRIDE * 2, Face::Right),
-            (MINI_FACE_STRIDE * 3, Face::Back),
-        ],
+        &[&net.left, &net.front, &net.right, &net.back],
+        front,
+        0,
     );
-    for row in 0..3 {
-        let mut spans = Vec::new();
-        for (idx, face) in [Face::Left, Face::Front, Face::Right, Face::Back]
-            .into_iter()
-            .enumerate()
-        {
-            push_mini_row(&mut spans, face, row, stickers);
-            if idx < 3 {
-                spans.push(Span::raw(" ".repeat(MINI_FACE_GAP)));
-            }
-        }
-        lines.push(Line::from(spans));
-    }
-    push_net_label_line(&mut lines, &[(NET_MIDDLE_FACE_INDENT, Face::Down)]);
-    push_net_face(&mut lines, Face::Down, stickers, NET_MIDDLE_FACE_INDENT);
+    push_net_box(&mut lines, &[&net.down], front, NET_MIDDLE_INDENT);
 
     lines.push(Line::from(""));
     lines.push(Line::from(Span::styled(
-        "lowercase clockwise",
+        "unfolded from your view; amber = front",
         Style::default().fg(theme::TEXT_DIM()),
     )));
     lines.push(Line::from(Span::styled(
-        "uppercase inverse",
+        "lowercase clockwise / uppercase inverse",
         Style::default().fg(theme::TEXT_DIM()),
     )));
 
     frame.render_widget(Paragraph::new(lines), area);
 }
 
-fn push_net_label_line(lines: &mut Vec<Line<'static>>, labels: &[(usize, Face)]) {
-    let mut text = String::new();
-    for (face_start, face) in labels {
-        let label_start = face_start + MINI_FACE_WIDTH / 2;
-        if text.len() < label_start {
-            text.push_str(&" ".repeat(label_start - text.len()));
-        }
-        text.push_str(face.label());
+fn net_border_style(face: Face, front: Face) -> Style {
+    if face == front {
+        Style::default()
+            .fg(theme::AMBER_GLOW())
+            .add_modifier(Modifier::BOLD)
+    } else {
+        Style::default().fg(theme::TEXT_DIM())
     }
-    lines.push(Line::from(Span::styled(
-        text,
-        Style::default().fg(theme::TEXT_DIM()),
-    )));
 }
 
-fn push_net_face(
+// Renders one horizontal strip of bordered, labeled face boxes (top edge with
+// label, three sticker rows, bottom edge). Tiles in a strip share rows so they
+// sit side by side. Each tile is already oriented to the current view.
+fn push_net_box(
     lines: &mut Vec<Line<'static>>,
-    face: Face,
-    stickers: &[[Sticker; 9]; 6],
+    tiles: &[&NetTile],
+    front: Face,
     indent: usize,
 ) {
+    let gap = || Span::raw(" ".repeat(NET_FACE_GAP));
+
+    let mut top = vec![Span::raw(" ".repeat(indent))];
+    for (idx, tile) in tiles.iter().enumerate() {
+        if idx > 0 {
+            top.push(gap());
+        }
+        let style = net_border_style(tile.face, front);
+        top.push(Span::styled("┌──", style));
+        top.push(Span::styled(
+            tile.face.label(),
+            style.add_modifier(Modifier::BOLD),
+        ));
+        top.push(Span::styled("───┐", style));
+    }
+    lines.push(Line::from(top));
+
     for row in 0..3 {
         let mut spans = vec![Span::raw(" ".repeat(indent))];
-        push_mini_row(&mut spans, face, row, stickers);
+        for (idx, tile) in tiles.iter().enumerate() {
+            if idx > 0 {
+                spans.push(gap());
+            }
+            let style = net_border_style(tile.face, front);
+            spans.push(Span::styled("│", style));
+            for col in 0..3 {
+                spans.push(sticker_span(tile.grid[row][col], MINI_STICKER_WIDTH));
+            }
+            spans.push(Span::styled("│", style));
+        }
         lines.push(Line::from(spans));
     }
-}
 
-fn push_mini_row(
-    spans: &mut Vec<Span<'static>>,
-    face: Face,
-    row: usize,
-    stickers: &[[Sticker; 9]; 6],
-) {
-    for col in 0..3 {
-        spans.push(sticker_span(
-            stickers[face.index()][row * 3 + col],
-            MINI_STICKER_WIDTH,
-        ));
+    let mut bottom = vec![Span::raw(" ".repeat(indent))];
+    for (idx, tile) in tiles.iter().enumerate() {
+        if idx > 0 {
+            bottom.push(gap());
+        }
+        bottom.push(Span::styled("└──────┘", net_border_style(tile.face, front)));
     }
+    lines.push(Line::from(bottom));
 }
 
 fn push_face_row(

--- a/late-ssh/src/app/arcade/rubiks_cube/ui.rs
+++ b/late-ssh/src/app/arcade/rubiks_cube/ui.rs
@@ -224,12 +224,7 @@ fn net_border_style(face: Face, front: Face) -> Style {
 // Renders one horizontal strip of bordered, labeled face boxes (top edge with
 // label, three sticker rows, bottom edge). Tiles in a strip share rows so they
 // sit side by side. Each tile is already oriented to the current view.
-fn push_net_box(
-    lines: &mut Vec<Line<'static>>,
-    tiles: &[&NetTile],
-    front: Face,
-    indent: usize,
-) {
+fn push_net_box(lines: &mut Vec<Line<'static>>, tiles: &[&NetTile], front: Face, indent: usize) {
     let gap = || Span::raw(" ".repeat(NET_FACE_GAP));
 
     let mut top = vec![Span::raw(" ".repeat(indent))];


### PR DESCRIPTION
## Summary
- Makes the Arcade Rubik's Cube easier to read by showing a viewpoint-aware “All sides” net next to a more solid isometric cube render.

## Changes
- Adds a `net_view` model that unfolds all six faces relative to the current camera view.
- Replaces the fixed compact net with bordered, labeled face tiles whose sticker orientation matches the current view.
- Highlights the current front face in amber and swaps the layout so the net sits beside the main cube view.
- Redraws the visible cube as filled background-color blocks so the faces read as one connected shape.

## Behavior notes
- The Rubik's Cube controls and puzzle rules are unchanged.
- The net is now view-relative rather than a fixed absolute-face layout.

## Feature flags
- None

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Not run; repo policy leaves `cargo test`, `cargo nextest`, and `cargo clippy` to the human owner.
- Manual: Not run; no terminal render capture was provided.