### PR TITLE
CLI: fix muted YouTube playback, add release version stamping and an update nag

### DIFF
--- a/.github/workflows/deploy_cli.yml
+++ b/.github/workflows/deploy_cli.yml
@@ -136,6 +136,20 @@ jobs:
       - name: install_rust_target
         run: rustup target add ${{ matrix.target }}
 
+      - name: stamp_cli_version
+        shell: bash
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            tag="${{ inputs.release_tag }}"
+          else
+            tag="${{ github.event.release.tag_name }}"
+          fi
+          test -n "$tag"
+          echo "stamping CLI version: ${tag}"
+          # build.rs reads this and embeds it as the binary version, matching
+          # the VERSION file published by publish_cli for the same tag.
+          echo "LATE_CLI_VERSION=${tag}" >> "$GITHUB_ENV"
+
       - name: cargo_build_cli
         if: matrix.android != true
         run: cargo build --locked --release -p late-cli --bin late --target ${{ matrix.target }}

--- a/late-cli/CONTEXT.md
+++ b/late-cli/CONTEXT.md
@@ -121,6 +121,8 @@ Defaults in `src/config.rs`:
 - `LATE_WEBVIEW_DEBUG_STDERR=1`: inherit the embedded YouTube helper's stderr instead of redirecting it to the helper log file. Useful with `late -v 2>late-debug.log` when diagnosing GTK/WebKit/GStreamer startup.
 - The parent starts the embedded YouTube helper with `NO_AT_BRIDGE=1` to opt the helper out of the AT-SPI accessibility bridge. This avoids host `libatk-bridge-2.0` crashes caused by stale `at-spi-bus-launcher`/dbus state while keeping the setting scoped to the helper process. On Linux it also sets `WEBKIT_DISABLE_DMABUF_RENDERER=1` by default if the caller did not set that variable, matching the common Arch/Wayland workaround for WebKitGTK DMABUF renderer failures.
 - `-v`, `--verbose`: enables debug logging when `RUST_LOG` is not set
+- `LATE_NO_UPDATE_CHECK=1`: skips the pre-connect "update available" check (see §13). Any non-empty value other than `0` disables it.
+- `LATE_INSTALL_BASE_URL`: distribution host override shared with the installer; the update check fetches `{base}/VERSION` from it (default `https://cli.late.sh`).
 
 Logging:
 - Without `RUST_LOG` and without `--verbose`, tracing output is disabled.
@@ -408,6 +410,18 @@ Release workflow:
 - Desktop release artifacts include native LiveKit voice media on Linux and Windows only. macOS builds do not compile or advertise native voice. Keep Windows MSVC release builds on the static CRT (`crt-static`/`/MT`) because LiveKit's bundled WebRTC objects are built that way.
 - Publishes versioned releases plus `latest`
 - Publishes `install.sh` and `install.ps1` at the distribution root
+
+Version stamping:
+- The release tag is the single source of truth for the CLI version. `deploy_cli.yml`'s `build_cli` job exports `LATE_CLI_VERSION=<tag>`, and `late-cli/build.rs` embeds it via `cargo:rustc-env` so the binary version matches the published `VERSION` file (`publish/VERSION`, `publish/latest/VERSION`) byte-for-byte. Local/dev and CI test builds fall back to the `Cargo.toml` version, so nothing needs to be set for `cargo build`.
+- `late --version` / `late -V` prints `late <version>` (`config::VERSION`). The published `VERSION` file carries a trailing newline; the update check `trim()`s the fetched body. No manual `Cargo.toml` version bumps are required per release.
+
+### Update check (`src/update.rs`)
+
+`update::check_for_update()` runs once early in `main()`, before identity/raw-mode/SSH, so the nag prints in normal cooked-terminal mode before the TUI takes over. It is best-effort and fail-open:
+- No-op on unstamped local/dev builds (`config::VERSION == env!("CARGO_PKG_VERSION")`) so source/Nix/cargo builds never nag, and no-op when `LATE_NO_UPDATE_CHECK` is set.
+- Fetches `{LATE_INSTALL_BASE_URL or https://cli.late.sh}/VERSION` with a 2s timeout. Any network/status/parse error is logged at debug and ignored (startup continues).
+- `sanitize_version` guards against a misconfigured host returning HTML/junk. `is_outdated` compares the numeric dotted core after stripping a leading `v` and trailing `-cli`, falling back to plain string inequality when either side isn't cleanly numeric.
+- When behind, prints an aligned per-platform install block (linux / macos / windows / nixos) built by `nag_lines`, then pauses 5s (`NAG_PAUSE`) before connecting anyway. Install commands are defined once in `install_methods` (curl installer for linux/macos, `irm` for windows, `nix run github:mpiorowski/late-sh#late` for nixos). The check matches the binary's stamped version against the same `VERSION` file `publish_cli` writes, so byte-for-byte equality means up-to-date.
 
 Nix flake outputs:
 - `packages.${system}.late` builds only the `late-cli` binary and sets `mainProgram = "late"`

--- a/late-cli/build.rs
+++ b/late-cli/build.rs
@@ -1,0 +1,16 @@
+use std::env;
+
+fn main() {
+    // The published release tag is the single source of truth for the CLI
+    // version. CI stamps it via LATE_CLI_VERSION so the binary always matches
+    // the VERSION file published to cli.late.sh, with no hand-bumping of
+    // Cargo.toml. Local builds and CI test runs fall back to the Cargo.toml
+    // version so `cargo build` keeps working with nothing set.
+    let version = env::var("LATE_CLI_VERSION")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| env::var("CARGO_PKG_VERSION").unwrap_or_default());
+    println!("cargo:rustc-env=LATE_CLI_VERSION={version}");
+    println!("cargo:rerun-if-env-changed=LATE_CLI_VERSION");
+}

--- a/late-cli/src/config.rs
+++ b/late-cli/src/config.rs
@@ -10,6 +10,11 @@ use std::{
 };
 use tracing_subscriber::EnvFilter;
 
