### PR TITLE
Refine TUI status surfaces and Lateania combat

### DIFF
--- a/late-core/src/models/chat_room_member.rs
+++ b/late-core/src/models/chat_room_member.rs
@@ -172,8 +172,8 @@ impl ChatRoomMember {
     pub async fn auto_join_public_rooms(client: &Client, user_id: Uuid) -> Result<u64> {
         let count = client
             .execute(
-                "INSERT INTO chat_room_members (room_id, user_id)
-                 SELECT id, $1
+                "INSERT INTO chat_room_members (room_id, user_id, last_read_at)
+                 SELECT id, $1, current_timestamp
                  FROM chat_rooms
                  WHERE visibility = 'public' AND auto_join = true
                    AND NOT EXISTS (

--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -571,34 +571,6 @@ pub fn handle_byte(app: &mut App, byte: u8) -> bool {
         return super::discover::input::handle_byte(app, byte);
     }
 
-    if let Some(room_id) = app.chat.selected_bumped_join_room_id() {
-        if is_next_room_key(byte) {
-            switch_room(app, 1);
-            return true;
-        }
-        if is_prev_room_key(byte) {
-            switch_room(app, -1);
-            return true;
-        }
-        if matches!(byte, b'\r' | b'\n') {
-            let slug = app
-                .shop_state
-                .active_room_effects()
-                .get(&room_id)
-                .and_then(|effects| effects.first())
-                .and_then(|effect| effect.room_slug.clone());
-            if let Some(slug) = slug {
-                app.banner = Some(app.chat.join_bumped_public_room(room_id, slug));
-            } else {
-                app.banner = Some(crate::app::common::primitives::Banner::error(
-                    "Could not join bumped room",
-                ));
-            }
-            return true;
-        }
-        return false;
-    }
-
     if app.chat.feeds_selected {
         if is_next_room_key(byte) {
             switch_room(app, 1);

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -192,7 +192,6 @@ pub(crate) enum VoiceCommand {
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub(crate) enum RoomSlot {
     Room(Uuid),
-    BumpedJoin(Uuid),
     Feeds,
     News,
     Notifications,
@@ -253,7 +252,6 @@ impl RoomSection {
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct SelectedRoomSlotState {
     pub selected_room_id: Option<Uuid>,
-    pub selected_bumped_join_room_id: Option<Uuid>,
     pub feeds_selected: bool,
     pub news_selected: bool,
     pub notifications_selected: bool,
@@ -271,17 +269,7 @@ pub(crate) fn is_selected_slot(slot: RoomSlot, selected: SelectedRoomSlotState) 
                 && !selected.discover_selected
                 && !selected.showcase_selected
                 && !selected.work_selected
-                && selected.selected_bumped_join_room_id.is_none()
                 && selected.selected_room_id == Some(room_id)
-        }
-        RoomSlot::BumpedJoin(room_id) => {
-            !selected.feeds_selected
-                && !selected.news_selected
-                && !selected.notifications_selected
-                && !selected.discover_selected
-                && !selected.showcase_selected
-                && !selected.work_selected
-                && selected.selected_bumped_join_room_id == Some(room_id)
         }
         RoomSlot::Feeds => selected.feeds_selected,
         RoomSlot::News => selected.news_selected,
@@ -299,7 +287,6 @@ fn synthetic_entry_selected(selected: SelectedRoomSlotState) -> bool {
         || selected.discover_selected
         || selected.showcase_selected
         || selected.work_selected
-        || selected.selected_bumped_join_room_id.is_some()
 }
 
 fn current_slot_from_state(state: SelectedRoomSlotState) -> Option<RoomSlot> {
@@ -320,9 +307,6 @@ fn current_slot_from_state(state: SelectedRoomSlotState) -> Option<RoomSlot> {
     }
     if state.work_selected {
         return Some(RoomSlot::Work);
-    }
-    if let Some(room_id) = state.selected_bumped_join_room_id {
-        return Some(RoomSlot::BumpedJoin(room_id));
     }
     state.selected_room_id.map(RoomSlot::Room)
 }
@@ -398,8 +382,6 @@ pub struct ChatState {
     refresh_room_id: Option<Uuid>,
     loading_tail_rooms: HashSet<Uuid>,
     pub(crate) selected_room_id: Option<Uuid>,
-    pub(crate) selected_bumped_join_room_id: Option<Uuid>,
-    active_bumped_join_room_ids: Vec<Uuid>,
     pub(crate) room_jump_active: bool,
     composer: TextArea<'static>,
     pub(crate) composing: bool,
@@ -598,8 +580,6 @@ impl ChatState {
             refresh_room_id: None,
             loading_tail_rooms: HashSet::new(),
             selected_room_id: None,
-            selected_bumped_join_room_id: None,
-            active_bumped_join_room_ids: Vec::new(),
             room_jump_active: false,
             composer: new_chat_textarea(),
             composing: false,
@@ -1006,7 +986,6 @@ impl ChatState {
             || self.discover_selected
             || self.showcase_selected
             || self.work_selected
-            || self.selected_bumped_join_room_id.is_some()
         {
             return None;
         }
@@ -1084,7 +1063,6 @@ impl ChatState {
         self.discover_selected = false;
         self.showcase_selected = false;
         self.work_selected = false;
-        self.selected_bumped_join_room_id = None;
         self.selected_room_id = Some(room_id);
         self.selected_message_id = Some(message_id);
         self.highlighted_message_id = Some(message_id);
@@ -1435,7 +1413,6 @@ impl ChatState {
     fn selected_slot_state(&self) -> SelectedRoomSlotState {
         SelectedRoomSlotState {
             selected_room_id: self.selected_room_id,
-            selected_bumped_join_room_id: self.selected_bumped_join_room_id,
             feeds_selected: self.feeds_selected,
             news_selected: self.news_selected,
             notifications_selected: self.notifications_selected,
@@ -1493,7 +1470,6 @@ impl ChatState {
         self.discover_selected = false;
         self.showcase_selected = false;
         self.work_selected = false;
-        self.selected_bumped_join_room_id = None;
 
         if self.selected_room_id.is_none() {
             self.selected_room_id = self
@@ -1528,28 +1504,6 @@ impl ChatState {
         &self.favorite_room_ids
     }
 
-    pub(crate) fn set_active_bumped_join_room_ids(&mut self, room_ids: Vec<Uuid>) -> bool {
-        if self.active_bumped_join_room_ids == room_ids {
-            return false;
-        }
-
-        self.active_bumped_join_room_ids = room_ids;
-        if let Some(selected_room_id) = self.selected_bumped_join_room_id
-            && !self.active_bumped_join_room_ids.contains(&selected_room_id)
-        {
-            self.selected_bumped_join_room_id = None;
-            if self.selected_room_id.is_none()
-                && let Some(slot) = self
-                    .visual_order()
-                    .into_iter()
-                    .find(|slot| !matches!(slot, RoomSlot::BumpedJoin(_)))
-            {
-                self.select_room_slot(slot);
-            }
-        }
-        true
-    }
-
     pub(crate) fn selected_favorite_room_id(&self) -> Option<Uuid> {
         if self.feeds_selected
             || self.news_selected
@@ -1571,13 +1525,7 @@ impl ChatState {
     /// Order matches the cozy rail exactly: favorites, core/mentions/news/rss,
     /// channels, updates, DMs.
     pub(crate) fn visual_order(&self) -> Vec<RoomSlot> {
-        let mut order = self
-            .active_bumped_join_room_ids
-            .iter()
-            .copied()
-            .map(RoomSlot::BumpedJoin)
-            .collect::<Vec<_>>();
-        order.extend(visual_order_for_rooms(RoomVisualOrderInput {
+        visual_order_for_rooms(RoomVisualOrderInput {
             rooms: &self.rooms,
             user_id: self.user_id,
             usernames: &self.usernames,
@@ -1586,8 +1534,7 @@ impl ChatState {
             feeds_available: self.feeds.has_feeds(),
             favorite_room_ids: &self.favorite_room_ids,
             collapsed_sections: &self.collapsed_sections,
-        }));
-        order
+        })
     }
 
     pub(crate) fn room_jump_targets(&self) -> Vec<(u8, RoomSlot)> {
@@ -1642,25 +1589,6 @@ impl ChatState {
                 self.select_work();
                 changed
             }
-            RoomSlot::BumpedJoin(next_id) => {
-                let changed = self.feeds_selected
-                    || self.news_selected
-                    || self.notifications_selected
-                    || self.discover_selected
-                    || self.showcase_selected
-                    || self.work_selected
-                    || self.selected_bumped_join_room_id != Some(next_id)
-                    || self.selected_room_id.is_some();
-                self.feeds_selected = false;
-                self.news_selected = false;
-                self.notifications_selected = false;
-                self.discover_selected = false;
-                self.showcase_selected = false;
-                self.work_selected = false;
-                self.selected_room_id = None;
-                self.selected_bumped_join_room_id = Some(next_id);
-                changed
-            }
             RoomSlot::Room(next_id) => {
                 if !self
                     .rooms
@@ -1682,7 +1610,6 @@ impl ChatState {
                 self.discover_selected = false;
                 self.showcase_selected = false;
                 self.work_selected = false;
-                self.selected_bumped_join_room_id = None;
                 self.selected_room_id = Some(next_id);
                 if !changed {
                     self.mark_room_read(next_id);
@@ -1733,8 +1660,6 @@ impl ChatState {
             RoomSlot::Work
         } else if self.news_selected {
             RoomSlot::News
-        } else if let Some(room_id) = self.selected_bumped_join_room_id {
-            RoomSlot::BumpedJoin(room_id)
         } else {
             self.selected_room_id
                 .map(RoomSlot::Room)
@@ -2940,7 +2865,6 @@ impl ChatState {
         self.discover_selected = false;
         self.showcase_selected = false;
         self.work_selected = false;
-        self.selected_bumped_join_room_id = None;
         self.selected_message_id = None;
         self.highlighted_message_id = None;
         self.feeds.list();
@@ -2955,7 +2879,6 @@ impl ChatState {
         self.discover_selected = false;
         self.showcase_selected = false;
         self.work_selected = false;
-        self.selected_bumped_join_room_id = None;
         self.selected_message_id = None;
         self.highlighted_message_id = None;
         self.news.list_articles();
@@ -2974,7 +2897,6 @@ impl ChatState {
         self.discover_selected = false;
         self.showcase_selected = false;
         self.work_selected = false;
-        self.selected_bumped_join_room_id = None;
         self.selected_message_id = None;
         self.highlighted_message_id = None;
         self.notifications.list();
@@ -2989,7 +2911,6 @@ impl ChatState {
         self.news_selected = false;
         self.showcase_selected = false;
         self.work_selected = false;
-        self.selected_bumped_join_room_id = None;
         self.selected_message_id = None;
         self.highlighted_message_id = None;
         self.discover.start_loading();
@@ -3004,7 +2925,6 @@ impl ChatState {
         self.notifications_selected = false;
         self.news_selected = false;
         self.work_selected = false;
-        self.selected_bumped_join_room_id = None;
         self.selected_message_id = None;
         self.highlighted_message_id = None;
         self.showcase.list();
@@ -3019,7 +2939,6 @@ impl ChatState {
         self.discover_selected = false;
         self.notifications_selected = false;
         self.news_selected = false;
-        self.selected_bumped_join_room_id = None;
         self.selected_message_id = None;
         self.highlighted_message_id = None;
         self.work.list();
@@ -3031,16 +2950,6 @@ impl ChatState {
         self.service
             .join_public_room_task(self.user_id, item.room_id, item.slug.clone());
         Some(Banner::success(&format!("Joining #{}...", item.slug)))
-    }
-
-    pub fn join_bumped_public_room(&mut self, room_id: Uuid, slug: String) -> Banner {
-        self.service
-            .join_public_room_task(self.user_id, room_id, slug.clone());
-        Banner::success(&format!("Joining #{slug}..."))
-    }
-
-    pub fn selected_bumped_join_room_id(&self) -> Option<Uuid> {
-        self.selected_bumped_join_room_id
     }
 
     pub fn cursor_visible(&self) -> bool {
@@ -3463,7 +3372,6 @@ impl ChatState {
                     self.discover_selected = false;
                     self.showcase_selected = false;
                     self.work_selected = false;
-                    self.selected_bumped_join_room_id = None;
                     self.selected_room_id = Some(room_id);
                     self.request_list();
                     self.pending_chat_screen_switch = true;
@@ -3512,7 +3420,6 @@ impl ChatState {
                     self.discover_selected = false;
                     self.showcase_selected = false;
                     self.work_selected = false;
-                    self.selected_bumped_join_room_id = None;
                     self.selected_room_id = Some(room_id);
                     self.request_list();
                     self.pending_chat_screen_switch = true;
@@ -3544,7 +3451,6 @@ impl ChatState {
                     self.discover_selected = false;
                     self.showcase_selected = false;
                     self.work_selected = false;
-                    self.selected_bumped_join_room_id = None;
                     self.selected_room_id = Some(room_id);
                     self.request_list();
                     self.pending_chat_screen_switch = true;
@@ -4805,8 +4711,7 @@ fn adjacent_composer_room(
         .iter()
         .filter_map(|slot| match slot {
             RoomSlot::Room(room_id) => Some(*room_id),
-            RoomSlot::BumpedJoin(_)
-            | RoomSlot::Feeds
+            RoomSlot::Feeds
             | RoomSlot::News
             | RoomSlot::Notifications
             | RoomSlot::Discover

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -2213,7 +2213,6 @@ pub struct ChatRenderInput<'a> {
     pub active_poll: Option<&'a ActiveChatPoll>,
     pub collapsed_sections: &'a HashSet<RoomSection>,
     pub selected_room_id: Option<Uuid>,
-    pub selected_bumped_join_room_id: Option<Uuid>,
     pub room_jump_active: bool,
     pub room_section_prefix_armed: bool,
     pub selected_message_id: Option<Uuid>,
@@ -2294,7 +2293,6 @@ pub(crate) struct ChatRoomListView<'a> {
     pub active_room_effects: &'a HashMap<Uuid, Vec<ActiveChatRoomEffect>>,
     pub collapsed_sections: &'a HashSet<RoomSection>,
     pub selected_room_id: Option<Uuid>,
-    pub selected_bumped_join_room_id: Option<Uuid>,
     pub room_jump_active: bool,
     pub room_section_prefix_armed: bool,
     pub current_user_id: Uuid,
@@ -2616,7 +2614,6 @@ fn room_list_view_from_render_input<'a>(view: &'a ChatRenderInput<'a>) -> ChatRo
         active_room_effects: view.active_room_effects,
         collapsed_sections: view.collapsed_sections,
         selected_room_id: view.selected_room_id,
-        selected_bumped_join_room_id: view.selected_bumped_join_room_id,
         room_jump_active: view.room_jump_active,
         room_section_prefix_armed: view.room_section_prefix_armed,
         current_user_id: view.current_user_id,
@@ -3195,7 +3192,7 @@ fn build_cozy_room_rail_rows(view: &ChatRoomListView<'_>, width: u16) -> RoomLis
     let mut hit_slots: Vec<Option<RoomSlot>> = Vec::new();
     let mut selected_row_index = None;
     let inner_width = width.saturating_sub(3) as usize; // 2 left gutter + 1 right margin
-    let mut order = visual_order_for_rooms(RoomVisualOrderInput {
+    let order = visual_order_for_rooms(RoomVisualOrderInput {
         rooms: view.chat_rooms,
         user_id: view.current_user_id,
         usernames: view.usernames,
@@ -3205,10 +3202,10 @@ fn build_cozy_room_rail_rows(view: &ChatRoomListView<'_>, width: u16) -> RoomLis
         favorite_room_ids: view.favorite_room_ids,
         collapsed_sections: view.collapsed_sections,
     });
-    let bumped_slots = bumped_join_room_slots(view.active_room_effects);
-    let mut promoted_order = bumped_slots.clone();
-    promoted_order.extend(order);
-    order = promoted_order;
+    // Bumped rooms are advertised as read-only text at the top of the rail;
+    // they are not part of `order`, so they take no jump key and never
+    // participate in selection or navigation.
+    let bumped_slugs = bumped_join_room_slugs(view.active_room_effects);
     let jump_targets: HashMap<RoomSlot, u8> = order
         .iter()
         .copied()
@@ -3258,7 +3255,6 @@ fn build_cozy_room_rail_rows(view: &ChatRoomListView<'_>, width: u16) -> RoomLis
     };
 
     let item_row = |label: String,
-                    slot: RoomSlot,
                     unread: i64,
                     active: bool,
                     jump_key: Option<u8>,
@@ -3305,8 +3301,6 @@ fn build_cozy_room_rail_rows(view: &ChatRoomListView<'_>, width: u16) -> RoomLis
         }
         let name_color = if active {
             theme::AMBER()
-        } else if matches!(slot, RoomSlot::BumpedJoin(_)) {
-            theme::TEXT()
         } else if has_room_effect(effects, "pinned_vibe") {
             theme::AMBER_GLOW()
         } else if unread > 0 {
@@ -3348,7 +3342,6 @@ fn build_cozy_room_rail_rows(view: &ChatRoomListView<'_>, width: u16) -> RoomLis
             push_row(
                 item_row(
                     label,
-                    slot,
                     unread,
                     active,
                     jump_targets.get(&slot).copied(),
@@ -3380,10 +3373,17 @@ fn build_cozy_room_rail_rows(view: &ChatRoomListView<'_>, width: u16) -> RoomLis
                 .any(|(r, _)| r.id == *id && is_chat_list_room(r))
         })
         .collect();
-    if !bumped_slots.is_empty() {
+    if !bumped_slugs.is_empty() {
         push_row(effect_section_header("bumped"), None, false);
-        for slot in bumped_slots.iter().copied() {
-            push_slot(slot, &mut push_row);
+        for slug in &bumped_slugs {
+            push_row(
+                Line::from(Span::styled(
+                    format!("#{slug}"),
+                    Style::default().fg(theme::AMBER_DIM()),
+                )),
+                None,
+                false,
+            );
         }
         push_row(blank(), None, false);
     }
@@ -3483,16 +3483,6 @@ fn room_slot_label_and_unread(view: &ChatRoomListView<'_>, slot: RoomSlot) -> (S
             let unread = view.unread_counts.get(&room.id).copied().unwrap_or(0);
             (label, unread)
         }
-        RoomSlot::BumpedJoin(room_id) => {
-            let label = view
-                .active_room_effects
-                .get(&room_id)
-                .and_then(|effects| effects.first())
-                .and_then(|effect| effect.room_slug.as_deref())
-                .map(|slug| format!("join #{slug}"))
-                .unwrap_or_else(|| "join room".to_string());
-            (label, 0)
-        }
         RoomSlot::Feeds => ("rss".to_string(), view.feeds_unread_count),
         RoomSlot::News => ("news".to_string(), view.news_unread_count),
         RoomSlot::Notifications => ("mentions".to_string(), view.notifications_unread_count),
@@ -3502,12 +3492,15 @@ fn room_slot_label_and_unread(view: &ChatRoomListView<'_>, slot: RoomSlot) -> (S
     }
 }
 
-fn bumped_join_room_slots(
+/// Slugs of public topic rooms currently carrying a `room_bump` effect,
+/// sorted alphabetically. These are advertised as read-only text at the top
+/// of the rail (no slot, no selection, no jump key).
+fn bumped_join_room_slugs(
     active_room_effects: &HashMap<Uuid, Vec<ActiveChatRoomEffect>>,
-) -> Vec<RoomSlot> {
-    let mut rooms = active_room_effects
-        .iter()
-        .filter_map(|(room_id, effects)| {
+) -> Vec<String> {
+    let mut slugs = active_room_effects
+        .values()
+        .filter_map(|effects| {
             let first = effects.first()?;
             (has_room_effect(effects, "room_bump")
                 && first.room_kind == "topic"
@@ -3517,14 +3510,11 @@ fn bumped_join_room_slots(
                     .room_slug
                     .as_deref()
                     .is_some_and(|slug| !slug.is_empty()))
-            .then_some((
-                first.room_slug.clone().unwrap_or_default(),
-                RoomSlot::BumpedJoin(*room_id),
-            ))
+            .then(|| first.room_slug.clone().unwrap_or_default())
         })
         .collect::<Vec<_>>();
-    rooms.sort_by(|(a, _), (b, _)| a.cmp(b));
-    rooms.into_iter().map(|(_, slot)| slot).collect()
+    slugs.sort();
+    slugs
 }
 
 fn room_slot_effects<'a>(
@@ -3537,7 +3527,6 @@ fn room_slot_effects<'a>(
             .get(&room_id)
             .map(Vec::as_slice)
             .unwrap_or(&[]),
-        RoomSlot::BumpedJoin(_) => &[],
         _ => &[],
     }
 }
@@ -3607,7 +3596,6 @@ fn cozy_slot_selected(view: &ChatRoomListView<'_>, slot: RoomSlot) -> bool {
         slot,
         SelectedRoomSlotState {
             selected_room_id: view.selected_room_id,
-            selected_bumped_join_room_id: view.selected_bumped_join_room_id,
             feeds_selected: view.feeds_selected,
             news_selected: view.news_selected,
             notifications_selected: view.notifications_selected,
@@ -3687,18 +3675,14 @@ fn draw_selected_content(
     } else if news_selected {
         super::news::ui::draw_article_list(frame, messages_area, &view.news_view);
     } else {
-        let selected_room = if view.selected_bumped_join_room_id.is_some() {
-            None
-        } else {
-            selected_room_id
-                .and_then(|id| view.chat_rooms.iter().find(|(room, _)| room.id == id))
-                .filter(|(room, _)| is_chat_list_room(room))
-                .or_else(|| {
-                    view.chat_rooms
-                        .iter()
-                        .find(|(room, _)| is_chat_list_room(room))
-                })
-        };
+        let selected_room = selected_room_id
+            .and_then(|id| view.chat_rooms.iter().find(|(room, _)| room.id == id))
+            .filter(|(room, _)| is_chat_list_room(room))
+            .or_else(|| {
+                view.chat_rooms
+                    .iter()
+                    .find(|(room, _)| is_chat_list_room(room))
+            });
 
         // A voice channel shows a compact voice strip pinned at the very top;
         // text-only rooms render unchanged with the messages at full height.
@@ -3781,20 +3765,6 @@ fn draw_selected_content(
             } else {
                 visible.lines
             }
-        } else if let Some(room_id) = view.selected_bumped_join_room_id {
-            let label = view
-                .active_room_effects
-                .get(&room_id)
-                .and_then(|effects| effects.first())
-                .and_then(|effect| effect.room_slug.as_deref())
-                .map(|slug| format!("join #{slug}"))
-                .unwrap_or_else(|| "join room".to_string());
-            vec![Line::from(Span::styled(
-                label,
-                Style::default()
-                    .fg(theme::AMBER())
-                    .add_modifier(Modifier::BOLD),
-            ))]
         } else {
             vec![Line::from(Span::styled(
                 "Select a room.",
@@ -4289,7 +4259,6 @@ mod tests {
             active_poll: None,
             collapsed_sections: COLLAPSED_SECTIONS.get_or_init(HashSet::new),
             selected_room_id,
-            selected_bumped_join_room_id: None,
             room_jump_active: false,
             room_section_prefix_armed: false,
             selected_message_id: None,

--- a/late-ssh/src/app/dashboard/ui.rs
+++ b/late-ssh/src/app/dashboard/ui.rs
@@ -534,6 +534,7 @@ fn draw_quest_meta(frame: &mut Frame, area: Rect, item: &QuestItem) {
     );
 }
 
+#[allow(clippy::too_many_arguments)]
 fn draw_box_activity(
     frame: &mut Frame,
     area: Rect,
@@ -611,8 +612,7 @@ fn draw_box_activity(
         let user = truncate(&event.username, 12);
         let user_part = format!("@{}", user);
         // Columns the action gets, sharing the row with the name and timestamp.
-        let action_w =
-            body_w.saturating_sub(user_part.chars().count() + ago.chars().count() + 4);
+        let action_w = body_w.saturating_sub(user_part.chars().count() + ago.chars().count() + 4);
         let action = marquee_text(&event.action, action_w, marquee_tick);
         frame.render_widget(
             Paragraph::new(Line::from(vec![

--- a/late-ssh/src/app/dashboard/ui.rs
+++ b/late-ssh/src/app/dashboard/ui.rs
@@ -759,7 +759,7 @@ fn marquee_text(text: &str, width: usize, tick: usize) -> String {
         return text.to_string();
     }
     let travel = chars.len() - width; // furthest left the window can scroll
-    let hold = 8; // ticks paused at each extreme
+    let hold = 20; // ticks paused at each extreme (~1.3s) before reversing
     let step = 3; // ticks per column of movement
     let sweep = travel * step;
     let period = 2 * hold + 2 * sweep;

--- a/late-ssh/src/app/dashboard/ui.rs
+++ b/late-ssh/src/app/dashboard/ui.rs
@@ -88,6 +88,10 @@ pub struct DashboardRenderInput<'a> {
     /// Mouse-wheel scroll offset for the Activity panel. `0` shows the
     /// newest event at the top; larger values reveal older events.
     pub activity_scroll: u16,
+    /// Free-running frame counter (advances every world tick). Long event
+    /// rows that overflow their width scroll horizontally off this so the
+    /// whole message is readable without wrapping.
+    pub marquee_tick: usize,
     /// Cell that, when present, receives the Activity panel's rendered
     /// rect so mouse-wheel hit-testing in `app::input` can route scroll
     /// events to it.
@@ -103,6 +107,7 @@ struct TopStripData<'a> {
     cycle_secs: u64,
     usernames: &'a UsernameLookup<'a>,
     activity_scroll: u16,
+    marquee_tick: usize,
     activity_rect_slot: Option<&'a std::cell::Cell<Option<Rect>>>,
 }
 
@@ -158,6 +163,7 @@ pub fn draw_dashboard(
                 cycle_secs: view.dashboard_cycle_secs,
                 usernames: view.chat_view.usernames,
                 activity_scroll: view.activity_scroll,
+                marquee_tick: view.marquee_tick,
                 activity_rect_slot: view.activity_rect_slot,
             },
         );
@@ -211,6 +217,7 @@ pub fn draw_chat_with_top_strip(
             cycle_secs: view.dashboard_cycle_secs,
             usernames: view.chat_view.usernames,
             activity_scroll: view.activity_scroll,
+            marquee_tick: view.marquee_tick,
             activity_rect_slot: view.activity_rect_slot,
         },
     );
@@ -332,6 +339,7 @@ fn draw_top_strip(frame: &mut Frame, area: Rect, data: TopStripData<'_>) {
         data.online_count,
         data.active_friend_names,
         data.activity_scroll,
+        data.marquee_tick,
         data.activity_rect_slot,
     );
     draw_box_multiplayer_rooms(frame, cols[2], data.multiplayer_rooms, data.usernames);
@@ -533,6 +541,7 @@ fn draw_box_activity(
     online_count: usize,
     active_friend_names: &[String],
     activity_scroll: u16,
+    marquee_tick: usize,
     activity_rect_slot: Option<&std::cell::Cell<Option<Rect>>>,
 ) {
     let area = horizontal_padding(area, 1);
@@ -583,16 +592,14 @@ fn draw_box_activity(
     let visible = event_rows.len();
     let max_offset = activity.len().saturating_sub(visible);
     let offset = (activity_scroll as usize).min(max_offset);
-    // Greedy fill: each event takes one row, or two when its action is too long
-    // to fit beside the name and timestamp. A two-line event spends an extra row,
-    // so a busy feed simply shows fewer (but fully readable) entries.
+    // One row per event. The action shares the row with the name and
+    // timestamp; when it's too long to fit, it scrolls horizontally so the
+    // whole message can be read without wrapping or being cut.
     let mut events = activity.iter().rev().skip(offset);
-    let mut row_idx = 0;
     let mut drawn = 0;
-    while row_idx < event_rows.len() {
+    for &row in event_rows {
         let Some(event) = events.next() else { break };
-        let first = event_rows[row_idx];
-        let body_w = first.width as usize;
+        let body_w = row.width as usize;
         let elapsed = event.at.elapsed().as_secs();
         let ago = if elapsed < 60 {
             format!("{}s", elapsed)
@@ -603,53 +610,20 @@ fn draw_box_activity(
         };
         let user = truncate(&event.username, 12);
         let user_part = format!("@{}", user);
-        let action_len = event.action.chars().count();
-        // Chars the action gets on a single line (sharing it with name + ago).
-        let single_action_w =
+        // Columns the action gets, sharing the row with the name and timestamp.
+        let action_w =
             body_w.saturating_sub(user_part.chars().count() + ago.chars().count() + 4);
-        // Chars the action gets on line one of a two-line event (full width after
-        // the name; the timestamp moves to line two).
-        let head_w = body_w.saturating_sub(user_part.chars().count() + 2);
-        let rows_left = event_rows.len() - row_idx;
-
-        if action_len > head_w && rows_left >= 2 {
-            // Two lines: action head beside the name, tail + timestamp below it.
-            let head: String = event.action.chars().take(head_w).collect();
-            let tail_full: String = event.action.chars().skip(head_w).collect();
-            let tail_w = body_w.saturating_sub(ago.chars().count() + 4);
-            let tail = truncate(&tail_full, tail_w);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled(user_part, Style::default().fg(theme::TEXT())),
-                    Span::raw("  "),
-                    Span::styled(head, Style::default().fg(theme::TEXT_DIM())),
-                ])),
-                first,
-            );
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::raw("  "),
-                    Span::styled(tail, Style::default().fg(theme::TEXT_DIM())),
-                    Span::raw("  "),
-                    Span::styled(ago, Style::default().fg(theme::TEXT_FAINT())),
-                ])),
-                event_rows[row_idx + 1],
-            );
-            row_idx += 2;
-        } else {
-            let action = truncate(&event.action, single_action_w);
-            frame.render_widget(
-                Paragraph::new(Line::from(vec![
-                    Span::styled(user_part, Style::default().fg(theme::TEXT())),
-                    Span::raw("  "),
-                    Span::styled(action, Style::default().fg(theme::TEXT_DIM())),
-                    Span::raw("  "),
-                    Span::styled(ago, Style::default().fg(theme::TEXT_FAINT())),
-                ])),
-                first,
-            );
-            row_idx += 1;
-        }
+        let action = marquee_text(&event.action, action_w, marquee_tick);
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(user_part, Style::default().fg(theme::TEXT())),
+                Span::raw("  "),
+                Span::styled(action, Style::default().fg(theme::TEXT_DIM())),
+                Span::raw("  "),
+                Span::styled(ago, Style::default().fg(theme::TEXT_FAINT())),
+            ])),
+            row,
+        );
         drawn += 1;
     }
     if drawn == 0 {
@@ -773,6 +747,34 @@ fn truncate(text: &str, max: usize) -> String {
     let mut out: String = chars.into_iter().take(max - 1).collect();
     out.push('…');
     out
+}
+
+/// Render `text` into a `width`-column window. Text that fits is returned
+/// unchanged; longer text scrolls back and forth so the whole thing can be
+/// read in place. `tick` advances once per world tick (~66ms); the window
+/// holds briefly at each end before reversing so both edges stay readable.
+fn marquee_text(text: &str, width: usize, tick: usize) -> String {
+    let chars: Vec<char> = text.chars().collect();
+    if width == 0 || chars.len() <= width {
+        return text.to_string();
+    }
+    let travel = chars.len() - width; // furthest left the window can scroll
+    let hold = 8; // ticks paused at each extreme
+    let step = 3; // ticks per column of movement
+    let sweep = travel * step;
+    let period = 2 * hold + 2 * sweep;
+    let t = tick % period;
+    let offset = if t < hold {
+        0
+    } else if t < hold + sweep {
+        (t - hold) / step
+    } else if t < 2 * hold + sweep {
+        travel
+    } else {
+        travel - (t - 2 * hold - sweep) / step
+    }
+    .min(travel);
+    chars[offset..offset + width].iter().collect()
 }
 
 #[cfg(test)]

--- a/late-ssh/src/app/door/hub/ui.rs
+++ b/late-ssh/src/app/door/hub/ui.rs
@@ -17,6 +17,8 @@ pub struct HubView {
     pub rebels_enabled: bool,
     pub nethack_enabled: bool,
     pub terminal_image_protocol: Option<TerminalImageProtocol>,
+    /// Players currently in the Lateania world, shown on its landing card.
+    pub lateania_online: usize,
 }
 
 pub fn draw_games_hub(
@@ -57,6 +59,7 @@ pub fn draw_games_hub(
             frame,
             layout[3],
             view.delete_confirm,
+            view.lateania_online,
             view.terminal_image_protocol,
             terminal_images,
         ),

--- a/late-ssh/src/app/door/lateania/screen.rs
+++ b/late-ssh/src/app/door/lateania/screen.rs
@@ -377,6 +377,14 @@ fn draw_native_frontier_banner(
     let Some(protocol) = protocol else {
         return false;
     };
+    // Sixel has no delete-by-id, so a non-modal banner that appears and
+    // vanishes on hub-card / screen changes leaves stale raster pixels behind
+    // (see pre_frame_sixel_wipe_bytes). Render the ASCII preview instead on
+    // Sixel terminals; Kitty/iTerm2 (delete-by-id) keep the native banner.
+    // Full-quality Sixel still applies to the chat image modal, a separate path.
+    if protocol == TerminalImageProtocol::Sixel {
+        return false;
+    }
     let Some(data) = frontier_terminal_image(protocol) else {
         return false;
     };

--- a/late-ssh/src/app/door/lateania/screen.rs
+++ b/late-ssh/src/app/door/lateania/screen.rs
@@ -45,7 +45,7 @@ impl DoorGame for LateaniaDoorGame {
     }
 
     fn description(&self) -> &'static str {
-        "A persistent terminal world with shared rooms, classes, quests, shops, titles, and loot."
+        "A persistent terminal world with shared rooms, twelve classes, quests, player housing, companions, titles, and loot."
     }
 
     fn activity_game(&self) -> Option<ActivityGame> {
@@ -80,6 +80,8 @@ pub struct LateaniaScreenView<'a> {
     pub state: Option<&'a super::state::State>,
     pub usernames: &'a UsernameLookup<'a>,
     pub terminal_image_protocol: Option<TerminalImageProtocol>,
+    /// Players currently in the Lateania world, shown on the landing.
+    pub online: usize,
 }
 
 fn draw_screen(
@@ -102,6 +104,7 @@ fn draw_screen(
         frame,
         area,
         view.delete_confirm,
+        view.online,
         view.terminal_image_protocol,
         terminal_images,
     );
@@ -201,6 +204,7 @@ pub fn draw_landing(
     frame: &mut Frame,
     area: Rect,
     delete_confirm: bool,
+    online: usize,
     terminal_image_protocol: Option<TerminalImageProtocol>,
     terminal_images: &mut TerminalImageFrame,
 ) {
@@ -213,13 +217,13 @@ pub fn draw_landing(
         })
         .split(area);
 
-    draw_launch_copy(frame, layout[0], delete_confirm);
+    draw_launch_copy(frame, layout[0], delete_confirm, online);
     if layout.len() > 1 && layout[1].width > 0 {
         draw_frontier_art(frame, layout[1], terminal_image_protocol, terminal_images);
     }
 }
 
-fn draw_launch_copy(frame: &mut Frame, area: Rect, delete_confirm: bool) {
+fn draw_launch_copy(frame: &mut Frame, area: Rect, delete_confirm: bool, online: usize) {
     let inner = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
@@ -245,11 +249,11 @@ fn draw_launch_copy(frame: &mut Frame, area: Rect, delete_confirm: bool) {
         ),
     ]));
     lines.push(Line::from(Span::styled(
-        "Shared rooms, old-school classes, frontier quests, shops, titles, loot, and real persistence.",
+        "Shared rooms, twelve classes, frontier quests, player housing, companions, titles, loot, and real persistence.",
         Style::default().fg(theme::TEXT_DIM()),
     )));
     lines.push(Line::raw(""));
-    lines.extend(world_stats());
+    lines.extend(world_stats(online));
     lines.push(Line::raw(""));
     lines.push(landing::heading("Boss Achievements"));
     lines.push(landing::stat(
@@ -345,9 +349,9 @@ fn draw_frontier_art(
         )),
         Line::raw(""),
         fact_line("20", "frontier zones"),
-        fact_line("1,565", "rooms in the world"),
-        fact_line("100", "generated frontier items"),
-        fact_line("5", "classes with unlockable abilities"),
+        fact_line("1,500+", "rooms in the world"),
+        fact_line("12", "classes, each with two archetype paths"),
+        fact_line("5", "home tiers to buy and furnish"),
         fact_line("30k", "one-time chips across final boss achievements"),
         Line::raw(""),
         Line::from(Span::styled(
@@ -419,20 +423,29 @@ fn lateania_logo() -> Vec<Line<'static>> {
     .collect()
 }
 
-fn world_stats() -> Vec<Line<'static>> {
+fn world_stats(online: usize) -> Vec<Line<'static>> {
+    let online_label = if online == 1 {
+        "1 adventurer".to_string()
+    } else {
+        format!("{online} adventurers")
+    };
     vec![
+        landing::stat(&online_label, "in the world right now", 22),
         landing::stat(
             "20 frontier zones",
             "boss quests, titles, and bounty rewards",
             22,
         ),
-        landing::stat("LAD / LFK", "profile badges for the two final clears", 22),
         landing::stat(
-            "1,565 rooms",
-            "towns, capitals, wilds, a crypt + forest maze, and a cave",
+            "1,500+ rooms",
+            "towns, capitals, wilds, mazes, a cave, and homes",
             22,
         ),
-        landing::stat("5 classes", "Warrior, Mage, Cleric, Rogue, Ranger", 22),
+        landing::stat(
+            "12 classes",
+            "the five originals plus seven new callings",
+            22,
+        ),
         landing::stat(
             "shared runtime",
             "mob state and combat persist server-side",

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -4069,7 +4069,7 @@ impl WorldState {
             .collect();
 
         for user_id in fighters {
-            let (mob_id, base_atk, opening, frenzy_pct) = match self.players.get(&user_id) {
+            let (mob_id, base_atk, opening, frenzy_pct, class) = match self.players.get(&user_id) {
                 Some(p) => {
                     // Berserker "Frenzy": no bonus above half health, then up to
                     // +50% damage as it falls from half toward death.
@@ -4080,7 +4080,7 @@ impl WorldState {
                     } else {
                         0
                     };
-                    (p.target, p.attack(), p.opening_strike, frenzy)
+                    (p.target, p.attack(), p.opening_strike, frenzy, p.class)
                 }
                 None => continue,
             };
@@ -4092,10 +4092,23 @@ impl WorldState {
                 }
                 continue;
             }
+            // Ranger "Hunter's Instinct": strikes against a wounded foe (below half
+            // health) bite harder, on auto-attacks as well as abilities.
+            let ranger_wounded = class == Some(Class::Ranger)
+                && self
+                    .mobs
+                    .get(&mob_id)
+                    .is_some_and(|m| m.hp * 2 < m.spawn.max_hp);
             // Opportunist: the Rogue's opening strike of a fight lands as a crit.
             let player_atk = if opening { base_atk * 2 } else { base_atk };
             // Berserker Frenzy scales the blow up as health runs low.
             let player_atk = player_atk * (100 + frenzy_pct) / 100;
+            // Hunter's Instinct: extra damage into the wounded foe.
+            let player_atk = if ranger_wounded {
+                player_atk + player_atk / 4
+            } else {
+                player_atk
+            };
             if opening {
                 if let Some(p) = self.players.get_mut(&user_id) {
                     p.opening_strike = false;

--- a/late-ssh/src/app/files/terminal_image.rs
+++ b/late-ssh/src/app/files/terminal_image.rs
@@ -153,6 +153,11 @@ pub(crate) struct TerminalImageRenderState {
 struct SixelIntent {
     image_modal_msg_id: Option<Uuid>,
     overlay_blocks_sixel: bool,
+    /// Stable per-screen tag (`Screen as u16`). Non-modal Sixel placements
+    /// like the Lateania landing banner appear and vanish on screen/selection
+    /// changes that touch neither flag above, so a screen change is its own
+    /// wipe trigger — otherwise those pixels leak onto the next screen.
+    screen_tag: u16,
 }
 
 impl TerminalImageRenderState {
@@ -167,17 +172,20 @@ impl TerminalImageRenderState {
     /// Sixel pixels are gone.
     ///
     /// Only fires on transitions that actually change what should be
-    /// visible — image modal closed, image swapped, overlay opened — so a
+    /// visible — image modal closed, image swapped, overlay opened, or the
+    /// screen changed out from under a non-modal placement — so a
     /// steady-state image modal does not trigger a wipe + re-emit each
     /// frame.
     pub(crate) fn pre_frame_sixel_wipe_bytes(
         &mut self,
         image_modal_msg_id: Option<Uuid>,
         overlay_blocks_sixel: bool,
+        screen_tag: u16,
     ) -> Vec<u8> {
         let current_intent = SixelIntent {
             image_modal_msg_id,
             overlay_blocks_sixel,
+            screen_tag,
         };
         let was_sixel = self.protocol == Some(TerminalImageProtocol::Sixel);
         if !was_sixel || self.placements.is_empty() {
@@ -189,7 +197,8 @@ impl TerminalImageRenderState {
         let last = self.last_intent;
         let modal_closed_or_swapped = image_modal_msg_id != last.image_modal_msg_id;
         let overlay_state_changed = overlay_blocks_sixel != last.overlay_blocks_sixel;
-        let needs_wipe = modal_closed_or_swapped || overlay_state_changed;
+        let screen_changed = screen_tag != last.screen_tag;
+        let needs_wipe = modal_closed_or_swapped || overlay_state_changed || screen_changed;
         self.last_intent = current_intent;
         if !needs_wipe {
             return Vec::new();
@@ -798,12 +807,17 @@ mod tests {
         }
     }
 
+    // Tag the seeded "previous frame" screen so tests that should NOT fire a
+    // wipe can hold the screen constant; the screen-change test flips it.
+    const SEED_SCREEN_TAG: u16 = 0;
+
     fn seed_sixel_state(state: &mut TerminalImageRenderState, msg_id: Uuid) {
         state.protocol = Some(TerminalImageProtocol::Sixel);
         state.placements = vec![sixel_placement_key(msg_id, 2, 3, 5, 2)];
         state.last_intent = SixelIntent {
             image_modal_msg_id: Some(msg_id),
             overlay_blocks_sixel: false,
+            screen_tag: SEED_SCREEN_TAG,
         };
     }
 
@@ -812,8 +826,8 @@ mod tests {
         let mut state = TerminalImageRenderState::default();
         let msg = Uuid::new_v4();
         seed_sixel_state(&mut state, msg);
-        // Same modal, no overlay → no wipe, no churn.
-        let out = state.pre_frame_sixel_wipe_bytes(Some(msg), false);
+        // Same modal, no overlay, same screen → no wipe, no churn.
+        let out = state.pre_frame_sixel_wipe_bytes(Some(msg), false, SEED_SCREEN_TAG);
         assert!(out.is_empty());
         assert_eq!(state.placements.len(), 1);
     }
@@ -823,7 +837,7 @@ mod tests {
         let mut state = TerminalImageRenderState::default();
         let msg = Uuid::new_v4();
         seed_sixel_state(&mut state, msg);
-        let out = state.pre_frame_sixel_wipe_bytes(None, false);
+        let out = state.pre_frame_sixel_wipe_bytes(None, false, SEED_SCREEN_TAG);
         assert!(!out.is_empty(), "expected wipe bytes when modal closed");
         // Each wiped row writes a cursor sequence; 2 rows for a 5x2 rect.
         let wipe = String::from_utf8_lossy(&out);
@@ -843,7 +857,7 @@ mod tests {
         let old_msg = Uuid::new_v4();
         let new_msg = Uuid::new_v4();
         seed_sixel_state(&mut state, old_msg);
-        let out = state.pre_frame_sixel_wipe_bytes(Some(new_msg), false);
+        let out = state.pre_frame_sixel_wipe_bytes(Some(new_msg), false, SEED_SCREEN_TAG);
         assert!(!out.is_empty());
         assert!(state.placements.is_empty());
     }
@@ -854,7 +868,7 @@ mod tests {
         let msg = Uuid::new_v4();
         seed_sixel_state(&mut state, msg);
         // Same modal still open, but a foreground overlay (icon picker) opened.
-        let out = state.pre_frame_sixel_wipe_bytes(Some(msg), true);
+        let out = state.pre_frame_sixel_wipe_bytes(Some(msg), true, SEED_SCREEN_TAG);
         assert!(
             !out.is_empty(),
             "expected wipe when overlay opens on top of Sixel"
@@ -862,9 +876,25 @@ mod tests {
     }
 
     #[test]
+    fn pre_frame_wipe_fires_when_screen_changes() {
+        let mut state = TerminalImageRenderState::default();
+        let msg = Uuid::new_v4();
+        seed_sixel_state(&mut state, msg);
+        // No modal/overlay change, but the screen changed out from under a
+        // non-modal Sixel placement (e.g. leaving the Lateania landing banner).
+        // The leftover pixels must be wiped or they leak onto the next screen.
+        let out = state.pre_frame_sixel_wipe_bytes(Some(msg), false, SEED_SCREEN_TAG + 1);
+        assert!(
+            !out.is_empty(),
+            "expected wipe when the screen changes while Sixel was visible"
+        );
+        assert!(state.placements.is_empty());
+    }
+
+    #[test]
     fn pre_frame_wipe_noop_when_no_prior_sixel() {
         let mut state = TerminalImageRenderState::default();
-        let out = state.pre_frame_sixel_wipe_bytes(None, false);
+        let out = state.pre_frame_sixel_wipe_bytes(None, false, SEED_SCREEN_TAG);
         assert!(out.is_empty());
     }
 

--- a/late-ssh/src/app/hub/shop/state.rs
+++ b/late-ssh/src/app/hub/shop/state.rs
@@ -155,33 +155,6 @@ impl ShopState {
         &self.snapshot.active_room_effects
     }
 
-    pub fn active_bumped_join_room_ids(&self) -> Vec<Uuid> {
-        let mut rooms = self
-            .snapshot
-            .active_room_effects
-            .iter()
-            .filter_map(|(room_id, effects)| {
-                let first = effects.first()?;
-                effects
-                    .iter()
-                    .any(|effect| effect.effect_kind == "room_bump")
-                    .then_some(first)
-                    .filter(|effect| {
-                        effect.room_kind == "topic"
-                            && effect.room_visibility == "public"
-                            && !effect.room_permanent
-                            && effect
-                                .room_slug
-                                .as_deref()
-                                .is_some_and(|slug| !slug.is_empty())
-                    })
-                    .map(|effect| (effect.room_slug.clone().unwrap_or_default(), *room_id))
-            })
-            .collect::<Vec<_>>();
-        rooms.sort_by(|(a, _), (b, _)| a.cmp(b));
-        rooms.into_iter().map(|(_, room_id)| room_id).collect()
-    }
-
     pub fn bot_username_color_active(&self) -> bool {
         self.snapshot.bot_username_color_active
             && self

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -2473,7 +2473,6 @@ fn chat_room_list_view<'a>(
         active_room_effects: app.shop_state.active_room_effects(),
         collapsed_sections: &app.chat.collapsed_sections,
         selected_room_id: app.chat.selected_room_id,
-        selected_bumped_join_room_id: app.chat.selected_bumped_join_room_id(),
         room_jump_active: app.chat.room_jump_active,
         room_section_prefix_armed: app.room_section_prefix_armed,
         current_user_id: app.user_id,

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -155,6 +155,8 @@ struct DrawContext<'a> {
     rebels_enabled: bool,
     nethack_enabled: bool,
     lateania_state: Option<&'a crate::app::door::lateania::state::State>,
+    /// Players currently in the Lateania world (for the landing/hub card).
+    lateania_online: usize,
     rebels_state: Option<&'a mut crate::app::door::rebels::state::State>,
     nethack_state: Option<&'a mut crate::app::door::nethack::state::State>,
     /// Detected terminal-image protocol for the current session.
@@ -523,6 +525,7 @@ impl App {
                 chat_hit_slot: Some(&self.chat.last_chat_hit_layout),
             },
             activity_scroll: self.dashboard_activity_scroll,
+            marquee_tick: self.marquee_tick,
             activity_rect_slot: Some(&self.last_dashboard_activity_rect),
         };
         let news_view = chat::news::ui::ArticleListView {
@@ -587,8 +590,7 @@ impl App {
             .chat
             .selected_room_id
             .is_some_and(|room_id| self.chat.selected_message_has_inline_image_in_room(room_id));
-        let selected_room_active_poll = if self.chat.selected_bumped_join_room_id().is_none()
-            && !self.chat.feeds_selected
+        let selected_room_active_poll = if !self.chat.feeds_selected
             && !self.chat.news_selected
             && !self.chat.discover_selected
             && !self.chat.notifications_selected
@@ -629,7 +631,6 @@ impl App {
             active_poll: selected_room_active_poll,
             collapsed_sections: &self.chat.collapsed_sections,
             selected_room_id: self.chat.selected_room_id,
-            selected_bumped_join_room_id: self.chat.selected_bumped_join_room_id(),
             room_jump_active: self.chat.room_jump_active,
             room_section_prefix_armed: self.room_section_prefix_armed,
             selected_message_id: self.chat.selected_message_id,
@@ -776,7 +777,7 @@ impl App {
             || self.booth_modal_state.is_open();
         let pre_wipe = self
             .terminal_image_render_state
-            .pre_frame_sixel_wipe_bytes(image_modal_msg_id, overlay_blocks_sixel);
+            .pre_frame_sixel_wipe_bytes(image_modal_msg_id, overlay_blocks_sixel, screen as u16);
         if !pre_wipe.is_empty() {
             use std::io::Write;
             let _ = self.shared.write_all(&pre_wipe);
@@ -821,6 +822,7 @@ impl App {
                         rebels_enabled: self.rebels_enabled,
                         nethack_enabled: self.nethack_enabled,
                         lateania_state: self.lateania_state.as_ref(),
+                        lateania_online: self.lateania_service.player_count(),
                         rebels_state: rebels_state_taken.as_mut(),
                         nethack_state: nethack_state_taken.as_mut(),
                         terminal_image_protocol: self.terminal_image_protocol,
@@ -1134,6 +1136,7 @@ impl App {
                         rebels_enabled: ctx.rebels_enabled,
                         nethack_enabled: ctx.nethack_enabled,
                         terminal_image_protocol: ctx.terminal_image_protocol,
+                        lateania_online: ctx.lateania_online,
                     },
                     terminal_images,
                 );
@@ -1147,6 +1150,7 @@ impl App {
                         state: ctx.lateania_state,
                         usernames: ctx.rooms_usernames,
                         terminal_image_protocol: ctx.terminal_image_protocol,
+                        online: ctx.lateania_online,
                     },
                     terminal_images,
                 );

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -775,9 +775,11 @@ impl App {
             || self.icon_picker_open
             || self.room_search_modal_state.is_open()
             || self.booth_modal_state.is_open();
-        let pre_wipe = self
-            .terminal_image_render_state
-            .pre_frame_sixel_wipe_bytes(image_modal_msg_id, overlay_blocks_sixel, screen as u16);
+        let pre_wipe = self.terminal_image_render_state.pre_frame_sixel_wipe_bytes(
+            image_modal_msg_id,
+            overlay_blocks_sixel,
+            screen as u16,
+        );
         if !pre_wipe.is_empty() {
             use std::io::Write;
             let _ = self.shared.write_all(&pre_wipe);

--- a/late-ssh/src/app/room_search_modal/state.rs
+++ b/late-ssh/src/app/room_search_modal/state.rs
@@ -94,7 +94,6 @@ pub(crate) fn search_items(chat: &ChatState, current_user_id: Uuid) -> Vec<RoomS
     let mut items = Vec::new();
     for slot in chat.visual_order() {
         match slot {
-            RoomSlot::BumpedJoin(_) => continue,
             RoomSlot::Room(room_id) => {
                 let Some((room, _)) = chat.rooms.iter().find(|(room, _)| room.id == room_id) else {
                     continue;
@@ -180,7 +179,7 @@ fn synthetic_item(slot: RoomSlot, chat: &ChatState) -> RoomSearchItem {
         RoomSlot::Discover => ("browse rooms", "custom rooms", 0),
         RoomSlot::Showcase => ("showcases", "projects", chat.showcase.unread_count()),
         RoomSlot::Work => ("work", "profiles", chat.work.unread_count()),
-        RoomSlot::Room(_) | RoomSlot::BumpedJoin(_) => {
+        RoomSlot::Room(_) => {
             unreachable!("real rooms are built from ChatRoom")
         }
     };

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -312,6 +312,9 @@ pub struct App {
     pub(crate) show_settings: bool,
     pub(crate) show_splash: bool,
     pub(crate) splash_ticks: usize,
+    /// Free-running frame counter (advances every world tick) used to animate
+    /// the bumped-room marquee in the room rail.
+    pub(crate) marquee_tick: usize,
     pub(crate) splash_hint: String,
     pub(crate) show_quit_confirm: bool,
     pub(crate) show_help: bool,
@@ -930,6 +933,7 @@ impl App {
             show_settings: true,
             show_splash: true,
             splash_ticks: 0,
+            marquee_tick: 0,
             splash_hint,
             show_quit_confirm: false,
             show_help: false,
@@ -1125,8 +1129,6 @@ impl App {
         }
         app.chat
             .set_favorite_room_ids(app.profile_state.profile().favorite_room_ids.clone());
-        app.chat
-            .set_active_bumped_join_room_ids(app.shop_state.active_bumped_join_room_ids());
         app.chat.sync_selection();
         app.sync_visible_chat_room();
         Ok(app)

--- a/late-ssh/src/app/tick.rs
+++ b/late-ssh/src/app/tick.rs
@@ -15,6 +15,8 @@ impl App {
     pub fn tick(&mut self) {
         crate::app::input::flush_pending_escape(self);
 
+        self.marquee_tick = self.marquee_tick.saturating_add(1);
+
         if self.show_splash {
             self.splash_ticks = self.splash_ticks.saturating_add(1);
             if self.splash_ticks > 90 {
@@ -613,13 +615,6 @@ impl App {
             let equipped_badge = self.shop_state.equipped_chat_badge();
             self.chat
                 .set_chat_badge(self.user_id, equipped_badge.as_deref());
-            let active_bumped_join_room_ids = self.shop_state.active_bumped_join_room_ids();
-            if self
-                .chat
-                .set_active_bumped_join_room_ids(active_bumped_join_room_ids)
-            {
-                self.sync_visible_chat_room();
-            }
             self.aquarium_state
                 .set_active_creatures(&self.shop_state.active_aquarium_fish());
             self.aquarium_state


### PR DESCRIPTION
## Summary
- Updates several terminal UI surfaces so status information is clearer and stale Sixel image pixels are cleaned up when changing screens.
- Adjusts Chat room-bump rendering and adds Lateania landing/runtime polish, including the Ranger wounded-target damage bonus.

## Changes
- Room Bump effects now render as read-only bumped room slugs at the top of the Home rail instead of selectable/joinable synthetic room slots.
- Dashboard activity rows keep one event per row and horizontally marquee long actions instead of wrapping into extra rows.
- Lateania landing copy now reflects current game scope, shows current online adventurer count, and updates room/class/housing facts.
- Ranger auto-attacks now apply Hunter's Instinct bonus damage against wounded foes.
- Sixel wipe intent now includes the current screen so non-modal images are cleared when navigating away.

## Behavior notes
- Bumped room rows no longer receive jump keys, selection state, or Enter handling.
- Sixel cleanup is intentionally triggered by screen changes in addition to image modal and overlay transitions.

## Feature flags
- None

## Screenshots / Video
- Not included in this draft; attach before review.

## Testing
- Automated: Not run per repo agent policy. The diff updates inline unit coverage for Sixel pre-frame wipe behavior, including screen-change cleanup.
- Manual: Not run.