### PR TITLE
Discover rooms: dense one-line list, slug filter, and Core-section placement

### DIFF
--- a/late-ssh/src/app/chat/CONTEXT.md
+++ b/late-ssh/src/app/chat/CONTEXT.md
@@ -161,10 +161,9 @@ Notifications:
 
 Visual order is defined in `state.rs::visual_order_for_rooms` and mirrored by cozy room-rail rendering in `ui.rs`. The base navigation order is:
 1. Favorite real rooms in `users.settings.favorite_room_ids` order.
-2. Core permanent rooms plus synthetic updates: `lounge`, `announcements`, `suggestions`, `bugs`, Notifications/Mentions, News, and RSS when available. Collapsing Core hides these synthetic update entries too.
+2. Core permanent rooms plus synthetic updates: `lounge`, `announcements`, `suggestions`, `bugs`, Notifications/Mentions, News, RSS when available, and Discover / `+ browse rooms` last. Collapsing Core hides these synthetic update entries too (Discover included).
 3. Other non-DM chat-list rooms/channels, excluding favorites.
 4. DMs, sorted by unread status, then snapshot latest-message activity, then peer display name. Do not derive this order from lazily loaded room tails.
-5. Discover / `+ browse rooms`.
 
 `RoomSection::Updates` remains only for legacy Directory-hosted Showcase/Work state; collapsing Updates does not affect Home rail entries.
 

--- a/late-ssh/src/app/chat/CONTEXT.md
+++ b/late-ssh/src/app/chat/CONTEXT.md
@@ -438,6 +438,8 @@ Synthetic entries are selected from the room list but are not normal `ChatRoom`s
 - `DiscoverRoomsLoaded { user_id, rooms }` and `DiscoverRoomsFailed { user_id, message }` are user-targeted.
 - `start_loading()` clears stale rows until results arrive; empty loaded state is distinct from loading.
 - Enter joins the selected public room.
+- Rooms render one dense line each (`ITEM_HEIGHT = 1` in `discover/ui.rs`): `#slug`, member/message counts, and last activity on a single row so the list shows many rooms at once.
+- `/` opens an inline substring filter over room slugs (footer shows the live query); typing edits it, `selected`/`visible_items` track the filtered subset, and `Esc` clears+closes it. While `discover.is_filtering()`, `app::input::handle_byte_event` and `chat::input::handle_byte` route every byte (digits, `space`, `h`/`l`) into the filter so it captures an unrestricted query; arrows still navigate. `start_slash_command_composer` excludes Discover so `/` never starts a slash command there.
 
 ---
 
@@ -558,7 +560,7 @@ modals and the icon picker). Username profile-opens are debounced via
 | Directory Projects | `j/k` navigate, `i` create, `e` edit own/admin, `d` delete own/admin, Enter copy/submit, Tab cycle fields while composing, `/` toggle filter to mine, `Esc` cancel |
 | Directory Profiles | `j/k` navigate, `i` create/edit own, `e` edit own/admin, `d` delete own/admin, Enter/`c` copy public profile link, Tab cycle fields while composing, `/` toggle filter to mine, `Esc` cancel |
 | Mentions | `j/k` navigate, Enter jump to referenced room/message |
-| Discover | `j/k` navigate, Enter join selected public room |
+| Discover | `j/k` navigate, Enter join selected public room, `/` open slug filter (type to narrow, Enter join, `Esc` clear) |
 
 Directory Projects and Profiles reshuffle their listing on page/tab entry. News keeps its chronological order — only mine-only filtering applies. The slash-command composer in `app/input.rs` skips itself when News is selected so `/` reaches the synthetic-entry handler; Directory page 7 routes `/` directly to Projects/Profiles filtering.
 

