### PR TITLE
Make ignore cover DMs and bot replies, hide ignored DMs from the room rail

### DIFF
--- a/late-core/migrations/093_add_chat_message_reply_to_user.sql
+++ b/late-core/migrations/093_add_chat_message_reply_to_user.sql
@@ -1,0 +1,6 @@
+ALTER TABLE chat_messages
+ADD COLUMN reply_to_user_id UUID REFERENCES users(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_chat_messages_reply_to_user
+ON chat_messages (reply_to_user_id)
+WHERE reply_to_user_id IS NOT NULL;

--- a/late-core/src/models/chat_message.rs
+++ b/late-core/src/models/chat_message.rs
@@ -11,7 +11,8 @@ crate::model! {
     struct ChatMessage {
         @generated
         pub pinned: bool,
-        pub reply_to_message_id: Option<Uuid>;
+        pub reply_to_message_id: Option<Uuid>,
+        pub reply_to_user_id: Option<Uuid>;
         @data
         pub room_id: Uuid,
         pub user_id: Uuid,
@@ -168,16 +169,29 @@ impl ChatMessage {
         params: ChatMessageParams,
         reply_to_message_id: Option<Uuid>,
     ) -> Result<Self> {
+        Self::create_with_reply_targets(client, params, reply_to_message_id, None).await
+    }
+
+    /// Create a message, optionally recording both the replied-to message and
+    /// the user this message is a response to. `reply_to_user_id` is used to
+    /// filter bot replies for viewers who ignore the triggering user.
+    pub async fn create_with_reply_targets(
+        client: &impl GenericClient,
+        params: ChatMessageParams,
+        reply_to_message_id: Option<Uuid>,
+        reply_to_user_id: Option<Uuid>,
+    ) -> Result<Self> {
         let row = client
             .query_one(
-                "INSERT INTO chat_messages (room_id, user_id, body, reply_to_message_id)
-                 VALUES ($1, $2, $3, $4)
+                "INSERT INTO chat_messages (room_id, user_id, body, reply_to_message_id, reply_to_user_id)
+                 VALUES ($1, $2, $3, $4, $5)
                  RETURNING *",
                 &[
                     &params.room_id,
                     &params.user_id,
                     &params.body,
                     &reply_to_message_id,
+                    &reply_to_user_id,
                 ],
             )
             .await?;

--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -408,13 +408,11 @@ impl GhostService {
         let delay = rng.next_between_inclusive(1, 4) as u64;
         tokio::time::sleep(Duration::from_secs(delay)).await;
 
-        self.chat_service.send_message_task(
+        self.chat_service.send_bot_reply_task(
             bot.id,
             trigger_message.room_id,
-            None,
             body,
-            Uuid::now_v7(),
-            false,
+            Some(trigger_message.user_id),
         );
 
         Ok(())
@@ -538,13 +536,11 @@ impl GhostService {
         let delay = rng.next_between_inclusive(2, 8) as u64;
         tokio::time::sleep(Duration::from_secs(delay)).await;
 
-        self.chat_service.send_message_task(
+        self.chat_service.send_bot_reply_task(
             gb.id,
             trigger_message.room_id,
-            None,
             safe_reply,
-            Uuid::now_v7(),
-            false,
+            Some(trigger_message.user_id),
         );
 
         Ok(())
@@ -697,13 +693,11 @@ impl GhostService {
         let delay = rng.next_between_inclusive(2, 6) as u64;
         tokio::time::sleep(Duration::from_secs(delay)).await;
 
-        self.chat_service.send_message_task(
+        self.chat_service.send_bot_reply_task(
             dealer.id,
             chat_room_id,
-            None,
             safe_reply,
-            Uuid::now_v7(),
-            false,
+            Some(trigger.user_id),
         );
 
         Ok(())
@@ -820,13 +814,11 @@ impl GhostService {
         let delay = rng.next_between_inclusive(1, 5) as u64;
         tokio::time::sleep(Duration::from_secs(delay)).await;
 
-        self.chat_service.send_message_task(
+        self.chat_service.send_bot_reply_task(
             dealer.id,
             trigger_message.room_id,
-            None,
             safe_reply,
-            Uuid::now_v7(),
-            false,
+            Some(trigger_message.user_id),
         );
 
         Ok(())

--- a/late-ssh/src/app/chat/CONTEXT.md
+++ b/late-ssh/src/app/chat/CONTEXT.md
@@ -140,6 +140,7 @@ Messages:
 - Recent/tail queries return newest-first: `ORDER BY created DESC, id DESC`.
 - Delta queries return ascending after `(created, id)` and are inserted into newest-first local state.
 - `reply_to_message_id` is nullable and uses `ON DELETE SET NULL`.
+- `reply_to_user_id` is nullable and uses `ON DELETE SET NULL`. It records the user a bot/automated reply is responding to, used to filter such replies for viewers who ignore that user. Set only by bot sends.
 - `pinned` is a global message-level flag with a partial pinned index.
 
 Reactions:
@@ -377,9 +378,9 @@ Ignores:
 - `users.settings.ignored_user_ids` stores UUIDs, not usernames.
 - `users.settings.friend_user_ids` stores private one-way friend marks as UUIDs.
 - `/ignore @user` and `/unignore @user` resolve usernames at command time.
-- Ignore filtering applies to non-DM rooms only.
-- DMs intentionally bypass ignored-user filtering; leaving the DM room is the dismissal path.
-- `IgnoreListUpdated` refilters local non-DM messages in place with no DB refetch, then refreshes the Mentions list/unread count.
+- A message is hidden if its author is ignored, OR if `chat_messages.reply_to_user_id` is an ignored user. The latter hides bot/automated replies directed at an ignored user so they cannot be heard by proxy through `@bot`/`@graybeard`/`@dealer`. Only bots set `reply_to_user_id` (via `ChatService::send_bot_reply_task`); human replies use `reply_to_message_id`. The shared filter helper is `state::message_is_ignored_in`.
+- Ignore filtering applies to DMs too. An ignored peer's DM messages are filtered, and the DM room is hidden from the room rail/navigation while the peer is ignored (`visual_order_for_rooms` skips DMs whose `dm_peer_id` is ignored), so a new DM from the ignored user can't resurface the room or its unread badge. Unignoring restores the DM on the next render/snapshot.
+- `IgnoreListUpdated` refilters local messages in place (all rooms, including DMs and `reply_to_user_id` matches) with no DB refetch, then refreshes the Mentions list/unread count.
 - `unignore` does not retroactively restore already-filtered local messages until a future tail/snapshot naturally reloads them.
 
 ---
@@ -663,7 +664,7 @@ Test gaps:
 - `(created, id)` is the catch-up cursor.
 - Any operation exposing room contents must check membership first.
 - DM/private message bodies must not leak to non-members through broadcast handling.
-- Ignore filtering is non-DM only.
+- Ignore filtering covers all rooms including DMs, and also hides bot replies whose `reply_to_user_id` is ignored. DMs with an ignored peer are hidden from the room rail entirely.
 - `#announcements` admin-only currently depends on the provided `room_slug`; stale/missing slug is a fragile path.
 - Login `#announcements` modal marks `chat_room_members.last_read_at` only when dismissed; do not add a separate announcement-read table unless the room model itself changes.
 - Reaction and pin tasks are async; UI should not assume optimistic success.

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -1534,6 +1534,7 @@ impl ChatState {
             feeds_available: self.feeds.has_feeds(),
             favorite_room_ids: &self.favorite_room_ids,
             collapsed_sections: &self.collapsed_sections,
+            ignored_user_ids: &self.ignored_user_ids,
         })
     }
 
@@ -3120,6 +3121,10 @@ impl ChatState {
         &self.friend_user_ids
     }
 
+    pub fn ignored_user_ids(&self) -> &HashSet<Uuid> {
+        &self.ignored_user_ids
+    }
+
     pub fn active_friend_names(&self) -> Vec<String> {
         let Some(active_users) = &self.active_users else {
             return Vec::new();
@@ -3254,12 +3259,9 @@ impl ChatState {
                     }
                     // Desktop notification queueing. target_user_ids is Some for
                     // DM/private rooms, None for public rooms. Don't notify on
-                    // messages we authored ourselves.
-                    let in_dm_room = self
-                        .rooms
-                        .iter()
-                        .any(|(room, _)| room.id == message.room_id && room.kind == "dm");
-                    let ignored_author = !in_dm_room && self.message_is_ignored(&message);
+                    // messages we authored ourselves, or on ignored users
+                    // (including DMs, so ignore silences DMs too).
+                    let ignored_author = self.message_is_ignored(&message);
                     if message.user_id != self.user_id && !ignored_author {
                         let nickname = self
                             .usernames
@@ -3737,17 +3739,12 @@ impl ChatState {
     fn push_message(&mut self, message: ChatMessage) {
         let room_id = message.room_id;
         let created = message.created;
-        let Some(in_dm_room) = self
-            .rooms
-            .iter()
-            .find(|(room, _)| room.id == room_id)
-            .map(|(room, _)| room.kind == "dm")
-        else {
+        if !self.rooms.iter().any(|(room, _)| room.id == room_id) {
             return;
-        };
+        }
 
         let is_viewing_room = Some(room_id) == self.visible_room_id;
-        if !in_dm_room && self.message_is_ignored(&message) {
+        if self.message_is_ignored(&message) {
             if is_viewing_room {
                 self.mark_room_read(room_id);
             }
@@ -3809,7 +3806,7 @@ impl ChatState {
     }
 
     fn merge_room_tail(&mut self, room_id: Uuid, messages: Vec<ChatMessage>) {
-        let Some((room, stored)) = self.rooms.iter_mut().find(|(room, _)| room.id == room_id)
+        let Some((_, stored)) = self.rooms.iter_mut().find(|(room, _)| room.id == room_id)
         else {
             return;
         };
@@ -3824,15 +3821,11 @@ impl ChatState {
         merged.sort_by(|a, b| b.created.cmp(&a.created).then_with(|| b.id.cmp(&a.id)));
         merged.truncate(500);
 
-        *stored = if room.kind == "dm" {
-            merged
-        } else {
-            let ignored = &self.ignored_user_ids;
-            merged
-                .into_iter()
-                .filter(|message| !ignored.contains(&message.user_id))
-                .collect()
-        };
+        let ignored = &self.ignored_user_ids;
+        *stored = merged
+            .into_iter()
+            .filter(|message| !message_is_ignored_in(ignored, message))
+            .collect();
     }
 
     fn replace_message(&mut self, message: ChatMessage) {
@@ -3867,12 +3860,7 @@ impl ChatState {
                 } else {
                     messages
                 };
-                // DMs: don't filter. Users leave the DM room if they want it gone.
-                let messages = if room.kind == "dm" {
-                    messages
-                } else {
-                    self.filter_messages(messages)
-                };
+                let messages = self.filter_messages(messages);
                 (room, messages)
             })
             .collect()
@@ -3946,21 +3934,28 @@ impl ChatState {
     }
 
     fn message_is_ignored(&self, message: &ChatMessage) -> bool {
-        self.ignored_user_ids.contains(&message.user_id)
+        message_is_ignored_in(&self.ignored_user_ids, message)
     }
 
-    /// Strip already-stored messages from any newly-ignored author.
-    /// DM rooms are exempt -leaving the DM room is the way to dismiss them.
+    /// Strip already-stored messages from any newly-ignored author, including
+    /// DMs and bot replies directed at the newly-ignored user.
     fn refilter_local_messages(&mut self) {
         let ignored = &self.ignored_user_ids;
-        for (room, messages) in &mut self.rooms {
-            if room.kind == "dm" {
-                continue;
-            }
-            messages.retain(|m| !ignored.contains(&m.user_id));
+        for (_, messages) in &mut self.rooms {
+            messages.retain(|m| !message_is_ignored_in(ignored, m));
         }
         self.sync_selection();
     }
+}
+
+/// A message is ignored if its author is ignored, or if it is a bot/automated
+/// reply directed at an ignored user (so an ignored user can't be heard by
+/// proxy through a bot).
+fn message_is_ignored_in(ignored: &HashSet<Uuid>, message: &ChatMessage) -> bool {
+    ignored.contains(&message.user_id)
+        || message
+            .reply_to_user_id
+            .is_some_and(|target| ignored.contains(&target))
 }
 
 fn inline_image_request_candidates(
@@ -4050,6 +4045,7 @@ pub(crate) struct RoomVisualOrderInput<'a, U: UsernameResolver + ?Sized> {
     pub feeds_available: bool,
     pub favorite_room_ids: &'a [Uuid],
     pub collapsed_sections: &'a HashSet<RoomSection>,
+    pub ignored_user_ids: &'a HashSet<Uuid>,
 }
 
 pub(crate) fn visual_order_for_rooms<U: UsernameResolver + ?Sized>(
@@ -4064,6 +4060,7 @@ pub(crate) fn visual_order_for_rooms<U: UsernameResolver + ?Sized>(
         feeds_available,
         favorite_room_ids,
         collapsed_sections,
+        ignored_user_ids,
     } = input;
 
     let mut order = Vec::new();
@@ -4120,8 +4117,16 @@ pub(crate) fn visual_order_for_rooms<U: UsernameResolver + ?Sized>(
     }
 
     // DMs: unread rooms first, then newest message, then display name.
+    // Hide DMs whose other participant is ignored so an ignored user can't
+    // resurface the DM (and its unread badge) by sending again.
     let dms_collapsed = collapsed_sections.contains(&RoomSection::Dms);
-    let mut dms: Vec<_> = rooms.iter().filter(|(r, _)| r.kind == "dm").collect();
+    let mut dms: Vec<_> = rooms
+        .iter()
+        .filter(|(r, _)| r.kind == "dm")
+        .filter(|(r, _)| {
+            dm_peer_id(r, user_id).is_none_or(|peer| !ignored_user_ids.contains(&peer))
+        })
+        .collect();
     dms.sort_by(|(a_room, _), (b_room, _)| {
         compare_dm_rooms_for_nav(
             a_room,
@@ -4169,18 +4174,22 @@ pub(crate) fn room_activity_at(
     room_last_message_at.get(&room_id).cloned().flatten()
 }
 
+/// The other participant in a DM room, from `user_id`'s perspective.
+fn dm_peer_id(room: &ChatRoom, user_id: Uuid) -> Option<Uuid> {
+    if room.dm_user_a == Some(user_id) {
+        room.dm_user_b
+    } else {
+        room.dm_user_a
+    }
+}
+
 /// Sort key for DMs: resolves the other participant's username.
 fn dm_sort_key(
     room: &ChatRoom,
     user_id: Uuid,
     usernames: &(impl UsernameResolver + ?Sized),
 ) -> String {
-    let other_id = if room.dm_user_a == Some(user_id) {
-        room.dm_user_b
-    } else {
-        room.dm_user_a
-    };
-    other_id
+    dm_peer_id(room, user_id)
         .and_then(|id| usernames.username(&id))
         .map(|name| format!("@{name}"))
         .unwrap_or_else(|| "DM".to_string())
@@ -5677,6 +5686,7 @@ mod tests {
                 feeds_available: true,
                 favorite_room_ids: &[],
                 collapsed_sections: &HashSet::new(),
+                ignored_user_ids: &HashSet::new(),
             }),
             vec![
                 RoomSlot::Room(lounge),
@@ -5740,6 +5750,7 @@ mod tests {
                 feeds_available: false,
                 favorite_room_ids: &[],
                 collapsed_sections: collapsed,
+                ignored_user_ids: &HashSet::new(),
             })
         };
 
@@ -5822,6 +5833,7 @@ mod tests {
             feeds_available: false,
             favorite_room_ids: &[],
             collapsed_sections: &HashSet::new(),
+            ignored_user_ids: &HashSet::new(),
         });
         let dm_order: Vec<_> = order
             .into_iter()
@@ -5832,6 +5844,68 @@ mod tests {
             .collect();
 
         assert_eq!(dm_order, vec![dm_bob.id, dm_alice.id]);
+    }
+
+    #[test]
+    fn visual_order_hides_dm_with_ignored_peer() {
+        let me = Uuid::from_u128(1);
+        let alice = Uuid::from_u128(2);
+        let bob = Uuid::from_u128(3);
+        let dm_alice = make_dm(me, alice);
+        let dm_bob = make_dm(me, bob);
+
+        let mut usernames = HashMap::new();
+        usernames.insert(alice, "alice".to_string());
+        usernames.insert(bob, "bob".to_string());
+
+        let rooms = vec![(dm_alice.clone(), Vec::new()), (dm_bob.clone(), Vec::new())];
+        let ignored = HashSet::from([bob]);
+
+        let order = visual_order_for_rooms(RoomVisualOrderInput {
+            rooms: &rooms,
+            user_id: me,
+            usernames: &usernames,
+            unread_counts: &HashMap::new(),
+            room_last_message_at: &HashMap::new(),
+            feeds_available: false,
+            favorite_room_ids: &[],
+            collapsed_sections: &HashSet::new(),
+            ignored_user_ids: &ignored,
+        });
+
+        assert!(order.contains(&RoomSlot::Room(dm_alice.id)));
+        // The ignored peer's DM must not resurface in the rail.
+        assert!(!order.contains(&RoomSlot::Room(dm_bob.id)));
+    }
+
+    #[test]
+    fn message_is_ignored_in_covers_author_and_reply_target() {
+        let ignored_user = Uuid::from_u128(2);
+        let other = Uuid::from_u128(3);
+        let bot = Uuid::from_u128(4);
+        let ignored = HashSet::from([ignored_user]);
+
+        // Author ignored.
+        let mut by_author = make_msg(Uuid::from_u128(10));
+        by_author.user_id = ignored_user;
+        assert!(message_is_ignored_in(&ignored, &by_author));
+
+        // Bot reply directed at the ignored user.
+        let mut bot_reply = make_msg(Uuid::from_u128(11));
+        bot_reply.user_id = bot;
+        bot_reply.reply_to_user_id = Some(ignored_user);
+        assert!(message_is_ignored_in(&ignored, &bot_reply));
+
+        // Bot reply directed at someone else is kept.
+        let mut other_reply = make_msg(Uuid::from_u128(12));
+        other_reply.user_id = bot;
+        other_reply.reply_to_user_id = Some(other);
+        assert!(!message_is_ignored_in(&ignored, &other_reply));
+
+        // Ordinary message from a non-ignored author is kept.
+        let mut normal = make_msg(Uuid::from_u128(13));
+        normal.user_id = other;
+        assert!(!message_is_ignored_in(&ignored, &normal));
     }
 
     #[test]
@@ -6331,6 +6405,7 @@ mod tests {
             updated: chrono::Utc::now(),
             pinned: false,
             reply_to_message_id: None,
+            reply_to_user_id: None,
             room_id: Uuid::from_u128(999),
             user_id: Uuid::from_u128(999),
             body: String::new(),

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -4072,10 +4072,11 @@ pub(crate) fn visual_order_for_rooms<U: UsernameResolver + ?Sized>(
     // then only appends to `order` when the section is expanded.
     let favorites_collapsed = collapsed_sections.contains(&RoomSection::Favorites);
     for favorite_id in favorite_room_ids {
-        if rooms
-            .iter()
-            .any(|(room, _)| room.id == *favorite_id && is_chat_list_room(room))
-            && pushed_rooms.insert(*favorite_id)
+        if rooms.iter().any(|(room, _)| {
+            room.id == *favorite_id
+                && is_chat_list_room(room)
+                && !dm_peer_is_ignored(room, user_id, ignored_user_ids)
+        }) && pushed_rooms.insert(*favorite_id)
             && !favorites_collapsed
         {
             order.push(RoomSlot::Room(*favorite_id));
@@ -4123,9 +4124,7 @@ pub(crate) fn visual_order_for_rooms<U: UsernameResolver + ?Sized>(
     let mut dms: Vec<_> = rooms
         .iter()
         .filter(|(r, _)| r.kind == "dm")
-        .filter(|(r, _)| {
-            dm_peer_id(r, user_id).is_none_or(|peer| !ignored_user_ids.contains(&peer))
-        })
+        .filter(|(r, _)| !dm_peer_is_ignored(r, user_id, ignored_user_ids))
         .collect();
     dms.sort_by(|(a_room, _), (b_room, _)| {
         compare_dm_rooms_for_nav(
@@ -4181,6 +4180,13 @@ fn dm_peer_id(room: &ChatRoom, user_id: Uuid) -> Option<Uuid> {
     } else {
         room.dm_user_a
     }
+}
+
+/// Whether `room` is a DM whose other participant is ignored. Such DMs are
+/// hidden from every room-list section (favorites included) so an ignored peer
+/// can't resurface the DM or its unread state by sending again.
+fn dm_peer_is_ignored(room: &ChatRoom, user_id: Uuid, ignored: &HashSet<Uuid>) -> bool {
+    room.kind == "dm" && dm_peer_id(room, user_id).is_some_and(|peer| ignored.contains(&peer))
 }
 
 /// Sort key for DMs: resolves the other participant's username.
@@ -5876,6 +5882,21 @@ mod tests {
         assert!(order.contains(&RoomSlot::Room(dm_alice.id)));
         // The ignored peer's DM must not resurface in the rail.
         assert!(!order.contains(&RoomSlot::Room(dm_bob.id)));
+
+        // Even when favorited, an ignored peer's DM stays hidden from every
+        // section so it can't be jump-addressable via the favorites path.
+        let favorited = visual_order_for_rooms(RoomVisualOrderInput {
+            rooms: &rooms,
+            user_id: me,
+            usernames: &usernames,
+            unread_counts: &HashMap::new(),
+            room_last_message_at: &HashMap::new(),
+            feeds_available: false,
+            favorite_room_ids: &[dm_bob.id],
+            collapsed_sections: &HashSet::new(),
+            ignored_user_ids: &ignored,
+        });
+        assert!(!favorited.contains(&RoomSlot::Room(dm_bob.id)));
     }
 
     #[test]

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -1508,6 +1508,38 @@ impl ChatService {
         });
     }
 
+    /// Send a bot/automated reply that is a response to `reply_to_user_id`.
+    /// Recording the triggering user lets each viewer hide the reply when they
+    /// ignore that user, so ignored users cannot use a bot to be heard.
+    pub fn send_bot_reply_task(
+        &self,
+        user_id: Uuid,
+        room_id: Uuid,
+        body: String,
+        reply_to_user_id: Option<Uuid>,
+    ) {
+        let service = self.clone();
+        tokio::spawn(
+            async move {
+                if let Err(e) = service
+                    .send_message(user_id, room_id, None, body, None, reply_to_user_id, false)
+                    .await
+                {
+                    late_core::error_span!(
+                        "chat_bot_send_failed",
+                        error = ?e,
+                        "failed to send bot reply"
+                    );
+                }
+            }
+            .instrument(info_span!(
+                "chat.send_bot_reply_task",
+                user_id = %user_id,
+                room_id = %room_id,
+            )),
+        );
+    }
+
     pub fn send_message_with_reply_task(&self, task: SendMessageTask) {
         let SendMessageTask {
             user_id,
@@ -1528,6 +1560,7 @@ impl ChatService {
                         room_slug,
                         body,
                         reply_to_message_id,
+                        None,
                         is_admin,
                     )
                     .await
@@ -1623,6 +1656,7 @@ impl ChatService {
             Some("lounge".to_string()),
             body,
             None,
+            None,
             false,
         )
         .await
@@ -1636,6 +1670,7 @@ impl ChatService {
         room_slug: Option<String>,
         body: String,
         reply_to_message_id: Option<Uuid>,
+        reply_to_user_id: Option<Uuid>,
         is_admin: bool,
     ) -> Result<()> {
         let body = body.trim_start_matches('\n').trim_end();
@@ -1682,7 +1717,13 @@ impl ChatService {
             user_id,
             body: body.to_string(),
         };
-        let chat = ChatMessage::create_with_reply_to(&client, message, reply_to_message_id).await?;
+        let chat = ChatMessage::create_with_reply_targets(
+            &client,
+            message,
+            reply_to_message_id,
+            reply_to_user_id,
+        )
+        .await?;
         ChatRoom::touch_updated(&client, room_id).await?;
         ChatRoomMember::mark_read_now(&client, room_id, user_id).await?;
         let target_user_ids = ChatRoom::get_target_user_ids(&client, room_id).await?;

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -2224,6 +2224,7 @@ pub struct ChatRenderInput<'a> {
     pub composing: bool,
     pub current_user_id: Uuid,
     pub afk_user_ids: &'a HashSet<Uuid>,
+    pub ignored_user_ids: &'a HashSet<Uuid>,
     pub show_flag_fallback: bool,
     pub cursor_visible: bool,
     pub mention_matches: &'a [MentionMatch],
@@ -2296,6 +2297,7 @@ pub(crate) struct ChatRoomListView<'a> {
     pub room_jump_active: bool,
     pub room_section_prefix_armed: bool,
     pub current_user_id: Uuid,
+    pub ignored_user_ids: &'a HashSet<Uuid>,
     pub feeds_available: bool,
     pub feeds_selected: bool,
     pub feeds_unread_count: i64,
@@ -2617,6 +2619,7 @@ fn room_list_view_from_render_input<'a>(view: &'a ChatRenderInput<'a>) -> ChatRo
         room_jump_active: view.room_jump_active,
         room_section_prefix_armed: view.room_section_prefix_armed,
         current_user_id: view.current_user_id,
+        ignored_user_ids: view.ignored_user_ids,
         feeds_available: view.feeds_view.has_feeds,
         feeds_selected: view.feeds_selected,
         feeds_unread_count: view.feeds_unread_count,
@@ -3201,6 +3204,7 @@ fn build_cozy_room_rail_rows(view: &ChatRoomListView<'_>, width: u16) -> RoomLis
         feeds_available: view.feeds_available,
         favorite_room_ids: view.favorite_room_ids,
         collapsed_sections: view.collapsed_sections,
+        ignored_user_ids: view.ignored_user_ids,
     });
     // Bumped rooms are advertised as read-only text at the top of the rail;
     // they are not part of `order`, so they take no jump key and never
@@ -4024,6 +4028,7 @@ mod tests {
             updated: Utc::now(),
             pinned: false,
             reply_to_message_id: None,
+            reply_to_user_id: None,
             room_id,
             user_id,
             body: "hello".to_string(),
@@ -4075,6 +4080,7 @@ mod tests {
             updated: Utc::now(),
             pinned: false,
             reply_to_message_id: None,
+            reply_to_user_id: None,
             room_id,
             user_id: author_id,
             body: "hello".to_string(),
@@ -4144,6 +4150,7 @@ mod tests {
             updated: created,
             pinned: false,
             reply_to_message_id: None,
+            reply_to_user_id: None,
             room_id,
             user_id,
             body: "hello".to_string(),
@@ -4206,6 +4213,7 @@ mod tests {
         static INLINE_IMAGES: OnceLock<HashMap<Uuid, InlineImagePreview>> = OnceLock::new();
         static FRIEND_USER_IDS: OnceLock<HashSet<Uuid>> = OnceLock::new();
         static AFK_USER_IDS: OnceLock<HashSet<Uuid>> = OnceLock::new();
+        static IGNORED_USER_IDS: OnceLock<HashSet<Uuid>> = OnceLock::new();
         static VOICE_SNAPSHOT: OnceLock<crate::app::voice::svc::VoiceSnapshot> = OnceLock::new();
         static VOICE_CHANNELS: OnceLock<
             HashMap<Uuid, late_core::models::voice_channel::VoiceChannel>,
@@ -4270,6 +4278,7 @@ mod tests {
             composing: false,
             current_user_id: Uuid::nil(),
             afk_user_ids: AFK_USER_IDS.get_or_init(HashSet::new),
+            ignored_user_ids: IGNORED_USER_IDS.get_or_init(HashSet::new),
             show_flag_fallback: false,
             cursor_visible: false,
             mention_matches: &[],

--- a/late-ssh/src/app/dashboard/ui.rs
+++ b/late-ssh/src/app/dashboard/ui.rs
@@ -794,6 +794,7 @@ mod tests {
             updated: now,
             pinned: true,
             reply_to_message_id: None,
+            reply_to_user_id: None,
             room_id: Uuid::nil(),
             user_id: Uuid::nil(),
             body: body.to_string(),

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -2476,6 +2476,7 @@ fn chat_room_list_view<'a>(
         room_jump_active: app.chat.room_jump_active,
         room_section_prefix_armed: app.room_section_prefix_armed,
         current_user_id: app.user_id,
+        ignored_user_ids: app.chat.ignored_user_ids(),
         feeds_available: app.chat.feeds.has_feeds(),
         feeds_selected: app.chat.feeds_selected,
         feeds_unread_count: app.chat.feeds.unread_count(),

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -621,6 +621,7 @@ impl App {
             countries: chat_countries,
             friend_user_ids: self.chat.friend_user_ids(),
             afk_user_ids: self.afk_user_ids.as_ref(),
+            ignored_user_ids: self.chat.ignored_user_ids(),
             message_reactions,
             inline_images: &self.chat.inline_image_cache,
             room_unread_markers: &self.chat.room_unread_markers,


### PR DESCRIPTION
## Summary
- Ignoring a user used to silence them only in public/topic rooms. DMs bypassed the ignore list entirely, and a user could still be heard "by proxy" through a bot: `@bot`/`@graybeard`/`@dealer` replies to an ignored user stayed visible. This branch closes both gaps so ignore behaves the way users expect everywhere.

## Changes
- Ignore filtering now applies to **all rooms, including DMs**. An ignored peer's DM messages are filtered, and the DM room is hidden from the room rail/navigation while the peer is ignored, so a new DM can't resurface the room or its unread badge. Unignoring restores it on the next render/snapshot.
- Bot/automated replies directed at an ignored user are now hidden. A new `chat_messages.reply_to_user_id` column records which user a bot is responding to; a message is filtered if its author is ignored **or** its `reply_to_user_id` is ignored. Only bots set this field (via the new `ChatService::send_bot_reply_task`); human replies continue to use `reply_to_message_id`.
- Desktop notifications are now suppressed for ignored users in DMs too (previously DM notifications fired regardless of ignore state).
- Filtering is consolidated behind a single shared helper, `state::message_is_ignored_in`, used by push, tail merge, snapshot filtering, and in-place refilter, removing the scattered per-call `room.kind == "dm"` special cases.

## Behavior notes
- New migration `093_add_chat_message_reply_to_user.sql` adds a nullable `reply_to_user_id` column with `ON DELETE SET NULL` and a partial index. Existing rows get `NULL`, so historical bot messages are unaffected (only newly sent bot replies carry the field).
- `unignore` still does not retroactively restore already-filtered local messages; they reappear on the next natural tail/snapshot reload. This matches prior behavior.
- The ghost/AI senders switch from `send_message_task` to `send_bot_reply_task`, which also stops minting a client-side `Uuid::now_v7()` per send and lets the message create path own the id.
- Context docs updated: the chat `CONTEXT.md` invariant "ignore filtering is non-DM only" is replaced to describe the new all-rooms + bot-proxy coverage.

## Feature flags
- None.

## Screenshots / Video
- Not included in this draft; no new UI surface, only filtering/visibility behavior. Attach before review if a reviewer wants the rail before/after.

## Testing
- Automated: new unit tests in `chat/state.rs` cover the two core cases — `visual_order_hides_dm_with_ignored_peer` (ignored peer's DM dropped from the rail, others kept) and `message_is_ignored_in_covers_author_and_reply_target` (ignored author, bot reply to ignored user, bot reply to someone else, and ordinary message). Existing fixtures across `state.rs`, `ui.rs`, and `dashboard/ui.rs` updated for the new `reply_to_user_id` field. Per repo policy, `cargo test`/`nextest` not run locally; left to the owner via `make check`.
- Manual: Not run.