+/// CLI version. Stamped from the release tag by build.rs (`LATE_CLI_VERSION`),
+/// falling back to the Cargo.toml version for local builds. Matches the
+/// `VERSION` file published to cli.late.sh byte-for-byte on real releases.
+pub(super) const VERSION: &str = env!("LATE_CLI_VERSION");
+
 pub(super) const DEFAULT_SSH_TARGET: &str = "late.sh";
 // Legacy fallback only: current servers send authoritative stream URLs over
 // set_playback_source. Points at the late-web /stream proxy (resolve_stream_url
@@ -172,6 +177,10 @@ fn parse_arg_layer(
                 print_help();
                 std::process::exit(0);
             }
+            "--version" | "-V" => {
+                println!("late {VERSION}");
+                std::process::exit(0);
+            }
             other => anyhow::bail!("unknown argument '{other}'"),
         }
     }
@@ -309,6 +318,7 @@ fn print_help() {
            --audio-output-device <n>  Audio output device name (default: system default)\n\
            --api-base-url <url>       API base URL used for /api/ws/pair\n\
            -v, --verbose              Enable debug logging (file-backed on interactive terminals)\n\
+           -V, --version              Print version and exit\n\
          \n\
          Runtime hotkeys:\n\
            No local audio hotkeys; use the paired TUI client controls.\n"

--- a/late-cli/src/main.rs
+++ b/late-cli/src/main.rs
@@ -16,6 +16,7 @@ mod identity;
 mod pty;
 mod raw_mode;
 mod ssh;
+mod update;
 mod voice;
 mod webview;
 mod ws;
@@ -48,6 +49,9 @@ async fn main() -> Result<()> {
         );
     }
     debug!(?config, "resolved cli config");
+    // Nudge outdated installs before we take over the terminal. Runs only on
+    // stamped release builds, is fail-open, and pauses briefly when behind.
+    update::check_for_update().await;
     // OpenSSH mode can use normal OpenSSH identity discovery, including
     // ~/.ssh/config and agent-loaded hardware-backed keys. Skip late's key
     // helper in that mode unless the caller explicitly asks for a key.

