### PR TITLE
Rate-limit chat links from fresh accounts by account age

### DIFF
--- a/late-core/src/models/user.rs
+++ b/late-core/src/models/user.rs
@@ -323,6 +323,18 @@ impl User {
         Ok(())
     }
 
+    /// Seconds since the account was created, or `None` if the user is unknown.
+    /// Used by the chat link rate-limiter to pick a cooldown tier by account age.
+    pub async fn account_age_seconds(client: &Client, user_id: Uuid) -> Result<Option<i64>> {
+        let row = client
+            .query_opt(
+                "SELECT EXTRACT(EPOCH FROM (now() - created))::bigint AS age FROM users WHERE id = $1",
+                &[&user_id],
+            )
+            .await?;
+        Ok(row.map(|r| r.get::<_, i64>("age")))
+    }
+
     pub async fn list_usernames_by_ids(
         client: &Client,
         user_ids: &[Uuid],

--- a/late-ssh/src/app/chat/svc.rs
+++ b/late-ssh/src/app/chat/svc.rs
@@ -73,6 +73,10 @@ pub struct ChatService {
     moderation_infra: ModerationInfra,
     chip_service: Option<ChipService>,
     gift_cooldowns: Arc<Mutex<HashMap<Uuid, std::time::Instant>>>,
+    /// Last time each user posted a message containing a link. Drives the
+    /// account-age link cooldown (blunts fresh-account spam-and-leave). Keyed by
+    /// user, so it survives reconnects; holds at most one entry per link-poster.
+    link_last_sent: Arc<Mutex<HashMap<Uuid, std::time::Instant>>>,
     username_refresh_started: Arc<AtomicBool>,
     refresh_sessions: Arc<Mutex<HashMap<Uuid, ChatRefreshSession>>>,
     refresh_scheduler_started: Arc<AtomicBool>,
@@ -137,17 +141,78 @@ pub struct RoomMemberListItem {
     pub username: Option<String>,
 }
 
-fn send_error_message(error: &anyhow::Error) -> &'static str {
+fn send_error_message(error: &anyhow::Error) -> String {
     let error = error.to_string();
     if error.contains("not a member") {
-        "You are not a member of this room."
+        "You are not a member of this room.".to_string()
     } else if error.contains("banned from this room") {
-        "You are banned from this room."
+        "You are banned from this room.".to_string()
     } else if error.contains("admin-only") {
-        "Only admins can post in #announcements."
+        "Only admins can post in #announcements.".to_string()
+    } else if let Some(secs) = error.strip_prefix("link-cooldown:") {
+        let secs = secs.parse::<u64>().unwrap_or(0);
+        format!("🔗 New accounts can only post a link occasionally — next link in {}.", format_cooldown(secs))
     } else {
-        "Could not send message. Please try again."
+        "Could not send message. Please try again.".to_string()
     }
+}
+
+/// Render a remaining cooldown as a compact human string, e.g. `29m 30s`, `45s`.
+fn format_cooldown(secs: u64) -> String {
+    let secs = secs.max(1);
+    let minutes = secs / 60;
+    let seconds = secs % 60;
+    if minutes > 0 {
+        format!("{minutes}m {seconds:02}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+/// Account-age tiers for the chat link rate limit. An account under a day old may
+/// only post a link every 30 minutes; under a week, every 5 minutes; older
+/// accounts are unlimited.
+const LINK_TIER_YOUNG_SECS: i64 = 24 * 60 * 60; // 1 day
+const LINK_TIER_ESTABLISHED_SECS: i64 = 7 * 24 * 60 * 60; // 7 days
+const LINK_COOLDOWN_FRESH: std::time::Duration = std::time::Duration::from_secs(30 * 60);
+const LINK_COOLDOWN_YOUNG: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
+/// The link cooldown for an account of the given age, or `None` if the account is
+/// established enough (7d+) to post links freely.
+fn link_cooldown_for_age(age_secs: i64) -> Option<std::time::Duration> {
+    if age_secs >= LINK_TIER_ESTABLISHED_SECS {
+        None
+    } else if age_secs >= LINK_TIER_YOUNG_SECS {
+        Some(LINK_COOLDOWN_YOUNG)
+    } else {
+        Some(LINK_COOLDOWN_FRESH)
+    }
+}
+
+/// Common TLDs used to spot a bare-domain link (one with no http/www scheme).
+const LINK_TLDS: &[&str] = &[
+    ".com", ".net", ".org", ".io", ".gg", ".xyz", ".co", ".me", ".tv", ".link", ".app", ".dev",
+    ".info", ".biz", ".online", ".site", ".shop", ".ru", ".cn", ".to", ".ly", ".ai",
+];
+
+/// Whether a message body contains anything that looks like a clickable link.
+/// Catches `http(s)://`, `www.`, and bare `domain.tld` forms so a link can't slip
+/// through without a scheme.
+fn contains_link(body: &str) -> bool {
+    let lower = body.to_ascii_lowercase();
+    if lower.contains("http://") || lower.contains("https://") || lower.contains("www.") {
+        return true;
+    }
+    LINK_TLDS.iter().any(|tld| {
+        lower.match_indices(tld).any(|(i, _)| {
+            // Require an alphanumeric host char before the dot and a boundary
+            // after the TLD, so "x.com" and "buy.io/now" match but "etc." does not.
+            let before = lower[..i].chars().last();
+            let after = lower[i + tld.len()..].chars().next();
+            before.is_some_and(|c| c.is_alphanumeric())
+                && after.is_none_or(|c| !c.is_alphanumeric())
+        })
+    })
 }
 
 fn poll_error_message(error: &anyhow::Error) -> String {
@@ -559,6 +624,7 @@ impl ChatService {
             moderation_infra: ModerationInfra::default(),
             chip_service: None,
             gift_cooldowns: Arc::new(Mutex::new(HashMap::new())),
+            link_last_sent: Arc::new(Mutex::new(HashMap::new())),
             username_refresh_started: Arc::new(AtomicBool::new(false)),
             refresh_sessions: Arc::new(Mutex::new(HashMap::new())),
             refresh_scheduler_started: Arc::new(AtomicBool::new(false)),
@@ -1746,6 +1812,32 @@ impl ChatService {
         .await
     }
 
+    /// How much longer `user_id` must wait before posting another link, or `None`
+    /// if they may post one now. Records the send time when it returns `None`.
+    /// Established accounts (7d+) always return `None`.
+    async fn link_cooldown_remaining(
+        &self,
+        client: &tokio_postgres::Client,
+        user_id: Uuid,
+    ) -> Result<Option<std::time::Duration>> {
+        let age = User::account_age_seconds(client, user_id)
+            .await?
+            .unwrap_or(i64::MAX);
+        let Some(cooldown) = link_cooldown_for_age(age) else {
+            return Ok(None);
+        };
+        let now = std::time::Instant::now();
+        let mut last_sent = self.link_last_sent.lock_recover();
+        if let Some(prev) = last_sent.get(&user_id) {
+            let elapsed = now.duration_since(*prev);
+            if elapsed < cooldown {
+                return Ok(Some(cooldown - elapsed));
+            }
+        }
+        last_sent.insert(user_id, now);
+        Ok(None)
+    }
+
     #[tracing::instrument(skip(self, params), fields(user_id = %params.user_id, room_id = %params.room_id, body_len = params.body.len()))]
     async fn send_message(&self, params: SendMessageParams) -> Result<()> {
         let SendMessageParams {
@@ -1774,6 +1866,17 @@ impl ChatService {
         if RoomBan::is_active_for_room_and_user(&client, room_id, user_id).await? {
             anyhow::bail!("user is banned from this room");
         }
+
+        // Account-age link rate limit: younger accounts can only post a link
+        // every so often, to blunt spam-and-leave without silencing them. Old
+        // (7d+) accounts and admins are unlimited. The age lookup only runs when
+        // a non-admin message actually contains a link, which is rare.
+        if !is_admin && contains_link(body) {
+            if let Some(remaining) = self.link_cooldown_remaining(&client, user_id).await? {
+                anyhow::bail!("link-cooldown:{}", remaining.as_secs());
+            }
+        }
+
         if let Some(reply_to_message_id) = reply_to_message_id {
             let reply_target = ChatMessage::get(&client, reply_to_message_id)
                 .await?
@@ -3132,6 +3235,52 @@ mod tests {
     use super::*;
     use chrono::Duration as ChronoDuration;
     use late_core::models::chat_poll::{ChatPoll, ChatPollOptionSummary};
+
+    #[test]
+    fn contains_link_catches_schemes_www_and_bare_domains() {
+        for spam in [
+            "click https://evil.example/win",
+            "HTTP://EVIL.io free chips",
+            "go to www.evil.io now",
+            "buy at evil.io/now",
+            "join evil.gg or evil.xyz",
+            "dm me on telegram t.me/scammer",
+        ] {
+            assert!(contains_link(spam), "should flag: {spam}");
+        }
+        for clean in [
+            "hello there, how are you?",
+            "i finished 2048 and got a high score",
+            "see you at 3pm. thanks!",
+            "node.js is fine to mention",
+            "e.g. that idea is good",
+        ] {
+            assert!(!contains_link(clean), "should not flag: {clean}");
+        }
+    }
+
+    #[test]
+    fn link_cooldown_tiers_by_account_age() {
+        let hour = 3_600;
+        let day = 24 * hour;
+        // Fresh (< 1 day): 30 minutes.
+        assert_eq!(link_cooldown_for_age(0), Some(LINK_COOLDOWN_FRESH));
+        assert_eq!(link_cooldown_for_age(23 * hour), Some(LINK_COOLDOWN_FRESH));
+        // Young (1–7 days): 5 minutes.
+        assert_eq!(link_cooldown_for_age(day), Some(LINK_COOLDOWN_YOUNG));
+        assert_eq!(link_cooldown_for_age(6 * day), Some(LINK_COOLDOWN_YOUNG));
+        // Established (7d+): no cooldown.
+        assert_eq!(link_cooldown_for_age(7 * day), None);
+        assert_eq!(link_cooldown_for_age(365 * day), None);
+    }
+
+    #[test]
+    fn format_cooldown_is_compact() {
+        assert_eq!(format_cooldown(0), "1s");
+        assert_eq!(format_cooldown(45), "45s");
+        assert_eq!(format_cooldown(60), "1m 00s");
+        assert_eq!(format_cooldown(29 * 60 + 30), "29m 30s");
+    }
 
     fn test_poll(options: Vec<(&str, i64)>) -> ActiveChatPoll {
         let now = Utc::now();


### PR DESCRIPTION
## Summary
- Blunts spam-and-leave from brand-new accounts by throttling how often a young account can post a message containing a link, without silencing legitimate chat.
- The cooldown is tiered by account age, so the friction fades as an account ages and disappears entirely once it's a week old.

## Changes
- Chat message sends now check for a link in the body (non-admins only) and enforce an account-age cooldown:
  - Under 1 day old: one link every 30 minutes.
  - 1–7 days old: one link every 5 minutes.
  - 7+ days old (and all admins): unlimited.
- Link detection catches `http://` / `https://`, `www.`, and bare `domain.tld` forms (curated common-TLD list with host/boundary checks, so `x.com` and `buy.io/now` match but `e.g.` and `node.js` do not).
- When blocked, the sender sees a friendly message with the remaining wait, e.g. `🔗 New accounts can only post a link occasionally — next link in 29m 30s.`
- Adds `User::account_age_seconds` to compute age from `users.created` in Postgres.
- `send_error_message` now returns `String` (was `&'static str`) to carry the formatted cooldown message.

## Behavior notes
- The age lookup (one small query) only runs when a non-admin message actually contains a link, so the common no-link path is unaffected.
- Cooldown state (`link_last_sent`) is an in-memory per-user map, keyed by user id so it survives reconnects. It is process-local and not shared across replicas, and resets on restart — acceptable for anti-spam friction, not a hard guarantee. It holds at most one entry per link-poster.
- The send time is only recorded when a link is allowed through; blocked attempts do not extend the window.

## Feature flags
- None.

## Screenshots / Video
- Not applicable; the only UI-visible change is the cooldown error text shown inline in chat.

## Testing
- Automated: added unit tests covering link detection (schemes, `www.`, bare domains, and clean-text false-positive guards), the age→cooldown tier mapping at each boundary, and the compact cooldown formatter. Per repo policy, `cargo test`/`nextest` are left to the human owner to run.
- Manual: Not run.