### PR TITLE
feat(home): Exit qq footer hint + mouse-driven radio stage

### DIFF
--- a/late-ssh/src/app/common/sidebar.rs
+++ b/late-ssh/src/app/common/sidebar.rs
@@ -105,6 +105,10 @@ pub(crate) struct SidebarProps<'a> {
     pub active_friend_names: &'a [String],
     /// Free-running frame counter for the music stage's marquee rows.
     pub marquee_tick: usize,
+    /// Slot the music stage records its dock area into each frame, so the mouse
+    /// handler in `app::input` can hit-test clicks (source headers, station
+    /// rows, mute) and scroll (volume) against it.
+    pub music_dock_rect: Option<&'a std::cell::Cell<Option<Rect>>>,
 }
 
 pub(crate) fn draw_sidebar(frame: &mut Frame, area: Rect, props: &SidebarProps<'_>) {
@@ -227,6 +231,7 @@ fn draw_sidebar_new_shell(frame: &mut Frame, area: Rect, props: &SidebarProps<'_
                         icecast_source_count: props.icecast_source_count,
                         radio_source_count: props.radio_source_count,
                         marquee_tick: props.marquee_tick,
+                        music_dock_rect: props.music_dock_rect,
                     },
                 );
             }
@@ -556,6 +561,8 @@ struct MusicStageProps<'a> {
     /// Free-running frame counter driving the marquee on now-playing rows
     /// too long for the rail.
     marquee_tick: usize,
+    /// See [`SidebarProps::music_dock_rect`].
+    music_dock_rect: Option<&'a std::cell::Cell<Option<Rect>>>,
 }
 
 /// Music stage: a small ambient equalizer strip pinned on top, then the
@@ -587,6 +594,12 @@ fn draw_music_stage(frame: &mut Frame, area: Rect, props: &MusicStageProps<'_>) 
 
     let [viz_area, dock_area] =
         Layout::vertical([Constraint::Length(MUSIC_VIZ_HEIGHT), Constraint::Fill(1)]).areas(area);
+    // Record the dock area so mouse clicks/scroll can drive the stage. The row
+    // layout in `music_stage_lines` is fixed, so the input handler maps a click
+    // row back to a source header, station row, or the mute toggle.
+    if let Some(slot) = props.music_dock_rect {
+        slot.set(Some(dock_area));
+    }
     let muted = props.paired_client.is_some_and(|client| client.muted);
     render_eq(frame, viz_area, props.marquee_tick, muted);
 

--- a/late-ssh/src/app/common/sidebar_test.rs
+++ b/late-ssh/src/app/common/sidebar_test.rs
@@ -60,6 +60,7 @@ fn stage_lines_with(
             icecast_source_count: 9,
             radio_source_count: 1,
             marquee_tick: 0,
+            music_dock_rect: None,
         },
     )
 }
@@ -166,6 +167,7 @@ fn radio_dock_row_prefers_sse_metadata() {
             icecast_source_count: 9,
             radio_source_count: 1,
             marquee_tick: 0,
+            music_dock_rect: None,
         },
     );
     let texts: Vec<String> = lines.iter().map(line_text).collect();
@@ -249,4 +251,23 @@ fn visible_components_skips_unfit_panel_without_stopping() {
         visible_components(&components, height),
         vec![RightSidebarComponent::Daily, RightSidebarComponent::Bonsai]
     );
+}
+
+#[test]
+fn music_stage_row_offsets_match_the_mouse_handler() {
+    // app::input::handle_music_stage_click maps dock click-rows to actions by
+    // these fixed offsets. If the stage layout is reordered, update both.
+    let radio = stage_lines(AudioSource::Radio);
+    assert!(line_text(&radio[1]).contains("mute"), "row 1 = mute hint");
+    assert!(line_text(&radio[2]).contains("radio"), "row 2 = radio header");
+    assert!(line_text(&radio[4]).contains("youtube"), "row 4 = youtube header");
+    assert!(line_text(&radio[6]).contains("icecast"), "row 6 = icecast header");
+    // Radio station selectors occupy detail rows 9..=13 (v1..v5).
+    assert!(line_text(&radio[9]).contains("v1"), "row 9 = radio v1");
+    assert!(line_text(&radio[13]).contains("v5"), "row 13 = radio v5");
+
+    // Icecast stream selectors occupy detail rows 10 and 11 (row 9 is progress).
+    let icecast = stage_lines(AudioSource::Icecast);
+    assert!(line_text(&icecast[10]).contains("v1"), "row 10 = icecast v1");
+    assert!(line_text(&icecast[11]).contains("v2"), "row 11 = icecast v2");
 }

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -2815,6 +2815,18 @@ fn handle_mouse_scroll_over_screen(
         return false;
     };
 