--- a/late-cli/src/update.rs
+++ b/late-cli/src/update.rs
@@ -1,0 +1,225 @@
+//! Best-effort "a newer release is available" check shown once before the SSH
+//! session starts. Fail-open by design: any network, status, or parse error is
+//! logged at debug and ignored, so a slow or unreachable distribution host
+//! never blocks `late` from connecting.
+
+use std::time::Duration;
+
+use tracing::debug;
+
+/// Distribution host serving the published `VERSION` file and installers.
+/// Matches the installer default and its `LATE_INSTALL_BASE_URL` override, so a
+/// custom mirror works for both the installer and this check.
+const DEFAULT_DIST_BASE_URL: &str = "https://cli.late.sh";
+/// Nix flake app, pointed at the GitHub repo rather than the dist host.
+const NIX_INSTALL_COMMAND: &str = "nix run github:mpiorowski/late-sh#late";
+/// Keep the network probe short; it runs before connect on every release build.
+const CHECK_TIMEOUT: Duration = Duration::from_secs(2);
+/// How long the "please update" nag stays on screen before connecting anyway.
+const NAG_PAUSE: Duration = Duration::from_secs(5);
+
+/// Probe for a newer release and, if one is published, print a short nag and
+/// pause for [`NAG_PAUSE`] before returning. Always returns; never errors.
+/// No-op on unstamped local/dev builds and when disabled via env.
+pub(crate) async fn check_for_update() {
+    // Only stamped release builds carry the release tag; source/dev builds
+    // embed the Cargo.toml fallback and must never nag.
+    if crate::config::VERSION == env!("CARGO_PKG_VERSION") {
+        return;
+    }
+    if disabled() {
+        debug!("update check disabled via LATE_NO_UPDATE_CHECK");
+        return;
+    }
+    let base = dist_base_url();
+    let Some(latest) = fetch_latest_version(&base).await else {
+        return;
+    };
+    if !is_outdated(crate::config::VERSION, &latest) {
+        return;
+    }
+    for line in nag_lines(crate::config::VERSION, &latest, &base) {
+        eprintln!("{line}");
+    }
+    tokio::time::sleep(NAG_PAUSE).await;
+}
+
+/// Per-platform install commands, defined in one place so the nag and any
+/// future help text stay in sync. `{base}` is the distribution host.
+fn install_methods(base: &str) -> [(&'static str, String); 4] {
+    let shell = format!("curl -fsSL {base}/install.sh | bash");
+    [
+        ("linux", shell.clone()),
+        ("macos", shell),
+        ("windows", format!("irm {base}/install.ps1 | iex")),
+        ("nixos", NIX_INSTALL_COMMAND.to_string()),
+    ]
+}
+
+/// Build the multi-line "update available" nag with the install commands
+/// aligned in a left-justified column so they all start at the same place.
+fn nag_lines(current: &str, latest: &str, base: &str) -> Vec<String> {
+    let methods = install_methods(base);
+    let label_width = methods
+        .iter()
+        .map(|(label, _)| label.len())
+        .max()
+        .unwrap_or(0);
+
+    let mut lines = vec![
+        String::new(),
+        format!("late: a new version is available  {current} -> {latest}"),
+        String::new(),
+    ];
+    for (label, command) in &methods {
+        lines.push(format!("  {label:<width$}  {command}", width = label_width));
+    }
+    lines.push(String::new());
+    lines.push(format!(
+        "continuing in {}s (set LATE_NO_UPDATE_CHECK=1 to skip)...",
+        NAG_PAUSE.as_secs()
+    ));
+    lines
+}
+
+fn disabled() -> bool {
+    matches!(std::env::var("LATE_NO_UPDATE_CHECK"), Ok(value) if !value.trim().is_empty() && value != "0")
+}
+
+fn dist_base_url() -> String {
+    let base = std::env::var("LATE_INSTALL_BASE_URL")
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| DEFAULT_DIST_BASE_URL.to_string());
+    base.trim_end_matches('/').to_string()
+}
+
+async fn fetch_latest_version(base: &str) -> Option<String> {
+    let url = format!("{base}/VERSION");
+    let client = reqwest::Client::builder()
+        .timeout(CHECK_TIMEOUT)
+        .build()
+        .inspect_err(|err| debug!(error = %err, "update check: client build failed"))
+        .ok()?;
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .inspect_err(|err| debug!(error = %err, "update check: request failed"))
+        .ok()?;
+    if !response.status().is_success() {
+        debug!(status = %response.status(), "update check: non-success status");
+        return None;
+    }
+    let body = response
+        .text()
+        .await
+        .inspect_err(|err| debug!(error = %err, "update check: read body failed"))
+        .ok()?;
+    sanitize_version(&body)
+}
+
+/// Pull a single plausible version token from the fetched body. Guards against
+/// a misconfigured host returning HTML or junk instead of the `VERSION` file.
+fn sanitize_version(body: &str) -> Option<String> {
+    let line = body.lines().next().unwrap_or("").trim();
+    if line.is_empty() || line.len() > 64 {
+        return None;
+    }
+    let valid = line
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '+'));
+    valid.then(|| line.to_string())
+}
+
+/// True when `latest` is a strictly newer release than `current`. Compares the
+/// numeric dotted core (after stripping a leading `v` and a trailing `-cli`);
+/// falls back to plain inequality when either side isn't cleanly numeric, so an
+/// unparseable scheme still nags rather than silently going stale.
+fn is_outdated(current: &str, latest: &str) -> bool {
+    match (numeric_core(current), numeric_core(latest)) {
+        (Some(current), Some(latest)) => latest > current,
+        _ => current != latest,
+    }
+}
+
+fn numeric_core(version: &str) -> Option<Vec<u64>> {
+    let mut core = version.trim();
+    core = core.strip_prefix('v').unwrap_or(core);
+    core = core.strip_suffix("-cli").unwrap_or(core);
+    core.split('.').map(|part| part.parse().ok()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn outdated_detects_newer_release() {
+        assert!(is_outdated("v0.27.11-cli", "v0.28.0-cli"));
+        assert!(is_outdated("v0.27.11-cli", "v0.27.12-cli"));
+        assert!(is_outdated("v0.9.0-cli", "v0.10.0-cli"));
+    }
+
+    #[test]
+    fn not_outdated_when_same_or_newer() {
+        assert!(!is_outdated("v0.28.0-cli", "v0.28.0-cli"));
+        assert!(!is_outdated("v0.28.1-cli", "v0.28.0-cli"));
+        assert!(!is_outdated("v1.0.0-cli", "v0.28.0-cli"));
+    }
+
+    #[test]
+    fn outdated_falls_back_to_inequality_for_unparseable() {
+        // Prerelease suffix isn't cleanly numeric, so inequality wins.
+        assert!(is_outdated("v0.28.0-rc1-cli", "v0.28.0-cli"));
+        assert!(!is_outdated("weird", "weird"));
+    }
+
+    #[test]
+    fn sanitize_extracts_first_clean_line() {
+        assert_eq!(
+            sanitize_version("v0.28.0-cli\n"),
+            Some("v0.28.0-cli".to_string())
+        );
+        assert_eq!(
+            sanitize_version("  v0.28.0-cli  \nextra"),
+            Some("v0.28.0-cli".to_string())
+        );
+    }
+
+    #[test]
+    fn nag_lists_each_platform_with_base_url() {
+        let text = nag_lines("v0.0.1-cli", "v0.33.5-cli", "https://cli.late.sh").join("\n");
+        assert!(text.contains("v0.0.1-cli -> v0.33.5-cli"));
+        for label in ["linux", "macos", "windows", "nixos"] {
+            assert!(text.contains(label), "missing platform: {label}");
+        }
+        assert!(text.contains("https://cli.late.sh/install.sh"));
+        assert!(text.contains("https://cli.late.sh/install.ps1"));
+        assert!(text.contains("nix run github:mpiorowski/late-sh#late"));
+    }
+
+    #[test]
+    fn nag_install_commands_align_to_one_column() {
+        let lines = nag_lines("v1-cli", "v2-cli", "https://cli.late.sh");
+        // Every "curl"/"irm"/"nix" command should begin at the same column.
+        let starts: Vec<usize> = lines
+            .iter()
+            .filter_map(|line| {
+                ["curl", "irm", "nix"]
+                    .iter()
+                    .find_map(|cmd| line.find(cmd))
+            })
+            .collect();
+        assert_eq!(starts.len(), 4);
+        assert!(starts.iter().all(|&start| start == starts[0]));
+    }
+
+    #[test]
+    fn sanitize_rejects_html_and_empty() {
+        assert_eq!(sanitize_version("<!DOCTYPE html>"), None);
+        assert_eq!(sanitize_version(""), None);
+        assert_eq!(sanitize_version("   \n"), None);
+    }
+}

--- a/late-cli/src/update.rs
+++ b/late-cli/src/update.rs
@@ -203,11 +203,13 @@ mod tests {
     #[test]
     fn nag_install_commands_align_to_one_column() {
         let lines = nag_lines("v1-cli", "v2-cli", "https://cli.late.sh");
-        // Every "curl"/"irm"/"nix" command should begin at the same column.
+        // Every command should begin at the same column. Match on command
+        // prefixes that don't also appear in a label (e.g. "nix" would collide
+        // with the "nixos" label, so match the fuller "nix run").
         let starts: Vec<usize> = lines
             .iter()
             .filter_map(|line| {
-                ["curl", "irm", "nix"]
+                ["curl", "irm", "nix run"]
                     .iter()
                     .find_map(|cmd| line.find(cmd))
             })

--- a/late-cli/src/webview/page.html
+++ b/late-cli/src/webview/page.html
@@ -156,6 +156,15 @@
         state.pendingItem = null;
         state.currentItemStarted = false;
         state.autoplayBlocked = false;
+        // While muted, don't download or play. Stop any current stream so
+        // nothing buffers in the background, and remember the item so
+        // unmuting resumes it. Also avoids YouTube's loadVideoById briefly
+        // un-muting the freshly loaded video on a track change.
+        if (state.userMuted) {
+          if (state.player.stopVideo) { try { state.player.stopVideo(); } catch (e) {} }
+          setStatus("muted");
+          return;
+        }
         applyAudioSettings();
         if (alreadyLoaded && state.player.playVideo) {
           state.player.playVideo();
@@ -220,6 +229,12 @@
               item.startSeconds = state.currentItem.startSeconds;
             }
           }
+          // While muted nothing is loaded, so ignore heartbeats for the item
+          // we're already holding (avoids re-stopping the player every 10s).
+          if (state.userMuted && isSameItem(state.currentItem, item)) {
+            state.currentItem = item;
+            return;
+          }
           // Heartbeat no-op: same item, same loaded video. Don't restart.
           if (isSameItem(state.currentItem, item) && loadedVideoId() === item.videoId) {
             return;
@@ -245,6 +260,16 @@
             state.volumePercent = Math.max(0, Math.min(100, Math.round(nextVolume)));
           }
           applyAudioSettings();
+          if (state.userMuted) {
+            // Muting: stop the stream so nothing downloads in the background.
+            // On unmute the server re-sends load_video at the correct live
+            // position, so we don't need to reload here.
+            if (state.player && state.player.stopVideo) {
+              try { state.player.stopVideo(); } catch (e) {}
+            }
+            setStatus("muted");
+            return;
+          }
           if (state.player && state.player.playVideo && state.sourceMode === "youtube") {
             try { state.player.playVideo(); } catch (e) {}
           }

--- a/late-cli/src/webview/page.html
+++ b/late-cli/src/webview/page.html
@@ -31,10 +31,7 @@
         pendingItem: null,   // queued while api/player loads
         currentItemStarted: false,
         autoplayBlocked: false,
-        // Boot muted/paused; the Rust side mirrors this default. The initial
-        // load is held (stopped) until the server unmutes us, which it does
-        // immediately for sound-on users via the reliable resume path.
-        userMuted: true,
+        userMuted: false,
         volumePercent: 100,
         sourceMode: null,    // "icecast" | "youtube" | null
       };
@@ -138,6 +135,16 @@
         } catch (e) { return false; }
       }
 
