### PR TITLE
Lateania: gathering skills & resource nodes (crafting economy, part 1 of 3)

### DIFF
--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -4,7 +4,7 @@
 - Scope: `late-ssh/src/app/door/lateania` plus Lateania screen lifecycle in `late-ssh/src/app/door`
 - Domain: Lateania, the persistent D&D-style MUD inside late.sh
 - Primary audience: LLM agents changing the Lateania game runtime, content, UI, combat, or persistence
-- Last updated: 2026-06-17
+- Last updated: 2026-07-13
 - Status: Active
 - Parent context: `../../../../../CONTEXT.md`
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change when gameplay/content changes.
@@ -58,13 +58,14 @@ Current game scale:
 | `input.rs` | Active-world key routing after launch. App-level launch/reset/leave handling belongs in `screen.rs`. |
 | `ui.rs` | Ratatui rendering for class select, log, compact mode, side panels, minimap, hints. The Character panel expands to a full-width dashboard (accent-tinted class portrait, dot-rated ability scores, vitals/XP meters) when the area is at least 72x18, else falls back to the narrow side panel; Foes/Adventurers/Follow render as aligned roster rows with HP meters. Lock-free, snapshot-only. |
 | `svc.rs` | Authoritative runtime: service tasks, `WorldState`, player/mob state, combat, movement, following, shops, persistence, snapshots, activity events. |
