### PR TITLE
site: feature Lateania + refresh the home feature list

### DIFF
--- a/late-web/src/pages/home/page.html
+++ b/late-web/src/pages/home/page.html
@@ -158,12 +158,23 @@
 
     <div class="stagger stagger-4 mb-14 text-sm leading-loose">
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> chill radio, classical, and guest stations</div>
-        <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> the arcade <span class="text-gray-700">(2048, sudoku, nonograms, solitaire)</span></div>
+        <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> <span class="text-green-600">lateania</span> &mdash; a whole persistent RPG world <span class="text-gray-700">(thousands of rooms, classes, crafting, loot)</span></div>
+        <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> the arcade <span class="text-gray-700">(2048, tetris, snake, minesweeper, sudoku, nonograms, solitaire &amp; more)</span></div>
+        <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> multiplayer lobby games <span class="text-gray-700">(reversi, checkers, backgammon, chess &amp; more)</span></div>
+        <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> classic door games <span class="text-gray-700">(nethack, dungeon crawl, dopewars &amp; more)</span></div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> collaborative artboard</div>
+        <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> voice rooms &amp; a music booth</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> daily challenges &amp; streaks</div>
         <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> live chat</div>
-        <div class="text-gray-500"><span class="text-gray-700">&#9500;&#9472;</span> share &amp; discuss news</div>
-        <div class="text-gray-500"><span class="text-gray-700">&#9492;&#9472;</span> multiplayer games <span class="text-gray-700">(coming soon)</span></div>
+        <div class="text-gray-500"><span class="text-gray-700">&#9492;&#9472;</span> share &amp; discuss news</div>
+    </div>
+
+    <div class="stagger stagger-5 mb-4 text-xs leading-relaxed">
+        <div class="text-gray-600 mb-3"><span class="text-gray-700">#</span> lateania</div>
+        <div class="text-gray-500">a persistent, shared terminal <span class="text-green-600">RPG</span>. six lands, thousands of hand-built rooms.</div>
+        <div class="text-gray-500">seventeen classes, crafting &amp; taming trades, player housing, bosses and loot.</div>
+        <div class="text-gray-600 mt-3">your character persists, the world persists,</div>
+        <div class="text-gray-600">and other adventurers are really there. built by Tasmania.</div>
     </div>
 
     <div class="stagger stagger-5 mb-4 text-xs leading-relaxed">


### PR DESCRIPTION
Thanks @mpiorowski! The home page (late.sh) had drifted from what the clubhouse actually offers — the feature list still read "arcade (2048, sudoku, nonograms, solitaire)" and "multiplayer games (coming soon)", with no mention of Lateania or the door games.

## What changed (just `late-web/src/pages/home/page.html`)
- **Refreshed the feature list** to what's live now: the expanded arcade, multiplayer lobby games, classic door games, voice rooms + music booth, and Lateania.
- **Added a `# lateania` highlight block**, mirroring the existing `# artboard` section — a persistent shared terminal RPG: six lands, thousands of hand-built rooms, seventeen classes, crafting/taming trades, player housing, bosses and loot.

Kept your lowercase / tree-marker / `text-gray` styling throughout. `cargo check -p late-web` is green (Askama template compiles).

Copy is a proposal — please trim or reword anything that overstates what's enabled in prod (e.g. if some door games are gated off), and tweak the Lateania blurb to taste.
