### PR TITLE
Lateania: crafting stations, recipes & the maker's trades (crafting economy, part 2 of 3)

### DIFF
--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -4,7 +4,7 @@
 - Scope: `late-ssh/src/app/door/lateania` plus Lateania screen lifecycle in `late-ssh/src/app/door`
 - Domain: Lateania, the persistent D&D-style MUD inside late.sh
 - Primary audience: LLM agents changing the Lateania game runtime, content, UI, combat, or persistence
-- Last updated: 2026-06-17
+- Last updated: 2026-07-13
 - Status: Active
 - Parent context: `../../../../../CONTEXT.md`
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change when gameplay/content changes.
@@ -58,13 +58,14 @@ Current game scale:
 | `input.rs` | Active-world key routing after launch. App-level launch/reset/leave handling belongs in `screen.rs`. |
 | `ui.rs` | Ratatui rendering for class select, log, compact mode, side panels, minimap, hints. The Character panel expands to a full-width dashboard (accent-tinted class portrait, dot-rated ability scores, vitals/XP meters) when the area is at least 72x18, else falls back to the narrow side panel; Foes/Adventurers/Follow render as aligned roster rows with HP meters. Lock-free, snapshot-only. |
 | `svc.rs` | Authoritative runtime: service tasks, `WorldState`, player/mob state, combat, movement, following, shops, persistence, snapshots, activity events. |