-| `world.rs` | Immutable world data and generation: rooms, exits, mobs, features, wildlife, minimap, overworld, Frontier. |
+| `world.rs` | Immutable world data and generation: rooms, exits, mobs, features, wildlife, minimap, overworld, Frontier. Also **resource nodes** (`NODES`/`ResourceNode`/`nodes_at`/`node_index`): trees, ore veins, fishing spots and herb/skinning patches keyed to rooms, modelled exactly like `WILDLIFE` (static data + a per-node service cooldown), each with a skill, tier, min-level gate, and derived yield item. |
 | `classes.rs` | Twelve playable classes (Warrior/Mage/Cleric/Rogue/Ranger/Druid/Necromancer/Bard/Monk/Paladin/Warlock/Berserker), resources (incl. Spirit/Souls/Tempo/Ki), passive traits, level 1-50 stat curves, XP curve. Adding a class means an arm in every `match self` here (name/primary_score/resource/tagline/description/trait_name/trait_desc/stats_at/as_key/from_key), an entry in `ALL`, an ability roster in `abilities.rs`, and (if the trait needs runtime behaviour) a hook in `svc.rs`: upkeep loop for regen (Druid/Paladin) and Tempo (Bard); `kill_mob` for harvest (Necromancer/Warlock); `strike_player` for Monk mitigation; the combat round for Berserker frenzy. **Every level grants something:** the curve grows each level (surfaced by `check_level_up`, which logs the concrete +HP/+attack/+resource gains per level), plus `level_milestone`/`milestone_hp_bonus` add a named milestone (Blooded…Ascended) with a permanent +HP every fifth level, a pure function of level, so no extra save state; `current_milestone(level)` shows on the character sheet. **Archetypes:** at `ARCHETYPE_LEVEL` each class offers two paths (the `ARCHETYPES` data table; `archetypes_for`/`archetype_by_key`), each carrying a `Role` (Tank/Healer/DPS) and four percent modifiers (`attack_pct`/`mitigation_pct`/`heal_pct`/`max_hp_pct`). The modifiers apply at existing combat hooks in `svc.rs` (DPS in `attack()`+`spell_damage`, Tank in `strike_player`, Healer in `heal_player`, max-HP in `max_hp()`); no engine changes; the chosen `&'static ArchetypeDef` is held on `PlayerState` and persisted by key. |
 | `abilities.rs` | Ability roster and unlock helpers. Effects are data, resolved in `svc.rs`. |
 | `housing.rs` | Player housing data + address arithmetic. `TIERS` (5 homes Hut→Tower: price/ground/upper rooms), the 50+-piece `FURNITURE` catalogue, `HOUSING_BASE`/`plot_base`/`plot_of_room`/`is_housing_room`. Homes are **static rooms** (generated in `world.rs::extend_housing` as Hearthward Close off Market Row); only **ownership** (`plot_owner`) and **furnishings** (`house_furniture`) are dynamic side-state on `svc.rs`, so movement/visiting/snapshot work unchanged and the homes are public shared-world plots. |
 | `appearance.rs` | Character appearance/bio. `FIELDS` (Build/Hair/Eyes/Bearing/Origin, each with a menu of options) + `compose_bio`. The TUI has no free-text, so a player customises by cycling preset options (`e` opens the Appearance panel; `Enter`/`x` cycle a field). Stored as `[u8; N_FIELDS]` on `PlayerState`, persisted, shown on the sheet and when profiling another adventurer (Follow panel). |
 | `pets.rs` | Combat companions. `PetSpecies` data table (`PET_SPECIES`, `pet_species_by_key`) of buyable beasts, and the live `Pet` (held on `PlayerState`, always co-located with its owner). Loyalty (earned by feeding) drives the level via a pure function; `max_hp`/`attack` scale with level. The world wiring (buying at a Stable, feeding, taking wounds, biting the owner's target each combat round) lives in `svc.rs`. Persisted by species key + loyalty (HP restored full on load). |
-| `items.rs` | Item catalog, equipment slots, consumables, valuables, shops, generated Frontier loot. |
+| `items.rs` | Item catalog, equipment slots, consumables, valuables, shops, generated Frontier loot. Also the **raw-material catalog** (`materials()`/`material_id`/`MATERIAL_BASE = 4000`): 5 skills x 5 tiers of gathered materials (logs/ores/fish/herbs/hides), `Valuable` kind (immediately sellable), IDs `4000..4100` (skill index x 20 + tier). |
+| `skills.rs` | **Gathering skills** (`GatherSkill`: Woodcutting/Mining/Fishing/Foraging/Skinning) and their own 1-50 xp curve (`xp_for_skill_level`/`skill_level_for_xp`/`skill_progress`), independent of class level and steepening past level 10. Persisted per-player as (skill key, xp). |
 | `damage.rs` | Damage schools, mob resistance/weakness profiles, damage multiplier math. |
 | `stats.rs` | D&D-style ability scores, 4d6-drop-lowest rolls, modifiers, HP/attack bonuses. |
 | `persist.rs` | JSON schemas for durable character saves and shared world saves. Versioned (`SCHEMA_VERSION`); new fields use `#[serde(default)]` so old saves load (e.g. `board_progress`/`board_done` for quests). |
@@ -149,7 +150,7 @@ Before class choice:
 - The Town Square Frontier descent requires `Bane of the Archdemon Mal'gareth`, `Bane of The Bonewright Lich`, `Bane of the Elder Dryad`, and `Bane of the Abyss-Thing`; after those title gates, it still uses a transient two-step warning: the first `>` logs that the Frontier is older, meaner country for seasoned adventurers, and the next `>` confirms descent. Service-backed non-movement actions clear the pending warning.
 - Combat: `space`, `x`, or Enter attacks when not in a list panel; `z` flees.
 - Abilities: `1-9` use unlocked ability slots unless a list panel is open; `0` uses slot 10. The Abilities panel is a list panel: Enter casts the highlighted ability, which is the only way to reach rosters deeper than ten (the classic classes' late slots).
-- World actions: `r` recalls to Embergate's Town Square when out of combat; `f` toggles the Follow panel; `g` casts the Resurrection rite on the nearest fallen adventurer in the room (Cleric/Paladin/Druid only); `p` opens the Stable (companion vendor) where one stands; `n` opens the housing ledger (at the clerk, or inside a home you own); `e` opens the appearance/bio builder.
+- World actions: `y` works a resource node in the room (chop/mine/fish/forage/skin - the highest tier you qualify for); `r` recalls to Embergate's Town Square when out of combat; `f` toggles the Follow panel; `g` casts the Resurrection rite on the nearest fallen adventurer in the room (Cleric/Paladin/Druid only); `p` opens the Stable (companion vendor) where one stands; `n` opens the housing ledger (at the clerk, or inside a home you own); `e` opens the appearance/bio builder.
 - While dead (a corpse): all normal keys are suppressed; only `r`/Enter (release to the temple) and `Esc` (leave) respond, until a resurrection or the auto-release deadline.
 - Panels: `c` character, `v` abilities, `t` inventory, `b` shop where a merchant exists, `o` examine/look, `k` titles, `j` quest journal, `f` follow.
 - List panels: `w/s` or up/down move cursor; `1-9` jump and activate; Enter activates. The view auto-scrolls to keep the highlighted row within a small scroll-off margin (top and bottom).
@@ -216,6 +217,14 @@ Non-Room side panels are rendered through `side_paragraph`, which enables Ratatu
 - `CritterKind::Game` can be hunted by attacking when no combat mob is present. Hunted game grants small XP and is hidden by a per-world 40-second cooldown keyed by global wildlife index.
 - `CritterKind::Boon(Perk)` applies on room entry. Perks are `Embolden`, `Mend`, and `Quicken`.
 - Wildlife appears in the Room panel; game critters show as huntable only while off cooldown.
+
+### Gathering and skills [VOLATILE]
+
+- Five gathering trades (`skills::GatherSkill`) - Woodcutting, Mining, Fishing, Foraging, Skinning - each levelled 1..=50 on its own steepening xp curve, tracked as a `skill -> total xp` map on `PlayerState` and persisted (schema v12).
+- `world::NODES` seeds harvestable nodes (trees/ore veins/fishing spots/herb & skinning patches) across the overworld, tiered 0..5 by area difficulty (roadside starters near town; the best materials deep in the harder wings and capital waters). Each node has a min skill level and a fixed yield material derived from `(skill, tier)`.
+- `y` works the highest-tier node in the room the player qualifies for (`svc::gather`/`try_gather`): it grants the raw material to the pack plus skill xp, then depletes for `NODE_RESPAWN` (45s, tracked in `WorldState::gathered`, mirroring `hunted`). Under-skilled or regrowing nodes log why and yield nothing. No combat and no safe/unsafe gate - gathering works anywhere a node stands.
+- Raw materials (`items::materials`, IDs `4000..4100`) are `Valuable` today, so they are immediately sellable ("tradeable"); the crafting update turns them into gear/consumables and further recipe chains.
+- The Room panel shows a **Resources** section (like Wildlife) with a `◆`/`·` marker per node and a gatherable/reason tag; the character sheet + narrow panel show a **Trades** block (each skill's level and progress) with the `y` hint.
 
 ### Frontier and Reaches loot
 
@@ -299,7 +308,7 @@ Progression:
 
 Character persistence uses `late_core::models::mud_character` / `mud_characters`.
 
-Saved character schema version: `11`.
+Saved character schema version: `12`.
 
 Durable fields:
 - class key, XP, level, carried gold, banked gold, current HP;
@@ -312,7 +321,8 @@ Durable fields:
 - chosen archetype key (validated against the saved class on load);
 - companion species key + accumulated loyalty (the pet reloads at full health; its level derives from loyalty);
 - owned housing plot (tier index) + placed furnishings as (room, key) pairs (re-registered into `plot_owner`/`house_furniture` on load);
-- appearance/bio trait indices (`Vec<u8>`, clamped to valid options on load).
+- appearance/bio trait indices (`Vec<u8>`, clamped to valid options on load);
+- gathering-skill xp as (skill key, total xp) pairs (unknown keys dropped on load).
 
 Transient by design:
 - current target;

--- a/late-ssh/src/app/door/lateania/input.rs
+++ b/late-ssh/src/app/door/lateania/input.rs
@@ -8,6 +8,7 @@
 //     slot 10; deeper rosters cast from the Abilities panel); z flee.
 //   - Death: while a corpse, r (or Enter) releases to the temple; g casts the
 //     Resurrection rite on a fallen adventurer in the room (holy/nature classes).
+//   - World: y works a resource node here (chop/mine/fish/forage/skin).
 //   - Panels: c character, v abilities, o look, b shop, t inventory ("things"),
 //     p the Stable (companion vendor) where one stands. In the Stable, Enter
 //     buys the selected beast and x feeds/tends the one you have. n opens the
@@ -198,6 +199,11 @@ pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
         b'e' | b'E' => {
             // Open the appearance / bio builder.
             state.open_appearance();
+            InputAction::Handled
+        }
+        b'y' | b'Y' => {
+            // Work a resource node here (chop/mine/fish/forage/skin).
+            state.gather();
             InputAction::Handled
         }
         b'\r' | b'\n' => {

--- a/late-ssh/src/app/door/lateania/items.rs
+++ b/late-ssh/src/app/door/lateania/items.rs
@@ -960,12 +960,118 @@ pub const ITEMS: &[Item] = &[
     },
 ];
 
+// ---- Raw gathering materials --------------------------------------------
+//
+// Trees, ore veins, fishing spots and herb/skinning patches (see world::NODES)
+// drop these raw materials when harvested (see svc gather). They are Valuables
+// for now - immediately sellable to any merchant, which is what "tradeable"
+// means today - and become crafting inputs in the crafting update. IDs live in
+// 4000..4100 (skill index * 20 + tier), clear of the authored (<1500) and
+// generated Frontier/Reaches (3000..3400) ranges.
+
+/// Base id for the raw-material catalog.
+pub const MATERIAL_BASE: u32 = 4000;
+/// Tiers per gathering skill (levels of material, low to high).
+pub const MATERIAL_TIERS: u32 = 5;
+
+/// The item id of the raw material a skill drops at a given tier (0-based). The
+/// `skill_index` is `skills::GatherSkill::index`.
+pub const fn material_id(skill_index: u32, tier: u32) -> u32 {
+    MATERIAL_BASE + skill_index * 20 + tier
+}
+
+/// Names per skill (rows follow `GatherSkill::index`) and tier (columns low->high).
+const MATERIAL_NAMES: [[&str; 5]; 5] = [
+    // Woodcutting
+    ["Birch Log", "Oak Log", "Ash Log", "Yew Log", "Ironbark Log"],
+    // Mining
+    [
+        "Copper Ore",
+        "Tin Ore",
+        "Iron Ore",
+        "Silver Ore",
+        "Mithril Ore",
+    ],
+    // Fishing
+    [
+        "River Bream",
+        "Silver Trout",
+        "Grey Pike",
+        "Deep Sturgeon",
+        "Moonscale Fish",
+    ],
+    // Foraging
+    [
+        "Marsh Sage",
+        "Redleaf",
+        "Bloodthistle",
+        "Frostbloom",
+        "Sunmoss",
+    ],
+    // Skinning
+    [
+        "Rough Hide",
+        "Thick Hide",
+        "Boar Hide",
+        "Bear Pelt",
+        "Direhide",
+    ],
+];
+
+/// One flavour line per skill (rows follow `GatherSkill::index`).
+const MATERIAL_FLAVOR: [&str; 5] = [
+    "A length of cut timber, ready for the sawbench.",
+    "Raw ore, still cold from the rock; a smith can smelt it down.",
+    "A fresh-landed fish, good eating or good bait.",
+    "A bundle of cut herbs, pungent and green.",
+    "A cleaned hide, ready for the tanner's rack.",
+];
+
+fn build_materials() -> Vec<Item> {
+    let mut out = Vec::with_capacity(25);
+    for (s, names) in MATERIAL_NAMES.iter().enumerate() {
+        for (t, name) in names.iter().enumerate() {
+            let tier = t as i64;
+            // 6, 24, 54, 96, 150 gold: a modest trickle, so gathering feeds
+            // crafting rather than replacing combat as a gold source.
+            let price = 6 * (tier + 1) * (tier + 1);
+            let rarity = match t {
+                0 | 1 => Rarity::Common,
+                2 | 3 => Rarity::Uncommon,
+                _ => Rarity::Rare,
+            };
+            out.push(Item {
+                id: material_id(s as u32, t as u32),
+                name,
+                desc: MATERIAL_FLAVOR[s],
+                kind: ItemKind::Valuable,
+                rarity,
+                mods: StatMods {
+                    attack: 0,
+                    max_hp: 0,
+                    armor: 0,
+                },
+                price,
+                class_hint: None,
+            });
+        }
+    }
+    out
+}
+
+/// The raw-material catalog, built once and reused for the `item` lookup.
+pub fn materials() -> &'static [Item] {
+    static CATALOG: OnceLock<Vec<Item>> = OnceLock::new();
+    CATALOG.get_or_init(build_materials)
+}
+
 pub fn item(id: u32) -> Option<&'static Item> {
     ITEMS
         .iter()
         .find(|i| i.id == id)
         .or_else(|| frontier_items().iter().find(|i| i.id == id))
         .or_else(|| reaches_items().iter().find(|i| i.id == id))
+        .or_else(|| materials().iter().find(|i| i.id == id))
 }
 
 // ---- Generated catalogs (Frontier and Sundered Reaches) ------------------
@@ -1292,12 +1398,32 @@ mod tests {
             .iter()
             .chain(frontier_items().iter())
             .chain(reaches_items().iter())
+            .chain(materials().iter())
             .map(|i| i.id)
             .collect();
         ids.sort_unstable();
         let n = ids.len();
         ids.dedup();
         assert_eq!(n, ids.len(), "duplicate item id");
+    }
+
+    #[test]
+    fn materials_form_a_clean_sellable_catalog() {
+        assert_eq!(materials().len(), 25, "five skills x five tiers");
+        for m in materials() {
+            assert!(
+                m.id >= MATERIAL_BASE && m.id < MATERIAL_BASE + 100,
+                "material {} sits in the 4000 band",
+                m.id
+            );
+            assert!(
+                matches!(m.kind, ItemKind::Valuable),
+                "raw materials are sellable valuables for now"
+            );
+            assert!(m.sell_price() >= 1, "materials are worth something");
+            // Look-ups resolve through the shared catalog.
+            assert!(item(m.id).is_some(), "material {} is not findable", m.id);
+        }
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/mod.rs
+++ b/late-ssh/src/app/door/lateania/mod.rs
@@ -13,6 +13,7 @@ pub mod items;
 pub mod persist;
 pub mod pets;
 pub mod screen;
+pub mod skills;
 pub mod state;
 pub mod stats;
 pub mod svc;

--- a/late-ssh/src/app/door/lateania/persist.rs
+++ b/late-ssh/src/app/door/lateania/persist.rs
@@ -17,7 +17,7 @@ use super::classes::Class;
 use super::stats::AbilityScores;
 use super::world::RoomId;
 
-const SCHEMA_VERSION: u32 = 11;
+const SCHEMA_VERSION: u32 = 12;
 const WORLD_SCHEMA_VERSION: u32 = 1;
 
 pub struct SavedCharacterInit {
@@ -45,6 +45,7 @@ pub struct SavedCharacterInit {
     pub owned_plot: Option<u32>,
     pub house_furniture: Vec<(u32, String)>,
     pub appearance: Vec<u8>,
+    pub skills: Vec<(String, i64)>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -122,6 +123,10 @@ pub struct SavedCharacter {
     /// Chosen appearance/bio trait indices (see `appearance::FIELDS`).
     #[serde(default)]
     pub appearance: Vec<u8>,
+    /// Gathering-skill xp as (skill key, total xp) pairs (see `skills`); empty
+    /// for pre-gathering saves, which simply start every trade at level 1.
+    #[serde(default)]
+    pub skills: Vec<(String, i64)>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -199,6 +204,7 @@ impl SavedCharacter {
             owned_plot: init.owned_plot,
             house_furniture: init.house_furniture,
             appearance: init.appearance,
+            skills: init.skills,
         }
     }
 
@@ -282,6 +288,7 @@ mod tests {
             owned_plot: Some(3),
             house_furniture: vec![(9040, "feather_bed".to_string())],
             appearance: vec![1, 2, 3, 4, 5],
+            skills: vec![("woodcutting".to_string(), 900), ("mining".to_string(), 40)],
         });
         let json = c.to_json();
         let back = SavedCharacter::from_json(&json).expect("parses");
@@ -307,6 +314,10 @@ mod tests {
             vec![(9040, "feather_bed".to_string())]
         );
         assert_eq!(back.appearance, vec![1, 2, 3, 4, 5]);
+        assert_eq!(
+            back.skills,
+            vec![("woodcutting".to_string(), 900), ("mining".to_string(), 40)]
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/skills.rs
+++ b/late-ssh/src/app/door/lateania/skills.rs
@@ -1,0 +1,197 @@
+// Gathering skills for Lateania: the first pillar of the crafting economy.
+//
+// Five gathering trades - Woodcutting, Mining, Fishing, Foraging, Skinning -
+// each levelled 1..=50 on its own XP curve that steepens every tier, so the
+// late materials are a genuine grind. A player's skill xp lives on PlayerState
+// (a map of skill -> total xp) and persists; the level is a pure function of xp.
+//
+// Resource NODES (trees, ore veins, fishing spots, herb/skinning patches) live
+// in `world.rs` and each belongs to one skill; harvesting a node grants its raw
+// MATERIAL item (see `items::material_id`) plus skill xp, gated behind a
+// per-node minimum skill level.
+
+use std::fmt;
+
+/// A gathering trade. The order here is the order shown on the character sheet
+/// and, via `index`, the layout of the raw-material item ids.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum GatherSkill {
+    Woodcutting,
+    Mining,
+    Fishing,
+    Foraging,
+    Skinning,
+}
+
+impl GatherSkill {
+    pub const ALL: [GatherSkill; 5] = [
+        GatherSkill::Woodcutting,
+        GatherSkill::Mining,
+        GatherSkill::Fishing,
+        GatherSkill::Foraging,
+        GatherSkill::Skinning,
+    ];
+
+    /// Stable index used to lay out raw-material item ids (see `items`). Never
+    /// change once shipped, or persisted materials would point at the wrong item.
+    pub const fn index(self) -> u32 {
+        match self {
+            Self::Woodcutting => 0,
+            Self::Mining => 1,
+            Self::Fishing => 2,
+            Self::Foraging => 3,
+            Self::Skinning => 4,
+        }
+    }
+
+    /// Stable key for persistence (never change once shipped).
+    pub fn key(self) -> &'static str {
+        match self {
+            Self::Woodcutting => "woodcutting",
+            Self::Mining => "mining",
+            Self::Fishing => "fishing",
+            Self::Foraging => "foraging",
+            Self::Skinning => "skinning",
+        }
+    }
+
+    pub fn from_key(key: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|s| s.key() == key)
+    }
+
+    /// Display name for panels and log lines.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Woodcutting => "Woodcutting",
+            Self::Mining => "Mining",
+            Self::Fishing => "Fishing",
+            Self::Foraging => "Foraging",
+            Self::Skinning => "Skinning",
+        }
+    }
+
+    /// The working verb for the harvest log line: "You chop ...", "You mine ...".
+    pub fn verb(self) -> &'static str {
+        match self {
+            Self::Woodcutting => "chop",
+            Self::Mining => "mine",
+            Self::Fishing => "fish",
+            Self::Foraging => "forage",
+            Self::Skinning => "skin",
+        }
+    }
+}
+
+impl fmt::Display for GatherSkill {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Skill level cap - the same 50 the class levels use, so "level 1 to 50" reads
+/// consistently across the game.
+pub const SKILL_MAX_LEVEL: i32 = 50;
+
+/// Total xp required to *reach* a given skill level. Level 1 is free; each tier
+/// costs more than the last, and a cubic term that only bites past level 10
+/// makes the back half of every trade the real work (harder and harder).
+pub fn xp_for_skill_level(level: i32) -> i64 {
+    if level <= 1 {
+        return 0;
+    }
+    let d = (level - 1) as i64;
+    let base = 30 * d * d;
+    let late = (level - 10).max(0) as i64;
+    base + 10 * late * late * late
+}
+
+/// The skill level a given total xp corresponds to (1..=SKILL_MAX_LEVEL).
+pub fn skill_level_for_xp(xp: i64) -> i32 {
+    let mut level = 1;
+    while level < SKILL_MAX_LEVEL && xp >= xp_for_skill_level(level + 1) {
+        level += 1;
+    }
+    level
+}
+
+/// Progress within the current level: (xp into this level, xp needed for the
+/// next). At the cap the second value is 0 ("maxed").
+pub fn skill_progress(xp: i64) -> (i64, i64) {
+    let level = skill_level_for_xp(xp);
+    if level >= SKILL_MAX_LEVEL {
+        return (0, 0);
+    }
+    let floor = xp_for_skill_level(level);
+    let next = xp_for_skill_level(level + 1);
+    (xp - floor, next - floor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_round_trip_and_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for s in GatherSkill::ALL {
+            assert!(seen.insert(s.key()), "duplicate skill key {}", s.key());
+            assert_eq!(GatherSkill::from_key(s.key()), Some(s));
+        }
+        assert_eq!(GatherSkill::from_key("nonsense"), None);
+    }
+
+    #[test]
+    fn indices_are_unique_and_dense() {
+        let mut idx: Vec<u32> = GatherSkill::ALL.iter().map(|s| s.index()).collect();
+        idx.sort_unstable();
+        assert_eq!(idx, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn level_one_is_free_and_curve_is_strictly_increasing() {
+        assert_eq!(xp_for_skill_level(1), 0);
+        assert_eq!(xp_for_skill_level(0), 0);
+        for level in 2..=SKILL_MAX_LEVEL {
+            assert!(
+                xp_for_skill_level(level) > xp_for_skill_level(level - 1),
+                "curve must rise at level {level}"
+            );
+        }
+    }
+
+    #[test]
+    fn curve_steepens_late() {
+        // The cost of a mid-game level must exceed the cost of an early one, and
+        // a late level must cost far more still (the "harder and harder" shape).
+        let early = xp_for_skill_level(5) - xp_for_skill_level(4);
+        let mid = xp_for_skill_level(20) - xp_for_skill_level(19);
+        let late = xp_for_skill_level(50) - xp_for_skill_level(49);
+        assert!(mid > early);
+        assert!(late > mid * 3);
+    }
+
+    #[test]
+    fn level_for_xp_inverts_the_curve_and_caps() {
+        for level in 1..=SKILL_MAX_LEVEL {
+            assert_eq!(skill_level_for_xp(xp_for_skill_level(level)), level);
+        }
+        // One short of a threshold stays on the lower level.
+        assert_eq!(
+            skill_level_for_xp(xp_for_skill_level(10) - 1),
+            9,
+            "just under the level-10 threshold is still level 9"
+        );
+        // Absurd xp still caps at the max level.
+        assert_eq!(skill_level_for_xp(i64::MAX / 2), SKILL_MAX_LEVEL);
+    }
+
+    #[test]
+    fn progress_stays_within_the_level_band() {
+        let xp = xp_for_skill_level(7) + 5;
+        let (into, need) = skill_progress(xp);
+        assert_eq!(into, 5);
+        assert_eq!(need, xp_for_skill_level(8) - xp_for_skill_level(7));
+        // At the cap there is no "next".
+        assert_eq!(skill_progress(xp_for_skill_level(SKILL_MAX_LEVEL)), (0, 0));
+    }
+}

--- a/late-ssh/src/app/door/lateania/state.rs
+++ b/late-ssh/src/app/door/lateania/state.rs
@@ -283,6 +283,13 @@ impl State {
         }
     }
 
+    /// Work a resource node in the current room (chop/mine/fish/forage/skin).
+    pub fn gather(&mut self) {
+        if self.ensure_player_present() {
+            self.svc.gather_task(self.user_id);
+        }
+    }
+
     /// Speak the word of recall: warp back to Embergate's Town Square.
     pub fn recall(&mut self) {
         if self.ensure_player_present() {

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -53,10 +53,12 @@ use super::persist::{
     SavedCharacter, SavedCharacterInit, SavedMob, SavedMobDot, SavedMobStun, SavedWorld,
 };
 use super::pets::{Pet, pet_species_by_key};
+use super::skills::{GatherSkill, skill_level_for_xp, skill_progress};
 use super::stats::AbilityScores;
 use super::world::{
-    CritterKind, Dir, FeatureKind, MiniMap, MobBehavior, MobSpawn, Perk, RoomId, World,
-    critter_index, critters_at, features_at, frontier_entrance_room, is_frontier_room, seed_world,
+    CritterKind, Dir, FeatureKind, MiniMap, MobBehavior, MobSpawn, Perk, ResourceNode, RoomId,
+    World, critter_index, critters_at, features_at, frontier_entrance_room, is_frontier_room,
+    node_index, nodes_at, seed_world,
 };
 
 /// World heartbeat. One combat round resolves per tick.
@@ -304,6 +306,29 @@ pub struct WildlifeView {
     pub perk: String,
 }
 
+/// One harvestable resource node in the room, for the Resources list.
+#[derive(Clone, Debug)]
+pub struct NodeView {
+    pub name: String,
+    pub note: String,
+    /// The gathering skill it belongs to, e.g. "Woodcutting".
+    pub skill: String,
+    /// True when the player can work it right now (off cooldown and skilled enough).
+    pub gatherable: bool,
+    /// Why it can't be worked, when `gatherable` is false: "needs Mining 16" or
+    /// "regrowing"; empty when it can.
+    pub reason: String,
+}
+
+/// One gathering skill's progress, for the character sheet Skills block.
+#[derive(Clone, Debug)]
+pub struct SkillView {
+    pub name: String,
+    pub level: i32,
+    pub xp_into: i64,
+    pub xp_next: i64,
+}
+
 #[derive(Clone, Debug)]
 pub struct OccupantView {
     pub user_id: Uuid,
@@ -470,6 +495,10 @@ pub struct PlayerView {
     pub following: Option<Uuid>,
     /// Wild creatures sharing the room.
     pub wildlife: Vec<WildlifeView>,
+    /// Harvestable resource nodes in the room (trees, veins, fishing spots...).
+    pub nodes: Vec<NodeView>,
+    /// The player's gathering skills and their progress, for the Skills block.
+    pub skills: Vec<SkillView>,
     pub in_combat_with: Option<String>,
     pub abilities: Vec<AbilityView>,
     pub inventory: Vec<InvView>,
@@ -553,6 +582,8 @@ impl PlayerView {
             occupants: Vec::new(),
             following: None,
             wildlife: Vec::new(),
+            nodes: Vec::new(),
+            skills: Vec::new(),
             in_combat_with: None,
             abilities: Vec::new(),
             inventory: Vec::new(),
@@ -1123,6 +1154,11 @@ impl LateaniaService {
         self.mutate(user_id, move |s| s.look(user_id));
     }
 
+    /// Work a resource node in the current room (chop/mine/fish/forage/skin).
+    pub fn gather_task(&self, user_id: Uuid) {
+        self.mutate(user_id, move |s| s.gather(user_id));
+    }
+
     /// Re-roll ability scores on the selection screen (before a class is chosen).
     pub fn reroll_task(&self, user_id: Uuid) {
         self.mutate(user_id, move |s| s.reroll(user_id));
@@ -1429,6 +1465,9 @@ struct PlayerState {
     pet: Option<Pet>,
     /// Chosen appearance/bio trait indices (see `appearance::FIELDS`).
     appearance: [u8; appearance::N_FIELDS],
+    /// Gathering-skill xp, keyed by trade; the level is a pure function of xp.
+    /// A missing entry means the trade is untrained (level 1, 0 xp).
+    skills: HashMap<GatherSkill, i64>,
     /// The friendly NPC the player is currently escorting, if any (transient).
     escort: Option<EscortState>,
     /// Transient warning gate for the start-room Frontier entrance.
@@ -1490,6 +1529,11 @@ impl PlayerState {
     fn armor(&self) -> i32 {
         let (_, _, armor) = self.equipment_mods();
         armor
+    }
+
+    /// Total xp trained in a gathering skill (0 if untrained).
+    fn skill_xp(&self, skill: GatherSkill) -> i64 {
+        self.skills.get(&skill).copied().unwrap_or(0)
     }
 }
 
@@ -1822,6 +1866,8 @@ struct WorldState {
     world_revision: u64,
     /// Hunt cooldowns for `Game` critters, keyed by global WILDLIFE index.
     hunted: HashMap<usize, Instant>,
+    /// Harvest cooldowns for resource nodes, keyed by global NODES index.
+    gathered: HashMap<usize, Instant>,
     /// Next id for a runtime-only summoned add (Summoner behavior). Kept well
     /// clear of authored spawn ids so the two never collide.
     next_summon_id: u32,
@@ -1842,6 +1888,8 @@ const SAVED_HOUSE_FURNITURE_LIMIT: usize = 512;
 const TEMPLE_ROOM: RoomId = 4;
 /// How long a hunted game critter stays gone before it wanders back.
 const GAME_RESPAWN: Duration = Duration::from_secs(40);
+/// How long a harvested resource node stays depleted before it regrows.
+const NODE_RESPAWN: Duration = Duration::from_secs(45);
 
 impl WorldState {
     fn new(room_id: Uuid, world: World) -> Self {
@@ -1880,6 +1928,7 @@ impl WorldState {
             world_dirty: false,
             world_revision: 0,
             hunted: HashMap::new(),
+            gathered: HashMap::new(),
             next_summon_id: SUMMON_ID_START,
             world_ticks: 0,
             world_boss: None,
@@ -1958,6 +2007,7 @@ impl WorldState {
             archetype: None,
             pet: None,
             appearance: [0; appearance::N_FIELDS],
+            skills: HashMap::new(),
             escort: None,
             frontier_descent_pending: false,
             resurrection_cap: 0,
@@ -2160,6 +2210,13 @@ impl WorldState {
             p.board_progress = saved.board_progress.clone();
             p.board_done = saved.board_done.clone();
             p.quest_cooldowns = saved.quest_cooldowns.clone();
+            // Restore gathering-skill xp (unknown keys are dropped, so retiring a
+            // trade never breaks a save).
+            p.skills = saved
+                .skills
+                .iter()
+                .filter_map(|(key, xp)| GatherSkill::from_key(key).map(|s| (s, *xp)))
+                .collect();
             // Restore the chosen archetype (ignored if the key is unknown or no
             // longer matches the class, e.g. a respec/rename).
             p.archetype = saved
@@ -2252,6 +2309,11 @@ impl WorldState {
                 .map(|plot| self.saved_house_furniture_for_plot(user_id, plot))
                 .unwrap_or_default(),
             appearance: p.appearance.to_vec(),
+            skills: p
+                .skills
+                .iter()
+                .map(|(s, xp)| (s.key().to_string(), *xp))
+                .collect(),
         }))
     }
 
@@ -2902,6 +2964,132 @@ impl WorldState {
             LogKind::Loot,
             format!("You stalk and catch {name}. (+{xp} xp)"),
         );
+        self.dirty = true;
+        true
+    }
+
+    /// Work a resource node in the current room: harvest the highest-tier node
+    /// the player qualifies for, granting its raw material and skill xp. Nodes
+    /// don't need a safe/unsafe room and never involve combat.
+    fn gather(&mut self, user_id: Uuid) {
+        if !self.is_classed(user_id) {
+            return;
+        }
+        let Some(player) = self.players.get(&user_id) else {
+            return;
+        };
+        if player.respawn_at.is_some() {
+            return;
+        }
+        let room_id = player.room;
+        if nodes_at(room_id).is_empty() {
+            self.log_to(
+                user_id,
+                LogKind::Normal,
+                "There's nothing to gather here.".to_string(),
+            );
+            return;
+        }
+        // `try_gather` logs its own reason when a node is present but unworkable.
+        self.try_gather(user_id, room_id);
+    }
+
+    /// Harvest the best node in the room the player can work right now. Returns
+    /// true if a material was taken. When a node is present but out of reach
+    /// (under-skilled) or still regrowing, it logs why and returns false.
+    fn try_gather(&mut self, user_id: Uuid, room_id: RoomId) -> bool {
+        let now = Instant::now();
+        let Some(player) = self.players.get(&user_id) else {
+            return false;
+        };
+        let nodes = nodes_at(room_id);
+
+        // Pick the highest-tier node the player qualifies for and that is off
+        // cooldown. Also remember the toughest node they're too unskilled for,
+        // and whether anything here is merely regrowing, for a helpful message.
+        let mut choice: Option<(usize, &'static ResourceNode)> = None;
+        let mut under_skilled: Option<(&'static ResourceNode, i32)> = None;
+        let mut regrowing = false;
+        for &n in &nodes {
+            let Some(ni) = node_index(n) else {
+                continue;
+            };
+            let level = skill_level_for_xp(player.skill_xp(n.skill));
+            if level < n.level_req {
+                if under_skilled.is_none_or(|(u, _)| n.tier > u.tier) {
+                    under_skilled = Some((n, level));
+                }
+                continue;
+            }
+            let ready = match self.gathered.get(&ni) {
+                Some(t) => now.duration_since(*t) >= NODE_RESPAWN,
+                None => true,
+            };
+            if !ready {
+                regrowing = true;
+                continue;
+            }
+            if choice.is_none_or(|(_, c)| n.tier > c.tier) {
+                choice = Some((ni, n));
+            }
+        }
+
+        let Some((ni, node)) = choice else {
+            if let Some((n, level)) = under_skilled {
+                self.log_to(
+                    user_id,
+                    LogKind::System,
+                    format!(
+                        "You can't work {} yet - it needs {} level {} (yours is {level}).",
+                        n.name,
+                        n.skill.label(),
+                        n.level_req,
+                    ),
+                );
+            } else if regrowing {
+                self.log_to(
+                    user_id,
+                    LogKind::Normal,
+                    "The resources here need time to recover.".to_string(),
+                );
+            }
+            return false;
+        };
+
+        self.gathered.insert(ni, now);
+        let skill = node.skill;
+        let yield_item = node.yield_item;
+        let gained = node.xp;
+        let node_name = node.name;
+        let item_name = item(yield_item)
+            .map(|i| i.name.to_string())
+            .unwrap_or_else(|| "something".to_string());
+        let (before, after) = if let Some(p) = self.players.get_mut(&user_id) {
+            p.inventory.push(yield_item);
+            let cur = p.skill_xp(skill);
+            let before = skill_level_for_xp(cur);
+            let new_xp = cur + gained as i64;
+            p.skills.insert(skill, new_xp);
+            (before, skill_level_for_xp(new_xp))
+        } else {
+            return false;
+        };
+        self.log_to(
+            user_id,
+            LogKind::Loot,
+            format!(
+                "You {} {node_name} and take {item_name}. (+{gained} {} xp)",
+                skill.verb(),
+                skill.label(),
+            ),
+        );
+        if after > before {
+            self.log_to(
+                user_id,
+                LogKind::System,
+                format!("Your {} rises to level {after}!", skill.label()),
+            );
+        }
         self.dirty = true;
         true
     }
@@ -5415,6 +5603,46 @@ impl WorldState {
                     },
                 })
                 .collect();
+            // Harvestable nodes in the room, each flagged with whether the player
+            // can work it now and, if not, why (under-skilled or regrowing).
+            let nodes: Vec<NodeView> = nodes_at(player.room)
+                .into_iter()
+                .map(|n| {
+                    let level = skill_level_for_xp(player.skill_xp(n.skill));
+                    let ready = match node_index(n).and_then(|ni| self.gathered.get(&ni)) {
+                        Some(t) => now.duration_since(*t) >= NODE_RESPAWN,
+                        None => true,
+                    };
+                    let (gatherable, reason) = if level < n.level_req {
+                        (false, format!("needs {} {}", n.skill.label(), n.level_req))
+                    } else if !ready {
+                        (false, "regrowing".to_string())
+                    } else {
+                        (true, String::new())
+                    };
+                    NodeView {
+                        name: n.name.to_string(),
+                        note: n.note.to_string(),
+                        skill: n.skill.label().to_string(),
+                        gatherable,
+                        reason,
+                    }
+                })
+                .collect();
+            // Every gathering trade, in a stable order, with its live progress.
+            let skills: Vec<SkillView> = GatherSkill::ALL
+                .iter()
+                .map(|&s| {
+                    let xp = player.skill_xp(s);
+                    let (xp_into, xp_next) = skill_progress(xp);
+                    SkillView {
+                        name: s.label().to_string(),
+                        level: skill_level_for_xp(xp),
+                        xp_into,
+                        xp_next,
+                    }
+                })
+                .collect();
             let in_combat_with = player.target.and_then(|mob_id| {
                 self.mobs
                     .get(&mob_id)
@@ -5660,6 +5888,8 @@ impl WorldState {
                     occupants,
                     following: player.following,
                     wildlife,
+                    nodes,
+                    skills,
                     in_combat_with,
                     abilities,
                     inventory,
@@ -5844,6 +6074,89 @@ mod tests {
 
     fn world() -> WorldState {
         WorldState::new(uid(999), seed_world())
+    }
+
+    #[test]
+    fn gathering_a_node_yields_its_material_and_trains_the_skill() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Ranger);
+        // Stand at the roadside birch (Woodcutting tier 0, room 600).
+        s.players.get_mut(&uid(1)).unwrap().room = 600;
+        let before = s.players[&uid(1)].inventory.len();
+        s.gather(uid(1));
+        let p = &s.players[&uid(1)];
+        assert_eq!(p.inventory.len(), before + 1, "a material is taken");
+        assert!(
+            p.inventory
+                .contains(&super::super::items::material_id(0, 0)),
+            "the birch log lands in the pack"
+        );
+        assert_eq!(
+            p.skill_xp(GatherSkill::Woodcutting),
+            12,
+            "woodcutting xp is granted"
+        );
+    }
+
+    #[test]
+    fn a_worked_node_is_depleted_until_it_regrows() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Ranger);
+        s.players.get_mut(&uid(1)).unwrap().room = 600;
+        s.gather(uid(1));
+        let after_one = s.players[&uid(1)].inventory.len();
+        s.gather(uid(1)); // still on cooldown
+        assert_eq!(
+            s.players[&uid(1)].inventory.len(),
+            after_one,
+            "the same node can't be stripped twice before it regrows"
+        );
+    }
+
+    #[test]
+    fn an_underskilled_node_refuses_to_be_worked() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Ranger);
+        // The ironbark (tier 4, room 803) needs Woodcutting 38; a fresh
+        // character has no woodcutting training at all.
+        s.players.get_mut(&uid(1)).unwrap().room = 803;
+        let before = s.players[&uid(1)].inventory.len();
+        s.gather(uid(1));
+        let p = &s.players[&uid(1)];
+        assert_eq!(
+            p.inventory.len(),
+            before,
+            "nothing is taken while under-skilled"
+        );
+        assert_eq!(
+            p.skill_xp(GatherSkill::Woodcutting),
+            0,
+            "no xp for a node you can't work"
+        );
+    }
+
+    #[test]
+    fn skill_xp_survives_a_save_load_round_trip() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Ranger);
+        s.players
+            .get_mut(&uid(1))
+            .unwrap()
+            .skills
+            .insert(GatherSkill::Mining, 500);
+        let saved = s.export_saved(uid(1)).expect("classed characters export");
+        let mut s2 = world();
+        s2.join(uid(1));
+        s2.hydrate(uid(1), &saved);
+        assert_eq!(
+            s2.players[&uid(1)].skill_xp(GatherSkill::Mining),
+            500,
+            "mining xp reloads through the save"
+        );
     }
 
     fn grant_frontier_unlock_titles(s: &mut WorldState, user_id: Uuid) {

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -716,6 +716,28 @@ fn room_panel(
             ));
         }
     }
+    if !view.nodes.is_empty() {
+        lines.push(section("Resources"));
+        for n in &view.nodes {
+            let (marker, color) = if n.gatherable {
+                ("◆ ", theme::AMBER())
+            } else {
+                ("· ", theme::TEXT_DIM())
+            };
+            let detail = if n.gatherable {
+                format!(", {} (press y)", n.skill.to_lowercase())
+            } else if !n.reason.is_empty() {
+                format!(", {}", n.reason)
+            } else {
+                String::new()
+            };
+            lines.extend(side_text_wrap(
+                &format!("{marker}{}{detail}", n.name),
+                color,
+                width,
+            ));
+        }
+    }
     lines.push(Line::raw(""));
     lines.extend(footer_hints(view));
     lines
@@ -906,6 +928,8 @@ fn sheet_attributes(view: &PlayerView, accent: Color) -> Vec<Line<'static>> {
             .add_modifier(Modifier::BOLD),
     )));
     lines.extend(wrap(&view.trait_desc, 24));
+    lines.push(Line::raw(""));
+    lines.extend(skills_block(view));
     lines
 }
 
@@ -956,6 +980,42 @@ fn sheet_derived(view: &PlayerView, accent: Color) -> Vec<Line<'static>> {
     }
     lines.push(Line::raw(""));
     lines.push(hint("c", "close  v abilities  t bag"));