--- a/late-ssh/src/app/chat/discover/input.rs
+++ b/late-ssh/src/app/chat/discover/input.rs
@@ -15,7 +15,34 @@ pub fn handle_arrow(app: &mut App, key: u8) -> bool {
 }
 
 pub fn handle_byte(app: &mut App, byte: u8) -> bool {
+    // While the filter is open every keystroke edits the query, except the few
+    // control keys that navigate/confirm/close it. Arrow keys still route
+    // through `handle_arrow`, so j/k are free to be typed into the query.
+    if app.chat.discover.is_filtering() {
+        match byte {
+            0x1B => {
+                // Esc is normally routed via dispatch_escape, but handle it here
+                // too so it cancels the filter rather than leaving the screen.
+                app.chat.discover.cancel_filter();
+            }
+            b'\r' | b'\n' => {
+                if let Some(banner) = app.chat.join_selected_discover_room() {
+                    app.banner = Some(banner);
+                }
+            }
+            0x15 => app.chat.discover.clear_query(), // Ctrl-U
+            0x7F | 0x08 => app.chat.discover.backspace(),
+            b if (32..127).contains(&b) => app.chat.discover.push_char(b as char),
+            _ => {}
+        }
+        return true;
+    }
+
     match byte {
+        b'/' => {
+            app.chat.discover.start_filter();
+            true
+        }
         b'j' | b'J' => {
             app.chat.discover.move_selection(1);
             true

--- a/late-ssh/src/app/chat/discover/state.rs
+++ b/late-ssh/src/app/chat/discover/state.rs
@@ -174,7 +174,11 @@ mod tests {
             state.push_char(ch);
         }
 
-        let visible: Vec<_> = state.visible_items().iter().map(|i| i.slug.clone()).collect();
+        let visible: Vec<_> = state
+            .visible_items()
+            .iter()
+            .map(|i| i.slug.clone())
+            .collect();
         assert_eq!(visible, vec!["rust", "rust-gamedev"]);
     }
 
@@ -189,13 +193,22 @@ mod tests {
         }
         // Query reset selection to the top of the filtered list.
         assert_eq!(state.selected_index(), 0);
-        assert_eq!(state.selected_item().map(|i| i.slug.clone()), Some("beta".into()));
+        assert_eq!(
+            state.selected_item().map(|i| i.slug.clone()),
+            Some("beta".into())
+        );
 
         state.move_selection(1);
-        assert_eq!(state.selected_item().map(|i| i.slug.clone()), Some("betamax".into()));
+        assert_eq!(
+            state.selected_item().map(|i| i.slug.clone()),
+            Some("betamax".into())
+        );
         // Cannot move past the end of the filtered list.
         state.move_selection(1);
-        assert_eq!(state.selected_item().map(|i| i.slug.clone()), Some("betamax".into()));
+        assert_eq!(
+            state.selected_item().map(|i| i.slug.clone()),
+            Some("betamax".into())
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/chat/discover/state.rs
+++ b/late-ssh/src/app/chat/discover/state.rs
@@ -2,8 +2,13 @@ use crate::app::chat::svc::DiscoverRoomItem;
 
 pub struct State {
     items: Vec<DiscoverRoomItem>,
+    /// Index into the *filtered* (visible) list, not the full `items`.
     selected: usize,
     loading: bool,
+    /// Live substring filter applied to room slugs. Empty means "show all".
+    query: String,
+    /// Whether the footer filter input is capturing keystrokes.
+    filtering: bool,
 }
 
 impl Default for State {
@@ -18,6 +23,8 @@ impl State {
             items: Vec::new(),
             selected: 0,
             loading: false,
+            query: String::new(),
+            filtering: false,
         }
     }
 
@@ -29,7 +36,7 @@ impl State {
 
     pub fn set_items(&mut self, items: Vec<DiscoverRoomItem>) {
         self.items = items;
-        self.selected = clamp_index(self.selected, self.items.len());
+        self.selected = clamp_index(self.selected, self.visible_len());
         self.loading = false;
     }
 
@@ -37,24 +44,74 @@ impl State {
         self.loading = false;
     }
 
-    pub fn all_items(&self) -> &[DiscoverRoomItem] {
-        &self.items
+    /// Rooms matching the current filter, in list order. When the query is
+    /// empty this is every room.
+    pub fn visible_items(&self) -> Vec<&DiscoverRoomItem> {
+        let query = self.query.trim().to_lowercase();
+        if query.is_empty() {
+            return self.items.iter().collect();
+        }
+        self.items
+            .iter()
+            .filter(|item| item.slug.to_lowercase().contains(&query))
+            .collect()
+    }
+
+    fn visible_len(&self) -> usize {
+        self.visible_items().len()
     }
 
     pub fn is_loading(&self) -> bool {
         self.loading
     }
 
+    pub fn is_filtering(&self) -> bool {
+        self.filtering
+    }
+
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
     pub fn selected_index(&self) -> usize {
-        clamp_index(self.selected, self.items.len())
+        clamp_index(self.selected, self.visible_len())
     }
 
     pub fn move_selection(&mut self, delta: isize) {
-        self.selected = move_index(self.selected_index(), delta, self.items.len());
+        self.selected = move_index(self.selected_index(), delta, self.visible_len());
     }
 
     pub fn selected_item(&self) -> Option<&DiscoverRoomItem> {
-        self.items.get(self.selected_index())
+        self.visible_items().into_iter().nth(self.selected_index())
+    }
+
+    /// Enter filter mode; keystrokes now edit the query.
+    pub fn start_filter(&mut self) {
+        self.filtering = true;
+    }
+
+    /// Leave filter mode and clear the query back to the full list.
+    pub fn cancel_filter(&mut self) {
+        self.filtering = false;
+        self.query.clear();
+        self.selected = 0;
+    }
+
+    pub fn push_char(&mut self, ch: char) {
+        if !ch.is_control() {
+            self.query.push(ch);
+            self.selected = 0;
+        }
+    }
+
+    pub fn backspace(&mut self) {
+        self.query.pop();
+        self.selected = 0;
+    }
+
+    pub fn clear_query(&mut self) {
+        self.query.clear();
+        self.selected = 0;
     }
 }
 
@@ -72,6 +129,18 @@ fn move_index(current: usize, delta: isize, len: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    fn item(slug: &str) -> DiscoverRoomItem {
+        DiscoverRoomItem {
+            room_id: Uuid::from_u128(1),
+            slug: slug.to_string(),
+            member_count: 1,
+            message_count: 0,
+            last_message_at: Some(Utc::now()),
+        }
+    }
 
     #[test]
     fn start_loading_clears_empty_state_until_items_arrive() {
@@ -80,7 +149,7 @@ mod tests {
         state.start_loading();
 
         assert!(state.is_loading());
-        assert!(state.all_items().is_empty());
+        assert!(state.visible_items().is_empty());
     }
 
     #[test]
@@ -91,6 +160,54 @@ mod tests {
         state.set_items(Vec::new());
 
         assert!(!state.is_loading());
-        assert!(state.all_items().is_empty());
+        assert!(state.visible_items().is_empty());
+    }
+
+    #[test]
+    fn filter_narrows_visible_items_case_insensitively() {
+        let mut state = State::new();
+        state.set_items(vec![item("rust"), item("Python"), item("rust-gamedev")]);
+
+        state.start_filter();
+        for ch in "RUST".chars() {
+            state.push_char(ch);
+        }
+
+        let visible: Vec<_> = state.visible_items().iter().map(|i| i.slug.clone()).collect();
+        assert_eq!(visible, vec!["rust", "rust-gamedev"]);
+    }
+
+    #[test]
+    fn selection_tracks_filtered_list() {
+        let mut state = State::new();
+        state.set_items(vec![item("alpha"), item("beta"), item("betamax")]);
+
+        state.start_filter();
+        for ch in "beta".chars() {
+            state.push_char(ch);
+        }
+        // Query reset selection to the top of the filtered list.
+        assert_eq!(state.selected_index(), 0);
+        assert_eq!(state.selected_item().map(|i| i.slug.clone()), Some("beta".into()));
+
+        state.move_selection(1);
+        assert_eq!(state.selected_item().map(|i| i.slug.clone()), Some("betamax".into()));
+        // Cannot move past the end of the filtered list.
+        state.move_selection(1);
+        assert_eq!(state.selected_item().map(|i| i.slug.clone()), Some("betamax".into()));
+    }
+
+    #[test]
+    fn cancel_filter_restores_full_list() {
+        let mut state = State::new();
+        state.set_items(vec![item("alpha"), item("beta")]);
+
+        state.start_filter();
+        state.push_char('z');
+        assert!(state.visible_items().is_empty());
+
+        state.cancel_filter();
+        assert!(!state.is_filtering());
+        assert_eq!(state.visible_items().len(), 2);
     }
 }

--- a/late-ssh/src/app/chat/discover/state.rs
+++ b/late-ssh/src/app/chat/discover/state.rs
@@ -139,6 +139,7 @@ mod tests {
             member_count: 1,
             message_count: 0,
             last_message_at: Some(Utc::now()),
+            recent: Vec::new(),
         }
     }
 

--- a/late-ssh/src/app/chat/discover/ui.rs
+++ b/late-ssh/src/app/chat/discover/ui.rs
@@ -5,16 +5,22 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
-    widgets::{Block, Borders, Paragraph, Wrap},
+    widgets::Paragraph,
 };
 
 pub struct DiscoverListView<'a> {
-    pub items: &'a [DiscoverRoomItem],
+    pub items: Vec<&'a DiscoverRoomItem>,
     pub selected_index: usize,
     pub loading: bool,
+    pub filtering: bool,
+    pub query: &'a str,
 }
 
-const ITEM_HEIGHT: u16 = 5;
+/// One dense line per room so the list shows many rooms at once.
+const ITEM_HEIGHT: u16 = 1;
+/// Fixed width for the `#slug` column so the stats align into a tidy second
+/// column regardless of room-name length.
+const NAME_WIDTH: usize = 24;
 
 pub fn draw_discover_list(frame: &mut Frame, area: Rect, view: &DiscoverListView<'_>) {
     let inner_area = area;
@@ -27,16 +33,21 @@ pub fn draw_discover_list(frame: &mut Frame, area: Rect, view: &DiscoverListView
     }
 
     if view.items.is_empty() {
-        let text = Text::from("No public rooms to discover right now.");
-        let empty_p = Paragraph::new(text).style(Style::default().fg(theme::TEXT_DIM()));
+        let msg = if view.query.trim().is_empty() {
+            "No public rooms to discover right now.".to_string()
+        } else {
+            format!("No rooms match \"{}\".", view.query.trim())
+        };
+        let empty_p =
+            Paragraph::new(Text::from(msg)).style(Style::default().fg(theme::TEXT_DIM()));
         frame.render_widget(empty_p, inner_area);
         return;
     }
 
-    let visible_items = (inner_area.height / ITEM_HEIGHT).max(1) as usize;
+    let visible_rows = (inner_area.height / ITEM_HEIGHT).max(1) as usize;
     let selected_index = view.selected_index.min(view.items.len().saturating_sub(1));
-    let start_index = selected_index.saturating_sub(visible_items.saturating_sub(1));
-    let end_index = (start_index + visible_items).min(view.items.len());
+    let start_index = selected_index.saturating_sub(visible_rows.saturating_sub(1));
+    let end_index = (start_index + visible_rows).min(view.items.len());
     let visible_len = end_index.saturating_sub(start_index);
 
     let constraints =
@@ -47,75 +58,97 @@ pub fn draw_discover_list(frame: &mut Frame, area: Rect, view: &DiscoverListView
         .constraints(constraints)
         .split(inner_area);
 
-    for (row, item_area) in layout.iter().copied().enumerate() {
+    for (row, row_area) in layout.iter().copied().enumerate() {
         let idx = start_index + row;
-        let item = &view.items[idx];
+        let item = view.items[idx];
+        let selected = idx == selected_index;
 
-        let bg_color = if idx == selected_index {
+        let bg_color = if selected {
             theme::BG_SELECTION()
         } else {
             Color::Reset
         };
 
-        let item_block = Block::default()
-            .borders(Borders::BOTTOM)
-            .border_style(Style::default().fg(theme::BORDER()))
-            .style(Style::default().bg(bg_color));
+        let line = room_line(item, selected);
+        let p = Paragraph::new(line).style(Style::default().bg(bg_color));
+        frame.render_widget(p, row_area);
+    }
+}
 
-        let content_area = item_block.inner(item_area);
-        frame.render_widget(item_block, item_area);
+fn room_line(item: &DiscoverRoomItem, selected: bool) -> Line<'static> {
+    let activity = item
+        .last_message_at
+        .map(format_relative_time)
+        .unwrap_or_else(|| "no messages yet".to_string());
+    let member_noun = if item.member_count == 1 {
+        "member"
+    } else {
+        "members"
+    };
+    let message_noun = if item.message_count == 1 {
+        "message"
+    } else {
+        "messages"
+    };
 
-        let activity = item
-            .last_message_at
-            .map(format_relative_time)
-            .unwrap_or_else(|| "no messages yet".to_string());
-        let member_noun = if item.member_count == 1 {
-            "member"
-        } else {
-            "members"
-        };
-        let message_noun = if item.message_count == 1 {
-            "message"
-        } else {
-            "messages"
-        };
+    let marker = if selected { "› " } else { "  " };
+    let name = pad_name(&format!("#{}", item.slug), NAME_WIDTH);
 
-        let lines = vec![
-            Line::from(vec![Span::styled(
-                format!("#{}", item.slug),
-                Style::default()
-                    .fg(theme::TEXT_BRIGHT())
-                    .add_modifier(Modifier::BOLD),
-            )]),
-            Line::from(vec![
-                Span::styled(
-                    format!("{} {}", item.member_count, member_noun),
-                    Style::default().fg(theme::AMBER()),
-                ),
-                Span::styled("  ·  ", Style::default().fg(theme::TEXT_DIM())),
-                Span::styled(
-                    format!("{} {}", item.message_count, message_noun),
-                    Style::default().fg(theme::TEXT()),
-                ),
-            ]),
-            Line::from(vec![Span::styled(
-                format!("Last activity: {activity}"),
-                Style::default().fg(theme::TEXT_DIM()),
-            )]),
-        ];
+    Line::from(vec![
+        Span::styled(marker, Style::default().fg(theme::AMBER())),
+        Span::styled(
+            name,
+            Style::default()
+                .fg(theme::TEXT_BRIGHT())
+                .add_modifier(Modifier::BOLD),
+        ),
+        Span::styled(
+            format!("{:>5} ", item.member_count),
+            Style::default().fg(theme::AMBER()),
+        ),
+        Span::styled(member_noun, Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("  ·  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled(
+            format!("{} ", item.message_count),
+            Style::default().fg(theme::TEXT()),
+        ),
+        Span::styled(message_noun, Style::default().fg(theme::TEXT_DIM())),
+        Span::styled("  ·  ", Style::default().fg(theme::TEXT_DIM())),
+        Span::styled(activity, Style::default().fg(theme::TEXT_DIM())),
+    ])
+}
 
-        let p = Paragraph::new(lines).wrap(Wrap { trim: true });
-        frame.render_widget(p, content_area);
+/// Left-pad `name` to `width`, truncating overly long slugs with an ellipsis so
+/// the stats column stays aligned.
+fn pad_name(name: &str, width: usize) -> String {
+    let count = name.chars().count();
+    if count > width {
+        let truncated: String = name.chars().take(width.saturating_sub(1)).collect();
+        format!("{truncated}…")
+    } else {
+        format!("{name:<width$}")
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Utc;
     use ratatui::{Terminal, backend::TestBackend};
+    use uuid::Uuid;
+
+    fn discover_item(slug: &str, members: i64, messages: i64) -> DiscoverRoomItem {
+        DiscoverRoomItem {
+            room_id: Uuid::from_u128(1),
+            slug: slug.to_string(),
+            member_count: members,
+            message_count: messages,
+            last_message_at: Some(Utc::now()),
+        }
+    }
 
     fn render_discover(view: DiscoverListView<'_>) -> String {
-        let width = 60;
+        let width = 80;
         let height = 10;
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).expect("terminal");
@@ -138,9 +171,11 @@ mod tests {
     #[test]
     fn loading_state_does_not_claim_there_are_no_rooms() {
         let rendered = render_discover(DiscoverListView {
-            items: &[],
+            items: Vec::new(),
             selected_index: 0,
             loading: true,
+            filtering: false,
+            query: "",
         });
 
         assert!(rendered.contains("Loading rooms..."));
@@ -150,11 +185,46 @@ mod tests {
     #[test]
     fn loaded_empty_state_explains_no_discoverable_rooms() {
         let rendered = render_discover(DiscoverListView {
-            items: &[],
+            items: Vec::new(),
             selected_index: 0,
             loading: false,
+            filtering: false,
+            query: "",
         });
 
         assert!(rendered.contains("No public rooms to discover right now."));
+    }
+
+    #[test]
+    fn empty_filter_result_names_the_query() {
+        let rendered = render_discover(DiscoverListView {
+            items: Vec::new(),
+            selected_index: 0,
+            loading: false,
+            filtering: true,
+            query: "zzz",
+        });
+
+        assert!(rendered.contains("No rooms match \"zzz\"."));
+    }
+
+    #[test]
+    fn each_room_renders_on_a_single_line() {
+        let a = discover_item("rust", 12, 3);
+        let b = discover_item("python", 6, 1);
+        let rendered = render_discover(DiscoverListView {
+            items: vec![&a, &b],
+            selected_index: 0,
+            loading: false,
+            filtering: false,
+            query: "",
+        });
+
+        let lines: Vec<&str> = rendered.lines().collect();
+        assert!(lines[0].contains("#rust"));
+        assert!(lines[0].contains("12 members"));
+        assert!(lines[0].contains("3 messages"));
+        // Second room is on the very next row — no multi-line blocks.
+        assert!(lines[1].contains("#python"));
     }
 }

--- a/late-ssh/src/app/chat/discover/ui.rs
+++ b/late-ssh/src/app/chat/discover/ui.rs
@@ -5,7 +5,7 @@ use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
     text::{Line, Span, Text},
-    widgets::Paragraph,
+    widgets::{Block, Borders, Padding, Paragraph, Wrap},
 };
 
 pub struct DiscoverListView<'a> {
@@ -16,19 +16,21 @@ pub struct DiscoverListView<'a> {
     pub query: &'a str,
 }
 
-/// One dense line per room so the list shows many rooms at once.
-const ITEM_HEIGHT: u16 = 1;
-/// Fixed width for the `#slug` column so the stats align into a tidy second
-/// column regardless of room-name length.
-const NAME_WIDTH: usize = 24;
+/// Each room takes two rows: the `#slug` name on top, its stats underneath.
+/// Two rows read comfortably in the narrow list column left by the preview pane.
+const ITEM_HEIGHT: u16 = 2;
+/// Below this total width there isn't room for both a readable list and a
+/// preview, so the list takes the whole area and the preview is dropped.
+const PREVIEW_MIN_WIDTH: u16 = 72;
+/// Share of the width given to the list when the preview pane is shown; the
+/// rest goes to the preview.
+const LIST_PERCENT: u16 = 45;
 
 pub fn draw_discover_list(frame: &mut Frame, area: Rect, view: &DiscoverListView<'_>) {
-    let inner_area = area;
-
     if view.loading {
         let text = Text::from("Loading rooms...");
         let loading_p = Paragraph::new(text).style(Style::default().fg(theme::TEXT_DIM()));
-        frame.render_widget(loading_p, inner_area);
+        frame.render_widget(loading_p, area);
         return;
     }
 
@@ -38,13 +40,36 @@ pub fn draw_discover_list(frame: &mut Frame, area: Rect, view: &DiscoverListView
         } else {
             format!("No rooms match \"{}\".", view.query.trim())
         };
-        let empty_p =
-            Paragraph::new(Text::from(msg)).style(Style::default().fg(theme::TEXT_DIM()));
-        frame.render_widget(empty_p, inner_area);
+        let empty_p = Paragraph::new(Text::from(msg)).style(Style::default().fg(theme::TEXT_DIM()));
+        frame.render_widget(empty_p, area);
         return;
     }
 
-    let visible_rows = (inner_area.height / ITEM_HEIGHT).max(1) as usize;
+    // Wide enough: split into a list column and a preview pane that tracks the
+    // highlighted room. Otherwise the list keeps the full width.
+    let (list_area, preview_area) = if area.width >= PREVIEW_MIN_WIDTH {
+        let cols = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([
+                Constraint::Percentage(LIST_PERCENT),
+                Constraint::Percentage(100 - LIST_PERCENT),
+            ])
+            .split(area);
+        (cols[0], Some(cols[1]))
+    } else {
+        (area, None)
+    };
+
+    draw_room_list(frame, list_area, view);
+
+    if let Some(preview_area) = preview_area {
+        let selected_index = view.selected_index.min(view.items.len().saturating_sub(1));
+        draw_preview(frame, preview_area, view.items[selected_index]);
+    }
+}
+
+fn draw_room_list(frame: &mut Frame, area: Rect, view: &DiscoverListView<'_>) {
+    let visible_rows = (area.height / ITEM_HEIGHT).max(1) as usize;
     let selected_index = view.selected_index.min(view.items.len().saturating_sub(1));
     let start_index = selected_index.saturating_sub(visible_rows.saturating_sub(1));
     let end_index = (start_index + visible_rows).min(view.items.len());
@@ -56,7 +81,7 @@ pub fn draw_discover_list(frame: &mut Frame, area: Rect, view: &DiscoverListView
     let layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints(constraints)
-        .split(inner_area);
+        .split(area);
 
     for (row, row_area) in layout.iter().copied().enumerate() {
         let idx = start_index + row;
@@ -69,13 +94,87 @@ pub fn draw_discover_list(frame: &mut Frame, area: Rect, view: &DiscoverListView
             Color::Reset
         };
 
-        let line = room_line(item, selected);
-        let p = Paragraph::new(line).style(Style::default().bg(bg_color));
+        let lines = room_lines(item, selected);
+        let p = Paragraph::new(lines).style(Style::default().bg(bg_color));
         frame.render_widget(p, row_area);
     }
 }
 
-fn room_line(item: &DiscoverRoomItem, selected: bool) -> Line<'static> {
+/// Render the highlighted room's recent activity so the user can size up a room
+/// without leaving the list. The messages are a snapshot captured at load time.
+fn draw_preview(frame: &mut Frame, area: Rect, item: &DiscoverRoomItem) {
+    let block = Block::default()
+        .borders(Borders::LEFT)
+        .border_style(Style::default().fg(theme::BORDER()))
+        .padding(Padding::new(2, 1, 0, 0));
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    let member_noun = if item.member_count == 1 {
+        "member"
+    } else {
+        "members"
+    };
+    let activity = item
+        .last_message_at
+        .map(format_relative_time)
+        .unwrap_or_else(|| "no messages yet".to_string());
+
+    let mut lines: Vec<Line<'static>> = vec![
+        Line::from(Span::styled(
+            format!("#{}", item.slug),
+            Style::default()
+                .fg(theme::TEXT_BRIGHT())
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::from(vec![
+            Span::styled(
+                format!("{} {}", item.member_count, member_noun),
+                Style::default().fg(theme::AMBER()),
+            ),
+            Span::styled("  ·  ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(
+                format!("active {activity}"),
+                Style::default().fg(theme::TEXT_DIM()),
+            ),
+        ]),
+        Line::from(""),
+    ];
+
+    if item.recent.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "No messages yet. Be the first to post.",
+            Style::default().fg(theme::TEXT_DIM()),
+        )));
+    } else {
+        for msg in &item.recent {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    msg.author.clone(),
+                    Style::default()
+                        .fg(theme::AMBER())
+                        .add_modifier(Modifier::BOLD),
+                ),
+                Span::styled(
+                    format!("  {}", format_relative_time(msg.created)),
+                    Style::default().fg(theme::TEXT_DIM()),
+                ),
+            ]));
+            lines.push(Line::from(Span::styled(
+                msg.body.clone(),
+                Style::default().fg(theme::TEXT()),
+            )));
+            lines.push(Line::from(""));
+        }
+    }
+
+    let p = Paragraph::new(lines).wrap(Wrap { trim: true });
+    frame.render_widget(p, inner);
+}
+
+/// The two rows for one room: the `#slug` name on top, its stats underneath.
+/// The second row is indented to align under the name past the marker.
+fn room_lines(item: &DiscoverRoomItem, selected: bool) -> Vec<Line<'static>> {
     let activity = item
         .last_message_at
         .map(format_relative_time)