-| `world.rs` | Immutable world data and generation: rooms, exits, mobs, features, wildlife, minimap, overworld, Frontier. |
+| `world.rs` | Immutable world data and generation: rooms, exits, mobs, features, wildlife, minimap, overworld, Frontier. Also **resource nodes** (`NODES`/`ResourceNode`/`nodes_at`/`node_index`): trees, ore veins, fishing spots and herb/skinning patches keyed to rooms, modelled exactly like `WILDLIFE` (static data + a per-node service cooldown), each with a skill, tier, min-level gate, and derived yield item. |
 | `classes.rs` | Twelve playable classes (Warrior/Mage/Cleric/Rogue/Ranger/Druid/Necromancer/Bard/Monk/Paladin/Warlock/Berserker), resources (incl. Spirit/Souls/Tempo/Ki), passive traits, level 1-50 stat curves, XP curve. Adding a class means an arm in every `match self` here (name/primary_score/resource/tagline/description/trait_name/trait_desc/stats_at/as_key/from_key), an entry in `ALL`, an ability roster in `abilities.rs`, and (if the trait needs runtime behaviour) a hook in `svc.rs`: upkeep loop for regen (Druid/Paladin) and Tempo (Bard); `kill_mob` for harvest (Necromancer/Warlock); `strike_player` for Monk mitigation; the combat round for Berserker frenzy. **Every level grants something:** the curve grows each level (surfaced by `check_level_up`, which logs the concrete +HP/+attack/+resource gains per level), plus `level_milestone`/`milestone_hp_bonus` add a named milestone (Blooded…Ascended) with a permanent +HP every fifth level, a pure function of level, so no extra save state; `current_milestone(level)` shows on the character sheet. **Archetypes:** at `ARCHETYPE_LEVEL` each class offers two paths (the `ARCHETYPES` data table; `archetypes_for`/`archetype_by_key`), each carrying a `Role` (Tank/Healer/DPS) and four percent modifiers (`attack_pct`/`mitigation_pct`/`heal_pct`/`max_hp_pct`). The modifiers apply at existing combat hooks in `svc.rs` (DPS in `attack()`+`spell_damage`, Tank in `strike_player`, Healer in `heal_player`, max-HP in `max_hp()`); no engine changes; the chosen `&'static ArchetypeDef` is held on `PlayerState` and persisted by key. |
 | `abilities.rs` | Ability roster and unlock helpers. Effects are data, resolved in `svc.rs`. |
 | `housing.rs` | Player housing data + address arithmetic. `TIERS` (5 homes Hut→Tower: price/ground/upper rooms), the 50+-piece `FURNITURE` catalogue, `HOUSING_BASE`/`plot_base`/`plot_of_room`/`is_housing_room`. Homes are **static rooms** (generated in `world.rs::extend_housing` as Hearthward Close off Market Row); only **ownership** (`plot_owner`) and **furnishings** (`house_furniture`) are dynamic side-state on `svc.rs`, so movement/visiting/snapshot work unchanged and the homes are public shared-world plots. |
 | `appearance.rs` | Character appearance/bio. `FIELDS` (Build/Hair/Eyes/Bearing/Origin, each with a menu of options) + `compose_bio`. The TUI has no free-text, so a player customises by cycling preset options (`e` opens the Appearance panel; `Enter`/`x` cycle a field). Stored as `[u8; N_FIELDS]` on `PlayerState`, persisted, shown on the sheet and when profiling another adventurer (Follow panel). |
 | `pets.rs` | Combat companions. `PetSpecies` data table (`PET_SPECIES`, `pet_species_by_key`) of buyable beasts, and the live `Pet` (held on `PlayerState`, always co-located with its owner). Loyalty (earned by feeding) drives the level via a pure function; `max_hp`/`attack` scale with level. The world wiring (buying at a Stable, feeding, taking wounds, biting the owner's target each combat round) lives in `svc.rs`. Persisted by species key + loyalty (HP restored full on load). |
-| `items.rs` | Item catalog, equipment slots, consumables, valuables, shops, generated Frontier loot. |
+| `items.rs` | Item catalog, equipment slots, consumables, valuables, shops, generated Frontier loot. Also the **raw-material catalog** (`materials()`/`material_id`/`MATERIAL_BASE = 4000`): 5 skills x 5 tiers of gathered materials (logs/ores/fish/herbs/hides), `Valuable` kind (immediately sellable), IDs `4000..4100` (skill index x 20 + tier). |
+| `skills.rs` | **Gathering skills** (`GatherSkill`: Woodcutting/Mining/Fishing/Foraging/Skinning) and their own 1-50 xp curve (`xp_for_skill_level`/`skill_level_for_xp`/`skill_progress`), independent of class level and steepening past level 10. Persisted per-player as (skill key, xp). |
 | `damage.rs` | Damage schools, mob resistance/weakness profiles, damage multiplier math. |
 | `stats.rs` | D&D-style ability scores, 4d6-drop-lowest rolls, modifiers, HP/attack bonuses. |
 | `persist.rs` | JSON schemas for durable character saves and shared world saves. Versioned (`SCHEMA_VERSION`); new fields use `#[serde(default)]` so old saves load (e.g. `board_progress`/`board_done` for quests). |
@@ -149,7 +150,7 @@ Before class choice:
 - The Town Square Frontier descent requires `Bane of the Archdemon Mal'gareth`, `Bane of The Bonewright Lich`, `Bane of the Elder Dryad`, and `Bane of the Abyss-Thing`; after those title gates, it still uses a transient two-step warning: the first `>` logs that the Frontier is older, meaner country for seasoned adventurers, and the next `>` confirms descent. Service-backed non-movement actions clear the pending warning.
 - Combat: `space`, `x`, or Enter attacks when not in a list panel; `z` flees.
 - Abilities: `1-9` use unlocked ability slots unless a list panel is open; `0` uses slot 10. The Abilities panel is a list panel: Enter casts the highlighted ability, which is the only way to reach rosters deeper than ten (the classic classes' late slots).
-- World actions: `r` recalls to Embergate's Town Square when out of combat; `f` toggles the Follow panel; `g` casts the Resurrection rite on the nearest fallen adventurer in the room (Cleric/Paladin/Druid only); `p` opens the Stable (companion vendor) where one stands; `n` opens the housing ledger (at the clerk, or inside a home you own); `e` opens the appearance/bio builder.
+- World actions: `y` works a resource node in the room (chop/mine/fish/forage/skin - the highest tier you qualify for); `r` recalls to Embergate's Town Square when out of combat; `f` toggles the Follow panel; `g` casts the Resurrection rite on the nearest fallen adventurer in the room (Cleric/Paladin/Druid only); `p` opens the Stable (companion vendor) where one stands; `n` opens the housing ledger (at the clerk, or inside a home you own); `e` opens the appearance/bio builder.
 - While dead (a corpse): all normal keys are suppressed; only `r`/Enter (release to the temple) and `Esc` (leave) respond, until a resurrection or the auto-release deadline.
 - Panels: `c` character, `v` abilities, `t` inventory, `b` shop where a merchant exists, `o` examine/look, `k` titles, `j` quest journal, `f` follow.
 - List panels: `w/s` or up/down move cursor; `1-9` jump and activate; Enter activates. The view auto-scrolls to keep the highlighted row within a small scroll-off margin (top and bottom).
@@ -216,6 +217,14 @@ Non-Room side panels are rendered through `side_paragraph`, which enables Ratatu
 - `CritterKind::Game` can be hunted by attacking when no combat mob is present. Hunted game grants small XP and is hidden by a per-world 40-second cooldown keyed by global wildlife index.
 - `CritterKind::Boon(Perk)` applies on room entry. Perks are `Embolden`, `Mend`, and `Quicken`.
 - Wildlife appears in the Room panel; game critters show as huntable only while off cooldown.
+
+### Gathering and skills [VOLATILE]
+
+- Five gathering trades (`skills::GatherSkill`) - Woodcutting, Mining, Fishing, Foraging, Skinning - each levelled 1..=50 on its own steepening xp curve, tracked as a `skill -> total xp` map on `PlayerState` and persisted (schema v12).
+- `world::NODES` seeds harvestable nodes (trees/ore veins/fishing spots/herb & skinning patches) across the overworld, tiered 0..5 by area difficulty (roadside starters near town; the best materials deep in the harder wings and capital waters). Each node has a min skill level and a fixed yield material derived from `(skill, tier)`.
+- `y` works the highest-tier node in the room the player qualifies for (`svc::gather`/`try_gather`): it grants the raw material to the pack plus skill xp, then depletes for `NODE_RESPAWN` (45s, tracked in `WorldState::gathered`, mirroring `hunted`). Under-skilled or regrowing nodes log why and yield nothing. No combat and no safe/unsafe gate - gathering works anywhere a node stands.
+- Raw materials (`items::materials`, IDs `4000..4100`) are `Valuable` today, so they are immediately sellable ("tradeable"); the crafting update turns them into gear/consumables and further recipe chains.
+- The Room panel shows a **Resources** section (like Wildlife) with a `◆`/`·` marker per node and a gatherable/reason tag; the character sheet + narrow panel show a **Trades** block (each skill's level and progress) with the `y` hint.
 
 ### Frontier and Reaches loot
 
@@ -299,7 +308,7 @@ Progression:
 
 Character persistence uses `late_core::models::mud_character` / `mud_characters`.
 
-Saved character schema version: `11`.
+Saved character schema version: `12`.
 
 Durable fields:
 - class key, XP, level, carried gold, banked gold, current HP;
@@ -312,7 +321,8 @@ Durable fields:
 - chosen archetype key (validated against the saved class on load);
 - companion species key + accumulated loyalty (the pet reloads at full health; its level derives from loyalty);
 - owned housing plot (tier index) + placed furnishings as (room, key) pairs (re-registered into `plot_owner`/`house_furniture` on load);
-- appearance/bio trait indices (`Vec<u8>`, clamped to valid options on load).
+- appearance/bio trait indices (`Vec<u8>`, clamped to valid options on load);
+- gathering-skill xp as (skill key, total xp) pairs (unknown keys dropped on load).
 
 Transient by design:
 - current target;

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -64,8 +64,9 @@ Current game scale:
 | `housing.rs` | Player housing data + address arithmetic. `TIERS` (5 homes Hut→Tower: price/ground/upper rooms), the 50+-piece `FURNITURE` catalogue, `HOUSING_BASE`/`plot_base`/`plot_of_room`/`is_housing_room`. Homes are **static rooms** (generated in `world.rs::extend_housing` as Hearthward Close off Market Row); only **ownership** (`plot_owner`) and **furnishings** (`house_furniture`) are dynamic side-state on `svc.rs`, so movement/visiting/snapshot work unchanged and the homes are public shared-world plots. |
 | `appearance.rs` | Character appearance/bio. `FIELDS` (Build/Hair/Eyes/Bearing/Origin, each with a menu of options) + `compose_bio`. The TUI has no free-text, so a player customises by cycling preset options (`e` opens the Appearance panel; `Enter`/`x` cycle a field). Stored as `[u8; N_FIELDS]` on `PlayerState`, persisted, shown on the sheet and when profiling another adventurer (Follow panel). |
 | `pets.rs` | Combat companions. `PetSpecies` data table (`PET_SPECIES`, `pet_species_by_key`) of buyable beasts, and the live `Pet` (held on `PlayerState`, always co-located with its owner). Loyalty (earned by feeding) drives the level via a pure function; `max_hp`/`attack` scale with level. The world wiring (buying at a Stable, feeding, taking wounds, biting the owner's target each combat round) lives in `svc.rs`. Persisted by species key + loyalty (HP restored full on load). |
-| `items.rs` | Item catalog, equipment slots, consumables, valuables, shops, generated Frontier loot. Also the **raw-material catalog** (`materials()`/`material_id`/`MATERIAL_BASE = 4000`): 5 skills x 5 tiers of gathered materials (logs/ores/fish/herbs/hides), `Valuable` kind (immediately sellable), IDs `4000..4100` (skill index x 20 + tier). |
-| `skills.rs` | **Gathering skills** (`GatherSkill`: Woodcutting/Mining/Fishing/Foraging/Skinning) and their own 1-50 xp curve (`xp_for_skill_level`/`skill_level_for_xp`/`skill_progress`), independent of class level and steepening past level 10. Persisted per-player as (skill key, xp). |
+| `items.rs` | Item catalog, equipment slots, consumables, valuables, shops, generated Frontier loot. Also the **raw-material catalog** (`materials()`/`material_id`/`MATERIAL_BASE = 4000`): 5 skills x 5 tiers of gathered materials (logs/ores/fish/herbs/hides), `Valuable` kind (immediately sellable), IDs `4000..4100` (skill index x 20 + tier). And the **crafted-goods catalog** (`crafted()`/`CRAFTED_BASE = 4200` + the `*_id(tier)` helpers): intermediates (ingots/planks/leather) and finished goods (weapons/armor/potions/poisons/food), IDs `4200..4500`. Both chained into `item()`. |
+| `skills.rs` | **Gathering skills** (`GatherSkill`: Woodcutting/Mining/Fishing/Foraging/Skinning) and **crafting skills** (`CraftSkill`: Smithing/Woodworking/Leatherworking/Alchemy/Cooking), both on one 1-50 xp curve (`xp_for_skill_level`/`skill_level_for_xp`/`skill_progress`), independent of class level and steepening past level 10. Persisted per-player as (skill key, xp) for each set. |
+| `crafting.rs` | **Recipes** (`Recipe`/`recipes()`/`recipe(i)`/`recipe_indices_for(skill)`): inputs -> output, gated by a `CraftSkill` + level. 50 recipes (10 per tier x 5 tiers) that **chain** (ore -> ingot -> weapon). Data only; `svc::craft` resolves and applies them. Built at runtime and cached (inputs are `Vec`, not a leaked slice). |
 | `damage.rs` | Damage schools, mob resistance/weakness profiles, damage multiplier math. |
 | `stats.rs` | D&D-style ability scores, 4d6-drop-lowest rolls, modifiers, HP/attack bonuses. |
 | `persist.rs` | JSON schemas for durable character saves and shared world saves. Versioned (`SCHEMA_VERSION`); new fields use `#[serde(default)]` so old saves load (e.g. `board_progress`/`board_done` for quests). |
@@ -150,7 +151,7 @@ Before class choice:
 - The Town Square Frontier descent requires `Bane of the Archdemon Mal'gareth`, `Bane of The Bonewright Lich`, `Bane of the Elder Dryad`, and `Bane of the Abyss-Thing`; after those title gates, it still uses a transient two-step warning: the first `>` logs that the Frontier is older, meaner country for seasoned adventurers, and the next `>` confirms descent. Service-backed non-movement actions clear the pending warning.
 - Combat: `space`, `x`, or Enter attacks when not in a list panel; `z` flees.
 - Abilities: `1-9` use unlocked ability slots unless a list panel is open; `0` uses slot 10. The Abilities panel is a list panel: Enter casts the highlighted ability, which is the only way to reach rosters deeper than ten (the classic classes' late slots).
-- World actions: `y` works a resource node in the room (chop/mine/fish/forage/skin - the highest tier you qualify for); `r` recalls to Embergate's Town Square when out of combat; `f` toggles the Follow panel; `g` casts the Resurrection rite on the nearest fallen adventurer in the room (Cleric/Paladin/Druid only); `p` opens the Stable (companion vendor) where one stands; `n` opens the housing ledger (at the clerk, or inside a home you own); `e` opens the appearance/bio builder.
+- World actions: `y` works a resource node in the room (chop/mine/fish/forage/skin - the highest tier you qualify for); `u` opens the crafting panel where a craft station stands; `r` recalls to Embergate's Town Square when out of combat; `f` toggles the Follow panel; `g` casts the Resurrection rite on the nearest fallen adventurer in the room (Cleric/Paladin/Druid only); `p` opens the Stable (companion vendor) where one stands; `n` opens the housing ledger (at the clerk, or inside a home you own); `e` opens the appearance/bio builder.
 - While dead (a corpse): all normal keys are suppressed; only `r`/Enter (release to the temple) and `Esc` (leave) respond, until a resurrection or the auto-release deadline.
 - Panels: `c` character, `v` abilities, `t` inventory, `b` shop where a merchant exists, `o` examine/look, `k` titles, `j` quest journal, `f` follow.
 - List panels: `w/s` or up/down move cursor; `1-9` jump and activate; Enter activates. The view auto-scrolls to keep the highlighted row within a small scroll-off margin (top and bottom).
@@ -171,6 +172,7 @@ Before class choice:
 - `Titles`: earned titles; selecting active title again clears it.
 - `Quests`: read-only Frontier zone quest list.
 - `Follow`: current occupants, follow target tag, stop-follow action.
+- `Crafting`: recipes worked at the craft station(s) in the room; select and Enter to craft.
 
 UI uses a two-column layout with compact fallback for terminals narrower than 50 columns or shorter than 9 rows. The left column splits current room context (`Now`) from newest-first action scrollback (`Recent`) with a visible divider; the `Now` region wraps the room description naturally and only truncates the whole context as a last resort to preserve recent-event space. Service room-description lines use `LogKind::Room` and are filtered out of `Recent` so movement does not bury combat, loot, chat, and system events. Arrivals use compact `LogKind::Travel` breadcrumbs so Recent still shows where the player has just been. Consecutive identical recent events are collapsed with an `xN` suffix so repeated blocked-movement warnings do not flood the split.
 In the Room panel, the minimap is rendered in a separate bottom-aligned side-panel region, not appended to the room detail lines; keep it anchored so changing foes/features/hints does not make the map jump vertically.
@@ -225,6 +227,14 @@ Non-Room side panels are rendered through `side_paragraph`, which enables Ratatu
 - `y` works the highest-tier node in the room the player qualifies for (`svc::gather`/`try_gather`): it grants the raw material to the pack plus skill xp, then depletes for `NODE_RESPAWN` (45s, tracked in `WorldState::gathered`, mirroring `hunted`). Under-skilled or regrowing nodes log why and yield nothing. No combat and no safe/unsafe gate - gathering works anywhere a node stands.
 - Raw materials (`items::materials`, IDs `4000..4100`) are `Valuable` today, so they are immediately sellable ("tradeable"); the crafting update turns them into gear/consumables and further recipe chains.
 - The Room panel shows a **Resources** section (like Wildlife) with a `◆`/`·` marker per node and a gatherable/reason tag; the character sheet + narrow panel show a **Trades** block (each skill's level and progress) with the `y` hint.
+
+### Crafting [VOLATILE]
+
+- Five crafting trades (`skills::CraftSkill`) - Smithing, Woodworking, Leatherworking, Alchemy, Cooking - level 1..=50 on the same curve, tracked as a separate `craft_skills` map on `PlayerState` and persisted (schema v13).
+- `world::FEATURES` places the five **craft stations** (`FeatureKind::CraftStation(CraftSkill)`) in Embergate's Market Row (room 3): a forge, workbench, tannery, alchemy lab and cooking fire. `craft_stations_at(room)` gates crafting and builds the panel. Stations read as actionable gold in the room (`ui::is_craft_station`).
+- `u` opens the **Crafting** panel (`Panel::Crafting`) where any station stands; it lists every recipe worked at the stations here, each flagged craftable/gated (station + skill level + materials). `Enter` crafts the selected recipe (`svc::craft` / `craft_task`): it consumes the inputs (`PlayerState::consume`/`item_count`), adds the output, and trains the craft skill. Recipes **chain** - smelt ore -> ingot, then forge ingot + plank -> sword.
+- Crafted outputs are ordinary items, so they equip / are consumed / sell through the existing systems (weapons & armor equip, potions & food heal/restore, poisons are sellable valuables until the depth update makes them applyable).
+- The **Trades** block shows all ten trades (gather then craft); the recipe `inputs` are summarised as `"3x Copper Ingot, 1x Oak Plank"`.
 
 ### Frontier and Reaches loot
 
@@ -308,7 +318,7 @@ Progression:
 
 Character persistence uses `late_core::models::mud_character` / `mud_characters`.
 
-Saved character schema version: `12`.
+Saved character schema version: `13`.
 
 Durable fields:
 - class key, XP, level, carried gold, banked gold, current HP;
@@ -322,7 +332,8 @@ Durable fields:
 - companion species key + accumulated loyalty (the pet reloads at full health; its level derives from loyalty);
 - owned housing plot (tier index) + placed furnishings as (room, key) pairs (re-registered into `plot_owner`/`house_furniture` on load);
 - appearance/bio trait indices (`Vec<u8>`, clamped to valid options on load);
-- gathering-skill xp as (skill key, total xp) pairs (unknown keys dropped on load).
+- gathering-skill xp as (skill key, total xp) pairs (unknown keys dropped on load);
+- crafting-skill xp as (skill key, total xp) pairs.
 
 Transient by design:
 - current target;

--- a/late-ssh/src/app/door/lateania/crafting.rs
+++ b/late-ssh/src/app/door/lateania/crafting.rs
@@ -1,0 +1,259 @@
+// Crafting recipes for Lateania.
+//
+// A recipe turns a set of input items (raw materials from gathering, or refined
+// intermediates) into an output item, training a craft skill (`skills::CraftSkill`).
+// Recipes chain - ore -> ingot -> weapon - so the maker's economy has depth. This
+// module is data only: the service (`svc::craft`) resolves the recipe, checks the
+// station/skill/materials, consumes the inputs and grants the output plus xp.
+//
+// Output ids come from the `items` crafted-goods catalog; input ids come from the
+// raw-material catalog (`items::material_id`) or lower-tier crafted intermediates.
+
+use std::sync::OnceLock;
+
+use super::items::{
+    food_id, ingot_id, leather_armor_id, leather_id, material_id, plank_id, poison_id, potion_id,
+    smith_armor_id, smith_weapon_id, wood_weapon_id,
+};
+use super::skills::CraftSkill;
+
+/// One input line of a recipe: an item id and how many are consumed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Ingredient {
+    pub item: u32,
+    pub qty: u32,
+}
+
+const fn ing(item: u32, qty: u32) -> Ingredient {
+    Ingredient { item, qty }
+}
+
+// Raw-material ids by gathering skill index (see `GatherSkill::index`): logs=0,
+// ore=1, fish=2, herbs=3, hides=4.
+const fn ore(t: u32) -> u32 {
+    material_id(1, t)
+}
+const fn log(t: u32) -> u32 {
+    material_id(0, t)
+}
+const fn hide(t: u32) -> u32 {
+    material_id(4, t)
+}
+const fn herb(t: u32) -> u32 {
+    material_id(3, t)
+}
+const fn fish(t: u32) -> u32 {
+    material_id(2, t)
+}
+
+/// A crafting recipe: inputs -> output, gated behind a craft skill and level.
+#[derive(Clone, Debug)]
+pub struct Recipe {
+    /// The item produced.
+    pub output: u32,
+    /// How many of the output a single craft yields (usually 1).
+    pub output_qty: u32,
+    pub skill: CraftSkill,
+    pub level_req: i32,
+    pub xp: i32,
+    pub inputs: Vec<Ingredient>,
+}
+
+/// Skill-level gate per tier (matches the gathering node gates).
+const LEVEL_REQ: [i32; 5] = [1, 8, 16, 26, 38];
+/// Xp for refining a raw material into an intermediate (the cheaper step).
+const REFINE_XP: [i32; 5] = [8, 20, 45, 100, 200];
+/// Xp for crafting a finished good (matches the gather xp curve).
+const CRAFT_XP: [i32; 5] = [12, 30, 70, 150, 320];
+
+fn build_recipes() -> Vec<Recipe> {
+    use CraftSkill::*;
+    let mut r = Vec::new();
+    for t in 0..5u32 {
+        let ti = t as usize;
+        let (gate, refine, craft) = (LEVEL_REQ[ti], REFINE_XP[ti], CRAFT_XP[ti]);
+
+        // ---- Refining: 2 raw -> 1 intermediate --------------------------
+        r.push(Recipe {
+            output: ingot_id(t),
+            output_qty: 1,
+            skill: Smithing,
+            level_req: gate,
+            xp: refine,
+            inputs: vec![ing(ore(t), 2)],
+        });
+        r.push(Recipe {
+            output: plank_id(t),
+            output_qty: 1,
+            skill: Woodworking,
+            level_req: gate,
+            xp: refine,
+            inputs: vec![ing(log(t), 2)],
+        });
+        r.push(Recipe {
+            output: leather_id(t),
+            output_qty: 1,
+            skill: Leatherworking,
+            level_req: gate,
+            xp: refine,
+            inputs: vec![ing(hide(t), 2)],
+        });
+
+        // ---- Smithing: weapon (ingots + a plank grip) and plate ---------
+        r.push(Recipe {
+            output: smith_weapon_id(t),
+            output_qty: 1,
+            skill: Smithing,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(ingot_id(t), 3), ing(plank_id(t), 1)],
+        });
+        r.push(Recipe {
+            output: smith_armor_id(t),
+            output_qty: 1,
+            skill: Smithing,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(ingot_id(t), 4)],
+        });
+
+        // ---- Woodworking: a bow (planks + a leather grip) ---------------
+        r.push(Recipe {
+            output: wood_weapon_id(t),
+            output_qty: 1,
+            skill: Woodworking,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(plank_id(t), 3), ing(leather_id(t), 1)],
+        });
+
+        // ---- Leatherworking: light armor --------------------------------
+        r.push(Recipe {
+            output: leather_armor_id(t),
+            output_qty: 1,
+            skill: Leatherworking,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(leather_id(t), 3)],
+        });
+
+        // ---- Alchemy: a healing draught and a coating poison ------------
+        r.push(Recipe {
+            output: potion_id(t),
+            output_qty: 1,
+            skill: Alchemy,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(herb(t), 2)],
+        });
+        r.push(Recipe {
+            output: poison_id(t),
+            output_qty: 1,
+            skill: Alchemy,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(herb(t), 3)],
+        });
+
+        // ---- Cooking: a restorative meal --------------------------------
+        r.push(Recipe {
+            output: food_id(t),
+            output_qty: 1,
+            skill: Cooking,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(fish(t), 1)],
+        });
+    }
+    r
+}
+
+/// Every recipe, built once and leaked to 'static for the service.
+pub fn recipes() -> &'static [Recipe] {
+    static RECIPES: OnceLock<Vec<Recipe>> = OnceLock::new();
+    RECIPES.get_or_init(build_recipes)
+}
+
+/// The recipe at a global index (the stable id the UI passes back to craft).
+pub fn recipe(index: usize) -> Option<&'static Recipe> {
+    recipes().get(index)
+}
+
+/// Global indices of the recipes worked at a given craft skill's station, in
+/// table order.
+pub fn recipe_indices_for(skill: CraftSkill) -> Vec<usize> {
+    recipes()
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.skill == skill)
+        .map(|(i, _)| i)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app::door::lateania::items::item;
+
+    #[test]
+    fn every_recipe_has_real_items_and_a_sane_gate() {
+        for r in recipes() {
+            assert!(
+                item(r.output).is_some(),
+                "recipe output {} is not a real item",
+                r.output
+            );
+            assert!(r.output_qty >= 1, "a recipe must yield something");
+            assert!(
+                (1..=super::super::skills::SKILL_MAX_LEVEL).contains(&r.level_req),
+                "recipe gate {} out of range",
+                r.level_req
+            );
+            assert!(r.xp > 0, "crafting must grant xp");
+            assert!(!r.inputs.is_empty(), "a recipe needs inputs");
+            for ingredient in &r.inputs {
+                assert!(
+                    item(ingredient.item).is_some(),
+                    "recipe input {} is not a real item",
+                    ingredient.item
+                );
+                assert!(ingredient.qty >= 1, "an input needs a positive quantity");
+            }
+        }
+    }
+
+    #[test]
+    fn every_craft_skill_has_recipes_and_indices_are_stable() {
+        for skill in CraftSkill::ALL {
+            let idx = recipe_indices_for(skill);
+            assert!(!idx.is_empty(), "no recipes for {}", skill.label());
+            for &i in &idx {
+                assert_eq!(
+                    recipe(i).unwrap().skill,
+                    skill,
+                    "index {i} maps to {skill:?}"
+                );
+            }
+        }
+        // 10 recipes per tier x 5 tiers.
+        assert_eq!(recipes().len(), 50);
+    }
+
+    #[test]
+    fn chains_link_up_ore_becomes_ingot_becomes_weapon() {
+        // The tier-0 sword recipe must consume the tier-0 ingot, which is itself
+        // a recipe output - a real chain, not a flat table.
+        let sword = recipes()
+            .iter()
+            .find(|r| r.output == smith_weapon_id(0))
+            .expect("a tier-0 sword recipe exists");
+        assert!(
+            sword.inputs.iter().any(|i| i.item == ingot_id(0)),
+            "the sword is forged from ingots"
+        );
+        assert!(
+            recipes().iter().any(|r| r.output == ingot_id(0)),
+            "the ingot is itself craftable from ore"
+        );
+    }
+}

--- a/late-ssh/src/app/door/lateania/input.rs
+++ b/late-ssh/src/app/door/lateania/input.rs
@@ -8,7 +8,8 @@
 //     slot 10; deeper rosters cast from the Abilities panel); z flee.
 //   - Death: while a corpse, r (or Enter) releases to the temple; g casts the
 //     Resurrection rite on a fallen adventurer in the room (holy/nature classes).