+    // Scrolling over the music stage adjusts the paired client's volume.
+    if let Some(dock) = app.last_music_dock_rect.get()
+        && rect_contains(dock, x, y)
+    {
+        if delta > 0 {
+            app.paired_client_volume_up();
+        } else {
+            app.paired_client_volume_down();
+        }
+        return true;
+    }
+
     if !matches!(screen, Screen::Dashboard) {
         return false;
     }
@@ -2871,6 +2883,79 @@ fn handle_pet_strip_click(app: &mut App, x: u16, y: u16) -> bool {
     false
 }
 
+/// Clicks on the sidebar music stage's render-recorded dock area. The row
+/// layout in `music_stage_lines` is fixed, so a click row maps to a source
+/// header (radio/youtube/icecast), a station/stream selector, or the mute
+/// toggle. Only live on frames where the stage drew.
+fn handle_music_stage_click(app: &mut App, x: u16, y: u16) -> bool {
+    use crate::app::common::primitives::Banner;
+    use late_core::models::user::AudioSource;
+
+    if chat_scroll_clicks_blocked(app) {
+        return false;
+    }
+    let Some(dock) = app.last_music_dock_rect.get() else {
+        return false;
+    };
+    if !rect_contains(dock, x, y) {
+        return false;
+    }
+    let rel = y - dock.y;
+
+    // Source headers and the mute row sit at fixed offsets in the dock.
+    match rel {
+        1 => {
+            app.toggle_paired_client_mute();
+            return true;
+        }
+        2 => {
+            app.set_paired_playback_source(AudioSource::Radio);
+            app.banner = Some(Banner::success("Audio source: Radio"));
+            return true;
+        }
+        4 => {
+            app.set_paired_playback_source(AudioSource::Youtube);
+            app.banner = Some(Banner::success("Audio source: YouTube"));
+            return true;
+        }
+        6 => {
+            app.set_paired_playback_source(AudioSource::Icecast);
+            app.banner = Some(Banner::success("Audio source: Icecast"));
+            return true;
+        }
+        _ => {}
+    }
+
+    // Selector rows in the detail area: radio stations start at dock row 9
+    // (v1..v5); icecast streams at row 10 (row 9 is the progress line).
+    use crate::app::audio::stations;
+    match app.paired_browser_source {
+        AudioSource::Radio if (9..=13).contains(&rel) => {
+            let index = (rel - 9 + 1) as u8;
+            if let Some(station) = stations::radio_station_by_index(index) {
+                app.select_radio_station(station);
+                app.banner = Some(Banner::success(&format!(
+                    "Station: {}",
+                    stations::radio_station_display_name(station)
+                )));
+            }
+            true
+        }
+        AudioSource::Icecast if (10..=11).contains(&rel) => {
+            let index = (rel - 10 + 1) as u8;
+            if let Some(stream) = stations::icecast_stream_by_index(index) {
+                app.select_icecast_stream(stream);
+                app.banner = Some(Banner::success(&format!(
+                    "Stream: {}",
+                    stations::icecast_stream_display_name(stream)
+                )));
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
 fn handle_mouse_click(app: &mut App, screen: Screen, mouse: MouseEvent) -> bool {
     if mouse.kind != MouseEventKind::Down || mouse.button != Some(MouseButton::Left) {
         return false;
@@ -2890,6 +2975,9 @@ fn handle_mouse_click(app: &mut App, screen: Screen, mouse: MouseEvent) -> bool 
         return true;
     }
     if handle_pet_strip_click(app, x, y) {
+        return true;
+    }
+    if handle_music_stage_click(app, x, y) {
         return true;
     }
     if handle_chat_scroll_click(app, screen, x, y) {

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -270,6 +270,7 @@ struct DrawContext<'a> {
     online_count: usize,
     active_friend_names: &'a [String],
     marquee_tick: usize,
+    music_dock_rect: &'a std::cell::Cell<Option<Rect>>,
     chat_state: &'a chat::state::ChatState,
     user_id: uuid::Uuid,
     pet_species: &'a str,
@@ -1056,6 +1057,7 @@ impl App {
                         online_count,
                         active_friend_names,
                         marquee_tick: self.marquee_tick,
+                        music_dock_rect: &self.last_music_dock_rect,
                         chat_state: &self.chat,
                         user_id: self.user_id,
                         pet_species: &self.pet_state.species,
@@ -1476,6 +1478,7 @@ impl App {
                     online_count: ctx.online_count,
                     active_friend_names: ctx.active_friend_names,
                     marquee_tick: ctx.marquee_tick,
+                    music_dock_rect: Some(ctx.music_dock_rect),
                 },
             );
         }
@@ -2075,6 +2078,7 @@ fn app_frame_help_hint_title(hint_style: HelpHintStyle) -> Line<'static> {
         ("Hub", ctrl_hint("G", use_caret)),
         ("Lobby", ctrl_hint("Q", use_caret)),
         ("Guide", "?"),
+        ("Exit", "qq"),
     ];
 
     let mut spans = Vec::new();

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -442,6 +442,9 @@ pub struct App {
     /// for the HUD click hit test; `None` when nothing is unread. Only the
     /// mentions segment is clickable, not the voice/chips text after it.
     pub(crate) last_mentions_hud_rect: std::cell::Cell<Option<Rect>>,
+    /// Dock area of the sidebar music stage, recorded each frame so the mouse
+    /// handler can click source headers / station rows / mute and scroll volume.
+    pub(crate) last_music_dock_rect: std::cell::Cell<Option<Rect>>,
     pub(crate) audio: crate::app::audio::state::AudioState,
     pub(crate) voice: crate::app::voice::state::VoiceState,
     pub(crate) voice_service: crate::app::voice::svc::VoiceService,
@@ -1174,6 +1177,7 @@ impl App {
             last_pet_strip_water_rect: std::cell::Cell::new(None),
             last_pet_strip_travel: std::cell::Cell::new(None),
             last_mentions_hud_rect: std::cell::Cell::new(None),
+            last_music_dock_rect: std::cell::Cell::new(None),
             audio: crate::app::audio::state::AudioState::new(config.audio_service, config.user_id),
             voice: crate::app::voice::state::VoiceState::new(config.voice_service),
             voice_service,
@@ -2283,14 +2287,24 @@ impl App {
             AudioSource::Youtube => AudioSource::Icecast,
             AudioSource::Icecast => AudioSource::Radio,
         };
-        self.paired_browser_source = next;
+        self.set_paired_playback_source(next)
+    }
+
+    /// Set the paired-browser audio source directly (mouse click on a dock
+    /// header). Mirrors [`Self::toggle_paired_playback_source`] but without
+    /// cycling. Returns the source set.
+    pub fn set_paired_playback_source(
+        &mut self,
+        source: late_core::models::user::AudioSource,
+    ) -> late_core::models::user::AudioSource {
+        self.paired_browser_source = source;
         if let Some(active_users) = &self.active_users
             && let Some(active) = active_users.lock_recover().get_mut(&self.user_id)
         {
-            active.audio_source = next;
+            active.audio_source = source;
         }
-        self.audio.persist_audio_source(next);
-        next
+        self.audio.persist_audio_source(source);
+        source
     }
 
     pub fn select_icecast_stream(&mut self, stream: late_core::models::user::IcecastStream) {


### PR DESCRIPTION
Two small home-screen quality-of-life changes.

## Footer: "Exit qq"
Adds `Exit qq` after `Guide ?` in the home footer. No behaviour change: `qq` already exits (first `q` opens the quit confirm, second `q` confirms), so this just surfaces the binding next to the others.

## Mouse-driven radio/music stage
The music stage was keyboard-only (v1..v5, v+x, m). It's now usable and configurable with the mouse. The stage records its dock area each frame; `app::input` maps clicks to actions by the stage's fixed row layout:

- **Click a source header** (radio / youtube / icecast) to switch the paired-browser source.
- **Click a station/stream row** to select it (v1..v5 for radio, v1/v2 for icecast).
- **Click the mute row** to toggle mute.
- **Scroll over the stage** to change the paired client's volume.

New `App::set_paired_playback_source` sets a source directly; the existing `toggle_paired_playback_source` now delegates to it. Threaded a single `Cell<Option<Rect>>` (the dock area) through `SidebarProps`/`MusicStageProps`, mirroring the existing pet-strip rect pattern, so the input handler can hit-test without new per-element plumbing.

## Tests
- New sidebar test pins the dock row offsets the click handler depends on (mute/radio/youtube/icecast headers, v1..v5 radio, v1/v2 icecast), so a future re-layout can't silently break the clicks.
- `clippy`/`fmt` clean on the changed code. Full lib test suite compiles; the only failures are pre-existing Postgres-backed `audio::svc_test` cases that need a local DB.

Note: terminal mouse events couldn't be driven in my environment, so the offsets are verified by the guard test and the deterministic layout rather than a live click, worth a quick manual check on your end.

Thanks @mpiorowski for late.sh.
