### PR TITLE
Add @bartender gift drinks with a confirm-before-charge flow

### DIFF
--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -893,7 +893,12 @@ impl GhostService {
                 drink,
                 price,
             } => {
-                self.pending_gift_drinks.lock_recover().insert(
+                let mut pending_gifts = self.pending_gift_drinks.lock_recover();
+                // Sweep offers no one confirmed before stashing this one, so the
+                // map can't accumulate abandoned tabs.
+                pending_gifts
+                    .retain(|_, gift| gift.created_at.elapsed() <= BARTENDER_GIFT_CONFIRM_TIMEOUT);
+                pending_gifts.insert(
                     PendingGiftDrinkKey {
                         payer_id: trigger_message.user_id,
                         room_id: trigger_message.room_id,
@@ -907,6 +912,7 @@ impl GhostService {
                         created_at: Instant::now(),
                     },
                 );
+                drop(pending_gifts);
                 format!(
                     "{patron} {drink} for @{recipient_handle}, {price} chips. reply @{bartender} confirm to put it on your tab.",
                     bartender = bartender.username
@@ -990,7 +996,7 @@ impl GhostService {
             let mut pending_gifts = self.pending_gift_drinks.lock_recover();
             match pending_gifts.remove(&key) {
                 Some(pending) if pending.created_at.elapsed() <= BARTENDER_GIFT_CONFIRM_TIMEOUT => {
-                    Some(pending)
+                    pending
                 }
                 Some(_) => {
                     return Ok(Some(format!(
@@ -1003,11 +1009,6 @@ impl GhostService {
                     )));
                 }
             }
-        };
-        let Some(pending) = pending else {
-            return Ok(Some(format!(
-                "{payer_mention} nothing on the bar waiting for confirmation."
-            )));
         };
 
         match self

--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -19,7 +19,8 @@
 //! - `generate_json` — ungrounded JSON with a hard-enforced `responseSchema`
 //!   (only possible without a tool). The **@bartender mention** uses this: it
 //!   answers house Q&A from the injected app context and decides drink orders
-//!   (`pour`/`offer`/`chat` + a priced drink) as guaranteed well-formed JSON.
+//!   (`pour`/`gift_offer`/`offer`/`chat` + a priced drink) as guaranteed
+//!   well-formed JSON.
 //!   It trades live web lookups for a reply shape that never breaks the parser.
 //! - `generate_short_reply` — ungrounded (no web lookup, so no grounded-call
 //!   latency), cheap. The output cap carries enough headroom for a thinking
@@ -49,6 +50,7 @@ use late_core::{
 };
 use serde_json::json;
 use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::broadcast;
 use uuid::Uuid;
@@ -75,6 +77,7 @@ pub struct GhostService {
     username_directory: crate::usernames::UsernameDirectory,
     chip_service: ChipService,
     clubhouse_lobby: SharedLobby,
+    pending_gift_drinks: SharedPendingGiftDrinks,
 }
 
 #[derive(Clone)]
@@ -97,6 +100,24 @@ struct DealerTrigger {
 struct DealerRoomState {
     action_count: usize,
     last_reply: Option<Instant>,
+}
+
+type SharedPendingGiftDrinks = Arc<Mutex<HashMap<PendingGiftDrinkKey, PendingGiftDrink>>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+struct PendingGiftDrinkKey {
+    payer_id: Uuid,
+    room_id: Uuid,
+}
+
+#[derive(Clone, Debug)]
+struct PendingGiftDrink {
+    recipient_id: Uuid,
+    recipient_handle: String,
+    payer_handle: String,
+    drink: String,
+    price: i64,
+    created_at: Instant,
 }
 
 const BOT_FINGERPRINT: &str = "bot-fp-000";
@@ -186,7 +207,8 @@ const GRAYBEARD_PERSONA: &str = "You are a burned-out senior developer, deeply n
 pub const GRAYBEARD_MENTION_COOLDOWN: Duration = Duration::from_secs(60); // 1 min
 const BARTENDER_FINGERPRINT: &str = "bartender-fp-000";
 const BARTENDER_USERNAME: &str = "bartender";
-const BARTENDER_MENTION_COOLDOWN: Duration = Duration::from_secs(25);
+const BARTENDER_MENTION_COOLDOWN: Duration = Duration::from_secs(5);
+const BARTENDER_GIFT_CONFIRM_TIMEOUT: Duration = Duration::from_secs(60);
 /// Cap on the tutorial greeting generation before the scripted line goes out
 /// instead. The greeting uses `generate_short_reply` (ungrounded, small output
 /// cap), which returns in ~1-2s, so this only needs to bound a slow or hung
@@ -244,6 +266,7 @@ impl GhostService {
             username_directory,
             chip_service,
             clubhouse_lobby,
+            pending_gift_drinks: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -698,13 +721,19 @@ impl GhostService {
                             if !contains_mention(&message.body, &bartender.username) {
                                 continue;
                             }
-                            if let Some(last) = last_reply.get(&message.user_id)
+                            let is_confirm_or_cancel =
+                                bartender_confirmation_intent(&message.body, &bartender.username)
+                                    .is_some();
+                            if !is_confirm_or_cancel
+                                && let Some(last) = last_reply.get(&message.user_id)
                                 && last.elapsed() < BARTENDER_MENTION_COOLDOWN
                             {
                                 continue;
                             }
 
-                            last_reply.insert(message.user_id, Instant::now());
+                            if !is_confirm_or_cancel {
+                                last_reply.insert(message.user_id, Instant::now());
+                            }
                             let svc = self.clone();
                             let bartender = bartender.clone();
                             tokio::spawn(async move {
@@ -729,14 +758,33 @@ impl GhostService {
         bartender: BotUser,
         trigger_message: ChatMessage,
     ) -> Result<()> {
-        let (messages, balance, drunk_level) = {
+        {
             let client = self.db.get().await?;
             ChatRoomMember::auto_join_public_rooms(&client, bartender.id).await?;
 
             if !ChatRoomMember::is_member(&client, trigger_message.room_id, bartender.id).await? {
                 return Ok(());
             }
+        }
 
+        if let Some(body) = self
+            .handle_bartender_confirmation(&bartender, &trigger_message)
+            .await?
+        {
+            let mut rng = TinyRng::seeded();
+            let delay = rng.next_between_inclusive(1, 3) as u64;
+            tokio::time::sleep(Duration::from_secs(delay)).await;
+            self.chat_service.send_bot_reply_task(
+                bartender.id,
+                trigger_message.room_id,
+                body,
+                Some(trigger_message.user_id),
+            );
+            return Ok(());
+        }
+
+        let (messages, balance, drunk_level, gift_recipients) = {
+            let client = self.db.get().await?;
             let messages = ChatMessage::list_recent(
                 &client,
                 trigger_message.room_id,
@@ -748,7 +796,9 @@ impl GhostService {
                 .await?
                 .map(|drinks| drinks.level(chrono::Utc::now()))
                 .unwrap_or(0);
-            (messages, chips.balance, drunk_level)
+            let gift_recipients =
+                mentioned_gift_recipients(&client, &trigger_message, &bartender.username).await?;
+            (messages, chips.balance, drunk_level, gift_recipients)
         };
         if messages.is_empty() {
             return Ok(());
@@ -780,12 +830,17 @@ impl GhostService {
             - chip balance: {balance}\n\
             - spendable on drinks: {spendable} (house rule: a patron always keeps {floor} chips; you can only pour a price that fits inside spendable)\n\
             - current state: {drunk_word} ({serving_note})\n\n\
+            GIFT DRINKS:\n\
+            - If the patron clearly asks to buy, give, send, or pay for a drink for another user, use \"gift_offer\" only when that recipient is explicitly mentioned in the latest message and appears in this candidate list: {gift_candidates}.\n\
+            - For \"gift_offer\", set recipient to that candidate's handle without @, invent the drink, set a whole-number price between {price_min} and {price_max} that fits the payer's spendable chips, and tell the payer to reply exactly \"@{username} confirm\". The server will not charge until they confirm.\n\
+            - If they ask for a gift drink but no candidate is listed, use \"chat\" and ask who it is for. If they try to buy their own drink as a gift, use \"chat\".\n\n\
             Decide ONE action:\n\
             - \"pour\": ONLY when the patron themselves asked for a drink — read their intent generously, an order comes in many forms (\"get me a stout\", \"what's strong tonight\", \"the usual\", \"surprise me\", \"I'll take one\"). But a pour spends their chips, so if it is a greeting, a house question, banter, or you are at all unsure, do NOT pour. Invent the drink, set a whole-number price between {price_min} and {price_max} that fits the pour (ale cheap, top shelf dear), and hand it over. If you name the price in your line it MUST equal the price field exactly.\n\
+            - \"gift_offer\": ONLY for a clear request to buy a drink for a different mentioned user from the gift candidate list. No charge yet; this only creates a pending confirmation.\n\
             - \"offer\": the patron asked for a drink but cannot afford it (or wants more than their spendable). Charge nothing; counter-offer something in their range, with its price, kindly.\n\
             - \"chat\": everything else — greetings, house questions, banter, anything ambiguous. Answer exactly as you always do. No charge. When in doubt, chat; never charge on a maybe.\n\n\
             Return ONLY a JSON object, no markdown fences:\n\
-            {{\"action\": \"pour\" | \"offer\" | \"chat\", \"drink\": string or null, \"price\": integer or null, \"line\": string}}\n\
+            {{\"action\": \"pour\" | \"gift_offer\" | \"offer\" | \"chat\", \"recipient\": string or null, \"drink\": string or null, \"price\": integer or null, \"line\": string}}\n\
             \"line\" is your chat message: 1-3 short lines, no markdown, no emoji, never prefixed with your own username, never SKIP.",
             username = bartender.username,
             persona = BARTENDER_PERSONA,
@@ -793,6 +848,7 @@ impl GhostService {
             floor = CHIP_FLOOR,
             price_min = DRINK_PRICE_MIN,
             price_max = DRINK_PRICE_MAX,
+            gift_candidates = format_gift_recipient_candidates(&gift_recipients),
         );
 
         let history_with_prompt = format!(
@@ -822,7 +878,8 @@ impl GhostService {
             }
         };
 
-        let decision = parse_bartender_order(&reply, spendable, &bartender.username);
+        let decision =
+            parse_bartender_order(&reply, spendable, &bartender.username, &gift_recipients);
 
         let mut rng = TinyRng::seeded();
         let delay = rng.next_between_inclusive(2, 6) as u64;
@@ -830,6 +887,31 @@ impl GhostService {
         let body = match decision {
             BartenderDecision::Skip => return Ok(()),
             BartenderDecision::Say { line } => line,
+            BartenderDecision::GiftOffer {
+                recipient_id,
+                recipient_handle,
+                drink,
+                price,
+            } => {
+                self.pending_gift_drinks.lock_recover().insert(
+                    PendingGiftDrinkKey {
+                        payer_id: trigger_message.user_id,
+                        room_id: trigger_message.room_id,
+                    },
+                    PendingGiftDrink {
+                        recipient_id,
+                        recipient_handle: recipient_handle.clone(),
+                        payer_handle: patron.trim_start_matches('@').to_string(),
+                        drink: drink.clone(),
+                        price,
+                        created_at: Instant::now(),
+                    },
+                );
+                format!(
+                    "{patron} {drink} for @{recipient_handle}, {price} chips. reply @{bartender} confirm to put it on your tab.",
+                    bartender = bartender.username
+                )
+            }
             BartenderDecision::Pour { drink, price, line } => {
                 match self
                     .chip_service
@@ -868,6 +950,99 @@ impl GhostService {
         );
 
         Ok(())
+    }
+
+    async fn handle_bartender_confirmation(
+        &self,
+        bartender: &BotUser,
+        trigger_message: &ChatMessage,
+    ) -> Result<Option<String>> {
+        let Some(intent) =
+            bartender_confirmation_intent(&trigger_message.body, &bartender.username)
+        else {
+            return Ok(None);
+        };
+
+        let client = self.db.get().await?;
+        let usernames = User::list_usernames_by_ids(&client, &[trigger_message.user_id]).await?;
+        let payer_mention = mention_target_for_user(
+            usernames.get(&trigger_message.user_id).map(String::as_str),
+            trigger_message.user_id,
+        );
+        drop(client);
+
+        let key = PendingGiftDrinkKey {
+            payer_id: trigger_message.user_id,
+            room_id: trigger_message.room_id,
+        };
+
+        if intent == BartenderConfirmationIntent::Cancel {
+            let removed = self.pending_gift_drinks.lock_recover().remove(&key);
+            let body = if removed.is_some() {
+                format!("{payer_mention} tab closed. nothing poured, nothing charged.")
+            } else {
+                format!("{payer_mention} nothing on the bar waiting for confirmation.")
+            };
+            return Ok(Some(body));
+        }
+
+        let pending = {
+            let mut pending_gifts = self.pending_gift_drinks.lock_recover();
+            match pending_gifts.remove(&key) {
+                Some(pending) if pending.created_at.elapsed() <= BARTENDER_GIFT_CONFIRM_TIMEOUT => {
+                    Some(pending)
+                }
+                Some(_) => {
+                    return Ok(Some(format!(
+                        "{payer_mention} that drink offer went flat. ask me for a fresh one."
+                    )));
+                }
+                None => {
+                    return Ok(Some(format!(
+                        "{payer_mention} nothing on the bar waiting for confirmation."
+                    )));
+                }
+            }
+        };
+        let Some(pending) = pending else {
+            return Ok(Some(format!(
+                "{payer_mention} nothing on the bar waiting for confirmation."
+            )));
+        };
+
+        match self
+            .chip_service
+            .buy_drink_for(
+                trigger_message.user_id,
+                pending.recipient_id,
+                pending.price,
+                &pending.drink,
+            )
+            .await?
+        {
+            Some(purchase) => {
+                self.clubhouse_lobby.record_drink(
+                    pending.recipient_id,
+                    purchase.drunk_points,
+                    purchase.last_drink_at,
+                );
+                tracing::info!(
+                    payer_id = %trigger_message.user_id,
+                    recipient_id = %pending.recipient_id,
+                    price = pending.price,
+                    drink = %pending.drink,
+                    payer_balance = purchase.balance,
+                    "bartender poured a gift drink"
+                );
+                Ok(Some(format!(
+                    "@{} {}, from @{}. enjoy it before it starts enjoying you.",
+                    pending.recipient_handle, pending.drink, pending.payer_handle
+                )))
+            }
+            None => Ok(Some(format!(
+                "{payer_mention} {BARTENDER_TAB_BOUNCED_LINE}"
+            ))),
+        }
     }
 
     /// Periodically mirror DB drunk state into the shared lobby so every
@@ -1395,6 +1570,13 @@ enum BartenderDecision {
         price: i64,
         line: String,
     },
+    /// Store an exact drink offer for a later deterministic confirmation.
+    GiftOffer {
+        recipient_id: Uuid,
+        recipient_handle: String,
+        drink: String,
+        price: i64,
+    },
     /// Post `line`, charge nothing (chat, counter-offer, or a downgraded
     /// pour the server refused to price).
     Say { line: String },
@@ -1405,26 +1587,40 @@ enum BartenderDecision {
 #[derive(serde::Deserialize)]
 struct BartenderOrderRaw {
     action: Option<String>,
+    recipient: Option<String>,
     drink: Option<String>,
     price: Option<i64>,
     line: Option<String>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct BartenderGiftRecipient {
+    id: Uuid,
+    handle: String,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum BartenderConfirmationIntent {
+    Confirm,
+    Cancel,
+}
+
 /// The response schema Gemini must conform the bartender's order to. Enforced
 /// server-side (only possible ungrounded), so the reply is always valid JSON in
-/// this exact shape — `action` is one of the three verbs, `line` is always
-/// present, and `drink`/`price` may be null for chat/offer.
+/// this exact shape — `action` is one of the bartender verbs, `line` is always
+/// present, and `recipient`/`drink`/`price` may be null for chat/offer.
 fn bartender_order_schema() -> serde_json::Value {
     json!({
         "type": "object",
         "properties": {
-            "action": { "type": "string", "enum": ["pour", "offer", "chat"] },
+            "action": { "type": "string", "enum": ["pour", "gift_offer", "offer", "chat"] },
+            "recipient": { "type": "string", "nullable": true },
             "drink": { "type": "string", "nullable": true },
             "price": { "type": "integer", "nullable": true },
             "line": { "type": "string" }
         },
         "required": ["action", "line"],
-        "propertyOrdering": ["action", "drink", "price", "line"]
+        "propertyOrdering": ["action", "recipient", "drink", "price", "line"]
     })
 }
 
@@ -1494,6 +1690,7 @@ fn extract_json_int_field(raw: &str, field: &str) -> Option<i64> {
 fn recover_bartender_order(raw: &str) -> Option<BartenderOrderRaw> {
     Some(BartenderOrderRaw {
         action: extract_json_string_field(raw, "action"),
+        recipient: extract_json_string_field(raw, "recipient"),
         drink: extract_json_string_field(raw, "drink"),
         price: extract_json_int_field(raw, "price"),
         line: Some(extract_json_string_field(raw, "line")?),
@@ -1506,7 +1703,12 @@ fn recover_bartender_order(raw: &str) -> Option<BartenderOrderRaw> {
 /// so the amount charged always equals the amount the line quoted. Whether the
 /// patron actually ordered is the model's call — the prompt coaches it to pour
 /// only on a clear order and to chat/offer on anything ambiguous.
-fn parse_bartender_order(raw: &str, spendable: i64, bot_username: &str) -> BartenderDecision {
+fn parse_bartender_order(
+    raw: &str,
+    spendable: i64,
+    bot_username: &str,
+    gift_recipients: &[BartenderGiftRecipient],
+) -> BartenderDecision {
     let cleaned = strip_code_fence(raw);
     let order = match serde_json::from_str::<BartenderOrderRaw>(cleaned) {
         Ok(order) => order,
@@ -1535,7 +1737,8 @@ fn parse_bartender_order(raw: &str, spendable: i64, bot_username: &str) -> Barte
         return BartenderDecision::Skip;
     };
 
-    if order.action.as_deref() != Some("pour") {
+    let action = order.action.as_deref();
+    if !matches!(action, Some("pour" | "gift_offer")) {
         return BartenderDecision::Say { line };
     }
 
@@ -1556,6 +1759,28 @@ fn parse_bartender_order(raw: &str, spendable: i64, bot_username: &str) -> Barte
         .map(|drink| drink.trim().to_string())
         .filter(|drink| !drink.is_empty())
         .unwrap_or_else(|| "house pour".to_string());
+    if action == Some("gift_offer") {
+        let Some(recipient) = order
+            .recipient
+            .as_deref()
+            .map(|recipient| recipient.trim().trim_start_matches('@'))
+            .filter(|recipient| !recipient.is_empty())
+            .and_then(|recipient| {
+                gift_recipients
+                    .iter()
+                    .find(|candidate| candidate.handle.eq_ignore_ascii_case(recipient))
+            })
+        else {
+            return BartenderDecision::Say { line };
+        };
+        return BartenderDecision::GiftOffer {
+            recipient_id: recipient.id,
+            recipient_handle: recipient.handle.clone(),
+            drink,
+            price,
+        };
+    }
+
     BartenderDecision::Pour { drink, price, line }
 }
 
@@ -1621,6 +1846,55 @@ fn mention_handle_for_user(username: Option<&str>, user_id: Uuid) -> String {
         .unwrap_or_else(|| short_user_id(user_id))
 }
 
+async fn mentioned_gift_recipients(
+    client: &tokio_postgres::Client,
+    trigger_message: &ChatMessage,
+    bot_username: &str,
+) -> Result<Vec<BartenderGiftRecipient>> {
+    let bot_username = bot_username.trim_start_matches('@');
+    let mut recipients = Vec::new();
+    let mut seen = Vec::<String>::new();
+
+    for handle in extract_mention_handles(&trigger_message.body) {
+        if handle.eq_ignore_ascii_case(bot_username)
+            || seen
+                .iter()
+                .any(|seen_handle| seen_handle.eq_ignore_ascii_case(&handle))
+        {
+            continue;
+        }
+        seen.push(handle.clone());
+
+        let Some(user) = User::find_by_username(client, &handle).await? else {
+            continue;
+        };
+        if user.id == trigger_message.user_id {
+            continue;
+        }
+        let handle = sanitize_mention_handle(&user.username);
+        if handle.is_empty() {
+            continue;
+        }
+        recipients.push(BartenderGiftRecipient {
+            id: user.id,
+            handle,
+        });
+    }
+
+    Ok(recipients)
+}
+
+fn format_gift_recipient_candidates(recipients: &[BartenderGiftRecipient]) -> String {
+    if recipients.is_empty() {
+        return "none".to_string();
+    }
+    recipients
+        .iter()
+        .map(|recipient| format!("@{}", recipient.handle))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 fn sanitize_mention_handle(input: &str) -> String {
     input
         .chars()
@@ -1682,6 +1956,71 @@ fn contains_mention(text: &str, target_handle: &str) -> bool {
     }
 
     false
+}
+
+fn extract_mention_handles(text: &str) -> Vec<String> {
+    let text = text_for_mention_detection(text);
+    let mut handles = Vec::new();
+    let mut idx = 0;
+    while idx < text.len() {
+        let Some(ch) = text[idx..].chars().next() else {
+            break;
+        };
+
+        if ch == '@' && valid_mention_start(text, idx) {
+            let start = idx + ch.len_utf8();
+            let mut end = start;
+            while end < text.len() {
+                let Some(next) = text[end..].chars().next() else {
+                    break;
+                };
+                if !is_mention_char(next) {
+                    break;
+                }
+                end += next.len_utf8();
+            }
+
+            if end > start {
+                handles.push(text[start..end].to_string());
+            }
+
+            idx = end;
+            continue;
+        }
+
+        idx += ch.len_utf8();
+    }
+    handles
+}
+
+fn bartender_confirmation_intent(
+    body: &str,
+    bartender_username: &str,
+) -> Option<BartenderConfirmationIntent> {
+    if !contains_mention(body, bartender_username) {
+        return None;
+    }
+
+    let bartender_username = bartender_username
+        .trim()
+        .trim_start_matches('@')
+        .to_ascii_lowercase();
+    let words: Vec<String> = text_for_mention_detection(body)
+        .split(|c: char| {
+            !(c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '.' || c == '@')
+        })
+        .filter_map(|word| {
+            let word = word.trim().trim_start_matches('@');
+            (!word.is_empty()).then(|| word.to_ascii_lowercase())
+        })
+        .filter(|word| word != &bartender_username)
+        .collect();
+
+    match words.as_slice() {
+        [word] if word == "confirm" => Some(BartenderConfirmationIntent::Confirm),
+        [word] if word == "cancel" => Some(BartenderConfirmationIntent::Cancel),
+        _ => None,
+    }
 }
 
 fn dealer_should_track_outcome(outcome: Outcome) -> bool {
@@ -1885,6 +2224,30 @@ hey @bot what do you think",
     }
 
     #[test]
+    fn extract_mention_handles_reads_only_live_reply_text() {
+        assert_eq!(
+            extract_mention_handles("> @alice old line\n@bartender buy @bob a drink"),
+            vec!["bartender".to_string(), "bob".to_string()]
+        );
+    }
+
+    #[test]
+    fn bartender_confirmation_intent_requires_simple_command() {
+        assert_eq!(
+            bartender_confirmation_intent("@bartender confirm", "bartender"),
+            Some(BartenderConfirmationIntent::Confirm)
+        );
+        assert_eq!(
+            bartender_confirmation_intent("@bartender cancel!", "bartender"),
+            Some(BartenderConfirmationIntent::Cancel)
+        );
+        assert_eq!(
+            bartender_confirmation_intent("@bartender should I confirm?", "bartender"),
+            None
+        );
+    }
+
+    #[test]
     fn is_dm_room_matches_kind_or_visibility() {
         assert!(is_dm_room("dm", "dm"));
         assert!(is_dm_room("topic", "dm"));
@@ -1938,7 +2301,7 @@ hey @bot what do you think",
     fn parse_bartender_order_pours_within_spendable() {
         let raw = r#"{"action": "pour", "drink": "Segfault Sour", "price": 400, "line": "one segfault sour, that is 400 chips"}"#;
         assert_eq!(
-            parse_bartender_order(raw, 900, "bartender"),
+            parse_bartender_order(raw, 900, "bartender", &[]),
             BartenderDecision::Pour {
                 drink: "Segfault Sour".to_string(),
                 price: 400,
@@ -1953,7 +2316,7 @@ hey @bot what do you think",
         // uncharged rather than clamp to a number the receipt never quoted.
         let cheap = r#"{"action": "pour", "drink": "tap water", "price": 5, "line": "here"}"#;
         assert_eq!(
-            parse_bartender_order(cheap, 5000, "bartender"),
+            parse_bartender_order(cheap, 5000, "bartender", &[]),
             BartenderDecision::Say {
                 line: "here".to_string()
             }
@@ -1961,7 +2324,7 @@ hey @bot what do you think",
 
         let dear = r#"{"action": "pour", "drink": "the vault", "price": 99999, "line": "here"}"#;
         assert_eq!(
-            parse_bartender_order(dear, 5000, "bartender"),
+            parse_bartender_order(dear, 5000, "bartender", &[]),
             BartenderDecision::Say {
                 line: "here".to_string()
             }
@@ -1974,7 +2337,7 @@ hey @bot what do you think",
         let raw =
             r#"{"action": "pour", "drink": "top shelf", "price": 800, "line": "the good stuff"}"#;
         assert_eq!(
-            parse_bartender_order(raw, 300, "bartender"),
+            parse_bartender_order(raw, 300, "bartender", &[]),
             BartenderDecision::Say {
                 line: "the good stuff".to_string()
             }
@@ -1988,7 +2351,7 @@ hey @bot what do you think",
                 r#"{{"action": "{action}", "drink": null, "price": null, "line": "welcome in"}}"#
             );
             assert_eq!(
-                parse_bartender_order(&raw, 900, "bartender"),
+                parse_bartender_order(&raw, 900, "bartender", &[]),
                 BartenderDecision::Say {
                     line: "welcome in".to_string()
                 }
@@ -1997,10 +2360,40 @@ hey @bot what do you think",
     }
 
     #[test]
+    fn parse_bartender_order_creates_gift_offer_for_known_recipient() {
+        let alice_id = Uuid::from_u128(1);
+        let recipients = [BartenderGiftRecipient {
+            id: alice_id,
+            handle: "alice".to_string(),
+        }];
+        let raw = r#"{"action": "gift_offer", "recipient": "alice", "drink": "Kernel Panic Punch", "price": 300, "line": "kernel panic punch for @alice, 300 chips. reply @bartender confirm."}"#;
+        assert_eq!(
+            parse_bartender_order(raw, 900, "bartender", &recipients),
+            BartenderDecision::GiftOffer {
+                recipient_id: alice_id,
+                recipient_handle: "alice".to_string(),
+                drink: "Kernel Panic Punch".to_string(),
+                price: 300,
+            }
+        );
+    }
+
+    #[test]
+    fn parse_bartender_order_refuses_gift_offer_for_unknown_recipient() {
+        let raw = r#"{"action": "gift_offer", "recipient": "mallory", "drink": "Kernel Panic Punch", "price": 300, "line": "who is that one for?"}"#;
+        assert_eq!(
+            parse_bartender_order(raw, 900, "bartender", &[]),
+            BartenderDecision::Say {
+                line: "who is that one for?".to_string()
+            }
+        );
+    }
+
+    #[test]
     fn parse_bartender_order_accepts_fenced_json_and_defaults_drink() {
         let raw = "```json\n{\"action\": \"pour\", \"price\": 200, \"line\": \"here you go\"}\n```";
         assert_eq!(
-            parse_bartender_order(raw, 900, "bartender"),
+            parse_bartender_order(raw, 900, "bartender", &[]),
             BartenderDecision::Pour {
                 drink: "house pour".to_string(),
                 price: 200,
@@ -2012,15 +2405,20 @@ hey @bot what do you think",
     #[test]
     fn parse_bartender_order_skips_garbage_and_empty_lines() {
         assert_eq!(
-            parse_bartender_order("not json at all", 900, "bartender"),
+            parse_bartender_order("not json at all", 900, "bartender", &[]),
             BartenderDecision::Skip
         );
         assert_eq!(
-            parse_bartender_order(r#"{"action": "pour", "price": 200}"#, 900, "bartender"),
+            parse_bartender_order(r#"{"action": "pour", "price": 200}"#, 900, "bartender", &[]),
             BartenderDecision::Skip
         );
         assert_eq!(
-            parse_bartender_order(r#"{"action": "chat", "line": "SKIP"}"#, 900, "bartender"),
+            parse_bartender_order(
+                r#"{"action": "chat", "line": "SKIP"}"#,
+                900,
+                "bartender",
+                &[]
+            ),
             BartenderDecision::Skip
         );
     }
@@ -2032,7 +2430,7 @@ hey @bot what do you think",
         // chat line instead of leaving the bartender mute.
         let raw = "{\n  \"action\": \"chat\",\n  \"drink\": null,\n  \"price\": null,\n  \"line\": \"The top shelf is closed for you tonight, friend. Here is ice water.\"\n\"\n}";
         assert_eq!(
-            parse_bartender_order(raw, 900, "bartender"),
+            parse_bartender_order(raw, 900, "bartender", &[]),
             BartenderDecision::Say {
                 line: "The top shelf is closed for you tonight, friend. Here is ice water."
                     .to_string()
@@ -2046,7 +2444,7 @@ hey @bot what do you think",
         // price all survive the hand-rolled recovery.
         let raw = "{\"action\": \"pour\", \"drink\": \"Kernel Panic Punch\", \"price\": 250, \"line\": \"one Kernel Panic Punch, 250 chips.\"\"}";
         assert_eq!(
-            parse_bartender_order(raw, 900, "bartender"),
+            parse_bartender_order(raw, 900, "bartender", &[]),
             BartenderDecision::Pour {
                 drink: "Kernel Panic Punch".to_string(),
                 price: 250,

--- a/late-ssh/src/app/door/greendragon/svc.rs
+++ b/late-ssh/src/app/door/greendragon/svc.rs
@@ -272,13 +272,20 @@ pub enum HauntLoad {
 pub enum TransferLoad {
     Loading,
     /// The gold is in their bank and the clerk's note in their reports.
-    Done { target: String },
+    Done {
+        target: String,
+    },
     /// They've taken the day's [`model::TRANSFERS_RECEIVED_PER_DAY`]
     /// transfers already (`transferreceive`).
-    TooManyToday { target: String },
+    TooManyToday {
+        target: String,
+    },
     /// The sum beats their per-transfer cap (`transferperlevel`), re-checked
     /// against the fresh blob's level.
-    OverCap { target: String, cap: u64 },
+    OverCap {
+        target: String,
+        cap: u64,
+    },
     /// The account vanished between the search and the settlement.
     Gone,
 }

--- a/late-ssh/src/app/games/chips/svc.rs
+++ b/late-ssh/src/app/games/chips/svc.rs
@@ -127,6 +127,30 @@ impl ChipService {
         }))
     }
 
+    /// Charge `payer_id` for a bartender drink and apply the buzz to
+    /// `recipient_id` in one transaction. Returns None when the payer can't
+    /// cover the drink while keeping the chip floor.
+    pub async fn buy_drink_for(
+        &self,
+        payer_id: Uuid,
+        recipient_id: Uuid,
+        price: i64,
+        drink: &str,
+    ) -> anyhow::Result<Option<DrinkPurchase>> {
+        let mut client = self.db.get().await?;
+        let tx = client.transaction().await?;
+        let Some(chips) = UserChips::deduct_for_drink(&tx, payer_id, price, drink).await? else {
+            return Ok(None);
+        };
+        let drinks = UserDrinks::record_purchase(&tx, recipient_id, price).await?;
+        tx.commit().await?;
+        Ok(Some(DrinkPurchase {
+            balance: chips.balance,
+            drunk_points: drinks.drunk_points,
+            last_drink_at: drinks.last_drink_at,
+        }))
+    }
+
     /// Comp the newcomer's welcome pour: record the buzz with no chip debit
     /// (it's on the house) and hand back the fresh buzz so the clubhouse glow
     /// can light up immediately.

--- a/late-ssh/tests/arcade/chips.rs
+++ b/late-ssh/tests/arcade/chips.rs
@@ -1,5 +1,10 @@
 use late_core::{
-    models::chips::{CHIP_GIFT_RECEIVED_REASON, CHIP_GIFT_SENT_REASON, UserChips},
+    models::{
+        chips::{
+            CHIP_GIFT_RECEIVED_REASON, CHIP_GIFT_SENT_REASON, DRINK_PURCHASE_REASON, UserChips,
+        },
+        drinks::UserDrinks,
+    },
     test_utils::create_test_user,
 };
 use late_ssh::app::games::chips::svc::ChipService;
@@ -133,4 +138,56 @@ async fn transfer_chips_insufficient_funds_leaves_balances_and_ledger_untouched(
         .expect("ledger count")
         .get::<_, i32>("count");
     assert_eq!(ledger_count, 0);
+}
+
+#[tokio::test]
+async fn buy_drink_for_charges_payer_and_buzzes_recipient() {
+    let test_db = new_test_db().await;
+    let payer = create_test_user(&test_db.db, "drink-gift-payer").await;
+    let recipient = create_test_user(&test_db.db, "drink-gift-recipient").await;
+    let client = test_db.db.get().await.expect("db client");
+    UserChips::ensure(&client, payer.id)
+        .await
+        .expect("payer chips");
+    drop(client);
+
+    let chips = ChipService::new(test_db.db.clone());
+    let purchase = chips
+        .buy_drink_for(payer.id, recipient.id, 300, "Kernel Panic Punch")
+        .await
+        .expect("gift drink succeeds")
+        .expect("poured");
+    assert_eq!(purchase.balance, 700);
+    assert_eq!(purchase.drunk_points, 300);
+
+    let client = test_db.db.get().await.expect("db client");
+    let payer_balance = client
+        .query_one(
+            "SELECT balance FROM user_chips WHERE user_id = $1",
+            &[&payer.id],
+        )
+        .await
+        .expect("payer balance")
+        .get::<_, i64>("balance");
+    assert_eq!(payer_balance, 700);
+
+    let recipient_drinks = UserDrinks::find(&client, recipient.id)
+        .await
+        .expect("recipient drinks")
+        .expect("recipient got buzz");
+    assert_eq!(recipient_drinks.drunk_points, 300);
+    assert_eq!(recipient_drinks.lifetime_spent, 300);
+
+    let ledger = client
+        .query_one(
+            "SELECT user_id, delta, reason, source_ref
+             FROM chip_ledger
+             WHERE user_id = $1 AND reason = $2",
+            &[&payer.id, &DRINK_PURCHASE_REASON],
+        )
+        .await
+        .expect("ledger row");
+    assert_eq!(ledger.get::<_, uuid::Uuid>("user_id"), payer.id);
+    assert_eq!(ledger.get::<_, i64>("delta"), -300);
+    assert_eq!(ledger.get::<_, String>("source_ref"), "Kernel Panic Punch");
 }


### PR DESCRIPTION
## Summary
- Lets a clubhouse patron ask **@bartender** to buy a drink for another user. The bartender now quotes the gift and holds it as a pending offer, and only charges once the payer replies `@bartender confirm`.
- Adds a deterministic confirm/cancel handshake so a chip debit never happens off a single ambiguous message, and the recipient (not the payer) gets the buzz.

## Changes
- New bartender AI action `gift_offer` alongside `pour`/`offer`/`chat`. The model may only pick it when the recipient is explicitly mentioned in the latest message and appears in a server-computed candidate list; self-gifts and unknown recipients fall back to `chat`.
- Gift offers are parked in a process-local pending map keyed by `(payer_id, room_id)`. The bartender replies with the drink, price, and recipient, and asks the payer to reply `@bartender confirm`.
- `@bartender confirm` charges the payer and applies the drunk buzz to the recipient in one transaction; `@bartender cancel` drops the pending offer without charging. Both are matched only as a bare single-word command to the bartender.
- New `ChipService::buy_drink_for(payer, recipient, price, drink)` — debits the payer with the 100-chip floor guard and records the recipient's buzz in a single DB transaction, returning `None` when the payer can't cover it.
- Response schema, prompt, and JSON recovery path extended with a `recipient` field; parsing validates the recipient against the candidate list before creating an offer.
- `BARTENDER_MENTION_COOLDOWN` lowered from 25s to 5s, and confirm/cancel messages bypass the cooldown entirely (and don't reset it) so a confirmation is never swallowed.
- Green Dragon `svc.rs` change is a rustfmt-only reformat of `TransferLoad` enum variants; no behavior change.

## Behavior notes
- Pending gift offers expire after 60s (`BARTENDER_GIFT_CONFIRM_TIMEOUT`); confirming a stale offer tells the payer it went flat, and confirming with nothing pending says so too.
- The pending-offer map is process-local (same as the shared lobby), so the confirmation must land on the same late-ssh process that stored the offer.
- If the payer's balance drops below the price between the offer and the confirm, the charge is refused uncharged and the payer is told their tab bounced.
- Mention extraction reads only the live reply text (quoted `>` lines are ignored), so an @mention from a quoted earlier message can't be treated as a gift recipient.

## Feature flags
- None.

## Screenshots / Video
- Not applicable; the change is chat-message behavior with no new visual chrome.

## Testing
- Automated: added unit tests for gift-offer parsing (known vs unknown recipient), confirmation-intent matching, and mention extraction from live text, plus an integration test (`buy_drink_for_charges_payer_and_buzzes_recipient`) asserting the payer debit, recipient buzz, and chip-ledger row. Per repo policy the agent does not run `cargo test`/`nextest`; leave the suite to the owner.
- Manual: Not run.