-//   - World: y works a resource node here (chop/mine/fish/forage/skin).
+//   - World: y works a resource node here (chop/mine/fish/forage/skin);
+//     u opens the crafting panel where a craft station stands.
 //   - Panels: c character, v abilities, o look, b shop, t inventory ("things"),
 //     p the Stable (companion vendor) where one stands. In the Stable, Enter
 //     buys the selected beast and x feeds/tends the one you have. n opens the
@@ -105,6 +106,7 @@ pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
             | Panel::Stable
             | Panel::Housing
             | Panel::Appearance
+            | Panel::Crafting
             | Panel::Abilities
     );
 
@@ -204,6 +206,13 @@ pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
         b'y' | b'Y' => {
             // Work a resource node here (chop/mine/fish/forage/skin).
             state.gather();
+            InputAction::Handled
+        }
+        b'u' | b'U' => {
+            // The crafting panel opens where a craft station stands.
+            if view.crafting.is_some() {
+                state.toggle_panel(Panel::Crafting);
+            }
             InputAction::Handled
         }
         b'\r' | b'\n' => {
@@ -312,6 +321,7 @@ pub fn handle_arrow(state: &mut State, key: u8) -> bool {
             | Panel::Stable
             | Panel::Housing
             | Panel::Appearance
+            | Panel::Crafting
     );
     match key {
         b'A' => {

--- a/late-ssh/src/app/door/lateania/input.rs
+++ b/late-ssh/src/app/door/lateania/input.rs
@@ -8,6 +8,7 @@
 //     slot 10; deeper rosters cast from the Abilities panel); z flee.
 //   - Death: while a corpse, r (or Enter) releases to the temple; g casts the
 //     Resurrection rite on a fallen adventurer in the room (holy/nature classes).
+//   - World: y works a resource node here (chop/mine/fish/forage/skin).
 //   - Panels: c character, v abilities, o look, b shop, t inventory ("things"),
 //     p the Stable (companion vendor) where one stands. In the Stable, Enter
 //     buys the selected beast and x feeds/tends the one you have. n opens the
@@ -198,6 +199,11 @@ pub fn handle_key(state: &mut State, byte: u8) -> InputAction {
         b'e' | b'E' => {
             // Open the appearance / bio builder.
             state.open_appearance();
+            InputAction::Handled
+        }
+        b'y' | b'Y' => {
+            // Work a resource node here (chop/mine/fish/forage/skin).
+            state.gather();
             InputAction::Handled
         }
         b'\r' | b'\n' => {

--- a/late-ssh/src/app/door/lateania/items.rs
+++ b/late-ssh/src/app/door/lateania/items.rs
@@ -202,6 +202,29 @@ const fn consumable(
     }
 }
 
+const fn valuable(
+    id: u32,
+    name: &'static str,
+    desc: &'static str,
+    rarity: Rarity,
+    price: i64,
+) -> Item {
+    Item {
+        id,
+        name,
+        desc,
+        kind: ItemKind::Valuable,
+        rarity,
+        mods: StatMods {
+            attack: 0,
+            max_hp: 0,
+            armor: 0,
+        },
+        price,
+        class_hint: None,
+    }
+}
+
 /// The full item catalog.
 pub const BONEWRIGHT_SCEPTER_ID: u32 = 1011;
 pub const HEARTWOOD_THORNBLADE_ID: u32 = 1012;
@@ -1065,6 +1088,265 @@ pub fn materials() -> &'static [Item] {
     CATALOG.get_or_init(build_materials)
 }
 
+// ---- Crafted goods -------------------------------------------------------
+//
+// Crafting turns raw materials into refined intermediates (ingots, planks,
+// leather) and finished goods (weapons, armor, potions, poisons, food). IDs live
+// in 4200..4500, clear of the raw materials (4000..4100). Recipes in
+// `crafting.rs` reference these ids by the const helpers below; `item` resolves
+// them like any other. Five tiers each, mirroring the material tiers.
+
+pub const CRAFTED_BASE: u32 = 4200;
+
+pub const fn ingot_id(tier: u32) -> u32 {
+    CRAFTED_BASE + tier
+}
+pub const fn plank_id(tier: u32) -> u32 {
+    CRAFTED_BASE + 20 + tier
+}
+pub const fn leather_id(tier: u32) -> u32 {
+    CRAFTED_BASE + 40 + tier
+}
+pub const fn smith_weapon_id(tier: u32) -> u32 {
+    CRAFTED_BASE + 100 + tier
+}
+pub const fn smith_armor_id(tier: u32) -> u32 {
+    CRAFTED_BASE + 120 + tier
+}
+pub const fn wood_weapon_id(tier: u32) -> u32 {
+    CRAFTED_BASE + 140 + tier
+}
+pub const fn leather_armor_id(tier: u32) -> u32 {
+    CRAFTED_BASE + 160 + tier
+}
+pub const fn potion_id(tier: u32) -> u32 {
+    CRAFTED_BASE + 200 + tier
+}
+pub const fn poison_id(tier: u32) -> u32 {
+    CRAFTED_BASE + 220 + tier
+}
+pub const fn food_id(tier: u32) -> u32 {
+    CRAFTED_BASE + 240 + tier
+}
+
+const INGOT_NAMES: [&str; 5] = [
+    "Copper Ingot",
+    "Tin Ingot",
+    "Iron Ingot",
+    "Silver Ingot",
+    "Mithril Ingot",
+];
+const PLANK_NAMES: [&str; 5] = [
+    "Birch Plank",
+    "Oak Plank",
+    "Ash Plank",
+    "Yew Plank",
+    "Ironbark Plank",
+];
+const LEATHER_NAMES: [&str; 5] = [
+    "Rough Leather",
+    "Thick Leather",
+    "Boar Leather",
+    "Bear Leather",
+    "Dire Leather",
+];
+const SMITH_WEAPON_NAMES: [&str; 5] = [
+    "Copper Sword",
+    "Tin Sabre",
+    "Iron Sword",
+    "Silver Sword",
+    "Mithril Sword",
+];
+const SMITH_ARMOR_NAMES: [&str; 5] = [
+    "Copper Cuirass",
+    "Tin Cuirass",
+    "Iron Cuirass",
+    "Silver Cuirass",
+    "Mithril Cuirass",
+];
+const WOOD_WEAPON_NAMES: [&str; 5] = [
+    "Birch Shortbow",
+    "Oak Longbow",
+    "Ash Recurve",
+    "Yew Warbow",
+    "Ironbark Greatbow",
+];
+const LEATHER_ARMOR_NAMES: [&str; 5] = [
+    "Rough Jerkin",
+    "Thick Jerkin",
+    "Boarhide Vest",
+    "Bearhide Coat",
+    "Direhide Cuirass",
+];
+const POTION_NAMES: [&str; 5] = [
+    "Minor Healing Draught",
+    "Lesser Healing Draught",
+    "Greater Healing Draught",
+    "Superior Healing Draught",
+    "Master Healing Draught",
+];
+const POISON_NAMES: [&str; 5] = [
+    "Weak Toxin",
+    "Numbing Poison",
+    "Virulent Bile",
+    "Deadly Venom",
+    "Wyrm Venom",
+];
+const FOOD_NAMES: [&str; 5] = [
+    "Grilled Bream",
+    "Pan-Seared Trout",
+    "Smoked Pike",
+    "Sturgeon Steak",
+    "Moonscale Feast",
+];
+
+const INTER_RARITY: [Rarity; 5] = [
+    Rarity::Common,
+    Rarity::Common,
+    Rarity::Uncommon,
+    Rarity::Uncommon,
+    Rarity::Rare,
+];
+const FINAL_RARITY: [Rarity; 5] = [
+    Rarity::Common,
+    Rarity::Uncommon,
+    Rarity::Uncommon,
+    Rarity::Rare,
+    Rarity::Epic,
+];
+
+fn build_crafted() -> Vec<Item> {
+    let mut out = Vec::new();
+    // Per-tier stat/price tables (index 0..5, low to high).
+    const INGOT_PRICE: [i64; 5] = [24, 54, 96, 150, 220];
+    const PLANK_PRICE: [i64; 5] = [20, 46, 84, 130, 190];
+    const LEATHER_PRICE: [i64; 5] = [22, 50, 90, 140, 205];
+    const WEAPON_ATK: [i32; 5] = [6, 11, 16, 21, 26];
+    const WEAPON_PRICE: [i64; 5] = [60, 140, 260, 440, 700];
+    const BOW_ATK: [i32; 5] = [5, 10, 15, 20, 25];
+    const BOW_PRICE: [i64; 5] = [55, 130, 250, 430, 690];
+    const PLATE_HP: [i32; 5] = [8, 16, 26, 40, 60];
+    const PLATE_ARM: [i32; 5] = [1, 2, 3, 4, 6];
+    const PLATE_PRICE: [i64; 5] = [70, 150, 280, 460, 720];
+    const JERKIN_HP: [i32; 5] = [6, 12, 20, 30, 44];
+    const JERKIN_ARM: [i32; 5] = [1, 1, 2, 3, 4];
+    const JERKIN_PRICE: [i64; 5] = [50, 120, 230, 400, 640];
+    const POTION_HEAL: [i32; 5] = [25, 45, 75, 120, 180];
+    const POTION_PRICE: [i64; 5] = [20, 45, 90, 160, 260];
+    const POISON_PRICE: [i64; 5] = [15, 40, 80, 140, 220];
+    const FOOD_HEAL: [i32; 5] = [20, 35, 55, 85, 130];
+    const FOOD_REST: [i32; 5] = [10, 20, 35, 55, 85];
+    const FOOD_PRICE: [i64; 5] = [15, 35, 70, 120, 190];
+
+    for t in 0..5usize {
+        let tu = t as u32;
+        // Intermediates (sellable valuables and recipe inputs).
+        out.push(valuable(
+            ingot_id(tu),
+            INGOT_NAMES[t],
+            "A refined metal bar, ready for the forge.",
+            INTER_RARITY[t],
+            INGOT_PRICE[t],
+        ));
+        out.push(valuable(
+            plank_id(tu),
+            PLANK_NAMES[t],
+            "A planed board, true and square for the workbench.",
+            INTER_RARITY[t],
+            PLANK_PRICE[t],
+        ));
+        out.push(valuable(
+            leather_id(tu),
+            LEATHER_NAMES[t],
+            "Supple tanned leather, ready to be worked.",
+            INTER_RARITY[t],
+            LEATHER_PRICE[t],
+        ));
+        // Finished goods.
+        out.push(eq(
+            smith_weapon_id(tu),
+            SMITH_WEAPON_NAMES[t],
+            "Forged steel with a keen, hammered edge.",
+            Slot::Weapon,
+            FINAL_RARITY[t],
+            WEAPON_ATK[t],
+            0,
+            0,
+            WEAPON_PRICE[t],
+            None,
+        ));
+        out.push(eq(
+            smith_armor_id(tu),
+            SMITH_ARMOR_NAMES[t],
+            "A forged breastplate, proof against a hard blow.",
+            Slot::Chest,
+            FINAL_RARITY[t],
+            0,
+            PLATE_HP[t],
+            PLATE_ARM[t],
+            PLATE_PRICE[t],
+            None,
+        ));
+        out.push(eq(
+            wood_weapon_id(tu),
+            WOOD_WEAPON_NAMES[t],
+            "A supple bow of seasoned wood, strung and true.",
+            Slot::Weapon,
+            FINAL_RARITY[t],
+            BOW_ATK[t],
+            0,
+            0,
+            BOW_PRICE[t],
+            Some(Class::Ranger),
+        ));
+        out.push(eq(
+            leather_armor_id(tu),
+            LEATHER_ARMOR_NAMES[t],
+            "Light leather armor that never slows a step.",
+            Slot::Chest,
+            FINAL_RARITY[t],
+            0,
+            JERKIN_HP[t],
+            JERKIN_ARM[t],
+            JERKIN_PRICE[t],
+            None,
+        ));
+        out.push(consumable(
+            potion_id(tu),
+            POTION_NAMES[t],
+            "A brewed cordial that knits wounds closed.",
+            FINAL_RARITY[t],
+            POTION_HEAL[t],
+            0,
+            POTION_PRICE[t],
+        ));
+        // Poisons are sellable for now; the depth update makes them applyable.
+        out.push(valuable(
+            poison_id(tu),
+            POISON_NAMES[t],
+            "A stoppered vial of poison, meant to coat a blade.",
+            FINAL_RARITY[t],
+            POISON_PRICE[t],
+        ));
+        out.push(consumable(
+            food_id(tu),
+            FOOD_NAMES[t],
+            "A hot cooked meal that restores body and focus.",
+            FINAL_RARITY[t],
+            FOOD_HEAL[t],
+            FOOD_REST[t],
+            FOOD_PRICE[t],
+        ));
+    }
+    out
+}
+
+/// The crafted-goods catalog, built once and reused for the `item` lookup.
+pub fn crafted() -> &'static [Item] {
+    static CATALOG: OnceLock<Vec<Item>> = OnceLock::new();
+    CATALOG.get_or_init(build_crafted)
+}
+
 pub fn item(id: u32) -> Option<&'static Item> {
     ITEMS
         .iter()
@@ -1072,6 +1354,7 @@ pub fn item(id: u32) -> Option<&'static Item> {
         .or_else(|| frontier_items().iter().find(|i| i.id == id))
         .or_else(|| reaches_items().iter().find(|i| i.id == id))
         .or_else(|| materials().iter().find(|i| i.id == id))
+        .or_else(|| crafted().iter().find(|i| i.id == id))
 }
 
 // ---- Generated catalogs (Frontier and Sundered Reaches) ------------------
@@ -1399,6 +1682,7 @@ mod tests {
             .chain(frontier_items().iter())
             .chain(reaches_items().iter())
             .chain(materials().iter())
+            .chain(crafted().iter())
             .map(|i| i.id)
             .collect();
         ids.sort_unstable();
@@ -1423,6 +1707,29 @@ mod tests {
             assert!(m.sell_price() >= 1, "materials are worth something");
             // Look-ups resolve through the shared catalog.
             assert!(item(m.id).is_some(), "material {} is not findable", m.id);
+        }
+    }
+
+    #[test]
+    fn crafted_goods_form_a_clean_catalog() {
+        assert_eq!(crafted().len(), 50, "ten crafted kinds x five tiers");
+        for c in crafted() {
+            assert!(
+                c.id >= CRAFTED_BASE && c.id < CRAFTED_BASE + 300,
+                "crafted item {} sits in the 4200 band",
+                c.id
+            );
+            assert!(c.sell_price() >= 1, "crafted goods are worth something");
+            assert!(
+                item(c.id).is_some(),
+                "crafted item {} is not findable",
+                c.id
+            );
+            assert!(
+                materials().iter().all(|m| m.id != c.id),
+                "crafted item {} collides with a raw material",
+                c.id
+            );
         }
     }
 

--- a/late-ssh/src/app/door/lateania/items.rs
+++ b/late-ssh/src/app/door/lateania/items.rs
@@ -960,12 +960,118 @@ pub const ITEMS: &[Item] = &[
     },
 ];
 