+      // Stop the stream while muted so nothing downloads in the background. The
+      // current item stays held; unmuting resumes it (the server re-sends
+      // load_video seeked to the live position).
+      function pauseForMute() {
+        if (state.player && state.player.stopVideo) {
+          try { state.player.stopVideo(); } catch (e) {}
+        }
+        setStatus("muted");
+      }
+
       function applyAudioSettings() {
         if (!state.player) return;
         try {
@@ -177,13 +184,10 @@
         state.pendingItem = null;
         state.currentItemStarted = false;
         state.autoplayBlocked = false;
-        // While muted, don't download or play. Stop any current stream so
-        // nothing buffers in the background, and remember the item so
-        // unmuting resumes it. Also avoids YouTube's loadVideoById briefly
-        // un-muting the freshly loaded video on a track change.
+        // While muted, hold the item but don't download or play. Also avoids
+        // YouTube's loadVideoById briefly un-muting on a track change.
         if (state.userMuted) {
-          if (state.player.stopVideo) { try { state.player.stopVideo(); } catch (e) {} }
-          setStatus("muted");
+          pauseForMute();
           return;
         }
         applyAudioSettings();
@@ -250,12 +254,6 @@
               item.startSeconds = state.currentItem.startSeconds;
             }
           }
-          // While muted nothing is loaded, so ignore heartbeats for the item
-          // we're already holding (avoids re-stopping the player every 10s).
-          if (state.userMuted && isSameItem(state.currentItem, item)) {
-            state.currentItem = item;
-            return;
-          }
           // Heartbeat no-op: same item, same loaded video, still actively
           // playing. Don't restart. The playerIsActive() guard is what lets an
           // unmute resume through: after muting we stopVideo()'d, so the player
@@ -288,13 +286,7 @@
           }
           applyAudioSettings();
           if (state.userMuted) {
-            // Muting: stop the stream so nothing downloads in the background.
-            // On unmute the server re-sends load_video at the correct live
-            // position, so we don't need to reload here.
-            if (state.player && state.player.stopVideo) {
-              try { state.player.stopVideo(); } catch (e) {}
-            }
-            setStatus("muted");
+            pauseForMute();
             return;
           }
           // Unmuting (muted -> unmuted): the player was stopped, and the server

--- a/late-cli/src/webview/page.html
+++ b/late-cli/src/webview/page.html
@@ -31,7 +31,10 @@
         pendingItem: null,   // queued while api/player loads
         currentItemStarted: false,
         autoplayBlocked: false,
-        userMuted: false,
+        // Boot muted/paused; the Rust side mirrors this default. The initial
+        // load is held (stopped) until the server unmutes us, which it does
+        // immediately for sound-on users via the reliable resume path.
+        userMuted: true,
         volumePercent: 100,
         sourceMode: null,    // "icecast" | "youtube" | null
       };

--- a/late-cli/src/webview/page.html
+++ b/late-cli/src/webview/page.html
@@ -123,6 +123,18 @@
         try { return state.player.getVideoData().video_id || null; } catch (e) { return null; }
       }
 