+    lines
+}
+
+/// The gathering-trades block: each skill's level and a compact progress
+/// readout. Shown on both the full character sheet and the narrow panel; the `y`
+/// hint teaches how to work a node.
+fn skills_block(view: &PlayerView) -> Vec<Line<'static>> {
+    let mut lines = vec![section("Trades")];
+    if view.skills.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  untrained",
+            Style::default().fg(theme::TEXT_DIM()),
+        )));
+        return lines;
+    }
+    for s in &view.skills {
+        let progress = if s.xp_next > 0 {
+            format!("{}/{}", s.xp_into, s.xp_next)
+        } else {
+            "max".to_string()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {} ", s.name), Style::default().fg(theme::TEXT())),
+            Span::styled(
+                format!("L{}", s.level),
+                Style::default()
+                    .fg(theme::AMBER())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("  {progress}"),
+                Style::default().fg(theme::TEXT_DIM()),
+            ),
+        ]));
+    }
+    lines.push(hint("y", "gather a resource node"));
     lines
 }
 
@@ -1173,6 +1233,8 @@ fn character_panel(view: &PlayerView) -> Vec<Line<'static>> {
             Style::default().fg(theme::BADGE_GOLD()),
         )));
     }
+    lines.push(Line::raw(""));
+    lines.extend(skills_block(view));
     lines.push(Line::raw(""));
     lines.push(hint("c", "close  v abilities  t bag"));
     lines.push(hint("[ ]", "scroll"));

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -21,6 +21,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::damage::{DamageProfile, DamageType};
+use super::skills::GatherSkill;
 
 /// Compass and vertical directions a player can move.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -781,6 +782,308 @@ pub fn critters_at(room: RoomId) -> Vec<&'static CritterSpawn> {
 /// per-world hunt cooldowns.
 pub fn critter_index(c: &CritterSpawn) -> Option<usize> {
     WILDLIFE.iter().position(|w| std::ptr::eq(w, c))
+}
+
+/// A harvestable resource node fixed to a room: a tree stand, an ore vein, a
+/// fishing spot, or a herb/skinning patch. Modelled exactly like wildlife -
+/// static data keyed to a home room, with a per-node respawn cooldown tracked on
+/// the service (`gathered`). Harvesting one grants its raw material plus skill
+/// xp, gated behind a minimum skill level so higher tiers stay out of reach
+/// until the trade is trained up.
+#[derive(Clone, Copy, Debug)]
+pub struct ResourceNode {
+    pub home: RoomId,
+    pub skill: GatherSkill,
+    /// What the player sees and acts on, e.g. "an old oak wood".
+    pub name: &'static str,
+    /// Short flavour shown in the Resources list.
+    pub note: &'static str,
+    /// Tier 0..5, low to high; sets the material and the difficulty band.
+    pub tier: u8,
+    /// Minimum skill level required to work it.
+    pub level_req: i32,
+    /// Item id granted on a successful harvest (derived from skill + tier).
+    pub yield_item: u32,
+    /// Skill xp granted per harvest.
+    pub xp: i32,
+}
+
+const fn node(
+    home: RoomId,
+    skill: GatherSkill,
+    name: &'static str,
+    note: &'static str,
+    tier: u8,
+    level_req: i32,
+    xp: i32,
+) -> ResourceNode {
+    ResourceNode {
+        home,
+        skill,
+        name,
+        note,
+        tier,
+        level_req,
+        // The yield is fixed by the node's skill and tier, so the material can
+        // never drift out of sync with its source.
+        yield_item: super::items::material_id(skill.index(), tier as u32),
+        xp,
+    }
+}
+
+/// Every harvestable node in the world, keyed to its home room. Tiers climb with
+/// distance/difficulty from Embergate: roadside starters near town, mid materials
+/// out in the overworld wings, and the best materials deep in the harder zones.
+pub const NODES: &[ResourceNode] = &[
+    // ---- Woodcutting: birch -> oak -> ash -> yew -> ironbark ------------
+    node(
+        600,
+        GatherSkill::Woodcutting,
+        "a stand of roadside birch",
+        "slim white birches along the verge",
+        0,
+        1,
+        12,
+    ),
+    node(
+        680,
+        GatherSkill::Woodcutting,
+        "an old oak wood",
+        "gnarled oaks on the hillside",
+        1,
+        8,
+        30,
+    ),
+    node(
+        684,
+        GatherSkill::Woodcutting,
+        "a grove of mountain ash",
+        "straight ash on the high slopes",
+        2,
+        16,
+        70,
+    ),
+    node(
+        688,
+        GatherSkill::Woodcutting,
+        "an ancient yew",
+        "a black, age-twisted yew",
+        3,
+        26,
+        150,
+    ),
+    node(
+        803,
+        GatherSkill::Woodcutting,
+        "ironbark rooted in the dark",
+        "iron-hard trunks in the fungal deep",
+        4,
+        38,
+        320,
+    ),
+    // ---- Mining: copper -> tin -> iron -> silver -> mithril -------------
+    node(
+        601,
+        GatherSkill::Mining,
+        "a weathered copper outcrop",
+        "green-streaked stone by the road",
+        0,
+        1,
+        12,
+    ),
+    node(
+        740,
+        GatherSkill::Mining,
+        "a tin-streaked rockface",
+        "pale ore in the desert rock",
+        1,
+        8,
+        30,
+    ),
+    node(
+        743,
+        GatherSkill::Mining,
+        "a deep iron seam",
+        "red iron banding the cliff",
+        2,
+        16,
+        70,
+    ),
+    node(
+        748,
+        GatherSkill::Mining,
+        "a glinting silver vein",
+        "silver threading the deep rock",
+        3,
+        26,
+        150,
+    ),
+    node(
+        750,
+        GatherSkill::Mining,
+        "a mithril lode",
+        "the fabled blue-white ore",
+        4,
+        38,
+        320,
+    ),
+    // ---- Fishing: bream -> trout -> pike -> sturgeon -> moonscale -------
+    node(
+        620,
+        GatherSkill::Fishing,
+        "the harbor shallows",
+        "small fish in the clear shallows",
+        0,
+        1,
+        12,
+    ),
+    node(
+        720,
+        GatherSkill::Fishing,
+        "the oasis pool",
+        "fish rising in the still oasis",
+        0,
+        1,
+        12,
+    ),
+    node(
+        660,
+        GatherSkill::Fishing,
+        "the high lake shore",
+        "trout holding in the cold lake",
+        1,
+        8,
+        30,
+    ),
+    node(
+        641,
+        GatherSkill::Fishing,
+        "a tidal cove",
+        "pike hunting the running cove",
+        2,
+        16,
+        70,
+    ),
+    node(
+        701,
+        GatherSkill::Fishing,
+        "a black fen pool",
+        "something big turns in the dark water",
+        3,
+        26,
+        150,
+    ),
+    node(
+        650,
+        GatherSkill::Fishing,
+        "the kraken's deep",
+        "pale shapes in the abyssal water",
+        4,
+        38,
+        320,
+    ),
+    // ---- Foraging: marsh sage -> redleaf -> bloodthistle -> frostbloom -> sunmoss
+    node(
+        603,
+        GatherSkill::Foraging,
+        "a verge of marsh sage",
+        "grey-green sage along the ditch",
+        0,
+        1,
+        12,
+    ),
+    node(
+        682,
+        GatherSkill::Foraging,
+        "a redleaf meadow",
+        "red-veined leaves in the meadow",
+        1,
+        8,
+        30,
+    ),
+    node(
+        700,
+        GatherSkill::Foraging,
+        "a bloodthistle bog",
+        "dark thistles standing in the mire",
+        2,
+        16,
+        70,
+    ),
+    node(
+        690,
+        GatherSkill::Foraging,
+        "a cold high meadow",
+        "pale blooms rimed with frost",
+        3,
+        26,
+        150,
+    ),
+    node(
+        801,
+        GatherSkill::Foraging,
+        "a cavern lit by sunmoss",
+        "moss that glows faintly in the dark",
+        4,
+        38,
+        320,
+    ),
+    // ---- Skinning: rough -> thick -> boar -> bear -> direhide -----------
+    node(
+        604,
+        GatherSkill::Skinning,
+        "fresh boar sign under the oaks",
+        "trampled ground and shed bristles",
+        0,
+        1,
+        12,
+    ),
+    node(
+        760,
+        GatherSkill::Skinning,
+        "a well-worn game trail",
+        "hoof-churned earth on the savanna",
+        1,
+        8,
+        30,
+    ),
+    node(
+        762,
+        GatherSkill::Skinning,
+        "a razorback wallow",
+        "a muddy wallow, still warm",
+        2,
+        16,
+        70,
+    ),
+    node(
+        765,
+        GatherSkill::Skinning,
+        "a cave-bear's kill",
+        "a fresh kill dragged half-eaten",
+        3,
+        26,
+        150,
+    ),
+    node(
+        767,
+        GatherSkill::Skinning,
+        "a dire-beast lair",
+        "old bones and a rank, huge musk",
+        4,
+        38,
+        320,
+    ),
+];
+
+pub fn nodes_at(room: RoomId) -> Vec<&'static ResourceNode> {
+    NODES.iter().filter(|n| n.home == room).collect()
+}
+
+/// Stable global index of a node (its position in `NODES`), used to key
+/// per-world harvest cooldowns.
+pub fn node_index(n: &ResourceNode) -> Option<usize> {
+    NODES.iter().position(|x| std::ptr::eq(x, n))
 }
 
 fn room(
@@ -7674,6 +7977,78 @@ mod tests {
                 "feature {:?} references missing room {}",
                 feature.name,
                 feature.room
+            );
+        }
+    }
+
+    #[test]
+    fn every_node_lives_in_a_real_room() {
+        let world = seed_world();
+        for n in NODES {
+            assert!(
+                world.rooms.contains_key(&n.home),
+                "node {:?} references missing room {}",
+                n.name,
+                n.home
+            );
+        }
+    }
+
+    #[test]
+    fn every_node_yields_a_real_material_matching_its_skill_and_tier() {
+        for n in NODES {
+            assert!(
+                (n.tier as u32) < super::super::items::MATERIAL_TIERS,
+                "node {:?} tier {} out of range",
+                n.name,
+                n.tier
+            );
+            assert_eq!(
+                n.yield_item,
+                super::super::items::material_id(n.skill.index(), n.tier as u32),
+                "node {:?} yield must follow its skill + tier",
+                n.name
+            );
+            assert!(
+                super::super::items::item(n.yield_item).is_some(),
+                "node {:?} yields missing item {}",
+                n.name,
+                n.yield_item
+            );
+            assert!(
+                n.level_req >= 1,
+                "node {:?} needs a real skill gate",
+                n.name
+            );
+        }
+    }
+
+    #[test]
+    fn node_indices_round_trip_and_cover_every_skill() {
+        // `node_index` is exercised exactly as the service uses it: on the
+        // 'static refs handed out by `nodes_at` (const promotion makes the two
+        // NODES views share storage, as with critters). Every node must be
+        // reachable and map back to a unique index.
+        let world = seed_world();
+        let mut seen = std::collections::HashSet::new();
+        for &id in world.rooms.keys() {
+            for n in nodes_at(id) {
+                let idx = node_index(n).expect("a node from nodes_at has an index");
+                seen.insert(idx);
+            }
+        }
+        assert_eq!(
+            seen.len(),
+            NODES.len(),
+            "every node is reachable via nodes_at and indexes uniquely"
+        );
+        // At least one node per gathering skill, so every trade has somewhere to
+        // train.
+        for skill in GatherSkill::ALL {
+            assert!(
+                NODES.iter().any(|n| n.skill == skill),
+                "no node trains {}",
+                skill.label()
             );
         }
     }