+// ---- Raw gathering materials --------------------------------------------
+//
+// Trees, ore veins, fishing spots and herb/skinning patches (see world::NODES)
+// drop these raw materials when harvested (see svc gather). They are Valuables
+// for now - immediately sellable to any merchant, which is what "tradeable"
+// means today - and become crafting inputs in the crafting update. IDs live in
+// 4000..4100 (skill index * 20 + tier), clear of the authored (<1500) and
+// generated Frontier/Reaches (3000..3400) ranges.
+
+/// Base id for the raw-material catalog.
+pub const MATERIAL_BASE: u32 = 4000;
+/// Tiers per gathering skill (levels of material, low to high).
+pub const MATERIAL_TIERS: u32 = 5;
+
+/// The item id of the raw material a skill drops at a given tier (0-based). The
+/// `skill_index` is `skills::GatherSkill::index`.
+pub const fn material_id(skill_index: u32, tier: u32) -> u32 {
+    MATERIAL_BASE + skill_index * 20 + tier
+}
+
+/// Names per skill (rows follow `GatherSkill::index`) and tier (columns low->high).
+const MATERIAL_NAMES: [[&str; 5]; 5] = [
+    // Woodcutting
+    ["Birch Log", "Oak Log", "Ash Log", "Yew Log", "Ironbark Log"],
+    // Mining
+    [
+        "Copper Ore",
+        "Tin Ore",
+        "Iron Ore",
+        "Silver Ore",
+        "Mithril Ore",
+    ],
+    // Fishing
+    [
+        "River Bream",
+        "Silver Trout",
+        "Grey Pike",
+        "Deep Sturgeon",
+        "Moonscale Fish",
+    ],
+    // Foraging
+    [
+        "Marsh Sage",
+        "Redleaf",
+        "Bloodthistle",
+        "Frostbloom",
+        "Sunmoss",
+    ],
+    // Skinning
+    [
+        "Rough Hide",
+        "Thick Hide",
+        "Boar Hide",
+        "Bear Pelt",
+        "Direhide",
+    ],
+];
+
+/// One flavour line per skill (rows follow `GatherSkill::index`).
+const MATERIAL_FLAVOR: [&str; 5] = [
+    "A length of cut timber, ready for the sawbench.",
+    "Raw ore, still cold from the rock; a smith can smelt it down.",
+    "A fresh-landed fish, good eating or good bait.",
+    "A bundle of cut herbs, pungent and green.",
+    "A cleaned hide, ready for the tanner's rack.",
+];
+
+fn build_materials() -> Vec<Item> {
+    let mut out = Vec::with_capacity(25);
+    for (s, names) in MATERIAL_NAMES.iter().enumerate() {
+        for (t, name) in names.iter().enumerate() {
+            let tier = t as i64;
+            // 6, 24, 54, 96, 150 gold: a modest trickle, so gathering feeds
+            // crafting rather than replacing combat as a gold source.
+            let price = 6 * (tier + 1) * (tier + 1);
+            let rarity = match t {
+                0 | 1 => Rarity::Common,
+                2 | 3 => Rarity::Uncommon,
+                _ => Rarity::Rare,
+            };
+            out.push(Item {
+                id: material_id(s as u32, t as u32),
+                name,
+                desc: MATERIAL_FLAVOR[s],
+                kind: ItemKind::Valuable,
+                rarity,
+                mods: StatMods {
+                    attack: 0,
+                    max_hp: 0,
+                    armor: 0,
+                },
+                price,
+                class_hint: None,
+            });
+        }
+    }
+    out
+}
+
+/// The raw-material catalog, built once and reused for the `item` lookup.
+pub fn materials() -> &'static [Item] {
+    static CATALOG: OnceLock<Vec<Item>> = OnceLock::new();
+    CATALOG.get_or_init(build_materials)
+}
+
 pub fn item(id: u32) -> Option<&'static Item> {
     ITEMS
         .iter()
         .find(|i| i.id == id)
         .or_else(|| frontier_items().iter().find(|i| i.id == id))
         .or_else(|| reaches_items().iter().find(|i| i.id == id))
+        .or_else(|| materials().iter().find(|i| i.id == id))
 }
 
 // ---- Generated catalogs (Frontier and Sundered Reaches) ------------------