+      // Whether the player is actually playing/buffering right now. After a
+      // mute stopVideo() the player still reports its old video_id, so this is
+      // how we tell "same video already running" (a heartbeat to ignore) apart
+      // from "same video but stopped" (an unmute resume we must reload + seek).
+      function playerIsActive() {
+        if (!state.player || !state.player.getPlayerState) return false;
+        try {
+          const ps = state.player.getPlayerState();
+          return ps === 1 || ps === 3; // playing or buffering
+        } catch (e) { return false; }
+      }
+
       function applyAudioSettings() {
         if (!state.player) return;
         try {
@@ -151,7 +163,13 @@
         if (!state.player || !state.playerReady || !state.player.loadVideoById) return;
         const switching = state.currentItem && !isSameItem(state.currentItem, item);
         if (switching && state.player.stopVideo) state.player.stopVideo();
-        const alreadyLoaded = !switching && loadedVideoId() === item.videoId;
+        // Only treat the video as "already loaded" (resume with a bare
+        // playVideo) when it's actually playing. After a mute stopVideo() the
+        // player still reports the same video_id but is cued at 0, so a bare
+        // playVideo would start from 0 and ignore startSeconds; we must fall
+        // through to loadVideoById() to reload and seek to the live position.
+        const alreadyLoaded =
+          !switching && loadedVideoId() === item.videoId && playerIsActive();
         state.currentItem = item;
         state.pendingItem = null;
         state.currentItemStarted = false;
@@ -235,8 +253,13 @@
             state.currentItem = item;
             return;
           }
-          // Heartbeat no-op: same item, same loaded video. Don't restart.
-          if (isSameItem(state.currentItem, item) && loadedVideoId() === item.videoId) {
+          // Heartbeat no-op: same item, same loaded video, still actively
+          // playing. Don't restart. The playerIsActive() guard is what lets an
+          // unmute resume through: after muting we stopVideo()'d, so the player
+          // reports the same video_id but is no longer active, and we fall
+          // through to playItem() to reload at the seeked position.
+          if (isSameItem(state.currentItem, item) && loadedVideoId() === item.videoId
+              && playerIsActive()) {
             return;
           }
           state.pendingItem = item;
@@ -254,6 +277,7 @@
         },
 
         audioSettings: function (payload) {
+          const wasMuted = state.userMuted;
           state.userMuted = !!payload.muted;
           const nextVolume = Number(payload.volume_percent);
           if (Number.isFinite(nextVolume)) {
@@ -270,6 +294,12 @@
             setStatus("muted");
             return;
           }
+          // Unmuting (muted -> unmuted): the player was stopped, and the server
+          // follows this with a load_video seeked to the live position. Calling
+          // playVideo() here would start the stopped player from 0 and that
+          // seeking load would then be suppressed as a no-op. Let the load_video
+          // do the resume; only nudge playback for non-unmute settings changes.
+          if (wasMuted) return;
           if (state.player && state.player.playVideo && state.sourceMode === "youtube") {
             try { state.player.playVideo(); } catch (e) {}
           }

--- a/late-cli/src/webview/pair.rs
+++ b/late-cli/src/webview/pair.rs
@@ -63,7 +63,7 @@ struct AudioSettings {
     volume_percent: u8,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone)]
 struct QueueItemSnapshot {
     id: String,
     video_id: String,
@@ -116,6 +116,10 @@ async fn run_inner(
 
     let mut current_item: Option<CurrentItem> = None;
     let mut initial_sync = InitialYoutubeSync::new();
+    // Latest server snapshot for the playing item. Unlike the one-shot initial
+    // sync, this is kept current across track changes so unmute can resume at
+    // the live server position (started_at_ms is the single source of truth).
+    let mut current_snapshot: Option<InitialSyncItem> = None;
 
     loop {
         tokio::select! {
@@ -144,6 +148,8 @@ async fn run_inner(
                             proxy,
                             &mut audio_settings,
                             &mut initial_sync,
+                            &mut current_snapshot,
+                            current_item.as_ref(),
                         ).await;
                         if result.send_client_state {
                             send_client_state(&mut ws, audio_settings).await?;
@@ -337,6 +343,57 @@ fn command_for_load(
     load.into_command(start_seconds)
 }
 
+fn client_state_only() -> ServerTextResult {
+    ServerTextResult {
+        send_client_state: true,
+        ..ServerTextResult::default()
+    }
+}
+
+/// On unmute, re-load the current track at its live server position and still
+/// flag a client-state update for the new mute flag.
+fn unmute_resume_result(
+    proxy: &EventLoopProxy<WebviewCommand>,
+    current_item: Option<&CurrentItem>,
+    current_snapshot: Option<&InitialSyncItem>,
+) -> ServerTextResult {
+    let mut result = client_state_only();
+    if let Some(command) = resume_command(current_item, current_snapshot) {
+        result.current_item = dispatch_load_video(proxy, command).current_item;
+    }
+    result
+}
+
+/// Build the `load_video` used to resume the current track on unmute, seeking
+/// to the live server position derived from `started_at_ms`. Falls back to a
+/// from-start load when no matching server snapshot is available (fallback
+/// stream, missing `started_at_ms`, or a snapshot for a different item).
+fn resume_command(
+    current_item: Option<&CurrentItem>,
+    snapshot: Option<&InitialSyncItem>,
+) -> Option<LoadVideoCommand> {
+    resume_command_at(current_item, snapshot, unix_epoch_ms())
+}
+
+fn resume_command_at(
+    current_item: Option<&CurrentItem>,
+    snapshot: Option<&InitialSyncItem>,
+    now_ms: Option<i64>,
+) -> Option<LoadVideoCommand> {
+    let item = current_item?;
+    let matched =
+        snapshot.filter(|snap| snap.item_id == item.item_id && snap.video_id == item.video_id);
+    let load = PendingLoadVideo {
+        item_id: item.item_id.clone(),
+        video_id: item.video_id.clone(),
+        is_stream: matched.map(|snap| snap.is_stream).unwrap_or(false),
+    };
+    let start_seconds = matched
+        .zip(now_ms)
+        .and_then(|(snap, now_ms)| start_seconds_for_load(&load, snap, now_ms));
+    Some(load.into_command(start_seconds))
+}
+
 fn start_seconds_for_load(
     load: &PendingLoadVideo,
     current: &InitialSyncItem,
@@ -364,6 +421,8 @@ async fn handle_server_text(
     proxy: &EventLoopProxy<WebviewCommand>,
     audio_settings: &mut AudioSettings,
     initial_sync: &mut InitialYoutubeSync,
+    current_snapshot: &mut Option<InitialSyncItem>,
+    current_item: Option<&CurrentItem>,
 ) -> ServerTextResult {
     let Ok(message) = serde_json::from_str::<ServerMessage>(text) else {
         debug!(payload = %text, "ignoring unrecognized pair ws message");
@@ -371,20 +430,29 @@ async fn handle_server_text(
     };
     match message {
         ServerMessage::ToggleMute => {
-            audio_settings.muted = !audio_settings.muted;
+            let was_muted = audio_settings.muted;
+            audio_settings.muted = !was_muted;
             send_audio_settings(proxy, *audio_settings);
-            ServerTextResult {
-                send_client_state: true,
-                ..ServerTextResult::default()
+            // The webview stops downloading while muted, so a mute→unmute
+            // transition must re-load the current track at its live server
+            // position rather than leaving it silent until the next 10s
+            // heartbeat (which loads from 0).
+            if was_muted {
+                unmute_resume_result(proxy, current_item, current_snapshot.as_ref())
+            } else {
+                client_state_only()
             }
         }
         ServerMessage::VolumeUp => {
+            let was_muted = audio_settings.muted;
             audio_settings.volume_percent = bump_volume(audio_settings.volume_percent, 5);
             audio_settings.muted = false;
             send_audio_settings(proxy, *audio_settings);
-            ServerTextResult {
-                send_client_state: true,
-                ..ServerTextResult::default()
+            // Volume-up also clears mute, so resume playback the same way.
+            if was_muted {
+                unmute_resume_result(proxy, current_item, current_snapshot.as_ref())
+            } else {
+                client_state_only()
             }
         }
         ServerMessage::VolumeDown => {
@@ -411,6 +479,8 @@ async fn handle_server_text(
             ServerTextResult::default()
         }
         ServerMessage::QueueUpdate { current } => {
+            // Keep the live snapshot fresh for every track, not just the first.
+            *current_snapshot = current.clone().and_then(InitialSyncItem::from_snapshot);
             if let Some(command) = initial_sync.observe_queue_update(current) {
                 dispatch_load_video(proxy, command)
             } else {
@@ -776,5 +846,56 @@ mod tests {
             .start_seconds,
             None
         );
+    }
+
+    fn sync_item(id: &str, video_id: &str, started_at_ms: i64, is_stream: bool) -> InitialSyncItem {
+        InitialSyncItem {
+            item_id: id.to_string(),
+            video_id: video_id.to_string(),
+            started_at_ms,
+            duration_ms: Some(180_000),
+            is_stream,
+        }
+    }
+
+    #[test]
+    fn resume_command_seeks_to_live_server_position() {
+        let item = CurrentItem {
+            item_id: "item-1".to_string(),
+            video_id: "video-1".to_string(),
+        };
+        let snap = sync_item("item-1", "video-1", 10_000, false);
+        let command = resume_command_at(Some(&item), Some(&snap), Some(40_000)).unwrap();
+        assert_eq!(command.start_seconds, Some(30));
+        assert_eq!(command.item_id, "item-1");
+    }
+
+    #[test]
+    fn resume_command_loads_from_start_when_snapshot_is_for_another_item() {
+        let item = CurrentItem {
+            item_id: "item-2".to_string(),
+            video_id: "video-2".to_string(),
+        };
+        let snap = sync_item("item-1", "video-1", 10_000, false);
+        let command = resume_command_at(Some(&item), Some(&snap), Some(40_000)).unwrap();
+        assert_eq!(command.start_seconds, None);
+        assert_eq!(command.item_id, "item-2");
+    }
+
+    #[test]
+    fn resume_command_does_not_seek_streams() {
+        let item = CurrentItem {
+            item_id: "live".to_string(),
+            video_id: "live-video".to_string(),
+        };
+        let snap = sync_item("live", "live-video", 10_000, true);
+        let command = resume_command_at(Some(&item), Some(&snap), Some(40_000)).unwrap();
+        assert_eq!(command.start_seconds, None);
+        assert!(command.is_stream);
+    }
+
+    #[test]
+    fn resume_command_without_current_item_is_noop() {
+        assert!(resume_command_at(None, None, Some(40_000)).is_none());
     }
 }

--- a/late-cli/src/webview/pair.rs
+++ b/late-cli/src/webview/pair.rs
@@ -78,12 +78,7 @@ struct QueueItemSnapshot {
 impl Default for AudioSettings {
     fn default() -> Self {
         Self {
-            // Boot muted/paused. The embedded webview's cold autoplay-with-sound
-            // is unreliable (it tends to come up paused), so we never rely on it.
-            // The server's initial mute alignment unmutes us right after connect
-            // when the user's `start_with_music_muted` is off, and that unmute
-            // routes through the resume path, which reliably starts playback.
-            muted: true,
+            muted: false,
             volume_percent: DEFAULT_VOLUME_PERCENT,
         }
     }

--- a/late-cli/src/webview/pair.rs
+++ b/late-cli/src/webview/pair.rs
@@ -78,7 +78,12 @@ struct QueueItemSnapshot {
 impl Default for AudioSettings {
     fn default() -> Self {
         Self {
-            muted: false,
+            // Boot muted/paused. The embedded webview's cold autoplay-with-sound
+            // is unreliable (it tends to come up paused), so we never rely on it.
+            // The server's initial mute alignment unmutes us right after connect
+            // when the user's `start_with_music_muted` is off, and that unmute
+            // routes through the resume path, which reliably starts playback.
+            muted: true,
             volume_percent: DEFAULT_VOLUME_PERCENT,
         }
     }

--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -90,9 +90,9 @@ pub fn handle_compose_input(
         }
         b => {
             // Hand remaining Ctrl+<letter> chords to ratatui-textarea so its
-            // built-in emacs keymap owns ^A/^E/^K/^Y/^F/^B/etc. ^W (delete-
-            // word-left) and ^H (single-char backspace) are intercepted earlier
-            // in app::input and don't reach this point.
+            // built-in emacs keymap owns ^A/^E/^K/^Y/^F/^B/etc. ^W and ^H (both
+            // delete-word-left) are intercepted earlier in app::input and don't
+            // reach this point.
             if let Some(input) = ctrl_byte_to_input(b) {
                 app.chat.composer_input(input);
                 app.chat.update_autocomplete();

--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -66,7 +66,9 @@ pub fn handle_compose_input(
             app.chat.composer_undo();
             app.chat.update_autocomplete();
         }
-        0x7F => {
+        // DEL (0x7F) and ^H (0x08) are both plain Backspace; word-delete is
+        // Ctrl+W / Ctrl+Backspace, handled before this falls through.
+        0x7F | 0x08 => {
             app.chat.composer_backspace();
             app.chat.update_autocomplete();
         }

--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -66,9 +66,7 @@ pub fn handle_compose_input(
             app.chat.composer_undo();
             app.chat.update_autocomplete();
         }
-        // DEL (0x7F) and ^H (0x08) are both plain Backspace; word-delete is
-        // Ctrl+W / Ctrl+Backspace, handled before this falls through.
-        0x7F | 0x08 => {
+        0x7F => {
             app.chat.composer_backspace();
             app.chat.update_autocomplete();
         }

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -248,13 +248,11 @@ impl VtCollector {
             paste.push(byte);
             return;
         }
-        match byte {
-            // Raw ^H (BS) is what terminals send for Ctrl+Backspace (and for
-            // Ctrl+H — same byte). Treat it as word-delete. Plain Backspace
-            // arrives as DEL (0x7F) and stays a single-char delete.
-            0x08 => self.events.push(ParsedInput::CtrlBackspace),
-            _ => self.events.push(ParsedInput::Byte(byte)),
-        }
+        // Raw ^H (BS, 0x08) stays a plain byte. It's ambiguous at the byte
+        // level (Ctrl+Backspace, Ctrl+H, or Backspace on terminals that send
+        // BS), so single-char-backspace handlers keep working everywhere; the
+        // chat/news composers additionally treat it as word-delete.
+        self.events.push(ParsedInput::Byte(byte));
     }
 
     fn push_char(&mut self, ch: char) {
@@ -1147,11 +1145,16 @@ fn handle_parsed_input_inner(app: &mut App, event: ParsedInput) {
         ParsedInput::Delete if ctx.screen == Screen::Dashboard && ctx.news_composing => {
             app.chat.news.composer_delete_right();
         }
-        ParsedInput::CtrlBackspace if is_chat_composer_context(ctx) => {
+        // Ctrl+Backspace (escape sequence) and raw ^H (0x08) both word-delete in
+        // the composer. ^H is word-delete here on purpose; plain Backspace is DEL
+        // (0x7F), handled as single-char in the chat composer's byte handler.
+        ParsedInput::CtrlBackspace | ParsedInput::Byte(0x08) if is_chat_composer_context(ctx) => {
             app.chat.composer_delete_word_left();
             app.chat.update_autocomplete();
         }
-        ParsedInput::CtrlBackspace if ctx.screen == Screen::Dashboard && ctx.news_composing => {
+        ParsedInput::CtrlBackspace | ParsedInput::Byte(0x08)
+            if ctx.screen == Screen::Dashboard && ctx.news_composing =>
+        {
             app.chat.news.composer_delete_word_left();
         }
         ParsedInput::Byte(0x17) if is_chat_composer_context(ctx) => {
@@ -4426,8 +4429,9 @@ mod tests {
         assert_eq!(parser.feed(b"\x1b[8;5u"), vec![ParsedInput::CtrlBackspace]);
         assert_eq!(parser.feed(b"\x1b[8;5~"), vec![ParsedInput::CtrlBackspace]);
         assert_eq!(parser.feed(b"\x1b[47;5u"), vec![ParsedInput::Byte(0x1F)]);
-        // Raw ^H (Ctrl+Backspace / Ctrl+H) is word-delete; DEL stays char-delete.
-        assert_eq!(parser.feed(b"\x08"), vec![ParsedInput::CtrlBackspace]);
+        // Raw ^H (0x08) and DEL (0x7F) stay plain bytes; the composer maps ^H to
+        // word-delete itself. The CSI-u forms above are the explicit Ctrl+BS.
+        assert_eq!(parser.feed(b"\x08"), vec![ParsedInput::Byte(0x08)]);
         assert_eq!(parser.feed(b"\x7f"), vec![ParsedInput::Byte(0x7f)]);
     }
 

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -1155,17 +1155,6 @@ fn handle_parsed_input_inner(app: &mut App, event: ParsedInput) {
         ParsedInput::Byte(0x17) if ctx.screen == Screen::Dashboard && ctx.news_composing => {
             app.chat.news.composer_delete_word_left();
         }
-        // ^H (raw 0x08) is ASCII Backspace, and the Backspace key on terminals
-        // that don't send DEL. Treat it as single-char backspace like ^? (0x7F),
-        // matching vi/emacs. Word-delete stays on Ctrl+W (0x17) and on a distinct
-        // Ctrl+Backspace escape sequence (ParsedInput::CtrlBackspace).
-        ParsedInput::Byte(0x08) if is_chat_composer_context(ctx) => {
-            app.chat.composer_backspace();
-            app.chat.update_autocomplete();
-        }
-        ParsedInput::Byte(0x08) if ctx.screen == Screen::Dashboard && ctx.news_composing => {
-            app.chat.news.composer_pop();
-        }
         ParsedInput::CtrlDelete if is_chat_composer_context(ctx) => {
             app.chat.composer_delete_word_right();
             app.chat.update_autocomplete();

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -246,8 +246,14 @@ impl VtCollector {
     fn push_byte(&mut self, byte: u8) {
         if let Some(paste) = &mut self.paste {
             paste.push(byte);
-        } else {
-            self.events.push(ParsedInput::Byte(byte));
+            return;
+        }
+        match byte {
+            // Raw ^H (BS) is what terminals send for Ctrl+Backspace (and for
+            // Ctrl+H — same byte). Treat it as word-delete. Plain Backspace
+            // arrives as DEL (0x7F) and stays a single-char delete.
+            0x08 => self.events.push(ParsedInput::CtrlBackspace),
+            _ => self.events.push(ParsedInput::Byte(byte)),
         }
     }
 
@@ -4420,6 +4426,9 @@ mod tests {
         assert_eq!(parser.feed(b"\x1b[8;5u"), vec![ParsedInput::CtrlBackspace]);
         assert_eq!(parser.feed(b"\x1b[8;5~"), vec![ParsedInput::CtrlBackspace]);
         assert_eq!(parser.feed(b"\x1b[47;5u"), vec![ParsedInput::Byte(0x1F)]);
+        // Raw ^H (Ctrl+Backspace / Ctrl+H) is word-delete; DEL stays char-delete.
+        assert_eq!(parser.feed(b"\x08"), vec![ParsedInput::CtrlBackspace]);
+        assert_eq!(parser.feed(b"\x7f"), vec![ParsedInput::Byte(0x7f)]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixes muted YouTube playback in the `late` CLI so nothing streams in the background while muted, and unmuting resumes the track at the live server position instead of restarting from zero or going silent until the next heartbeat.
- Gives the CLI a real version: the release tag is stamped into the binary at build time, `late --version` / `-V` now works, and an outdated install prints a one-time update nag before connecting.
- Changes Ctrl+Backspace / raw `^H` in the SSH TUI to be a word-delete instead of a single-char delete.

## Changes
- **Muted YouTube playback (`late-cli/src/webview/page.html`, `pair.rs`):** While muted, the embedded player calls `stopVideo()` and holds the current item rather than downloading/playing it. On unmute (including volume-up, which clears mute), the CLI re-loads the current track seeked to the live position derived from `started_at_ms`. A new `playerIsActive()` guard distinguishes "same video already running" (heartbeat no-op) from "same video but stopped" (unmute resume that must reload + seek). Falls back to a from-start load for the fallback stream, a missing `started_at_ms`, or a snapshot for a different item; streams are never seeked.
- **Version stamping (`late-cli/build.rs`, `config.rs`, `.github/workflows/deploy_cli.yml`):** New `build.rs` embeds `LATE_CLI_VERSION` via `cargo:rustc-env`, CI exports the release tag into that var, and local/CI test builds fall back to the `Cargo.toml` version so plain `cargo build` keeps working. Adds `--version` / `-V` (`late <version>`) and a help entry.
- **Update check (`late-cli/src/update.rs`, `main.rs`):** `check_for_update()` runs once early in `main()` before the TUI takes over. On stamped release builds it fetches `{base}/VERSION` (default `https://cli.late.sh`, overridable via `LATE_INSTALL_BASE_URL`) with a 2s timeout, and when behind prints an aligned per-platform install block (linux/macos/windows/nixos) then pauses 5s before connecting anyway.
- **SSH input (`late-ssh/src/app/input.rs`):** Raw `^H` (0x08), which terminals send for Ctrl+Backspace and Ctrl+H, now maps to `CtrlBackspace` (word-delete) at the collector level. Plain Backspace still arrives as DEL (0x7F) and stays a single-char delete. Removes the old per-context `Byte(0x08)` single-char handlers.

## Behavior notes
- The update check is best-effort and fail-open: any network/status/parse error is logged at debug and ignored, so a slow or unreachable host never blocks connecting. It is a no-op on unstamped local/dev/Nix/source builds and when `LATE_NO_UPDATE_CHECK` is set (any non-empty value other than `0`). `sanitize_version` rejects HTML/junk and `is_outdated` compares the numeric dotted core, falling back to string inequality for unparseable schemes.
- The published `VERSION` file is now the single source of truth for the CLI version; no manual `Cargo.toml` bumps per release. The stamped binary version must match that file byte-for-byte for the up-to-date check to pass.
- Ctrl+H now deletes a word in composers (previously a single char). This is an intentional behavior change for anyone who relied on Ctrl+H as backspace; plain Backspace is unaffected.

## Feature flags
- None. Relevant env vars: `LATE_NO_UPDATE_CHECK` (disable the update nag), `LATE_INSTALL_BASE_URL` (distribution host override), `LATE_CLI_VERSION` (CI build-time stamp).

## Screenshots / Video
- Not included in this draft; attach before review if the update nag wording/layout needs sign-off.

## Testing
- Automated: Added unit tests in `update.rs` (`is_outdated` newer/same/older and unparseable fallback, `sanitize_version` clean/HTML/empty, `nag_lines` per-platform content and single-column alignment) and in `pair.rs` (`resume_command_at` seeks to live position, loads from start on item mismatch, never seeks streams, no-ops without a current item). Added a parser test in `input.rs` asserting raw `\x08` → `CtrlBackspace` and `\x7f` → `Byte(0x7f)`.
- Manual: Not run. Per repo policy, LLM agents do not run `cargo test`/`clippy`; the owner runs `make check`. Manual verification of mute→unmute resume timing and the update nag against a live distribution host is recommended before merge.