@@ -92,47 +191,39 @@ fn room_line(item: &DiscoverRoomItem, selected: bool) -> Line<'static> {
     };
 
     let marker = if selected { "› " } else { "  " };
-    let name = pad_name(&format!("#{}", item.slug), NAME_WIDTH);
 
-    Line::from(vec![
+    let name_line = Line::from(vec![
         Span::styled(marker, Style::default().fg(theme::AMBER())),
         Span::styled(
-            name,
+            format!("#{}", item.slug),
             Style::default()
                 .fg(theme::TEXT_BRIGHT())
                 .add_modifier(Modifier::BOLD),
         ),
+    ]);
+
+    let stats_line = Line::from(vec![
+        Span::raw("  "),
         Span::styled(
-            format!("{:>5} ", item.member_count),
+            format!("{} {}", item.member_count, member_noun),
             Style::default().fg(theme::AMBER()),
         ),
-        Span::styled(member_noun, Style::default().fg(theme::TEXT_DIM())),
         Span::styled("  ·  ", Style::default().fg(theme::TEXT_DIM())),
         Span::styled(
-            format!("{} ", item.message_count),
+            format!("{} {}", item.message_count, message_noun),
             Style::default().fg(theme::TEXT()),
         ),
-        Span::styled(message_noun, Style::default().fg(theme::TEXT_DIM())),
         Span::styled("  ·  ", Style::default().fg(theme::TEXT_DIM())),
         Span::styled(activity, Style::default().fg(theme::TEXT_DIM())),
-    ])
-}
+    ]);
 