@@ -1292,12 +1398,32 @@ mod tests {
             .iter()
             .chain(frontier_items().iter())
             .chain(reaches_items().iter())
+            .chain(materials().iter())
             .map(|i| i.id)
             .collect();
         ids.sort_unstable();
         let n = ids.len();
         ids.dedup();
         assert_eq!(n, ids.len(), "duplicate item id");
+    }
+
+    #[test]
+    fn materials_form_a_clean_sellable_catalog() {
+        assert_eq!(materials().len(), 25, "five skills x five tiers");
+        for m in materials() {
+            assert!(
+                m.id >= MATERIAL_BASE && m.id < MATERIAL_BASE + 100,
+                "material {} sits in the 4000 band",
+                m.id
+            );
+            assert!(
+                matches!(m.kind, ItemKind::Valuable),
+                "raw materials are sellable valuables for now"
+            );
+            assert!(m.sell_price() >= 1, "materials are worth something");
+            // Look-ups resolve through the shared catalog.
+            assert!(item(m.id).is_some(), "material {} is not findable", m.id);
+        }
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/mod.rs
+++ b/late-ssh/src/app/door/lateania/mod.rs
@@ -6,6 +6,7 @@
 pub mod abilities;
 pub mod appearance;
 pub mod classes;
+pub mod crafting;
 pub mod damage;
 pub mod housing;
 pub mod input;

--- a/late-ssh/src/app/door/lateania/mod.rs
+++ b/late-ssh/src/app/door/lateania/mod.rs
@@ -13,6 +13,7 @@ pub mod items;
 pub mod persist;
 pub mod pets;
 pub mod screen;
+pub mod skills;
 pub mod state;
 pub mod stats;
 pub mod svc;

--- a/late-ssh/src/app/door/lateania/persist.rs
+++ b/late-ssh/src/app/door/lateania/persist.rs
@@ -17,7 +17,7 @@ use super::classes::Class;
 use super::stats::AbilityScores;
 use super::world::RoomId;
 
-const SCHEMA_VERSION: u32 = 12;
+const SCHEMA_VERSION: u32 = 13;
 const WORLD_SCHEMA_VERSION: u32 = 1;
 
 pub struct SavedCharacterInit {
@@ -46,6 +46,7 @@ pub struct SavedCharacterInit {
     pub house_furniture: Vec<(u32, String)>,
     pub appearance: Vec<u8>,
     pub skills: Vec<(String, i64)>,
+    pub craft_skills: Vec<(String, i64)>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -127,6 +128,10 @@ pub struct SavedCharacter {
     /// for pre-gathering saves, which simply start every trade at level 1.
     #[serde(default)]
     pub skills: Vec<(String, i64)>,
+    /// Crafting-skill xp as (skill key, total xp) pairs; empty for pre-crafting
+    /// saves.
+    #[serde(default)]
+    pub craft_skills: Vec<(String, i64)>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -205,6 +210,7 @@ impl SavedCharacter {
             house_furniture: init.house_furniture,
             appearance: init.appearance,
             skills: init.skills,
+            craft_skills: init.craft_skills,
         }
     }
 
@@ -289,6 +295,7 @@ mod tests {
             house_furniture: vec![(9040, "feather_bed".to_string())],
             appearance: vec![1, 2, 3, 4, 5],
             skills: vec![("woodcutting".to_string(), 900), ("mining".to_string(), 40)],
+            craft_skills: vec![("smithing".to_string(), 300)],
         });
         let json = c.to_json();
         let back = SavedCharacter::from_json(&json).expect("parses");
@@ -318,6 +325,7 @@ mod tests {
             back.skills,
             vec![("woodcutting".to_string(), 900), ("mining".to_string(), 40)]
         );
+        assert_eq!(back.craft_skills, vec![("smithing".to_string(), 300)]);
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/persist.rs
+++ b/late-ssh/src/app/door/lateania/persist.rs
@@ -17,7 +17,7 @@ use super::classes::Class;
 use super::stats::AbilityScores;
 use super::world::RoomId;
 
-const SCHEMA_VERSION: u32 = 11;
+const SCHEMA_VERSION: u32 = 12;
 const WORLD_SCHEMA_VERSION: u32 = 1;
 
 pub struct SavedCharacterInit {
@@ -45,6 +45,7 @@ pub struct SavedCharacterInit {
     pub owned_plot: Option<u32>,
     pub house_furniture: Vec<(u32, String)>,
     pub appearance: Vec<u8>,
+    pub skills: Vec<(String, i64)>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -122,6 +123,10 @@ pub struct SavedCharacter {
     /// Chosen appearance/bio trait indices (see `appearance::FIELDS`).
     #[serde(default)]
     pub appearance: Vec<u8>,
+    /// Gathering-skill xp as (skill key, total xp) pairs (see `skills`); empty
+    /// for pre-gathering saves, which simply start every trade at level 1.
+    #[serde(default)]
+    pub skills: Vec<(String, i64)>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -199,6 +204,7 @@ impl SavedCharacter {
             owned_plot: init.owned_plot,
             house_furniture: init.house_furniture,
             appearance: init.appearance,
+            skills: init.skills,
         }
     }
 
@@ -282,6 +288,7 @@ mod tests {
             owned_plot: Some(3),
             house_furniture: vec![(9040, "feather_bed".to_string())],
             appearance: vec![1, 2, 3, 4, 5],
+            skills: vec![("woodcutting".to_string(), 900), ("mining".to_string(), 40)],
         });
         let json = c.to_json();
         let back = SavedCharacter::from_json(&json).expect("parses");
@@ -307,6 +314,10 @@ mod tests {
             vec![(9040, "feather_bed".to_string())]
         );
         assert_eq!(back.appearance, vec![1, 2, 3, 4, 5]);
+        assert_eq!(
+            back.skills,
+            vec![("woodcutting".to_string(), 900), ("mining".to_string(), 40)]
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/skills.rs
+++ b/late-ssh/src/app/door/lateania/skills.rs
@@ -88,6 +88,92 @@ impl fmt::Display for GatherSkill {
     }
 }
 
+/// A crafting trade - the maker's side of the economy. Each turns gathered raw
+/// materials (and refined intermediates) into usable, sellable goods, and levels
+/// 1..=50 on the very same curve as the gathering skills.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CraftSkill {
+    Smithing,
+    Woodworking,
+    Leatherworking,
+    Alchemy,
+    Cooking,
+}
+
+impl CraftSkill {
+    pub const ALL: [CraftSkill; 5] = [
+        CraftSkill::Smithing,
+        CraftSkill::Woodworking,
+        CraftSkill::Leatherworking,
+        CraftSkill::Alchemy,
+        CraftSkill::Cooking,
+    ];
+
+    /// Stable index used to lay out crafted-item ids (see `items`). Never change.
+    pub const fn index(self) -> u32 {
+        match self {
+            Self::Smithing => 0,
+            Self::Woodworking => 1,
+            Self::Leatherworking => 2,
+            Self::Alchemy => 3,
+            Self::Cooking => 4,
+        }
+    }
+
+    /// Stable key for persistence (never change once shipped).
+    pub fn key(self) -> &'static str {
+        match self {
+            Self::Smithing => "smithing",
+            Self::Woodworking => "woodworking",
+            Self::Leatherworking => "leatherworking",
+            Self::Alchemy => "alchemy",
+            Self::Cooking => "cooking",
+        }
+    }
+
+    pub fn from_key(key: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|s| s.key() == key)
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Smithing => "Smithing",
+            Self::Woodworking => "Woodworking",
+            Self::Leatherworking => "Leatherworking",
+            Self::Alchemy => "Alchemy",
+            Self::Cooking => "Cooking",
+        }
+    }
+
+    /// The making verb for the craft log line: "You forge ...", "You brew ...".
+    pub fn verb(self) -> &'static str {
+        match self {
+            Self::Smithing => "forge",
+            Self::Woodworking => "craft",
+            Self::Leatherworking => "tan",
+            Self::Alchemy => "brew",
+            Self::Cooking => "cook",
+        }
+    }
+
+    /// The station a crafter works at (feature name / panel wording).
+    pub fn station(self) -> &'static str {
+        match self {
+            Self::Smithing => "forge",
+            Self::Woodworking => "workbench",
+            Self::Leatherworking => "tannery",
+            Self::Alchemy => "alchemy lab",
+            Self::Cooking => "cooking fire",
+        }
+    }
+}
+
+impl fmt::Display for CraftSkill {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
 /// Skill level cap - the same 50 the class levels use, so "level 1 to 50" reads
 /// consistently across the game.
 pub const SKILL_MAX_LEVEL: i32 = 50;
@@ -145,6 +231,19 @@ mod tests {
         let mut idx: Vec<u32> = GatherSkill::ALL.iter().map(|s| s.index()).collect();
         idx.sort_unstable();
         assert_eq!(idx, vec![0, 1, 2, 3, 4]);
+        let mut cidx: Vec<u32> = CraftSkill::ALL.iter().map(|s| s.index()).collect();
+        cidx.sort_unstable();
+        assert_eq!(cidx, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn craft_keys_round_trip_and_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for s in CraftSkill::ALL {
+            assert!(seen.insert(s.key()), "duplicate craft key {}", s.key());
+            assert_eq!(CraftSkill::from_key(s.key()), Some(s));
+        }
+        assert_eq!(CraftSkill::from_key("nonsense"), None);
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/skills.rs
+++ b/late-ssh/src/app/door/lateania/skills.rs
@@ -1,0 +1,197 @@
+// Gathering skills for Lateania: the first pillar of the crafting economy.
+//
+// Five gathering trades - Woodcutting, Mining, Fishing, Foraging, Skinning -
+// each levelled 1..=50 on its own XP curve that steepens every tier, so the
+// late materials are a genuine grind. A player's skill xp lives on PlayerState
+// (a map of skill -> total xp) and persists; the level is a pure function of xp.
+//
+// Resource NODES (trees, ore veins, fishing spots, herb/skinning patches) live
+// in `world.rs` and each belongs to one skill; harvesting a node grants its raw
+// MATERIAL item (see `items::material_id`) plus skill xp, gated behind a
+// per-node minimum skill level.
+
+use std::fmt;
+
+/// A gathering trade. The order here is the order shown on the character sheet
+/// and, via `index`, the layout of the raw-material item ids.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum GatherSkill {
+    Woodcutting,
+    Mining,
+    Fishing,
+    Foraging,
+    Skinning,
+}
+
+impl GatherSkill {
+    pub const ALL: [GatherSkill; 5] = [
+        GatherSkill::Woodcutting,
+        GatherSkill::Mining,
+        GatherSkill::Fishing,
+        GatherSkill::Foraging,
+        GatherSkill::Skinning,
+    ];
+
+    /// Stable index used to lay out raw-material item ids (see `items`). Never
+    /// change once shipped, or persisted materials would point at the wrong item.
+    pub const fn index(self) -> u32 {
+        match self {
+            Self::Woodcutting => 0,
+            Self::Mining => 1,
+            Self::Fishing => 2,
+            Self::Foraging => 3,
+            Self::Skinning => 4,
+        }
+    }
+
+    /// Stable key for persistence (never change once shipped).
+    pub fn key(self) -> &'static str {
+        match self {
+            Self::Woodcutting => "woodcutting",
+            Self::Mining => "mining",
+            Self::Fishing => "fishing",
+            Self::Foraging => "foraging",
+            Self::Skinning => "skinning",
+        }
+    }
+
+    pub fn from_key(key: &str) -> Option<Self> {
+        Self::ALL.into_iter().find(|s| s.key() == key)
+    }
+
+    /// Display name for panels and log lines.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Woodcutting => "Woodcutting",
+            Self::Mining => "Mining",
+            Self::Fishing => "Fishing",
+            Self::Foraging => "Foraging",
+            Self::Skinning => "Skinning",
+        }
+    }
+
+    /// The working verb for the harvest log line: "You chop ...", "You mine ...".
+    pub fn verb(self) -> &'static str {
+        match self {
+            Self::Woodcutting => "chop",
+            Self::Mining => "mine",
+            Self::Fishing => "fish",
+            Self::Foraging => "forage",
+            Self::Skinning => "skin",
+        }
+    }
+}
+
+impl fmt::Display for GatherSkill {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.label())
+    }
+}
+
+/// Skill level cap - the same 50 the class levels use, so "level 1 to 50" reads
+/// consistently across the game.
+pub const SKILL_MAX_LEVEL: i32 = 50;
+
+/// Total xp required to *reach* a given skill level. Level 1 is free; each tier
+/// costs more than the last, and a cubic term that only bites past level 10
+/// makes the back half of every trade the real work (harder and harder).
+pub fn xp_for_skill_level(level: i32) -> i64 {
+    if level <= 1 {
+        return 0;
+    }
+    let d = (level - 1) as i64;
+    let base = 30 * d * d;
+    let late = (level - 10).max(0) as i64;
+    base + 10 * late * late * late
+}
+
+/// The skill level a given total xp corresponds to (1..=SKILL_MAX_LEVEL).
+pub fn skill_level_for_xp(xp: i64) -> i32 {
+    let mut level = 1;
+    while level < SKILL_MAX_LEVEL && xp >= xp_for_skill_level(level + 1) {
+        level += 1;
+    }
+    level
+}
+
+/// Progress within the current level: (xp into this level, xp needed for the
+/// next). At the cap the second value is 0 ("maxed").
+pub fn skill_progress(xp: i64) -> (i64, i64) {
+    let level = skill_level_for_xp(xp);
+    if level >= SKILL_MAX_LEVEL {
+        return (0, 0);
+    }
+    let floor = xp_for_skill_level(level);
+    let next = xp_for_skill_level(level + 1);
+    (xp - floor, next - floor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keys_round_trip_and_are_unique() {
+        let mut seen = std::collections::HashSet::new();
+        for s in GatherSkill::ALL {
+            assert!(seen.insert(s.key()), "duplicate skill key {}", s.key());
+            assert_eq!(GatherSkill::from_key(s.key()), Some(s));
+        }
+        assert_eq!(GatherSkill::from_key("nonsense"), None);
+    }
+
+    #[test]
+    fn indices_are_unique_and_dense() {
+        let mut idx: Vec<u32> = GatherSkill::ALL.iter().map(|s| s.index()).collect();
+        idx.sort_unstable();
+        assert_eq!(idx, vec![0, 1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn level_one_is_free_and_curve_is_strictly_increasing() {
+        assert_eq!(xp_for_skill_level(1), 0);
+        assert_eq!(xp_for_skill_level(0), 0);
+        for level in 2..=SKILL_MAX_LEVEL {
+            assert!(
+                xp_for_skill_level(level) > xp_for_skill_level(level - 1),
+                "curve must rise at level {level}"
+            );
+        }
+    }
+
+    #[test]
+    fn curve_steepens_late() {
+        // The cost of a mid-game level must exceed the cost of an early one, and
+        // a late level must cost far more still (the "harder and harder" shape).
+        let early = xp_for_skill_level(5) - xp_for_skill_level(4);
+        let mid = xp_for_skill_level(20) - xp_for_skill_level(19);
+        let late = xp_for_skill_level(50) - xp_for_skill_level(49);
+        assert!(mid > early);
+        assert!(late > mid * 3);
+    }
+
+    #[test]
+    fn level_for_xp_inverts_the_curve_and_caps() {
+        for level in 1..=SKILL_MAX_LEVEL {
+            assert_eq!(skill_level_for_xp(xp_for_skill_level(level)), level);
+        }
+        // One short of a threshold stays on the lower level.
+        assert_eq!(
+            skill_level_for_xp(xp_for_skill_level(10) - 1),
+            9,
+            "just under the level-10 threshold is still level 9"
+        );
+        // Absurd xp still caps at the max level.
+        assert_eq!(skill_level_for_xp(i64::MAX / 2), SKILL_MAX_LEVEL);
+    }
+
+    #[test]
+    fn progress_stays_within_the_level_band() {
+        let xp = xp_for_skill_level(7) + 5;
+        let (into, need) = skill_progress(xp);
+        assert_eq!(into, 5);
+        assert_eq!(need, xp_for_skill_level(8) - xp_for_skill_level(7));
+        // At the cap there is no "next".
+        assert_eq!(skill_progress(xp_for_skill_level(SKILL_MAX_LEVEL)), (0, 0));
+    }
+}

--- a/late-ssh/src/app/door/lateania/state.rs
+++ b/late-ssh/src/app/door/lateania/state.rs
@@ -283,6 +283,13 @@ impl State {
         }
     }
 
+    /// Work a resource node in the current room (chop/mine/fish/forage/skin).
+    pub fn gather(&mut self) {
+        if self.ensure_player_present() {
+            self.svc.gather_task(self.user_id);
+        }
+    }
+
     /// Speak the word of recall: warp back to Embergate's Town Square.
     pub fn recall(&mut self) {
         if self.ensure_player_present() {

--- a/late-ssh/src/app/door/lateania/state.rs
+++ b/late-ssh/src/app/door/lateania/state.rs
@@ -45,6 +45,8 @@ pub enum Panel {
     /// The appearance/bio builder: pick a field with the cursor, `Enter` cycles
     /// its option forward and `x` cycles back.
     Appearance,
+    /// The crafting panel at a station: select a recipe and `Enter` to make it.
+    Crafting,
 }
 
 pub struct State {
@@ -219,6 +221,7 @@ impl State {
             Panel::Stable => self.view().stable.map(|s| s.entries.len()).unwrap_or(0),
             Panel::Housing => self.view().housing.map(|h| h.entries.len()).unwrap_or(0),
             Panel::Appearance => self.view().appearance.len(),
+            Panel::Crafting => self.view().crafting.map(|c| c.entries.len()).unwrap_or(0),
             _ => 0,
         }
     }
@@ -437,6 +440,13 @@ impl State {
                 }
             }
             Panel::Appearance => self.cycle_appearance(1),
+            Panel::Crafting => {
+                if let Some(cr) = self.view().crafting
+                    && let Some(entry) = cr.entries.get(self.cursor)
+                {
+                    self.svc.craft_task(self.user_id, entry.recipe);
+                }
+            }
             _ => {}
         }
     }

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -53,10 +53,12 @@ use super::persist::{
     SavedCharacter, SavedCharacterInit, SavedMob, SavedMobDot, SavedMobStun, SavedWorld,
 };
 use super::pets::{Pet, pet_species_by_key};
+use super::skills::{GatherSkill, skill_level_for_xp, skill_progress};
 use super::stats::AbilityScores;
 use super::world::{
-    CritterKind, Dir, FeatureKind, MiniMap, MobBehavior, MobSpawn, Perk, RoomId, World,
-    critter_index, critters_at, features_at, frontier_entrance_room, is_frontier_room, seed_world,
+    CritterKind, Dir, FeatureKind, MiniMap, MobBehavior, MobSpawn, Perk, ResourceNode, RoomId,
+    World, critter_index, critters_at, features_at, frontier_entrance_room, is_frontier_room,
+    node_index, nodes_at, seed_world,
 };
 
 /// World heartbeat. One combat round resolves per tick.
@@ -304,6 +306,29 @@ pub struct WildlifeView {
     pub perk: String,
 }
 
+/// One harvestable resource node in the room, for the Resources list.
+#[derive(Clone, Debug)]
+pub struct NodeView {
+    pub name: String,
+    pub note: String,
+    /// The gathering skill it belongs to, e.g. "Woodcutting".
+    pub skill: String,
+    /// True when the player can work it right now (off cooldown and skilled enough).
+    pub gatherable: bool,
+    /// Why it can't be worked, when `gatherable` is false: "needs Mining 16" or
+    /// "regrowing"; empty when it can.
+    pub reason: String,
+}
+
+/// One gathering skill's progress, for the character sheet Skills block.
+#[derive(Clone, Debug)]
+pub struct SkillView {
+    pub name: String,
+    pub level: i32,
+    pub xp_into: i64,
+    pub xp_next: i64,
+}
+
 #[derive(Clone, Debug)]
 pub struct OccupantView {
     pub user_id: Uuid,
@@ -470,6 +495,10 @@ pub struct PlayerView {
     pub following: Option<Uuid>,
     /// Wild creatures sharing the room.
     pub wildlife: Vec<WildlifeView>,
+    /// Harvestable resource nodes in the room (trees, veins, fishing spots...).
+    pub nodes: Vec<NodeView>,
+    /// The player's gathering skills and their progress, for the Skills block.
+    pub skills: Vec<SkillView>,
     pub in_combat_with: Option<String>,
     pub abilities: Vec<AbilityView>,
     pub inventory: Vec<InvView>,
@@ -553,6 +582,8 @@ impl PlayerView {
             occupants: Vec::new(),
             following: None,
             wildlife: Vec::new(),
+            nodes: Vec::new(),
+            skills: Vec::new(),
             in_combat_with: None,
             abilities: Vec::new(),
             inventory: Vec::new(),
@@ -1123,6 +1154,11 @@ impl LateaniaService {
         self.mutate(user_id, move |s| s.look(user_id));
     }
 
+    /// Work a resource node in the current room (chop/mine/fish/forage/skin).
+    pub fn gather_task(&self, user_id: Uuid) {
+        self.mutate(user_id, move |s| s.gather(user_id));
+    }
+
     /// Re-roll ability scores on the selection screen (before a class is chosen).
     pub fn reroll_task(&self, user_id: Uuid) {
         self.mutate(user_id, move |s| s.reroll(user_id));
@@ -1429,6 +1465,9 @@ struct PlayerState {
     pet: Option<Pet>,
     /// Chosen appearance/bio trait indices (see `appearance::FIELDS`).
     appearance: [u8; appearance::N_FIELDS],
+    /// Gathering-skill xp, keyed by trade; the level is a pure function of xp.
+    /// A missing entry means the trade is untrained (level 1, 0 xp).
+    skills: HashMap<GatherSkill, i64>,
     /// The friendly NPC the player is currently escorting, if any (transient).
     escort: Option<EscortState>,
     /// Transient warning gate for the start-room Frontier entrance.
@@ -1490,6 +1529,11 @@ impl PlayerState {
     fn armor(&self) -> i32 {
         let (_, _, armor) = self.equipment_mods();
         armor
+    }
+
+    /// Total xp trained in a gathering skill (0 if untrained).
+    fn skill_xp(&self, skill: GatherSkill) -> i64 {
+        self.skills.get(&skill).copied().unwrap_or(0)
     }
 }
 
@@ -1822,6 +1866,8 @@ struct WorldState {
     world_revision: u64,
     /// Hunt cooldowns for `Game` critters, keyed by global WILDLIFE index.
     hunted: HashMap<usize, Instant>,
+    /// Harvest cooldowns for resource nodes, keyed by global NODES index.
+    gathered: HashMap<usize, Instant>,
     /// Next id for a runtime-only summoned add (Summoner behavior). Kept well
     /// clear of authored spawn ids so the two never collide.
     next_summon_id: u32,
@@ -1842,6 +1888,8 @@ const SAVED_HOUSE_FURNITURE_LIMIT: usize = 512;
 const TEMPLE_ROOM: RoomId = 4;
 /// How long a hunted game critter stays gone before it wanders back.
 const GAME_RESPAWN: Duration = Duration::from_secs(40);
+/// How long a harvested resource node stays depleted before it regrows.
+const NODE_RESPAWN: Duration = Duration::from_secs(45);
 
 impl WorldState {
     fn new(room_id: Uuid, world: World) -> Self {
@@ -1880,6 +1928,7 @@ impl WorldState {
             world_dirty: false,
             world_revision: 0,
             hunted: HashMap::new(),
+            gathered: HashMap::new(),
             next_summon_id: SUMMON_ID_START,
             world_ticks: 0,
             world_boss: None,
@@ -1958,6 +2007,7 @@ impl WorldState {
             archetype: None,
             pet: None,
             appearance: [0; appearance::N_FIELDS],
+            skills: HashMap::new(),
             escort: None,
             frontier_descent_pending: false,
             resurrection_cap: 0,
@@ -2160,6 +2210,13 @@ impl WorldState {
             p.board_progress = saved.board_progress.clone();
             p.board_done = saved.board_done.clone();
             p.quest_cooldowns = saved.quest_cooldowns.clone();
+            // Restore gathering-skill xp (unknown keys are dropped, so retiring a
+            // trade never breaks a save).
+            p.skills = saved
+                .skills
+                .iter()
+                .filter_map(|(key, xp)| GatherSkill::from_key(key).map(|s| (s, *xp)))
+                .collect();
             // Restore the chosen archetype (ignored if the key is unknown or no
             // longer matches the class, e.g. a respec/rename).
             p.archetype = saved
@@ -2252,6 +2309,11 @@ impl WorldState {
                 .map(|plot| self.saved_house_furniture_for_plot(user_id, plot))
                 .unwrap_or_default(),
             appearance: p.appearance.to_vec(),
+            skills: p
+                .skills
+                .iter()
+                .map(|(s, xp)| (s.key().to_string(), *xp))
+                .collect(),
         }))
     }
 
@@ -2902,6 +2964,132 @@ impl WorldState {
             LogKind::Loot,
             format!("You stalk and catch {name}. (+{xp} xp)"),
         );
+        self.dirty = true;
+        true
+    }
+
+    /// Work a resource node in the current room: harvest the highest-tier node
+    /// the player qualifies for, granting its raw material and skill xp. Nodes
+    /// don't need a safe/unsafe room and never involve combat.
+    fn gather(&mut self, user_id: Uuid) {
+        if !self.is_classed(user_id) {
+            return;
+        }
+        let Some(player) = self.players.get(&user_id) else {
+            return;
+        };
+        if player.respawn_at.is_some() {
+            return;
+        }
+        let room_id = player.room;
+        if nodes_at(room_id).is_empty() {
+            self.log_to(
+                user_id,
+                LogKind::Normal,
+                "There's nothing to gather here.".to_string(),
+            );
+            return;
+        }
+        // `try_gather` logs its own reason when a node is present but unworkable.
+        self.try_gather(user_id, room_id);
+    }
+
+    /// Harvest the best node in the room the player can work right now. Returns
+    /// true if a material was taken. When a node is present but out of reach
+    /// (under-skilled) or still regrowing, it logs why and returns false.
+    fn try_gather(&mut self, user_id: Uuid, room_id: RoomId) -> bool {
+        let now = Instant::now();
+        let Some(player) = self.players.get(&user_id) else {
+            return false;
+        };
+        let nodes = nodes_at(room_id);
+
+        // Pick the highest-tier node the player qualifies for and that is off
+        // cooldown. Also remember the toughest node they're too unskilled for,
+        // and whether anything here is merely regrowing, for a helpful message.
+        let mut choice: Option<(usize, &'static ResourceNode)> = None;
+        let mut under_skilled: Option<(&'static ResourceNode, i32)> = None;
+        let mut regrowing = false;
+        for &n in &nodes {
+            let Some(ni) = node_index(n) else {
+                continue;
+            };
+            let level = skill_level_for_xp(player.skill_xp(n.skill));
+            if level < n.level_req {
+                if under_skilled.is_none_or(|(u, _)| n.tier > u.tier) {
+                    under_skilled = Some((n, level));
+                }
+                continue;
+            }
+            let ready = match self.gathered.get(&ni) {
+                Some(t) => now.duration_since(*t) >= NODE_RESPAWN,
+                None => true,
+            };
+            if !ready {
+                regrowing = true;
+                continue;
+            }
+            if choice.is_none_or(|(_, c)| n.tier > c.tier) {
+                choice = Some((ni, n));
+            }
+        }
+
+        let Some((ni, node)) = choice else {
+            if let Some((n, level)) = under_skilled {
+                self.log_to(
+                    user_id,
+                    LogKind::System,
+                    format!(
+                        "You can't work {} yet - it needs {} level {} (yours is {level}).",
+                        n.name,
+                        n.skill.label(),
+                        n.level_req,
+                    ),
+                );
+            } else if regrowing {
+                self.log_to(
+                    user_id,
+                    LogKind::Normal,
+                    "The resources here need time to recover.".to_string(),
+                );
+            }
+            return false;
+        };
+
+        self.gathered.insert(ni, now);
+        let skill = node.skill;
+        let yield_item = node.yield_item;
+        let gained = node.xp;
+        let node_name = node.name;
+        let item_name = item(yield_item)
+            .map(|i| i.name.to_string())
+            .unwrap_or_else(|| "something".to_string());
+        let (before, after) = if let Some(p) = self.players.get_mut(&user_id) {
+            p.inventory.push(yield_item);
+            let cur = p.skill_xp(skill);
+            let before = skill_level_for_xp(cur);
+            let new_xp = cur + gained as i64;
+            p.skills.insert(skill, new_xp);
+            (before, skill_level_for_xp(new_xp))
+        } else {
+            return false;
+        };
+        self.log_to(
+            user_id,
+            LogKind::Loot,
+            format!(
+                "You {} {node_name} and take {item_name}. (+{gained} {} xp)",
+                skill.verb(),
+                skill.label(),
+            ),
+        );
+        if after > before {
+            self.log_to(
+                user_id,
+                LogKind::System,
+                format!("Your {} rises to level {after}!", skill.label()),
+            );
+        }
         self.dirty = true;
         true
     }
@@ -5415,6 +5603,46 @@ impl WorldState {
                     },
                 })
                 .collect();
+            // Harvestable nodes in the room, each flagged with whether the player
+            // can work it now and, if not, why (under-skilled or regrowing).
+            let nodes: Vec<NodeView> = nodes_at(player.room)
+                .into_iter()
+                .map(|n| {
+                    let level = skill_level_for_xp(player.skill_xp(n.skill));
+                    let ready = match node_index(n).and_then(|ni| self.gathered.get(&ni)) {
+                        Some(t) => now.duration_since(*t) >= NODE_RESPAWN,
+                        None => true,
+                    };
+                    let (gatherable, reason) = if level < n.level_req {
+                        (false, format!("needs {} {}", n.skill.label(), n.level_req))
+                    } else if !ready {
+                        (false, "regrowing".to_string())
+                    } else {
+                        (true, String::new())
+                    };
+                    NodeView {
+                        name: n.name.to_string(),
+                        note: n.note.to_string(),
+                        skill: n.skill.label().to_string(),
+                        gatherable,
+                        reason,
+                    }
+                })
+                .collect();
+            // Every gathering trade, in a stable order, with its live progress.
+            let skills: Vec<SkillView> = GatherSkill::ALL
+                .iter()
+                .map(|&s| {
+                    let xp = player.skill_xp(s);
+                    let (xp_into, xp_next) = skill_progress(xp);
+                    SkillView {
+                        name: s.label().to_string(),
+                        level: skill_level_for_xp(xp),
+                        xp_into,
+                        xp_next,
+                    }
+                })
+                .collect();
             let in_combat_with = player.target.and_then(|mob_id| {
                 self.mobs
                     .get(&mob_id)
@@ -5660,6 +5888,8 @@ impl WorldState {
                     occupants,
                     following: player.following,
                     wildlife,
+                    nodes,
+                    skills,
                     in_combat_with,
                     abilities,
                     inventory,
@@ -5844,6 +6074,89 @@ mod tests {
 
     fn world() -> WorldState {
         WorldState::new(uid(999), seed_world())
+    }
+
+    #[test]
+    fn gathering_a_node_yields_its_material_and_trains_the_skill() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Ranger);
+        // Stand at the roadside birch (Woodcutting tier 0, room 600).
+        s.players.get_mut(&uid(1)).unwrap().room = 600;
+        let before = s.players[&uid(1)].inventory.len();
+        s.gather(uid(1));
+        let p = &s.players[&uid(1)];
+        assert_eq!(p.inventory.len(), before + 1, "a material is taken");
+        assert!(
+            p.inventory
+                .contains(&super::super::items::material_id(0, 0)),
+            "the birch log lands in the pack"
+        );
+        assert_eq!(
+            p.skill_xp(GatherSkill::Woodcutting),
+            12,
+            "woodcutting xp is granted"
+        );
+    }
+
+    #[test]
+    fn a_worked_node_is_depleted_until_it_regrows() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Ranger);
+        s.players.get_mut(&uid(1)).unwrap().room = 600;
+        s.gather(uid(1));
+        let after_one = s.players[&uid(1)].inventory.len();
+        s.gather(uid(1)); // still on cooldown
+        assert_eq!(
+            s.players[&uid(1)].inventory.len(),
+            after_one,
+            "the same node can't be stripped twice before it regrows"
+        );
+    }
+
+    #[test]
+    fn an_underskilled_node_refuses_to_be_worked() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Ranger);
+        // The ironbark (tier 4, room 803) needs Woodcutting 38; a fresh
+        // character has no woodcutting training at all.
+        s.players.get_mut(&uid(1)).unwrap().room = 803;
+        let before = s.players[&uid(1)].inventory.len();
+        s.gather(uid(1));
+        let p = &s.players[&uid(1)];
+        assert_eq!(
+            p.inventory.len(),
+            before,
+            "nothing is taken while under-skilled"
+        );
+        assert_eq!(
+            p.skill_xp(GatherSkill::Woodcutting),
+            0,
+            "no xp for a node you can't work"
+        );
+    }
+
+    #[test]
+    fn skill_xp_survives_a_save_load_round_trip() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Ranger);
+        s.players
+            .get_mut(&uid(1))
+            .unwrap()
+            .skills
+            .insert(GatherSkill::Mining, 500);
+        let saved = s.export_saved(uid(1)).expect("classed characters export");
+        let mut s2 = world();
+        s2.join(uid(1));
+        s2.hydrate(uid(1), &saved);
+        assert_eq!(
+            s2.players[&uid(1)].skill_xp(GatherSkill::Mining),
+            500,
+            "mining xp reloads through the save"
+        );
     }
 
     fn grant_frontier_unlock_titles(s: &mut WorldState, user_id: Uuid) {

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -44,6 +44,7 @@ use crate::app::{
 use super::abilities::{Ability, AbilityEffect, learned_at, unlocked_for};
 use super::appearance;
 use super::classes::{ARCHETYPE_LEVEL, ArchetypeDef, Class, level_for_xp, xp_for_level};
+use super::crafting::{recipe, recipe_indices_for};
 use super::damage::{DamageProfile, DamageType, Defense};
 use super::housing::{self, furniture_by_key, plot_of_room};
 use super::items::{
@@ -53,12 +54,12 @@ use super::persist::{
     SavedCharacter, SavedCharacterInit, SavedMob, SavedMobDot, SavedMobStun, SavedWorld,
 };
 use super::pets::{Pet, pet_species_by_key};
-use super::skills::{GatherSkill, skill_level_for_xp, skill_progress};
+use super::skills::{CraftSkill, GatherSkill, skill_level_for_xp, skill_progress};
 use super::stats::AbilityScores;
 use super::world::{
     CritterKind, Dir, FeatureKind, MiniMap, MobBehavior, MobSpawn, Perk, ResourceNode, RoomId,
-    World, critter_index, critters_at, features_at, frontier_entrance_room, is_frontier_room,
-    node_index, nodes_at, seed_world,
+    World, craft_stations_at, critter_index, critters_at, features_at, frontier_entrance_room,
+    is_frontier_room, node_index, nodes_at, seed_world,
 };
 
 /// World heartbeat. One combat round resolves per tick.
@@ -329,6 +330,32 @@ pub struct SkillView {
     pub xp_next: i64,
 }
 
+/// One recipe row in the crafting panel.
+#[derive(Clone, Debug)]
+pub struct CraftEntryView {
+    /// Global recipe index, passed back to `craft`.
+    pub recipe: usize,
+    pub name: String,
+    /// The craft skill it trains, e.g. "Smithing".
+    pub skill: String,
+    /// Compact ingredient list, e.g. "3x Copper Ingot, 1x Oak Plank".
+    pub inputs: String,
+    /// True when it can be made right now (station here, skilled enough, have
+    /// the materials).
+    pub craftable: bool,
+    /// Why it can't be made, when `craftable` is false; empty when it can.
+    pub reason: String,
+}
+
+/// The crafting panel, present when the player stands at any craft station. Lists
+/// every recipe worked at the stations in this room.
+#[derive(Clone, Debug)]
+pub struct CraftView {
+    /// The stations standing here, e.g. "forge, alchemy lab".
+    pub stations: String,
+    pub entries: Vec<CraftEntryView>,
+}
+
 #[derive(Clone, Debug)]
 pub struct OccupantView {
     pub user_id: Uuid,
@@ -509,6 +536,8 @@ pub struct PlayerView {
     pub stable: Option<StableView>,
     /// The housing ledger, present at the clerk or inside a home you own.
     pub housing: Option<HousingView>,
+    /// The crafting panel, present when standing at any craft station.
+    pub crafting: Option<CraftView>,
     /// The composed character bio (from the appearance choices).
     pub bio: String,
     /// The appearance/bio builder rows: (field label, chosen option).
@@ -591,6 +620,7 @@ impl PlayerView {
             pet: None,
             stable: None,
             housing: None,
+            crafting: None,
             bio: String::new(),
             appearance: Vec::new(),
             log: Vec::new(),
@@ -1159,6 +1189,11 @@ impl LateaniaService {
         self.mutate(user_id, move |s| s.gather(user_id));
     }
 
+    /// Craft the recipe at a global index, if the station/skill/materials allow.
+    pub fn craft_task(&self, user_id: Uuid, recipe_index: usize) {
+        self.mutate(user_id, move |s| s.craft(user_id, recipe_index));
+    }
+
     /// Re-roll ability scores on the selection screen (before a class is chosen).
     pub fn reroll_task(&self, user_id: Uuid) {
         self.mutate(user_id, move |s| s.reroll(user_id));
@@ -1468,6 +1503,8 @@ struct PlayerState {
     /// Gathering-skill xp, keyed by trade; the level is a pure function of xp.
     /// A missing entry means the trade is untrained (level 1, 0 xp).
     skills: HashMap<GatherSkill, i64>,
+    /// Crafting-skill xp, keyed by trade (same shape and curve as `skills`).
+    craft_skills: HashMap<CraftSkill, i64>,
     /// The friendly NPC the player is currently escorting, if any (transient).
     escort: Option<EscortState>,
     /// Transient warning gate for the start-room Frontier entrance.
@@ -1534,6 +1571,28 @@ impl PlayerState {
     /// Total xp trained in a gathering skill (0 if untrained).
     fn skill_xp(&self, skill: GatherSkill) -> i64 {
         self.skills.get(&skill).copied().unwrap_or(0)
+    }
+
+    /// Total xp trained in a crafting skill (0 if untrained).
+    fn craft_xp(&self, skill: CraftSkill) -> i64 {
+        self.craft_skills.get(&skill).copied().unwrap_or(0)
+    }
+
+    /// How many of an item id sit in the pack.
+    fn item_count(&self, id: u32) -> u32 {
+        self.inventory.iter().filter(|&&i| i == id).count() as u32
+    }
+
+    /// Remove up to `n` copies of an item id from the pack.
+    fn consume(&mut self, id: u32, mut n: u32) {
+        self.inventory.retain(|&x| {
+            if n > 0 && x == id {
+                n -= 1;
+                false
+            } else {
+                true
+            }
+        });
     }
 }
 
@@ -2008,6 +2067,7 @@ impl WorldState {
             pet: None,
             appearance: [0; appearance::N_FIELDS],
             skills: HashMap::new(),
+            craft_skills: HashMap::new(),
             escort: None,
             frontier_descent_pending: false,
             resurrection_cap: 0,
@@ -2217,6 +2277,11 @@ impl WorldState {
                 .iter()
                 .filter_map(|(key, xp)| GatherSkill::from_key(key).map(|s| (s, *xp)))
                 .collect();
+            p.craft_skills = saved
+                .craft_skills
+                .iter()
+                .filter_map(|(key, xp)| CraftSkill::from_key(key).map(|s| (s, *xp)))
+                .collect();
             // Restore the chosen archetype (ignored if the key is unknown or no
             // longer matches the class, e.g. a respec/rename).
             p.archetype = saved
@@ -2311,6 +2376,11 @@ impl WorldState {
             appearance: p.appearance.to_vec(),
             skills: p
                 .skills
+                .iter()
+                .map(|(s, xp)| (s.key().to_string(), *xp))
+                .collect(),
+            craft_skills: p
+                .craft_skills
                 .iter()
                 .map(|(s, xp)| (s.key().to_string(), *xp))
                 .collect(),
@@ -3092,6 +3162,103 @@ impl WorldState {
         }
         self.dirty = true;
         true
+    }
+
+    /// Craft the recipe at `recipe_index`: requires the matching station in the
+    /// room, enough craft-skill level, and all input materials. Consumes the
+    /// inputs, adds the output, and trains the craft skill.
+    fn craft(&mut self, user_id: Uuid, recipe_index: usize) {
+        if !self.is_classed(user_id) {
+            return;
+        }
+        let Some(rc) = recipe(recipe_index) else {
+            return;
+        };
+        // Gather everything decidable under a read borrow, then drop it.
+        let room_id;
+        let level;
+        let missing: Option<(u32, u32)>;
+        {
+            let Some(player) = self.players.get(&user_id) else {
+                return;
+            };
+            if player.respawn_at.is_some() {
+                return;
+            }
+            room_id = player.room;
+            level = skill_level_for_xp(player.craft_xp(rc.skill));
+            missing = rc
+                .inputs
+                .iter()
+                .find(|ing| player.item_count(ing.item) < ing.qty)
+                .map(|ing| (ing.item, ing.qty));
+        }
+        if !craft_stations_at(room_id).contains(&rc.skill) {
+            self.log_to(
+                user_id,
+                LogKind::System,
+                format!("You need a {} to make that.", rc.skill.station()),
+            );
+            return;
+        }
+        if level < rc.level_req {
+            self.log_to(
+                user_id,
+                LogKind::System,
+                format!(
+                    "Your {} ({level}) isn't skilled enough - that needs level {}.",
+                    rc.skill.label(),
+                    rc.level_req,
+                ),
+            );
+            return;
+        }
+        if let Some((item_id, qty)) = missing {
+            let name = item(item_id).map(|i| i.name).unwrap_or("materials");
+            self.log_to(
+                user_id,
+                LogKind::System,
+                format!("You don't have the materials ({qty}x {name})."),
+            );
+            return;
+        }
+
+        let out_name = item(rc.output)
+            .map(|i| i.name.to_string())
+            .unwrap_or_else(|| "something".to_string());
+        let (before, after) = {
+            let p = self.players.get_mut(&user_id).expect("player present");
+            for ing in &rc.inputs {
+                p.consume(ing.item, ing.qty);
+            }
+            for _ in 0..rc.output_qty {
+                p.inventory.push(rc.output);
+            }
+            let cur = p.craft_xp(rc.skill);
+            p.craft_skills.insert(rc.skill, cur + rc.xp as i64);
+            (
+                skill_level_for_xp(cur),
+                skill_level_for_xp(cur + rc.xp as i64),
+            )
+        };
+        self.log_to(
+            user_id,
+            LogKind::Loot,
+            format!(
+                "You {} {out_name}. (+{} {} xp)",
+                rc.skill.verb(),
+                rc.xp,
+                rc.skill.label(),
+            ),
+        );
+        if after > before {
+            self.log_to(
+                user_id,
+                LogKind::System,
+                format!("Your {} rises to level {after}!", rc.skill.label()),
+            );
+        }
+        self.dirty = true;
     }
 
     fn look(&mut self, user_id: Uuid) {
@@ -5630,7 +5797,7 @@ impl WorldState {
                 })
                 .collect();
             // Every gathering trade, in a stable order, with its live progress.
-            let skills: Vec<SkillView> = GatherSkill::ALL
+            let mut skills: Vec<SkillView> = GatherSkill::ALL
                 .iter()
                 .map(|&s| {
                     let xp = player.skill_xp(s);
@@ -5643,6 +5810,72 @@ impl WorldState {
                     }
                 })
                 .collect();
+            // The maker's trades follow the gatherer's in the same Trades block.
+            skills.extend(CraftSkill::ALL.iter().map(|&s| {
+                let xp = player.craft_xp(s);
+                let (xp_into, xp_next) = skill_progress(xp);
+                SkillView {
+                    name: s.label().to_string(),
+                    level: skill_level_for_xp(xp),
+                    xp_into,
+                    xp_next,
+                }
+            }));
+            // The crafting panel: every recipe worked at the stations in this room.
+            let crafting = {
+                let stations = craft_stations_at(player.room);
+                if stations.is_empty() {
+                    None
+                } else {
+                    let mut entries = Vec::new();
+                    for &st in &stations {
+                        let clevel = skill_level_for_xp(player.craft_xp(st));
+                        for ri in recipe_indices_for(st) {
+                            let Some(rc) = recipe(ri) else {
+                                continue;
+                            };
+                            let inputs = rc
+                                .inputs
+                                .iter()
+                                .map(|ing| {
+                                    let n = item(ing.item).map(|i| i.name).unwrap_or("?");
+                                    format!("{}x {n}", ing.qty)
+                                })
+                                .collect::<Vec<_>>()
+                                .join(", ");
+                            let have_mats = rc
+                                .inputs
+                                .iter()
+                                .all(|ing| player.item_count(ing.item) >= ing.qty);
+                            let (craftable, reason) = if clevel < rc.level_req {
+                                (false, format!("needs {} {}", st.label(), rc.level_req))
+                            } else if !have_mats {
+                                (false, "need materials".to_string())
+                            } else {
+                                (true, String::new())
+                            };
+                            entries.push(CraftEntryView {
+                                recipe: ri,
+                                name: item(rc.output)
+                                    .map(|i| i.name.to_string())
+                                    .unwrap_or_default(),
+                                skill: st.label().to_string(),
+                                inputs,
+                                craftable,
+                                reason,
+                            });
+                        }
+                    }
+                    Some(CraftView {
+                        stations: stations
+                            .iter()
+                            .map(|s| s.station())
+                            .collect::<Vec<_>>()
+                            .join(", "),
+                        entries,
+                    })
+                }
+            };
             let in_combat_with = player.target.and_then(|mob_id| {
                 self.mobs
                     .get(&mob_id)
@@ -5897,6 +6130,7 @@ impl WorldState {
                     pet,
                     stable,
                     housing,
+                    crafting,
                     bio: appearance::compose_bio(&player.appearance),
                     appearance: (0..appearance::N_FIELDS)
                         .map(|i| {
@@ -6156,6 +6390,93 @@ mod tests {
             s2.players[&uid(1)].skill_xp(GatherSkill::Mining),
             500,
             "mining xp reloads through the save"
+        );
+    }
+
+    fn copper_ingot_recipe() -> usize {
+        recipe_indices_for(CraftSkill::Smithing)
+            .into_iter()
+            .find(|&i| recipe(i).unwrap().output == super::super::items::ingot_id(0))
+            .expect("a copper ingot recipe exists")
+    }
+
+    #[test]
+    fn crafting_at_a_station_consumes_inputs_and_makes_the_output() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+        // Stand at Embergate's crafters' row (room 3) with 2 copper ore.
+        {
+            let p = s.players.get_mut(&uid(1)).unwrap();
+            p.room = 3;
+            p.inventory.push(super::super::items::material_id(1, 0));
+            p.inventory.push(super::super::items::material_id(1, 0));
+        }
+        s.craft(uid(1), copper_ingot_recipe());
+        let p = &s.players[&uid(1)];
+        assert_eq!(
+            p.item_count(super::super::items::material_id(1, 0)),
+            0,
+            "the ore is consumed"
+        );
+        assert_eq!(
+            p.item_count(super::super::items::ingot_id(0)),
+            1,
+            "an ingot is produced"
+        );
+        assert!(
+            p.craft_xp(CraftSkill::Smithing) > 0,
+            "smithing is trained by crafting"
+        );
+    }
+
+    #[test]
+    fn crafting_needs_both_the_station_and_the_materials() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+        let ri = copper_ingot_recipe();
+        // Away from a forge (town square) with no ore: nothing is made.
+        s.players.get_mut(&uid(1)).unwrap().room = 1;
+        s.craft(uid(1), ri);
+        assert_eq!(
+            s.players[&uid(1)].item_count(super::super::items::ingot_id(0)),
+            0,
+            "no station means no craft"
+        );
+        // At the forge but still without ore: still nothing, and no xp.
+        s.players.get_mut(&uid(1)).unwrap().room = 3;
+        s.craft(uid(1), ri);
+        assert_eq!(
+            s.players[&uid(1)].item_count(super::super::items::ingot_id(0)),
+            0,
+            "no materials means no craft"
+        );
+        assert_eq!(
+            s.players[&uid(1)].craft_xp(CraftSkill::Smithing),
+            0,
+            "a failed craft trains nothing"
+        );
+    }
+
+    #[test]
+    fn craft_skill_xp_survives_a_save_load_round_trip() {
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+        s.players
+            .get_mut(&uid(1))
+            .unwrap()
+            .craft_skills
+            .insert(CraftSkill::Alchemy, 250);
+        let saved = s.export_saved(uid(1)).expect("classed characters export");
+        let mut s2 = world();
+        s2.join(uid(1));
+        s2.hydrate(uid(1), &saved);
+        assert_eq!(
+            s2.players[&uid(1)].craft_xp(CraftSkill::Alchemy),
+            250,
+            "alchemy xp reloads through the save"
         );
     }
 

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -337,6 +337,7 @@ fn draw_side(
         Panel::Stable => stable_panel(view, state.cursor()),
         Panel::Housing => housing_panel(view, state.cursor()),
         Panel::Appearance => (appearance_panel(view, state.cursor()), None),
+        Panel::Crafting => crafting_panel(view, state.cursor()),
     };
     let off = scroll_offset(
         state.list_scroll(),
@@ -1493,6 +1494,69 @@ fn shop_panel(view: &PlayerView, cursor: usize) -> (Vec<Line<'static>>, Option<u
     (lines, sel_line)
 }
 
+fn crafting_panel(view: &PlayerView, cursor: usize) -> (Vec<Line<'static>>, Option<usize>) {
+    let Some(craft) = &view.crafting else {
+        return (
+            vec![Line::from(Span::styled(
+                "No crafting station here.",
+                Style::default().fg(theme::TEXT_DIM()),
+            ))],
+            None,
+        );
+    };
+    let mut sel_line = None;
+    let mut lines = vec![
+        Line::from(Span::styled(
+            format!("Crafting - {}", craft.stations),
+            Style::default()
+                .fg(theme::AMBER_GLOW())
+                .add_modifier(Modifier::BOLD),
+        )),
+        Line::raw(""),
+    ];
+    if craft.entries.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  no recipes here",
+            Style::default().fg(theme::TEXT_DIM()),
+        )));
+    }
+    for (i, e) in craft.entries.iter().enumerate() {
+        let selected = i == cursor;
+        if selected {
+            sel_line = Some(lines.len());
+        }
+        let marker = if selected { ">" } else { " " };
+        let name_style = if selected {
+            Style::default()
+                .fg(theme::TEXT_BRIGHT())
+                .bg(theme::BG_SELECTION())
+                .add_modifier(Modifier::BOLD)
+        } else if e.craftable {
+            Style::default().fg(theme::TEXT())
+        } else {
+            Style::default().fg(theme::TEXT_DIM())
+        };
+        // Name row, with a gated reason when it can't be made.
+        let mut name_spans = vec![Span::styled(format!("{marker} {}", e.name), name_style)];
+        if !e.craftable && !e.reason.is_empty() {
+            name_spans.push(Span::styled(
+                format!("  ({})", e.reason),
+                Style::default().fg(theme::ERROR()),
+            ));
+        }
+        lines.push(Line::from(name_spans));
+        // Ingredient row.
+        lines.push(Line::from(Span::styled(
+            format!("    {} · {}", e.skill.to_lowercase(), e.inputs),
+            Style::default().fg(theme::TEXT_DIM()),
+        )));
+    }
+    lines.push(Line::raw(""));
+    lines.push(hint("w/s", "select  Enter craft"));
+    lines.push(hint("u", "close"));
+    (lines, sel_line)
+}
+
 fn stable_panel(view: &PlayerView, cursor: usize) -> (Vec<Line<'static>>, Option<usize>) {
     let Some(stable) = &view.stable else {
         return (
@@ -1783,6 +1847,9 @@ fn footer_hints(view: &PlayerView) -> Vec<Line<'static>> {
     }
     if view.housing.is_some() {
         lines.push(hint("n", "housing ledger"));
+    }
+    if view.crafting.is_some() {
+        lines.push(hint("u", "craft (station here)"));
     }
     lines.push(hint("Esc", "leave"));
     lines
@@ -2251,14 +2318,24 @@ fn interactable_color(kind: &str) -> ratatui::style::Color {
     match kind {
         "fountain" => theme::SUCCESS(),
         "bank" | "board" | "stable" | "clerk" => theme::AMBER_GLOW(),
+        _ if is_craft_station(kind) => theme::AMBER_GLOW(),
         _ => theme::MENTION(),
     }
+}
+
+/// The craft-station feature tags (see `CraftSkill::station`), which read as
+/// actionable like the other vendors.
+fn is_craft_station(kind: &str) -> bool {
+    matches!(
+        kind,
+        "forge" | "workbench" | "tannery" | "alchemy lab" | "cooking fire"
+    )
 }
 
 /// Whether a feature kind is something you actively use/trade at (vs. just look
 /// at). Drives a brighter, bolder treatment so actionable things pop.
 fn is_actionable_feature(kind: &str) -> bool {
-    matches!(kind, "fountain" | "bank" | "board" | "stable" | "clerk")
+    matches!(kind, "fountain" | "bank" | "board" | "stable" | "clerk") || is_craft_station(kind)
 }
 
 #[cfg(test)]

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -716,6 +716,28 @@ fn room_panel(
             ));
         }
     }
+    if !view.nodes.is_empty() {
+        lines.push(section("Resources"));
+        for n in &view.nodes {
+            let (marker, color) = if n.gatherable {
+                ("◆ ", theme::AMBER())
+            } else {
+                ("· ", theme::TEXT_DIM())
+            };
+            let detail = if n.gatherable {
+                format!(", {} (press y)", n.skill.to_lowercase())
+            } else if !n.reason.is_empty() {
+                format!(", {}", n.reason)
+            } else {
+                String::new()
+            };
+            lines.extend(side_text_wrap(
+                &format!("{marker}{}{detail}", n.name),
+                color,
+                width,
+            ));
+        }
+    }
     lines.push(Line::raw(""));
     lines.extend(footer_hints(view));
     lines
@@ -906,6 +928,8 @@ fn sheet_attributes(view: &PlayerView, accent: Color) -> Vec<Line<'static>> {
             .add_modifier(Modifier::BOLD),
     )));
     lines.extend(wrap(&view.trait_desc, 24));
+    lines.push(Line::raw(""));
+    lines.extend(skills_block(view));
     lines
 }
 
@@ -956,6 +980,42 @@ fn sheet_derived(view: &PlayerView, accent: Color) -> Vec<Line<'static>> {
     }
     lines.push(Line::raw(""));
     lines.push(hint("c", "close  v abilities  t bag"));
+    lines
+}
+
+/// The gathering-trades block: each skill's level and a compact progress
+/// readout. Shown on both the full character sheet and the narrow panel; the `y`
+/// hint teaches how to work a node.
+fn skills_block(view: &PlayerView) -> Vec<Line<'static>> {
+    let mut lines = vec![section("Trades")];
+    if view.skills.is_empty() {
+        lines.push(Line::from(Span::styled(
+            "  untrained",
+            Style::default().fg(theme::TEXT_DIM()),
+        )));
+        return lines;
+    }
+    for s in &view.skills {
+        let progress = if s.xp_next > 0 {
+            format!("{}/{}", s.xp_into, s.xp_next)
+        } else {
+            "max".to_string()
+        };
+        lines.push(Line::from(vec![
+            Span::styled(format!("  {} ", s.name), Style::default().fg(theme::TEXT())),
+            Span::styled(
+                format!("L{}", s.level),
+                Style::default()
+                    .fg(theme::AMBER())
+                    .add_modifier(Modifier::BOLD),
+            ),
+            Span::styled(
+                format!("  {progress}"),
+                Style::default().fg(theme::TEXT_DIM()),
+            ),
+        ]));
+    }
+    lines.push(hint("y", "gather a resource node"));
     lines
 }
 
@@ -1173,6 +1233,8 @@ fn character_panel(view: &PlayerView) -> Vec<Line<'static>> {
             Style::default().fg(theme::BADGE_GOLD()),
         )));
     }
+    lines.push(Line::raw(""));
+    lines.extend(skills_block(view));
     lines.push(Line::raw(""));
     lines.push(hint("c", "close  v abilities  t bag"));
     lines.push(hint("[ ]", "scroll"));

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -21,7 +21,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::damage::{DamageProfile, DamageType};
-use super::skills::GatherSkill;
+use super::skills::{CraftSkill, GatherSkill};
 
 /// Compass and vertical directions a player can move.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -373,6 +373,9 @@ pub enum FeatureKind {
     Stable,
     /// A housing clerk: examine it to buy a deed and furnish a home.
     Housing,
+    /// A crafting station (forge/workbench/tannery/alchemy lab/cooking fire):
+    /// stand here and press the craft key to work its recipes.
+    CraftStation(CraftSkill),
 }
 
 impl FeatureKind {
@@ -387,6 +390,7 @@ impl FeatureKind {
             Self::Board => "board",
             Self::Stable => "stable",
             Self::Housing => "clerk",
+            Self::CraftStation(skill) => skill.station(),
         }
     }
 }
