### PR TITLE
fix(lateania): order the adventure log oldest-to-newest

### DIFF
--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -2533,7 +2533,11 @@ fn recent_log_tail(view: &PlayerView, width: usize, height: usize) -> Vec<Line<'
         return Vec::new();
     }
 
-    let mut events = collapsed_recent_log_lines(view, width);
+    let entries = collapsed_recent_entries(view);
+    let mut events: Vec<Line<'static>> = entries
+        .iter()
+        .flat_map(|(kind, text)| wrapped_log_line(*kind, text, width))
+        .collect();
     if events.is_empty() {
         events.push(Line::from(Span::styled(
             "  no recent events",
@@ -2541,15 +2545,26 @@ fn recent_log_tail(view: &PlayerView, width: usize, height: usize) -> Vec<Line<'
         )));
     }
 
+    // Keep the most recent events that fit, trimming the oldest off the top so
+    // the newest line rests at the bottom - a normal MUD feed reads top to
+    // bottom, oldest to newest.
     let event_h = height.saturating_sub(1);
+    let start = events.len().saturating_sub(event_h);
+    let events = events.split_off(start);
+
     let mut lines = vec![section("Recent")];
-    lines.extend(events.into_iter().take(event_h));
+    lines.extend(events);
     lines.truncate(height);
     lines
 }
 
-fn collapsed_recent_log_lines(view: &PlayerView, width: usize) -> Vec<Line<'static>> {
-    let mut lines = Vec::new();
+/// Recent non-room log entries, consecutive duplicates collapsed to "text (xN)",
+/// returned oldest-first. Collapsing walks the log newest-first so a run of
+/// repeats folds into a single entry; the list is then flipped back into
+/// chronological order for a top-to-bottom MUD feed. Wrapping is left to the
+/// caller so multi-line entries never get their wrapped rows reversed.
+fn collapsed_recent_entries(view: &PlayerView) -> Vec<(LogKind, String)> {
+    let mut entries = Vec::new();
     let mut iter = view
         .log
         .iter()
@@ -2569,9 +2584,10 @@ fn collapsed_recent_log_lines(view: &PlayerView, width: usize) -> Vec<Line<'stat
         } else {
             line.text.clone()
         };
-        lines.extend(wrapped_log_line(line.kind, &text, width));
+        entries.push((line.kind, text));
     }
-    lines
+    entries.reverse();
+    entries
 }
 
 fn truncate_lines(mut lines: Vec<Line<'static>>, height: u16) -> Vec<Line<'static>> {

--- a/late-ssh/src/app/door/lateania/ui_test.rs
+++ b/late-ssh/src/app/door/lateania/ui_test.rs
@@ -129,3 +129,72 @@ fn equipped_inventory_tags_show_the_slot() {
     assert_eq!(inventory_item_tag(true, Some("chest")), " [worn chest]");
     assert_eq!(inventory_item_tag(false, Some("ring")), " (ring)");
 }
+
+use super::recent_log_tail;
+use super::super::svc::{LogKind, LogLine, empty_player_view};
+
+fn line_text(line: &Line) -> String {
+    line.spans.iter().map(|span| span.content.as_ref()).collect()
+}
+
+fn log_view(entries: &[&str]) -> super::PlayerView {
+    let mut view = empty_player_view();
+    view.log = entries
+        .iter()
+        .map(|text| LogLine {
+            text: (*text).to_string(),
+            kind: LogKind::Normal,
+        })
+        .collect();
+    view
+}
+
+#[test]
+fn recent_log_reads_oldest_top_newest_bottom() {
+    // view.log is chronological (oldest first). The feed must render the same
+    // way: oldest at the top, newest resting on the bottom row, like any MUD
+    // scrollback. This is the exact regression fix/mud-log-order corrects.
+    let view = log_view(&["first", "second", "third"]);
+    // Wide enough that nothing wraps, tall enough that all three fit.
+    let rendered: Vec<String> = recent_log_tail(&view, 40, 8)
+        .iter()
+        .map(line_text)
+        .collect();
+
+    let index_of = |needle: &str| {
+        rendered
+            .iter()
+            .position(|line| line.contains(needle))
+            .unwrap_or_else(|| panic!("{needle:?} missing from {rendered:?}"))
+    };
+    assert!(index_of("first") < index_of("second"));
+    assert!(index_of("second") < index_of("third"));
+    assert!(
+        rendered.last().is_some_and(|line| line.contains("third")),
+        "newest event must rest on the bottom row, got {rendered:?}"
+    );
+}
+
+#[test]
+fn recent_log_trims_oldest_when_it_overflows_height() {
+    // Five events into a window that only fits two under the "Recent" header:
+    // the two newest survive, in order, and the three oldest fall off the top.
+    let view = log_view(&["e1", "e2", "e3", "e4", "e5"]);
+    let rendered: Vec<String> = recent_log_tail(&view, 40, 3)
+        .iter()
+        .map(line_text)
+        .collect();
+    let joined = rendered.join("\n");
+
+    for dropped in ["e1", "e2", "e3"] {
+        assert!(
+            !joined.contains(dropped),
+            "oldest event {dropped:?} should have been trimmed, got {rendered:?}"
+        );
+    }
+    assert!(joined.contains("e4") && joined.contains("e5"));
+    assert!(
+        rendered.last().is_some_and(|line| line.contains("e5")),
+        "newest event must rest on the bottom row, got {rendered:?}"
+    );
+}


### PR DESCRIPTION
The main adventure log collapsed entries newest-first and painted them top-down, so the feed read upside down. This flips it back to a normal MUD feed.

## Change
- Collapse recent log entries at the **entry** level, then flip to **chronological** order (oldest first).
- Wrap after collapsing, keep the most recent lines that fit, and trim the oldest off the top.
- The newest line now rests at the **bottom** by the prompt — reads top-to-bottom like a normal MUD.

Splitting collapse from wrapping keeps multi-line entries' wrapped rows in order. The side-panel log was already chronological and is untouched.

## Tests
`cargo test -p late-ssh --lib lateania` — all lateania world/ui/svc tests pass (210). No test pinned the old order.

Thanks @mpiorowski for late.sh.