-/// Left-pad `name` to `width`, truncating overly long slugs with an ellipsis so
-/// the stats column stays aligned.
-fn pad_name(name: &str, width: usize) -> String {
-    let count = name.chars().count();
-    if count > width {
-        let truncated: String = name.chars().take(width.saturating_sub(1)).collect();
-        format!("{truncated}…")
-    } else {
-        format!("{name:<width$}")
-    }
+    vec![name_line, stats_line]
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app::chat::svc::PreviewMessage;
     use chrono::Utc;
     use ratatui::{Terminal, backend::TestBackend};
     use uuid::Uuid;
@@ -144,11 +235,27 @@ mod tests {
             member_count: members,
             message_count: messages,
             last_message_at: Some(Utc::now()),
+            recent: Vec::new(),
         }
     }
 
+    fn with_recent(mut item: DiscoverRoomItem, recent: &[(&str, &str)]) -> DiscoverRoomItem {
+        item.recent = recent
+            .iter()
+            .map(|(author, body)| PreviewMessage {
+                author: author.to_string(),
+                body: body.to_string(),
+                created: Utc::now(),
+            })
+            .collect();
+        item
+    }
+
     fn render_discover(view: DiscoverListView<'_>) -> String {
-        let width = 80;
+        render_discover_at(view, 80)
+    }
+
+    fn render_discover_at(view: DiscoverListView<'_>, width: u16) -> String {
         let height = 10;
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).expect("terminal");
@@ -209,22 +316,102 @@ mod tests {
     }
 
     #[test]
-    fn each_room_renders_on_a_single_line() {
+    fn each_room_renders_name_then_stats_on_two_rows() {
         let a = discover_item("rust", 12, 3);
         let b = discover_item("python", 6, 1);
-        let rendered = render_discover(DiscoverListView {
-            items: vec![&a, &b],
-            selected_index: 0,
-            loading: false,
-            filtering: false,
-            query: "",
-        });
+        let rendered = render_discover_at(
+            DiscoverListView {
+                items: vec![&a, &b],
+                selected_index: 0,
+                loading: false,
+                filtering: false,
+                query: "",
+            },
+            70,
+        );
 
         let lines: Vec<&str> = rendered.lines().collect();
+        // Row one: name on its own line; row two: the stats underneath.
         assert!(lines[0].contains("#rust"));
-        assert!(lines[0].contains("12 members"));
-        assert!(lines[0].contains("3 messages"));
-        // Second room is on the very next row — no multi-line blocks.
-        assert!(lines[1].contains("#python"));
+        assert!(lines[1].contains("12 members"));
+        assert!(lines[1].contains("3 messages"));
+        // The next room begins two rows down.
+        assert!(lines[2].contains("#python"));
+    }
+
+    #[test]
+    fn preview_shows_recent_messages_of_selected_room() {
+        let a = with_recent(discover_item("rust", 12, 3), &[("alice", "hello rustaceans")]);
+        let b = with_recent(discover_item("python", 6, 1), &[("bob", "pythonic greeting")]);
+        let rendered = render_discover_at(
+            DiscoverListView {
+                items: vec![&a, &b],
+                selected_index: 0,
+                loading: false,
+                filtering: false,
+                query: "",
+            },
+            96,
+        );
+
+        // The preview tracks the highlighted room (rust), not the other one.
+        assert!(rendered.contains("alice"));
+        assert!(rendered.contains("hello rustaceans"));
+        assert!(!rendered.contains("pythonic greeting"));
+    }
+
+    #[test]
+    fn preview_follows_selection() {
+        let a = with_recent(discover_item("rust", 12, 3), &[("alice", "hello rustaceans")]);
+        let b = with_recent(discover_item("python", 6, 1), &[("bob", "pythonic greeting")]);
+        let rendered = render_discover_at(
+            DiscoverListView {
+                items: vec![&a, &b],
+                selected_index: 1,
+                loading: false,
+                filtering: false,
+                query: "",
+            },
+            96,
+        );
+
+        assert!(rendered.contains("pythonic greeting"));
+        assert!(!rendered.contains("hello rustaceans"));
+    }
+
+    #[test]
+    fn preview_hidden_when_too_narrow() {
+        let a = with_recent(discover_item("rust", 12, 3), &[("alice", "hello rustaceans")]);
+        let rendered = render_discover_at(
+            DiscoverListView {
+                items: vec![&a],
+                selected_index: 0,
+                loading: false,
+                filtering: false,
+                query: "",
+            },
+            60,
+        );
+
+        // No preview column: the message body never renders.
+        assert!(!rendered.contains("hello rustaceans"));
+        assert!(rendered.contains("#rust"));
+    }
+
+    #[test]
+    fn preview_handles_room_with_no_messages() {
+        let a = discover_item("rust", 12, 3);
+        let rendered = render_discover_at(
+            DiscoverListView {
+                items: vec![&a],
+                selected_index: 0,
+                loading: false,
+                filtering: false,
+                query: "",
+            },
+            96,
+        );
+
+        assert!(rendered.contains("No messages yet."));
     }
 }