@@ -521,6 +525,48 @@ pub const FEATURES: &[Feature] = &[
         FeatureKind::Bank,
         EMBERGATE_BANK_DESC,
     ),
+    // ---- Embergate crafters' row (Market Row, room 3): the craft stations ----
+    feat(
+        3,
+        "the public forge",
+        FeatureKind::CraftStation(CraftSkill::Smithing),
+        "A great stone forge roars at the head of Market Row, its coals kept lit \
+         for any traveller with ore to smelt and the arm to swing a hammer. Anvils, \
+         tongs, and quenching-troughs stand ready; smelt ore into ingots here, then \
+         beat them into blades and plate.",
+    ),
+    feat(
+        3,
+        "the carpenter's workbench",
+        FeatureKind::CraftStation(CraftSkill::Woodworking),
+        "A long, scarred workbench under an awning, hung with saws, drawknives and \
+         clamps and drifted deep in fragrant shavings. Season your logs into planks \
+         here, and shape them into bows and hafts.",
+    ),
+    feat(
+        3,
+        "the tannery",
+        FeatureKind::CraftStation(CraftSkill::Leatherworking),
+        "A row of stretching-frames and reeking tan-pits behind the market, where \
+         raw hides are cured into supple leather. Not a place to linger downwind - \
+         but the only place to turn a kill's hide into armor.",
+    ),
+    feat(
+        3,
+        "the alchemy lab",
+        FeatureKind::CraftStation(CraftSkill::Alchemy),
+        "A cramped stall of bubbling retorts, hanging bunches of dried herbs, and \
+         shelves of stoppered vials in every colour of harm and healing. Brew \
+         draughts to mend yourself here - or poisons to coat a waiting blade.",
+    ),
+    feat(
+        3,
+        "the cooking fire",
+        FeatureKind::CraftStation(CraftSkill::Cooking),
+        "A broad communal cook-fire with spits, griddles and a blackened stockpot, \
+         where the market's traders take their meals. Cook your catch into hot food \
+         that restores far more than raw fish ever could.",
+    ),
     // ---- Tasmania (harbor capital) --------------------------------------
     feat(
         TASMANIA_SQUARE,
@@ -591,6 +637,19 @@ pub const FEATURES: &[Feature] = &[
 
 pub fn features_at(room: RoomId) -> Vec<&'static Feature> {
     FEATURES.iter().filter(|f| f.room == room).collect()
+}
+
+/// The crafting skills whose stations stand in a room (empty if none). Used to
+/// gate crafting and to build the craft panel.
+pub fn craft_stations_at(room: RoomId) -> Vec<CraftSkill> {
+    FEATURES
+        .iter()
+        .filter(|f| f.room == room)
+        .filter_map(|f| match f.kind {
+            FeatureKind::CraftStation(skill) => Some(skill),
+            _ => None,
+        })
+        .collect()
 }
 
 /// A small benefit a Boon creature confers while you share its room.
@@ -7979,6 +8038,31 @@ mod tests {
                 feature.room
             );
         }