### PR DESCRIPTION
First pillar of a UO / Aardwolf-style **crafting economy** for Lateania: five gathering trades and harvestable resource nodes seeded across the world. Thanks as always @mpiorowski for the world to build in. 🙏

This is **part 1 of 3**, and is deliberately additive and low-risk — it reuses the existing wildlife/cooldown, item-catalog and persistence patterns rather than touching combat or the service contract.

### What's in
- **Five gathering trades** (`skills.rs` → `GatherSkill`): Woodcutting, Mining, Fishing, Foraging, Skinning — each on its own **1→50** xp curve that steepens past level 10, so the top-tier materials are a real grind. Independent of class level; persisted per character.
- **Resource nodes** (`world::NODES`): trees, ore veins, fishing spots and herb/skinning patches keyed to rooms, modelled exactly like `WILDLIFE` (static data + a per-node service cooldown). Tiered **0–5 by area difficulty** — roadside starters near town, the best materials deep in the harder wings and the capital waters — each with a minimum skill level and a yield material fixed by `(skill, tier)`.
- **Raw materials** (`items::materials`, IDs `4000..4100`): a 5×5 catalog of logs / ores / fish / herbs / hides. `Valuable` for now, so they're **immediately sellable** — and they become the recipe inputs in part 2.
- **Gather action** (`y`): works the highest-tier node in the room you qualify for, grants the material + skill xp, then depletes the node for 45s (`WorldState::gathered`, mirroring the existing hunt cooldown). Under-skilled or regrowing nodes tell you why. No combat, no safe/unsafe gate.
- **UI**: a **Resources** section in the room panel (like Wildlife) and a **Trades** block on the character sheet (each skill's level + progress), with the `y` hint.
- **Persistence**: schema bumped to **v12** with a serde-default `skills` field, so existing saves load untouched.

### Coming next (stacked)
- **Part 2 — Crafting**: recipes + craft stations (forge/workbench/alchemy lab/cooking fire), ore→ingot→gear chains, poison/potion brewing, cooking; outputs equip/consume/sell.
- **Part 3 — Depth**: applied combat poisons, cooking buffs, masterwork/high-tier recipe sinks.

### Verification
- `cargo test -p late-ssh --lib door::lateania` → **151 passed** (new tests cover the xp curve, node placement/yields, gather grant + depletion + under-skill gating, and the save round-trip).
- `cargo clippy -p late-ssh --lib` → clean.
- `cargo fmt -p late-ssh -- --check` → clean.

`CONTEXT.md` updated to document the new module, nodes, keys and persistence. Happy to split, reshape, or hold any of this to fit your direction.