--- a/late-ssh/src/app/chat/discover/ui.rs
+++ b/late-ssh/src/app/chat/discover/ui.rs
@@ -341,8 +341,14 @@ mod tests {
 
     #[test]
     fn preview_shows_recent_messages_of_selected_room() {
-        let a = with_recent(discover_item("rust", 12, 3), &[("alice", "hello rustaceans")]);
-        let b = with_recent(discover_item("python", 6, 1), &[("bob", "pythonic greeting")]);
+        let a = with_recent(
+            discover_item("rust", 12, 3),
+            &[("alice", "hello rustaceans")],
+        );
+        let b = with_recent(
+            discover_item("python", 6, 1),
+            &[("bob", "pythonic greeting")],
+        );
         let rendered = render_discover_at(
             DiscoverListView {
                 items: vec![&a, &b],
@@ -362,8 +368,14 @@ mod tests {
 
     #[test]
     fn preview_follows_selection() {
-        let a = with_recent(discover_item("rust", 12, 3), &[("alice", "hello rustaceans")]);
-        let b = with_recent(discover_item("python", 6, 1), &[("bob", "pythonic greeting")]);
+        let a = with_recent(
+            discover_item("rust", 12, 3),
+            &[("alice", "hello rustaceans")],
+        );
+        let b = with_recent(
+            discover_item("python", 6, 1),
+            &[("bob", "pythonic greeting")],
+        );
         let rendered = render_discover_at(
             DiscoverListView {
                 items: vec![&a, &b],
@@ -381,7 +393,10 @@ mod tests {
 
     #[test]
     fn preview_hidden_when_too_narrow() {
-        let a = with_recent(discover_item("rust", 12, 3), &[("alice", "hello rustaceans")]);
+        let a = with_recent(
+            discover_item("rust", 12, 3),
+            &[("alice", "hello rustaceans")],
+        );
         let rendered = render_discover_at(
             DiscoverListView {
                 items: vec![&a],

--- a/late-ssh/src/app/chat/input.rs
+++ b/late-ssh/src/app/chat/input.rs
@@ -524,6 +524,13 @@ pub fn handle_arrow(app: &mut App, key: u8) -> bool {
 }
 
 pub fn handle_byte(app: &mut App, byte: u8) -> bool {
+    // While the Discover filter is open it owns every byte (including space and
+    // h/l, which would otherwise trigger room-jump / room-switch) so the user
+    // can type an unrestricted query.
+    if app.chat.discover_selected && app.chat.discover.is_filtering() {
+        return super::discover::input::handle_byte(app, byte);
+    }
+
     if app.chat.room_jump_active {
         match byte {
             b' ' => {

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -4101,6 +4101,8 @@ pub(crate) fn visual_order_for_rooms<U: UsernameResolver + ?Sized>(
         if feeds_available {
             order.push(RoomSlot::Feeds);
         }
+        // Discover ("browse rooms") lives at the bottom of Core.
+        order.push(RoomSlot::Discover);
     }
 
     // Channels: all non-DM rooms outside Core, public + private merged.
@@ -4138,7 +4140,6 @@ pub(crate) fn visual_order_for_rooms<U: UsernameResolver + ?Sized>(
     order.extend(dms.iter().filter_map(|(r, _)| {
         (pushed_rooms.insert(r.id) && !dms_collapsed).then_some(RoomSlot::Room(r.id))
     }));
-    order.push(RoomSlot::Discover);
 
     order
 }
@@ -5699,12 +5700,12 @@ mod tests {
                 RoomSlot::Notifications,
                 RoomSlot::News,
                 RoomSlot::Feeds,
+                RoomSlot::Discover,
                 RoomSlot::Room(public_zeta),
                 RoomSlot::Room(private_beta),
                 RoomSlot::Room(public_alpha),
                 RoomSlot::Room(dm_alice.id),
                 RoomSlot::Room(dm_bob.id),
-                RoomSlot::Discover,
             ]
         );
     }
@@ -5780,6 +5781,8 @@ mod tests {
         assert!(!co.contains(&RoomSlot::Room(announcements)));
         assert!(!co.contains(&RoomSlot::Notifications));
         assert!(!co.contains(&RoomSlot::News));
+        // Discover now lives at the bottom of Core, so it collapses with it.
+        assert!(!co.contains(&RoomSlot::Discover));
         assert!(co.contains(&RoomSlot::Room(public_alpha)));
 
         // Updates is now hosted by the Directory page, not the Home rail.
@@ -5788,7 +5791,7 @@ mod tests {
         assert!(u.contains(&RoomSlot::News));
         assert!(!u.contains(&RoomSlot::Showcase));
         assert!(!u.contains(&RoomSlot::Work));
-        // Discover is not part of a collapsible section — always present.
+        // Discover lives in Core, which is expanded here, so it stays present.
         assert!(u.contains(&RoomSlot::Discover));
 
         // DMs collapsed: the DM drops out.

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -88,6 +88,18 @@ pub struct DiscoverRoomItem {
     pub member_count: i64,
     pub message_count: i64,
     pub last_message_at: Option<DateTime<Utc>>,
+    /// A snapshot of the room's most recent messages, oldest-first, captured at
+    /// list-load time so the discover preview pane can render instantly while
+    /// scrolling. Empty when the room has no messages yet.
+    pub recent: Vec<PreviewMessage>,
+}
+
+/// One line of a room's recent activity, shown in the discover preview pane.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct PreviewMessage {
+    pub author: String,
+    pub body: String,
+    pub created: DateTime<Utc>,
 }
 
 pub struct SendMessageTask {
@@ -893,6 +905,7 @@ impl ChatService {
                 member_count: row.member_count,
                 message_count: row.message_count,
                 last_message_at: row.last_message_at,
+                recent: Vec::new(),
             })
             .collect())
     }
@@ -1244,11 +1257,62 @@ impl ChatService {
             .into_iter()
             .map(|room| room.id)
             .collect();
-        Ok(Self::list_all_discover_rooms(&client)
+        let mut rooms: Vec<DiscoverRoomItem> = Self::list_all_discover_rooms(&client)
             .await?
             .into_iter()
             .filter(|room| !joined_ids.contains(&room.room_id))
-            .collect())
+            .collect();
+
+        Self::attach_recent_previews(&client, &mut rooms).await?;
+        Ok(rooms)
+    }
+
+    /// Fetch a snapshot of each room's most recent messages and attach them as
+    /// the `recent` preview, so the discover UI can render a preview pane
+    /// instantly while the user scrolls. Best-effort: a preview-fetch failure is
+    /// logged but leaves the rooms usable with empty previews.
+    async fn attach_recent_previews(
+        client: &tokio_postgres::Client,
+        rooms: &mut [DiscoverRoomItem],
+    ) -> Result<()> {
+        const PREVIEW_MESSAGES_PER_ROOM: i64 = 5;
+
+        let room_ids: Vec<Uuid> = rooms.iter().map(|room| room.room_id).collect();
+        if room_ids.is_empty() {
+            return Ok(());
+        }
+
+        let mut messages_by_room =
+            ChatMessage::list_recent_for_rooms(client, &room_ids, PREVIEW_MESSAGES_PER_ROOM).await?;
+
+        let author_ids: Vec<Uuid> = messages_by_room
+            .values()
+            .flatten()
+            .map(|msg| msg.user_id)
+            .collect();
+        let usernames = User::list_usernames_by_ids(client, &author_ids).await?;
+
+        for room in rooms.iter_mut() {
+            let Some(mut messages) = messages_by_room.remove(&room.room_id) else {
+                continue;
+            };
+            // `list_recent_for_rooms` returns newest-first; flip to chronological
+            // so the preview reads top-to-bottom like a normal chat transcript.
+            messages.reverse();
+            room.recent = messages
+                .into_iter()
+                .map(|msg| PreviewMessage {
+                    author: usernames
+                        .get(&msg.user_id)
+                        .cloned()
+                        .unwrap_or_else(|| "someone".to_string()),
+                    body: msg.body,
+                    created: msg.created,
+                })
+                .collect();
+        }
+
+        Ok(())
     }
 
     pub fn list_discover_rooms_task(&self, user_id: Uuid) {

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -1283,7 +1283,8 @@ impl ChatService {
         }
 
         let mut messages_by_room =
-            ChatMessage::list_recent_for_rooms(client, &room_ids, PREVIEW_MESSAGES_PER_ROOM).await?;
+            ChatMessage::list_recent_for_rooms(client, &room_ids, PREVIEW_MESSAGES_PER_ROOM)
+                .await?;
 
         let author_ids: Vec<Uuid> = messages_by_room
             .values()

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -4960,13 +4960,16 @@ mod tests {
             .collect();
 
         assert_eq!(
-            &keyed_slots[..5],
+            &keyed_slots[..6],
             &[
                 (RoomSlot::Room(lounge.id), "a lounge".to_string()),
                 (RoomSlot::Notifications, "s mentions".to_string()),
                 (RoomSlot::News, "d news".to_string()),
                 (RoomSlot::Feeds, "f rss".to_string()),
-                (RoomSlot::Room(rust.id), "g rust".to_string()),
+                // Discover ("+ browse rooms") is the last entry in Core, so the
+                // topic rooms below it start one jump key later.
+                (RoomSlot::Discover, "g + browse rooms".to_string()),
+                (RoomSlot::Room(rust.id), "h rust".to_string()),
             ]
         );
     }

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -3419,6 +3419,8 @@ fn build_cozy_room_rail_rows(view: &ChatRoomListView<'_>, width: u16) -> RoomLis
         if view.feeds_available {
             push_slot(RoomSlot::Feeds, &mut push_row);
         }
+        // Discover ("+ browse rooms") is the last entry in Core.
+        push_slot(RoomSlot::Discover, &mut push_row);
     }
 
     let channels: Vec<&(ChatRoom, Vec<ChatMessage>)> = view
@@ -3465,9 +3467,6 @@ fn build_cozy_room_rail_rows(view: &ChatRoomListView<'_>, width: u16) -> RoomLis
             }
         }
     }
-
-    push_row(blank(), None, false);
-    push_slot(RoomSlot::Discover, &mut push_row);
 
     RoomListRows {
         lines,

--- a/late-ssh/src/app/chat/ui.rs
+++ b/late-ssh/src/app/chat/ui.rs
@@ -3591,7 +3591,7 @@ fn build_rail_nav_hint_lines() -> Vec<Line<'static>> {
         Line::from(vec![key("h l space"), hint(" jump room")]),
         Line::from(vec![key("f"), hint("         favorite")]),
         Line::from(vec![key("[ ]/z"), hint("     sort/fold")]),
-        Line::from(vec![key("ctrl+/"), hint("    room picker")]),
+        Line::from(vec![key("ctrl+/"), hint("    picker")]),
     ]
 }
 
@@ -3850,16 +3850,36 @@ fn draw_selected_content(
             );
         }
     } else if view.discover_selected {
-        let hint_block = Block::default()
-            .title(" Discover ")
-            .borders(Borders::ALL)
-            .border_style(Style::default().fg(theme::BORDER()));
-        let hint_text = Paragraph::new(Line::from(Span::styled(
-            " j/k navigate · Enter join room",
-            Style::default().fg(theme::TEXT_DIM()),
-        )))
-        .block(hint_block);
-        frame.render_widget(hint_text, composer_area);
+        if view.discover_view.filtering {
+            let filter_block = Block::default()
+                .title(" Filter rooms ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(theme::BORDER_ACTIVE()));
+            let filter_text = Paragraph::new(Line::from(vec![
+                Span::styled(
+                    format!(" {}", view.discover_view.query),
+                    Style::default().fg(theme::TEXT_BRIGHT()),
+                ),
+                Span::styled("_", Style::default().fg(theme::TEXT_DIM())),
+                Span::styled(
+                    "   Enter join · Esc clear",
+                    Style::default().fg(theme::TEXT_DIM()),
+                ),
+            ]))
+            .block(filter_block);
+            frame.render_widget(filter_text, composer_area);
+        } else {
+            let hint_block = Block::default()
+                .title(" Discover ")
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(theme::BORDER()));
+            let hint_text = Paragraph::new(Line::from(Span::styled(
+                " j/k navigate · Enter join room · / filter",
+                Style::default().fg(theme::TEXT_DIM()),
+            )))
+            .block(hint_block);
+            frame.render_widget(hint_text, composer_area);
+        }
     } else if news_selected {
         if view.news_processing || view.news_composing {
             let (title, border_style) = if view.news_processing {
@@ -4246,9 +4266,11 @@ mod tests {
             },
             discover_selected: false,
             discover_view: crate::app::chat::discover::ui::DiscoverListView {
-                items: &[],
+                items: Vec::new(),
                 selected_index: 0,
                 loading: false,
+                filtering: false,
+                query: "",
             },
             rows_cache,
             chat_rooms: rooms,

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -150,7 +150,8 @@ Before class choice:
 - World actions: `r` recalls to Embergate's Town Square when out of combat; `f` toggles the Follow panel; `g` casts the Resurrection rite on the nearest fallen adventurer in the room (Cleric/Paladin/Druid only); `p` opens the Stable (companion vendor) where one stands; `n` opens the housing ledger (at the clerk, or inside a home you own).
 - While dead (a corpse): all normal keys are suppressed; only `r`/Enter (release to the temple) and `Esc` (leave) respond, until a resurrection or the auto-release deadline.
 - Panels: `c` character, `v` abilities, `t` inventory, `b` shop where a merchant exists, `o` examine/look, `k` titles, `j` quest journal, `f` follow.
-- List panels: `w/s` or up/down move cursor; `1-9` jump and activate; Enter activates.
+- List panels: `w/s` or up/down move cursor; `1-9` jump and activate; Enter activates. The view auto-scrolls to keep the highlighted row within a small scroll-off margin (top and bottom).
+- Cursor-less text panels (character/abilities/quests): `[` / `]` scroll. Both scroll offsets share one interior-mutable `list_scroll` on `state::State`, clamped to content by the render pass and reset on panel change.
 - Inventory panel: `x` sells the selected inventory row when a shop is present.
 - Follow panel: Enter follows/stops the selected in-room adventurer; `x` stops following whoever is currently followed, including absent/separated targets.
 - `Esc` leaves active Lateania and returns to the Games hub.

--- a/late-ssh/src/app/door/lateania/input.rs
+++ b/late-ssh/src/app/door/lateania/input.rs
@@ -12,7 +12,8 @@
 //     buys the selected beast and x feeds/tends the one you have. n opens the
 //     housing ledger (buy a deed at the clerk, furnish a home you own from inside).
 //     In a list panel, 1-9 select a row, Enter activates (equip/use/buy),
-//     w/s move the cursor, x sells (inventory).
+//     w/s move the cursor, x sells (inventory). List panels auto-scroll to
+//     follow the cursor; [ / ] scroll the cursor-less text panels.
 //   - Esc leaves the world for the Lateania landing page.
 //
 // A full typed command prompt needs an input-capture mode; deferred.
@@ -246,6 +247,16 @@ pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
         }
         b'z' | b'Z' => {
             state.flee();
+            InputAction::Handled
+        }
+        // Manual scroll for cursor-less text panels (character/abilities/quests).
+        // List panels auto-follow their cursor, so these are no-ops there.
+        b'[' => {
+            state.scroll_text_up();
+            InputAction::Handled
+        }
+        b']' => {
+            state.scroll_text_down();
             InputAction::Handled
         }
         _ => InputAction::Ignored,

--- a/late-ssh/src/app/door/lateania/state.rs
+++ b/late-ssh/src/app/door/lateania/state.rs
@@ -6,6 +6,7 @@
 // list panels. All real actions delegate to the service's *_task methods; this
 // struct never blocks and never mutates world truth.
 
+use std::cell::Cell;
 use std::time::{Duration, Instant};
 
 use tokio::sync::watch;
@@ -14,6 +15,9 @@ use uuid::Uuid;
 use super::classes::Class;
 use super::svc::{LateaniaService, MudSnapshot, PlayerView, empty_player_view};
 use super::world::Dir;
+
+/// Lines moved per `[` / `]` press when scrolling a text panel.
+const SCROLL_STEP: usize = 3;
 
 /// Which side panel the session is looking at.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -49,6 +53,10 @@ pub struct State {
     panel: Panel,
     /// Selection cursor for the inventory/shop list panels.
     cursor: usize,
+    /// Line the list view is scrolled to. Interior-mutable so the render pass
+    /// (which only holds `&State`) can keep the highlighted row inside a
+    /// scroll-off margin. Reset whenever the panel changes.
+    list_scroll: Cell<usize>,
     joined: bool,
     join_pending: bool,
     join_requested_at: Instant,
@@ -68,6 +76,7 @@ impl State {
             snapshot_rx,
             panel: Panel::Room,
             cursor: 0,
+            list_scroll: Cell::new(0),
             joined: true,
             join_pending: true,
             join_requested_at,
@@ -131,6 +140,7 @@ impl State {
         if self.panel != panel {
             self.panel = panel;
             self.cursor = 0;
+            self.list_scroll.set(0);
         }
     }
 
@@ -141,6 +151,31 @@ impl State {
             self.panel = panel;
         }
         self.cursor = 0;
+        self.list_scroll.set(0);
+    }
+
+    /// Current list scroll offset (first visible line).
+    pub fn list_scroll(&self) -> usize {
+        self.list_scroll.get()
+    }
+
+    /// Store the list scroll offset chosen by the render pass.
+    pub fn set_list_scroll(&self, off: usize) {
+        self.list_scroll.set(off);
+    }
+
+    /// Manual scroll for cursor-less text panels (`[` / `]`). List panels
+    /// auto-follow their cursor and re-clamp this on the next render, so these
+    /// only have a lasting effect on text panels. The render pass clamps the
+    /// value to the content, so growing it past the end is harmless.
+    pub fn scroll_text_up(&mut self) {
+        let cur = self.list_scroll.get();
+        self.list_scroll.set(cur.saturating_sub(SCROLL_STEP));
+    }
+
+    pub fn scroll_text_down(&mut self) {
+        let cur = self.list_scroll.get();
+        self.list_scroll.set(cur + SCROLL_STEP);
     }
 
     /// Current list length for whichever list panel is active (for cursor clamp).

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -299,20 +299,67 @@ fn draw_side(
         return;
     }
 
-    let lines = match state.panel() {
+    // List panels return the line index of the highlighted row so the view can
+    // scroll to keep the selection visible; text panels return `None`.
+    let (lines, selected) = match state.panel() {
         Panel::Room => unreachable!("room panel is rendered by draw_room_side"),
-        Panel::Character => character_panel(view),
-        Panel::Abilities => abilities_panel(view),
+        Panel::Character => (character_panel(view), None),
+        Panel::Abilities => (abilities_panel(view), None),
         Panel::Inventory => inventory_panel(view, state.cursor()),
         Panel::Shop => shop_panel(view, state.cursor()),
         Panel::Examine => examine_panel(view, state.cursor()),
         Panel::Titles => titles_panel(view, state.cursor()),
-        Panel::Quests => quests_panel(view),
+        Panel::Quests => (quests_panel(view), None),
         Panel::Follow => follow_panel(view, state.cursor(), usernames),
         Panel::Stable => stable_panel(view, state.cursor()),
         Panel::Housing => housing_panel(view, state.cursor()),
     };
-    frame.render_widget(side_paragraph(lines), area);
+    let off = scroll_offset(
+        state.list_scroll(),
+        lines.len(),
+        selected,
+        area.height as usize,
+    );
+    state.set_list_scroll(off);
+    let shown = if off == 0 {
+        lines
+    } else {
+        lines.into_iter().skip(off).collect()
+    };
+    frame.render_widget(side_paragraph(shown), area);
+}
+
+/// Lines of context kept between the highlighted row and the top/bottom edges of
+/// the list view, so navigating never parks the selection flush against a
+/// border (except at the very start/end of the list, where there's nothing more
+/// to show).
+const LIST_SCROLL_MARGIN: usize = 2;
+
+/// New first-visible line for a side panel, given the previous scroll `prev`.
+///
+/// List panels pass the highlighted row as `selected` and auto-follow it,
+/// nudging only when it would come within `LIST_SCROLL_MARGIN` of an edge so
+/// the list scrolls under the cursor. Cursor-less text panels pass
+/// `selected = None` and are scrolled manually (`[` / `]`); here we just clamp
+/// the requested offset to the content.
+fn scroll_offset(prev: usize, total: usize, selected: Option<usize>, height: usize) -> usize {
+    if height == 0 || total <= height {
+        return 0;
+    }
+    let max = total - height;
+    let Some(sel) = selected else {
+        // Text panel: honor the manual offset, clamped to the content.
+        return prev.min(max);
+    };
+    // Margin can't exceed what fits above and below within the window.
+    let margin = LIST_SCROLL_MARGIN.min(height.saturating_sub(1) / 2);
+    let mut off = prev.min(max);
+    if sel < off + margin {
+        off = sel.saturating_sub(margin);
+    } else if sel + margin >= off + height {
+        off = sel + margin + 1 - height;
+    }
+    off.min(max)
 }
 
 fn draw_room_side(
@@ -341,8 +388,9 @@ fn draw_room_side(
 
 /// Titles panel: a selectable list of earned titles with their levels. Enter
 /// sets the highlighted one as your displayed title (or clears it).
-fn titles_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
+fn titles_panel(view: &PlayerView, cursor: usize) -> (Vec<Line<'static>>, Option<usize>) {
     let mut lines = vec![section("Titles")];
+    let mut sel_line = None;
     if view.titles.is_empty() {
         lines.push(Line::from(Span::styled(
             "  none earned yet - slay notable foes",
@@ -351,6 +399,9 @@ fn titles_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     }
     for (i, title) in view.titles.iter().enumerate() {
         let selected = i == cursor;
+        if selected {
+            sel_line = Some(lines.len());
+        }
         let active = view.active_title == Some(i);
         let level = view.title_levels.get(i).copied().unwrap_or(1);
         let marker = if selected { ">" } else { " " };
@@ -375,7 +426,7 @@ fn titles_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     lines.push(Line::raw(""));
     lines.push(hint("w/s", "select  Enter display"));
     lines.push(hint("k", "close  (* = shown by your name)"));
-    lines
+    (lines, sel_line)
 }
 
 /// Quest journal: Frontier zone clears plus active board bounties.
@@ -410,6 +461,7 @@ fn quests_panel(view: &PlayerView) -> Vec<Line<'static>> {
     )));
     lines.push(Line::raw(""));
     lines.push(hint("j", "close"));
+    lines.push(hint("[ ]", "scroll"));
     lines
 }
 
@@ -1085,12 +1137,14 @@ fn character_panel(view: &PlayerView) -> Vec<Line<'static>> {
     }
     lines.push(Line::raw(""));
     lines.push(hint("c", "close  v abilities  t bag"));
+    lines.push(hint("[ ]", "scroll"));
     lines
 }
 
 /// Examine panel: the lookable things in the current room.
-fn examine_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
+fn examine_panel(view: &PlayerView, cursor: usize) -> (Vec<Line<'static>>, Option<usize>) {
     let mut lines = vec![section("Look at")];
+    let mut sel_line = None;
     if view.features.is_empty() {
         lines.push(Line::from(Span::styled(
             "  nothing of note here",
@@ -1099,6 +1153,9 @@ fn examine_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     }
     for (i, feat) in view.features.iter().enumerate() {
         let selected = i == cursor;
+        if selected {
+            sel_line = Some(lines.len());
+        }
         let marker = if selected { ">" } else { " " };
         let tag = if feat.kind.is_empty() {
             String::new()
@@ -1121,7 +1178,7 @@ fn examine_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     lines.push(Line::raw(""));
     lines.push(hint("w/s", "select  Enter look"));
     lines.push(hint("o", "close"));
-    lines
+    (lines, sel_line)
 }
 
 /// One compact line of the six ability scores with their modifiers.
@@ -1177,10 +1234,12 @@ fn abilities_panel(view: &PlayerView) -> Vec<Line<'static>> {
     lines.push(Line::raw(""));
     lines.push(hint("1-9", "use ability in combat"));
     lines.push(hint("v", "close"));
+    lines.push(hint("[ ]", "scroll"));
     lines
 }
 
-fn inventory_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
+fn inventory_panel(view: &PlayerView, cursor: usize) -> (Vec<Line<'static>>, Option<usize>) {
+    let mut sel_line = None;
     let mut lines = vec![
         section("Inventory"),
         Line::from(Span::styled(
@@ -1202,6 +1261,9 @@ fn inventory_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     }
     for (i, it) in view.inventory.iter().enumerate() {
         let selected = i == cursor;
+        if selected {
+            sel_line = Some(lines.len());
+        }
         let marker = if selected { ">" } else { " " };
         let tag = inventory_item_tag(it.equipped, it.slot.as_deref());
         let style = if selected {
@@ -1226,7 +1288,7 @@ fn inventory_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     lines.push(Line::raw(""));
     lines.push(hint("w/s", "select  Enter equip/use"));
     lines.push(hint("x", "sell (at a shop)  t close"));
-    lines
+    (lines, sel_line)
 }
 
 fn inventory_item_tag(equipped: bool, slot: Option<&str>) -> String {
@@ -1238,13 +1300,17 @@ fn inventory_item_tag(equipped: bool, slot: Option<&str>) -> String {
     slot.map(|slot| format!(" ({slot})")).unwrap_or_default()
 }
 
-fn shop_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
+fn shop_panel(view: &PlayerView, cursor: usize) -> (Vec<Line<'static>>, Option<usize>) {
     let Some(shop) = &view.shop else {
-        return vec![Line::from(Span::styled(
-            "No shop here.",
-            Style::default().fg(theme::TEXT_DIM()),
-        ))];
+        return (
+            vec![Line::from(Span::styled(
+                "No shop here.",
+                Style::default().fg(theme::TEXT_DIM()),
+            ))],
+            None,
+        );
     };
+    let mut sel_line = None;
     let gold_line = if view.banked_gold > 0 {
         format!(
             "{} - your gold: {} (bank: {})",
@@ -1268,6 +1334,9 @@ fn shop_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     ];
     for (i, e) in shop.entries.iter().enumerate() {
         let selected = i == cursor;
+        if selected {
+            sel_line = Some(lines.len());
+        }
         let marker = if selected { ">" } else { " " };
         let price_color = if e.affordable {
             theme::BADGE_GOLD()
@@ -1303,16 +1372,20 @@ fn shop_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     lines.push(Line::raw(""));
     lines.push(hint("w/s", "select  Enter buy"));
     lines.push(hint("b", "leave shop"));
-    lines
+    (lines, sel_line)
 }
 
-fn stable_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
+fn stable_panel(view: &PlayerView, cursor: usize) -> (Vec<Line<'static>>, Option<usize>) {
     let Some(stable) = &view.stable else {
-        return vec![Line::from(Span::styled(
-            "No stable here.",
-            Style::default().fg(theme::TEXT_DIM()),
-        ))];
+        return (
+            vec![Line::from(Span::styled(
+                "No stable here.",
+                Style::default().fg(theme::TEXT_DIM()),
+            ))],
+            None,
+        );
     };
+    let mut sel_line = None;
     let mut lines = vec![
         Line::from(Span::styled(
             "The Stable",
@@ -1354,6 +1427,9 @@ fn stable_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     lines.push(Line::raw(""));
     for (i, e) in stable.entries.iter().enumerate() {
         let selected = i == cursor;
+        if selected {
+            sel_line = Some(lines.len());
+        }
         let marker = if selected { ">" } else { " " };
         let price_color = if e.affordable {
             theme::BADGE_GOLD()
@@ -1381,16 +1457,20 @@ fn stable_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     lines.push(hint("w/s", "select  Enter buy"));
     lines.push(hint("x", &format!("feed/tend ({}g)", stable.feed_cost)));
     lines.push(hint("p", "leave stable"));
-    lines
+    (lines, sel_line)
 }
 
-fn housing_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
+fn housing_panel(view: &PlayerView, cursor: usize) -> (Vec<Line<'static>>, Option<usize>) {
     let Some(housing) = &view.housing else {
-        return vec![Line::from(Span::styled(
-            "No housing ledger here.",
-            Style::default().fg(theme::TEXT_DIM()),
-        ))];
+        return (
+            vec![Line::from(Span::styled(
+                "No housing ledger here.",
+                Style::default().fg(theme::TEXT_DIM()),
+            ))],
+            None,
+        );
     };
+    let mut sel_line = None;
     let mut lines = vec![
         Line::from(Span::styled(
             housing.title.clone(),
@@ -1406,6 +1486,9 @@ fn housing_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     ];
     for (i, e) in housing.entries.iter().enumerate() {
         let selected = i == cursor;
+        if selected {
+            sel_line = Some(lines.len());
+        }
         let marker = if selected { ">" } else { " " };
         let price_color = if e.owned {
             theme::SUCCESS()
@@ -1443,7 +1526,7 @@ fn housing_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     lines.push(Line::raw(""));
     lines.push(hint("w/s", "select  Enter buy"));
     lines.push(hint("n", "close ledger"));
-    lines
+    (lines, sel_line)
 }
 
 /// Trim a string to `max` chars, adding an ellipsis when cut.
@@ -1859,8 +1942,9 @@ fn follow_panel(
     view: &PlayerView,
     cursor: usize,
     usernames: &UsernameLookup<'_>,
-) -> Vec<Line<'static>> {
+) -> (Vec<Line<'static>>, Option<usize>) {
     let mut lines = vec![section("Follow")];
+    let mut sel_line = None;
     if view.occupants.is_empty() {
         lines.push(Line::from(Span::styled(
             "  no one else is here",
@@ -1873,6 +1957,9 @@ fn follow_panel(
             .cloned()
             .unwrap_or_else(|| "adventurer".to_string());
         let selected = i == cursor;
+        if selected {
+            sel_line = Some(lines.len());
+        }
         let following = view.following == Some(occ.user_id);
         let marker = if selected { "> " } else { "  " };
         let tag = if !occ.alive {
@@ -1914,7 +2001,7 @@ fn follow_panel(
         lines.push(hint("x", "stop following"));
     }
     lines.push(hint("f", "close"));
-    lines
+    (lines, sel_line)
 }
 
 fn rarity_color(rarity: &str) -> ratatui::style::Color {

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -2102,6 +2102,13 @@ fn handle_byte_event(app: &mut App, ctx: InputContext, byte: u8) {
         return;
     }
 
+    // The Discover filter is a text input; let it capture digits, `/`, etc.
+    // before the global screen-switch / slash-command handlers claim them.
+    if discover_filter_active(app, ctx.screen) {
+        let _ = chat::input::handle_byte(app, byte);
+        return;
+    }
+
     if handle_modal_input(app, ctx, byte) {
         return;
     }
@@ -2120,6 +2127,12 @@ fn handle_byte_event(app: &mut App, ctx: InputContext, byte: u8) {
 
 fn room_jump_active_on_current_screen(app: &App, screen: Screen) -> bool {
     app.chat.room_jump_active && matches!(screen, Screen::Dashboard)
+}
+
+fn discover_filter_active(app: &App, screen: Screen) -> bool {
+    matches!(screen, Screen::Dashboard)
+        && app.chat.discover_selected
+        && app.chat.discover.is_filtering()
 }
 
 fn toggle_room_section_from_key(app: &mut App, ctx: InputContext, section: RoomSection) -> bool {
@@ -2234,6 +2247,10 @@ fn dispatch_escape(app: &mut App) {
     }
     if ctx.screen == Screen::Dashboard && app.chat.room_jump_active {
         app.chat.cancel_room_jump();
+        return;
+    }
+    if discover_filter_active(app, ctx.screen) {
+        app.chat.discover.cancel_filter();
         return;
     }
     if handle_modal_input(app, ctx, 0x1B) {
@@ -3127,10 +3144,13 @@ fn start_slash_command_composer(app: &mut App, screen: Screen) -> bool {
         return false;
     }
 
-    // On synthetic chat entries (News/Showcase/Work), `/` is the
-    // filter-mine toggle, not a slash-command starter.
+    // On synthetic chat entries (News/Showcase/Work/Discover), `/` is a
+    // per-view filter shortcut, not a slash-command starter.
     if matches!(screen, Screen::Dashboard)
-        && (app.chat.news_selected || app.chat.showcase_selected || app.chat.work_selected)
+        && (app.chat.news_selected
+            || app.chat.showcase_selected
+            || app.chat.work_selected
+            || app.chat.discover_selected)
     {
         return false;
     }

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -548,9 +548,11 @@ impl App {
             marker_read_at: self.chat.feeds.marker_read_at(),
         };
         let discover_view = chat::discover::ui::DiscoverListView {
-            items: self.chat.discover.all_items(),
+            items: self.chat.discover.visible_items(),
             selected_index: self.chat.discover.selected_index(),
             loading: self.chat.discover.is_loading(),
+            filtering: self.chat.discover.is_filtering(),
+            query: self.chat.discover.query(),
         };
         let notifications_view = chat::notifications::ui::NotificationListView {
             items: self.chat.notifications.all_items(),

--- a/late-ssh/tests/app_input_flow.rs
+++ b/late-ssh/tests/app_input_flow.rs
@@ -815,7 +815,10 @@ async fn chat_room_list_is_mouse_clickable() {
     let mut app = make_app(test_db.db.clone(), user.id, "chat-room-mouse-flow-it");
     wait_for_render_contains(&mut app, "rust").await;
 
-    app.handle_input(b"\x1b[<0;5;9M");
+    // Click the #rust row in the sidebar. It sits below the Core section
+    // (lounge, mentions, news, "+ browse rooms") and the Channels header, at
+    // rail row 10 (SGR mouse rows are 1-based).
+    app.handle_input(b"\x1b[<0;5;10M");
 
     wait_for_render_contains(&mut app, "rust room backlog").await;
 }
@@ -1224,9 +1227,9 @@ async fn sheet_command_opens_character_sheet_modal_in_dnd_room() {
     wait_for_render_contains(&mut app, "dnd").await;
 
     // Navigate to the dnd room. The sidebar order is lounge, mentions, news,
-    // then dnd (channels section). Press l three times to reach dnd from
-    // lounge.
-    app.handle_input(b"lll");
+    // "+ browse rooms" (Discover, last in Core), then dnd (channels section).
+    // Press l four times to reach dnd from lounge.
+    app.handle_input(b"llll");
     wait_for_render_contains(&mut app, "Home · dnd").await;
 
     app.handle_input(b"i");


### PR DESCRIPTION
## Summary
- Reworks the Home "Discover / + browse rooms" screen so it's faster to scan and search. Each room now renders on a single dense line instead of a five-line block, a `/` filter narrows the list by slug, and the Discover entry moves into the Core section of the room rail so it collapses with it.

## Changes
- **Dense list rows** (`discover/ui.rs`): `ITEM_HEIGHT` drops from 5 to 1. Each room is now one line — a `#slug` name column (fixed 24-wide, ellipsis-truncated), member count, message count, and last activity — so many more rooms fit on screen. The bordered per-item blocks and wrapping are gone; the selected row is marked with `›` and a selection background.
- **Slug filter** (`discover/state.rs`, `discover/input.rs`): `/` opens an inline substring filter over room slugs. Typing edits a live query (case-insensitive `contains`), selection and navigation track the filtered subset, and `Esc` clears the query and closes the filter. Backspace, `Ctrl-U`, and Enter (join selected) work while filtering.
- **Filter input routing** (`app/input.rs`, `chat/input.rs`): while the filter is active it owns every byte — digits, `space`, `h`/`l` — so the query is unrestricted; arrow keys still navigate. `start_slash_command_composer` now excludes Discover so `/` starts the filter instead of a slash command there.
- **Room-rail placement** (`chat/state.rs`, `chat/ui.rs`): Discover moves from the very bottom of the rail (after DMs) to the last entry in the Core section. It now collapses when Core is collapsed.
- **Footer / hints** (`chat/ui.rs`): the composer-area hint shows `/ filter` and swaps to a live "Filter rooms" input box while filtering; empty results name the query (`No rooms match "…"`). Nav-hint label shortened to `picker`.
- Context docs updated in `chat/CONTEXT.md` for the new order, single-line rendering, and filter keybinding.

## Behavior notes
- Because Discover is now inside Core, collapsing Core hides it — this is a deliberate change from the previous "always present" behavior.
- Filter matches only room slugs (not member/message stats), and the query resets selection to the top of the filtered list on each edit.

## Feature flags
- None.

## Screenshots / Video
- Not included in this draft; attach before review (visible TUI change to the Discover list and filter input).

## Testing
- Automated: added unit tests in `discover/state.rs` (case-insensitive filtering, selection tracking the filtered list, cancel restoring the full list) and `discover/ui.rs` (single-line rendering, empty-filter message naming the query); updated existing state/ui tests and the room-order test to reflect Discover's new Core placement. Per repo policy, `cargo test`/`clippy` were not run locally — left to the owner via `make check`.
- Manual: Not run.