+    }
+
+    #[test]
+    fn craft_stations_stand_in_real_rooms_and_cover_every_trade() {
+        let world = seed_world();
+        for skill in CraftSkill::ALL {
+            let rooms: Vec<RoomId> = FEATURES
+                .iter()
+                .filter(|f| f.kind == FeatureKind::CraftStation(skill))
+                .map(|f| f.room)
+                .collect();
+            assert!(!rooms.is_empty(), "no station trains {}", skill.label());
+            for r in rooms {
+                assert!(
+                    world.rooms.contains_key(&r),
+                    "{} station in missing room {}",
+                    skill.label(),
+                    r
+                );
+            }
+        }
+        assert!(
+            !craft_stations_at(3).is_empty(),
+            "Embergate's crafters' row exposes stations"
+        );
     }
 
     #[test]

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -21,6 +21,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 
 use super::damage::{DamageProfile, DamageType};
+use super::skills::GatherSkill;
 
 /// Compass and vertical directions a player can move.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -781,6 +782,308 @@ pub fn critters_at(room: RoomId) -> Vec<&'static CritterSpawn> {
 /// per-world hunt cooldowns.
 pub fn critter_index(c: &CritterSpawn) -> Option<usize> {
     WILDLIFE.iter().position(|w| std::ptr::eq(w, c))
+}
+
+/// A harvestable resource node fixed to a room: a tree stand, an ore vein, a
+/// fishing spot, or a herb/skinning patch. Modelled exactly like wildlife -
+/// static data keyed to a home room, with a per-node respawn cooldown tracked on
+/// the service (`gathered`). Harvesting one grants its raw material plus skill
+/// xp, gated behind a minimum skill level so higher tiers stay out of reach
+/// until the trade is trained up.
+#[derive(Clone, Copy, Debug)]
+pub struct ResourceNode {
+    pub home: RoomId,
+    pub skill: GatherSkill,
+    /// What the player sees and acts on, e.g. "an old oak wood".
+    pub name: &'static str,
+    /// Short flavour shown in the Resources list.
+    pub note: &'static str,
+    /// Tier 0..5, low to high; sets the material and the difficulty band.
+    pub tier: u8,
+    /// Minimum skill level required to work it.
+    pub level_req: i32,
+    /// Item id granted on a successful harvest (derived from skill + tier).
+    pub yield_item: u32,
+    /// Skill xp granted per harvest.
+    pub xp: i32,
+}
+
+const fn node(
+    home: RoomId,
+    skill: GatherSkill,
+    name: &'static str,
+    note: &'static str,
+    tier: u8,
+    level_req: i32,
+    xp: i32,
+) -> ResourceNode {
+    ResourceNode {
+        home,
+        skill,
+        name,
+        note,
+        tier,
+        level_req,
+        // The yield is fixed by the node's skill and tier, so the material can
+        // never drift out of sync with its source.
+        yield_item: super::items::material_id(skill.index(), tier as u32),
+        xp,
+    }
+}
+
+/// Every harvestable node in the world, keyed to its home room. Tiers climb with
+/// distance/difficulty from Embergate: roadside starters near town, mid materials
+/// out in the overworld wings, and the best materials deep in the harder zones.
+pub const NODES: &[ResourceNode] = &[
+    // ---- Woodcutting: birch -> oak -> ash -> yew -> ironbark ------------
+    node(
+        600,
+        GatherSkill::Woodcutting,
+        "a stand of roadside birch",
+        "slim white birches along the verge",
+        0,
+        1,
+        12,
+    ),
+    node(
+        680,
+        GatherSkill::Woodcutting,
+        "an old oak wood",
+        "gnarled oaks on the hillside",
+        1,
+        8,
+        30,
+    ),
+    node(
+        684,
+        GatherSkill::Woodcutting,
+        "a grove of mountain ash",
+        "straight ash on the high slopes",
+        2,
+        16,
+        70,
+    ),
+    node(
+        688,
+        GatherSkill::Woodcutting,
+        "an ancient yew",
+        "a black, age-twisted yew",
+        3,
+        26,
+        150,
+    ),
+    node(
+        803,
+        GatherSkill::Woodcutting,
+        "ironbark rooted in the dark",
+        "iron-hard trunks in the fungal deep",
+        4,
+        38,
+        320,
+    ),
+    // ---- Mining: copper -> tin -> iron -> silver -> mithril -------------
+    node(
+        601,
+        GatherSkill::Mining,
+        "a weathered copper outcrop",
+        "green-streaked stone by the road",
+        0,
+        1,
+        12,
+    ),
+    node(
+        740,
+        GatherSkill::Mining,
+        "a tin-streaked rockface",
+        "pale ore in the desert rock",
+        1,
+        8,
+        30,
+    ),
+    node(
+        743,
+        GatherSkill::Mining,
+        "a deep iron seam",
+        "red iron banding the cliff",
+        2,
+        16,
+        70,
+    ),
+    node(
+        748,
+        GatherSkill::Mining,
+        "a glinting silver vein",
+        "silver threading the deep rock",
+        3,
+        26,
+        150,
+    ),
+    node(
+        750,
+        GatherSkill::Mining,
+        "a mithril lode",
+        "the fabled blue-white ore",
+        4,
+        38,
+        320,
+    ),
+    // ---- Fishing: bream -> trout -> pike -> sturgeon -> moonscale -------
+    node(
+        620,
+        GatherSkill::Fishing,
+        "the harbor shallows",
+        "small fish in the clear shallows",
+        0,
+        1,
+        12,
+    ),
+    node(
+        720,
+        GatherSkill::Fishing,
+        "the oasis pool",
+        "fish rising in the still oasis",
+        0,
+        1,
+        12,
+    ),
+    node(
+        660,
+        GatherSkill::Fishing,
+        "the high lake shore",
+        "trout holding in the cold lake",
+        1,
+        8,
+        30,
+    ),
+    node(
+        641,
+        GatherSkill::Fishing,
+        "a tidal cove",
+        "pike hunting the running cove",
+        2,
+        16,
+        70,
+    ),
+    node(
+        701,
+        GatherSkill::Fishing,
+        "a black fen pool",
+        "something big turns in the dark water",
+        3,
+        26,
+        150,
+    ),
+    node(
+        650,
+        GatherSkill::Fishing,
+        "the kraken's deep",
+        "pale shapes in the abyssal water",
+        4,
+        38,
+        320,
+    ),
+    // ---- Foraging: marsh sage -> redleaf -> bloodthistle -> frostbloom -> sunmoss
+    node(
+        603,
+        GatherSkill::Foraging,
+        "a verge of marsh sage",
+        "grey-green sage along the ditch",
+        0,
+        1,
+        12,
+    ),
+    node(
+        682,
+        GatherSkill::Foraging,
+        "a redleaf meadow",
+        "red-veined leaves in the meadow",
+        1,
+        8,
+        30,
+    ),
+    node(
+        700,
+        GatherSkill::Foraging,
+        "a bloodthistle bog",
+        "dark thistles standing in the mire",
+        2,
+        16,
+        70,
+    ),
+    node(
+        690,
+        GatherSkill::Foraging,
+        "a cold high meadow",
+        "pale blooms rimed with frost",
+        3,
+        26,
+        150,
+    ),
+    node(
+        801,
+        GatherSkill::Foraging,
+        "a cavern lit by sunmoss",
+        "moss that glows faintly in the dark",
+        4,
+        38,
+        320,
+    ),
+    // ---- Skinning: rough -> thick -> boar -> bear -> direhide -----------
+    node(
+        604,
+        GatherSkill::Skinning,
+        "fresh boar sign under the oaks",
+        "trampled ground and shed bristles",
+        0,
+        1,
+        12,
+    ),
+    node(
+        760,
+        GatherSkill::Skinning,
+        "a well-worn game trail",
+        "hoof-churned earth on the savanna",
+        1,
+        8,
+        30,
+    ),
+    node(
+        762,
+        GatherSkill::Skinning,
+        "a razorback wallow",
+        "a muddy wallow, still warm",
+        2,
+        16,
+        70,
+    ),
+    node(
+        765,
+        GatherSkill::Skinning,
+        "a cave-bear's kill",
+        "a fresh kill dragged half-eaten",
+        3,
+        26,
+        150,
+    ),
+    node(
+        767,
+        GatherSkill::Skinning,
+        "a dire-beast lair",
+        "old bones and a rank, huge musk",
+        4,
+        38,
+        320,
+    ),
+];
+
+pub fn nodes_at(room: RoomId) -> Vec<&'static ResourceNode> {
+    NODES.iter().filter(|n| n.home == room).collect()
+}
+
+/// Stable global index of a node (its position in `NODES`), used to key
+/// per-world harvest cooldowns.
+pub fn node_index(n: &ResourceNode) -> Option<usize> {
+    NODES.iter().position(|x| std::ptr::eq(x, n))
 }
 
 fn room(
@@ -7674,6 +7977,78 @@ mod tests {
                 "feature {:?} references missing room {}",
                 feature.name,
                 feature.room
+            );
+        }
+    }
+
+    #[test]
+    fn every_node_lives_in_a_real_room() {
+        let world = seed_world();
+        for n in NODES {
+            assert!(
+                world.rooms.contains_key(&n.home),
+                "node {:?} references missing room {}",
+                n.name,
+                n.home
+            );
+        }
+    }
+
+    #[test]
+    fn every_node_yields_a_real_material_matching_its_skill_and_tier() {
+        for n in NODES {
+            assert!(
+                (n.tier as u32) < super::super::items::MATERIAL_TIERS,
+                "node {:?} tier {} out of range",
+                n.name,
+                n.tier
+            );
+            assert_eq!(
+                n.yield_item,
+                super::super::items::material_id(n.skill.index(), n.tier as u32),
+                "node {:?} yield must follow its skill + tier",
+                n.name
+            );
+            assert!(
+                super::super::items::item(n.yield_item).is_some(),
+                "node {:?} yields missing item {}",
+                n.name,
+                n.yield_item
+            );
+            assert!(
+                n.level_req >= 1,
+                "node {:?} needs a real skill gate",
+                n.name
+            );
+        }
+    }
+
+    #[test]
+    fn node_indices_round_trip_and_cover_every_skill() {
+        // `node_index` is exercised exactly as the service uses it: on the
+        // 'static refs handed out by `nodes_at` (const promotion makes the two
+        // NODES views share storage, as with critters). Every node must be
+        // reachable and map back to a unique index.
+        let world = seed_world();
+        let mut seen = std::collections::HashSet::new();
+        for &id in world.rooms.keys() {
+            for n in nodes_at(id) {
+                let idx = node_index(n).expect("a node from nodes_at has an index");
+                seen.insert(idx);
+            }
+        }
+        assert_eq!(
+            seen.len(),
+            NODES.len(),
+            "every node is reachable via nodes_at and indexes uniquely"
+        );
+        // At least one node per gathering skill, so every trade has somewhere to
+        // train.
+        for skill in GatherSkill::ALL {
+            assert!(
+                NODES.iter().any(|n| n.skill == skill),
+                "no node trains {}",
+                skill.label()
             );
         }
     }


### PR DESCRIPTION
Part 2 of the crafting economy: the **maker's side**. Gathered materials now become usable, sellable gear and consumables through real recipe chains. Thanks again @mpiorowski. 🙏

**Stacked on #421** (gathering skills & resource nodes) — its commit is included here; merge that first. Additive and low-risk again: crafted goods are ordinary items, so they equip / consume / sell through the systems you already have.

### What's in
- **Five crafting trades** (`CraftSkill`): Smithing, Woodworking, Leatherworking, Alchemy, Cooking — 1→50 on the same curve as gathering.
- **Craft stations** in Embergate's Market Row (a forge, workbench, tannery, alchemy lab and cooking fire). Press **`u`** where one stands to open the **Crafting** panel; it lists every recipe worked at the stations there, each flagged craftable or gated (station present / skill level / materials).
- **50 recipes that chain**: smelt 2 ore → an ingot, then forge 3 ingots + a plank → a sword; season logs → planks → bows; tan hides → leather → light armor; brew herbs → healing draughts and coating poisons; cook fish → restorative meals. Five tiers throughout.
- **Crafted-goods catalog** (IDs `4200..4500`): intermediates (ingots/planks/leather) and finished goods (weapons/armor/potions/poisons/food). Weapons & armor equip; potions & food heal/restore; poisons are sellable for now (they become *applyable* in part 3).
- **Crafting** consumes the inputs, produces the output, and trains the craft skill; the character sheet's **Trades** block now shows all ten trades.
- **Persistence**: schema **v13** adds craft-skill xp (serde-default; existing saves load untouched).

### Coming next (part 3 — depth)
Applied combat poisons (coat a blade → a poison DoT on your next hits), cooking buffs, and masterwork/high-tier recipe sinks.

### Verification
- `cargo test -p late-ssh --lib door::lateania` → **160 passed** (recipe integrity + chains, craft consumes/produces/trains, station+material gating, save round-trip).
- `cargo clippy -p late-ssh --lib` → clean.
- `cargo fmt -p late-ssh -- --check` → clean.

`CONTEXT.md` updated. Happy to reshape or hold to fit your direction.