### PR TITLE
Stabilize adaptive tick tests under scheduler load

### DIFF
--- a/late-core/src/db.rs
+++ b/late-core/src/db.rs
@@ -193,3 +193,24 @@ impl Db {
         Ok(())
     }
 }
+
+/// Stable fingerprint of the embedded migration set.
+///
+/// Every migration's name and body is length-prefixed into the hash, so any
+/// edit, addition, removal, or rename produces a different value. Test-database
+/// templating (`test_utils`) keys its template name on this, which is what makes
+/// a stale template impossible rather than merely unlikely: change a migration
+/// and the next run simply builds a template under a new name.
+#[cfg(feature = "testing")]
+pub(crate) fn migrations_fingerprint() -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    for (name, sql) in MIGRATIONS {
+        hasher.update((name.len() as u64).to_le_bytes());
+        hasher.update(name.as_bytes());
+        hasher.update((sql.len() as u64).to_le_bytes());
+        hasher.update(sql.as_bytes());
+    }
+    hex::encode(&hasher.finalize()[..8])
+}

--- a/late-core/src/test_utils.rs
+++ b/late-core/src/test_utils.rs
@@ -1,8 +1,26 @@
 use crate::db::{Db, DbConfig};
 use crate::models::user::{User, UserParams};
-use tokio_postgres::NoTls;
+use anyhow::{Context, Result, bail};
+use std::time::{Duration, Instant};
+use tokio_postgres::{Client, NoTls};
 
 const TEST_DB_POOL_SIZE: usize = 8;
+
+/// Set `LATE_TEST_DB_TEMPLATE=0` to force every test database through the plain
+/// `CREATE DATABASE` + `migrate()` path. An escape hatch, not a tuning knob: the
+/// templated path already falls back on its own if anything goes wrong.
+const TEMPLATE_ENV: &str = "LATE_TEST_DB_TEMPLATE";
+
+/// How long a process waits on whichever peer is building the template before
+/// giving up and migrating its own database. Building it is one migration
+/// replay — well under a second locally, a few seconds on a cold CI runner — so
+/// this is pure headroom: it exists so that a wedged builder degrades the suite
+/// to "slow" rather than "hung".
+const TEMPLATE_WAIT: Duration = Duration::from_secs(120);
+const TEMPLATE_POLL: Duration = Duration::from_millis(50);
+
+/// Attempts at `CREATE DATABASE ... TEMPLATE` before falling back to migrating.
+const TEMPLATE_CREATE_ATTEMPTS: u32 = 3;
 
 pub struct TestDb {
     pub db: Db,
@@ -17,54 +35,322 @@ pub async fn test_db() -> TestDb {
     test_db_external(&url).await
 }
 
+/// The server test databases are provisioned on, minus the database name.
+#[derive(Clone)]
+struct Server {
+    host: String,
+    port: u16,
+    user: String,
+    password: String,
+}
+
+impl Server {
+    fn parse(url: &str) -> Self {
+        let config: tokio_postgres::Config = url.parse().expect("parse TEST_DATABASE_URL");
+
+        Self {
+            host: config
+                .get_hosts()
+                .first()
+                .map(|h| match h {
+                    tokio_postgres::config::Host::Tcp(s) => s.clone(),
+                    _ => "127.0.0.1".to_string(),
+                })
+                .unwrap_or_else(|| "127.0.0.1".to_string()),
+            port: config.get_ports().first().copied().unwrap_or(5432),
+            user: config.get_user().unwrap_or("postgres").to_string(),
+            password: config
+                .get_password()
+                .map(|p| String::from_utf8_lossy(p).to_string())
+                .unwrap_or_else(|| "postgres".to_string()),
+        }
+    }
+
+    fn db_config(&self, dbname: String, max_pool_size: usize) -> DbConfig {
+        DbConfig {
+            host: self.host.clone(),
+            port: self.port,
+            user: self.user.clone(),
+            password: self.password.clone(),
+            dbname,
+            max_pool_size,
+        }
+    }
+
+    /// A single unpooled connection, so callers own its exact lifetime — which
+    /// is what makes the session advisory lock below safe.
+    async fn connect(&self, dbname: &str) -> Result<Client> {
+        let Self {
+            host,
+            port,
+            user,
+            password,
+        } = self;
+        let (client, conn) = tokio_postgres::connect(
+            &format!("host={host} port={port} user={user} password={password} dbname={dbname}"),
+            NoTls,
+        )
+        .await
+        .with_context(|| format!("connect to database {dbname}"))?;
+        tokio::spawn(conn);
+        Ok(client)
+    }
+}
+
 /// Connect to an already-running postgres and create a unique database.
 async fn test_db_external(url: &str) -> TestDb {
-    let admin_config: tokio_postgres::Config = url.parse().expect("parse TEST_DATABASE_URL");
-
-    let host = admin_config
-        .get_hosts()
-        .first()
-        .map(|h| match h {
-            tokio_postgres::config::Host::Tcp(s) => s.clone(),
-            _ => "127.0.0.1".to_string(),
-        })
-        .unwrap_or_else(|| "127.0.0.1".to_string());
-    let port = admin_config.get_ports().first().copied().unwrap_or(5432);
-    let user = admin_config.get_user().unwrap_or("postgres").to_string();
-    let password = admin_config
-        .get_password()
-        .map(|p| String::from_utf8_lossy(p).to_string())
-        .unwrap_or_else(|| "postgres".to_string());
+    let server = Server::parse(url);
 
     // Each test gets its own database to avoid conflicts.
     let db_name = format!("test_{}", uuid::Uuid::now_v7().to_string().replace('-', ""));
 
     // Connect to the default database to create our test database.
-    let admin_conn_str =
-        format!("host={host} port={port} user={user} password={password} dbname=postgres");
-    let (client, conn) = tokio_postgres::connect(&admin_conn_str, NoTls)
+    let admin = server
+        .connect("postgres")
         .await
         .expect("connect to admin postgres");
-    tokio::spawn(conn);
-    client
-        .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
-        .await
-        .expect("create test database");
-    drop(client);
 
-    let config = DbConfig {
-        host,
-        port,
-        user,
-        password,
-        dbname: db_name,
-        max_pool_size: TEST_DB_POOL_SIZE,
-    };
+    // Copying a pre-migrated template beats replaying every migration, and the
+    // suite provisions hundreds of these. Any trouble falls back to the plain
+    // path: a test must never fail merely because templating was unavailable.
+    let templated = templating_enabled()
+        && match provision_from_template(&admin, &server, &db_name).await {
+            Ok(()) => true,
+            Err(e) => {
+                eprintln!("late-core test_db: templating unavailable, migrating instead ({e:#})");
+                false
+            }
+        };
 
-    let db = Db::new(&config).expect("create db");
-    db.migrate().await.expect("migrate db");
+    if !templated {
+        admin
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\""))
+            .await
+            .expect("create test database");
+    }
+    drop(admin);
+
+    let db = Db::new(&server.db_config(db_name, TEST_DB_POOL_SIZE)).expect("create db");
+    if !templated {
+        // A templated database is a copy of an already-migrated one, its
+        // `_migrations` bookkeeping included, so there is nothing left to apply.
+        db.migrate().await.expect("migrate db");
+    }
 
     TestDb { db }
+}
+
+fn templating_enabled() -> bool {
+    !matches!(
+        std::env::var(TEMPLATE_ENV).as_deref(),
+        Ok("0" | "false" | "off" | "no")
+    )
+}
+
+/// Create `db_name` as a copy of the migrated template, building that template
+/// first if this is the process that got there first.
+async fn provision_from_template(admin: &Client, server: &Server, db_name: &str) -> Result<()> {
+    let template = format!("late_tmpl_{}", crate::db::migrations_fingerprint());
+
+    if !database_exists(admin, &template).await? {
+        ensure_template(server, &template).await?;
+    }
+
+    let sql = format!("CREATE DATABASE \"{db_name}\" TEMPLATE \"{template}\"");
+    let mut attempts = TEMPLATE_CREATE_ATTEMPTS;
+    loop {
+        match admin.batch_execute(&sql).await {
+            Ok(()) => return Ok(()),
+            Err(e) => {
+                attempts -= 1;
+                if attempts == 0 {
+                    // A failed CREATE DATABASE rolls its own catalog row back,
+                    // but drop defensively so the caller's fallback cannot trip
+                    // over a half-created name.
+                    let _ = admin
+                        .batch_execute(&format!("DROP DATABASE IF EXISTS \"{db_name}\""))
+                        .await;
+                    return Err(anyhow::Error::new(e))
+                        .with_context(|| format!("copy template {template} into {db_name}"));
+                }
+                tokio::time::sleep(TEMPLATE_POLL).await;
+            }
+        }
+    }
+}
+
+/// Build the template unless somebody already has, waiting out whichever
+/// process is currently doing it.
+///
+/// The coordination is a Postgres session advisory lock rather than anything
+/// in-process, because nextest runs every test in its own process: "set this up
+/// once, before the concurrent work starts" has to be agreed through the only
+/// thing all those processes share, which is the server itself. The lock sits on
+/// a dedicated connection so a builder that panics or gets killed releases it
+/// when its backend exits, instead of wedging every other process.
+async fn ensure_template(server: &Server, template: &str) -> Result<()> {
+    let client = server.connect("postgres").await?;
+    let key = advisory_key(template);
+    let deadline = Instant::now() + TEMPLATE_WAIT;
+
+    loop {
+        let acquired: bool = client
+            .query_one("SELECT pg_try_advisory_lock($1)", &[&key])
+            .await
+            .context("take template build lock")?
+            .get(0);
+        if acquired {
+            break;
+        }
+        // Somebody else is building it. Watch for the finished article rather
+        // than for the lock: the moment it appears we are done, lock or no lock.
+        if database_exists(&client, template).await? {
+            return Ok(());
+        }
+        if Instant::now() >= deadline {
+            bail!("timed out waiting for another process to build template {template}");
+        }
+        tokio::time::sleep(TEMPLATE_POLL).await;
+    }
+
+    let built = build_template(&client, server, template).await;
+    let _ = client
+        .execute("SELECT pg_advisory_unlock($1)", &[&key])
+        .await;
+    built
+}
+
+/// Migrate a fresh database and publish it as the template. Caller holds the
+/// build lock.
+async fn build_template(admin: &Client, server: &Server, template: &str) -> Result<()> {
+    // Re-check under the lock: the peer we queued behind may have just finished.
+    if database_exists(admin, template).await? {
+        return Ok(());
+    }
+
+    // Migrate under a scratch name and rename only on success, so a builder
+    // killed mid-migration leaves behind a scratch database rather than a
+    // half-migrated one under the name every other process trusts. Existence of
+    // the final name means "finished", full stop.
+    let scratch = format!(
+        "{template}_b{}",
+        &uuid::Uuid::now_v7().simple().to_string()[..12]
+    );
+    admin
+        .batch_execute(&format!("CREATE DATABASE \"{scratch}\""))
+        .await
+        .with_context(|| format!("create scratch database {scratch}"))?;
+
+    // Migrated through the ordinary path, so the template is exactly what the
+    // fallback would have produced — and the pool is dropped before we seal it.
+    let migrated = async {
+        let db = Db::new(&server.db_config(scratch.clone(), 1))?;
+        db.migrate().await
+    }
+    .await;
+
+    let published = match migrated {
+        Ok(()) => publish_template(admin, &scratch, template).await,
+        Err(e) => Err(e).with_context(|| format!("migrate template {template}")),
+    };
+    if published.is_err() {
+        let _ = admin
+            .batch_execute(&format!("DROP DATABASE IF EXISTS \"{scratch}\""))
+            .await;
+    }
+    published
+}
+
+/// Close everything attached to `scratch`, make it unconnectable, and rename it
+/// into place as `template`.
+async fn publish_template(admin: &Client, scratch: &str, template: &str) -> Result<()> {
+    // `ALTER DATABASE ... RENAME` and `CREATE DATABASE ... TEMPLATE` both refuse
+    // to run while any backend is attached to the database in question, and the
+    // migration pool above closes its connections asynchronously. Force them
+    // shut and wait for the count to reach zero rather than hoping the pool's
+    // drop has already landed.
+    disconnect_all(admin, scratch).await?;
+
+    // Sealed before it is published, so the template is never connectable under
+    // its final name. That demotes "source database is being accessed by other
+    // users" — the error that makes naive templating flaky — from unlikely to
+    // unreachable, because nothing can attach to it in the first place.
+    admin
+        .batch_execute(&format!(
+            "ALTER DATABASE \"{scratch}\" WITH ALLOW_CONNECTIONS false"
+        ))
+        .await
+        .with_context(|| format!("seal template {scratch}"))?;
+
+    if let Err(e) = admin
+        .batch_execute(&format!(
+            "ALTER DATABASE \"{scratch}\" RENAME TO \"{template}\""
+        ))
+        .await
+    {
+        // Lost a race with a builder that was not holding our lock. Its template
+        // is as good as ours, so drop ours and use theirs.
+        if !database_exists(admin, template).await.unwrap_or(false) {
+            return Err(anyhow::Error::new(e))
+                .with_context(|| format!("publish template {template}"));
+        }
+        let _ = admin
+            .batch_execute(&format!("DROP DATABASE IF EXISTS \"{scratch}\""))
+            .await;
+    }
+
+    Ok(())
+}
+
+/// Terminate every other backend attached to `dbname` and wait for the count to
+/// reach zero.
+async fn disconnect_all(admin: &Client, dbname: &str) -> Result<()> {
+    const ATTEMPTS: u32 = 100;
+    const POLL: Duration = Duration::from_millis(20);
+
+    for _ in 0..ATTEMPTS {
+        let remaining: i64 = admin
+            .query_one(
+                "SELECT count(*) FROM pg_stat_activity
+                 WHERE datname = $1 AND pid <> pg_backend_pid()",
+                &[&dbname],
+            )
+            .await
+            .with_context(|| format!("count backends on {dbname}"))?
+            .get(0);
+        if remaining == 0 {
+            return Ok(());
+        }
+        admin
+            .execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity
+                 WHERE datname = $1 AND pid <> pg_backend_pid()",
+                &[&dbname],
+            )
+            .await
+            .with_context(|| format!("terminate backends on {dbname}"))?;
+        tokio::time::sleep(POLL).await;
+    }
+
+    bail!("connections to {dbname} would not close")
+}
+
+async fn database_exists(client: &Client, name: &str) -> Result<bool> {
+    Ok(client
+        .query_opt("SELECT 1 FROM pg_database WHERE datname = $1", &[&name])
+        .await
+        .with_context(|| format!("look up database {name}"))?
+        .is_some())
+}
+
+/// Advisory-lock key for a template name. Derived from the name — and so from
+/// the migration fingerprint in it — so two different migration sets never
+/// serialize against each other.
+fn advisory_key(template: &str) -> i64 {
+    use sha2::{Digest, Sha256};
+
+    let digest = Sha256::digest(template.as_bytes());
+    i64::from_le_bytes(digest[..8].try_into().expect("sha256 yields 32 bytes"))
 }
 
 /// Create a user for integration tests. Returns the `User`.

--- a/late-ssh/src/app/tick_test.rs
+++ b/late-ssh/src/app/tick_test.rs
@@ -1,11 +1,15 @@
 use std::time::{Duration, Instant};
 
 use late_core::models::user::RightSidebarMode;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 
+use crate::app::chat::svc::ChatEvent;
 use crate::app::state::App;
 use crate::app::tick::{ANIM_HALF_TICK, HOT_TICK, IDLE_TICK};
 use crate::test_helpers::chat_compose_app;
+
+const CLEAN_SETTLE_WINDOW: Duration = Duration::from_millis(250);
+const CLEAN_SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// The ambient sidebar wave paints on anim_half edges whenever the right
 /// sidebar is visible, so a session showing it never settles by design.
@@ -23,22 +27,27 @@ fn drain_frame(app: &mut App) {
     let _ = std::mem::take(&mut app.pending_terminal_commands);
 }
 
-/// Drive ticks until `consecutive` in a row report no change. Initial
+/// Drive ticks until the app stays clean for a wall-clock window. Initial
 /// prefetches, the splash, chat refresh cadence, and at most one clock
-/// rollover may keep early ticks dirty, so this loops with a deadline
-/// instead of asserting on a fixed tick count.
-async fn settle_clean(app: &mut App, consecutive: usize) {
-    let deadline = Instant::now() + Duration::from_secs(10);
-    let mut clean = 0usize;
-    while Instant::now() < deadline {
-        if app.tick() {
-            clean = 0;
+/// rollover may keep early ticks dirty. Wall time, rather than a count of
+/// 5ms sleeps, keeps scheduler load from changing the success condition.
+async fn settle_clean(app: &mut App) {
+    let deadline = Instant::now() + CLEAN_SETTLE_TIMEOUT;
+    let mut clean_since = None;
+    loop {
+        let changed = app.tick();
+        let now = Instant::now();
+        if changed {
+            clean_since = None;
             drain_frame(app);
         } else {
-            clean += 1;
-            if clean >= consecutive {
+            let since = clean_since.get_or_insert(now);
+            if now.duration_since(*since) >= CLEAN_SETTLE_WINDOW {
                 return;
             }
+        }
+        if Instant::now() >= deadline {
+            break;
         }
         sleep(Duration::from_millis(5)).await;
     }
@@ -47,11 +56,12 @@ async fn settle_clean(app: &mut App, consecutive: usize) {
     let screen_before = app.screen;
     let dirty_again = app.tick();
     panic!(
-        "app never settled to {consecutive} consecutive clean ticks\n\
+        "app never stayed clean for {}ms\n\
          one more tick changed={dirty_again} screen={screen_before:?}->{:?}\n\
          chat_epoch {context_epoch_before}->{} app_epoch {app_epoch_before}->{}\n\
          splash={} banner={} outbox={} term_cmds={} clipboard={} image_modal={}\n\
          settings={} ultimate={} hub={} lobby={} profile={} bonsai={} bonsai2={} poll={} icon={} booth={} search={}",
+        CLEAN_SETTLE_WINDOW.as_millis(),
         app.screen,
         app.chat.context_epoch(),
         app.chat_ctx_epoch,
@@ -83,22 +93,38 @@ async fn idle_ticks_settle_clean_and_chat_send_marks_changed() {
     let (_test_db, mut app) = chat_compose_app("tick-gate").await;
     hide_sidebar(&mut app);
 
-    settle_clean(&mut app, 30).await;
+    settle_clean(&mut app).await;
 
+    let mut chat_events = app.chat.service.subscribe_events();
+    let user_id = app.user_id;
     app.handle_input(b"hello\r");
-    let deadline = Instant::now() + Duration::from_secs(5);
-    let mut woke = false;
-    while Instant::now() < deadline {
-        if app.tick() {
-            woke = true;
-            drain_frame(&mut app);
-            break;
+    timeout(Duration::from_secs(5), async {
+        loop {
+            match chat_events.recv().await {
+                Ok(ChatEvent::MessageCreated { message, .. })
+                    if message.user_id == user_id && message.body == "hello" =>
+                {
+                    return;
+                }
+                Ok(_) => {}
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    panic!("chat event receiver lagged by {skipped} events");
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    panic!("chat event channel closed before the message was created");
+                }
+            }
         }
-        sleep(Duration::from_millis(5)).await;
-    }
-    assert!(woke, "chat send never produced a changed tick");
+    })
+    .await
+    .expect("chat send never produced MessageCreated");
+    assert!(
+        app.tick(),
+        "queued chat message event did not dirty the tick"
+    );
+    drain_frame(&mut app);
 
-    settle_clean(&mut app, 30).await;
+    settle_clean(&mut app).await;
 }
 
 /// The adaptive loop's cadence contract: a settled idle session on a
@@ -110,7 +136,7 @@ async fn wake_hint_idles_when_settled_and_heats_on_input() {
     let (_test_db, mut app) = chat_compose_app("wake-hint").await;
     hide_sidebar(&mut app);
 
-    settle_clean(&mut app, 30).await;
+    settle_clean(&mut app).await;
 
     // Age the app past the post-input hot window.
     app.last_input_at = Instant::now() - Duration::from_secs(10);
@@ -129,7 +155,7 @@ async fn open_ultimate_modal_settles_clean_then_fires_once_on_ready() {
     let (_test_db, mut app) = chat_compose_app("tick-gate-ultimate").await;
     hide_sidebar(&mut app);
 
-    settle_clean(&mut app, 30).await;
+    settle_clean(&mut app).await;
 
     app.ultimate_state.set_cooldown(
         crate::app::ultimates::UltimateKind::Wonderland.id(),
@@ -137,7 +163,7 @@ async fn open_ultimate_modal_settles_clean_then_fires_once_on_ready() {
     );
     app.show_ultimate_modal = true;
     drain_frame(&mut app);
-    settle_clean(&mut app, 30).await;
+    settle_clean(&mut app).await;
 
     app.ultimate_state.set_cooldown(
         crate::app::ultimates::UltimateKind::Wonderland.id(),
@@ -155,7 +181,7 @@ async fn open_ultimate_modal_settles_clean_then_fires_once_on_ready() {
     }
     assert!(woke, "cooldown expiry never produced a changed tick");
 
-    settle_clean(&mut app, 30).await;
+    settle_clean(&mut app).await;
 }
 
 /// Phase-1 tightening: an open, untouched modal is static between async
@@ -167,13 +193,13 @@ async fn open_settings_modal_settles_clean() {
     let (_test_db, mut app) = chat_compose_app("tick-gate-modal").await;
     hide_sidebar(&mut app);
 
-    settle_clean(&mut app, 30).await;
+    settle_clean(&mut app).await;
 
     app.handle_input(&[0x0F]); // Ctrl+O
     assert!(app.show_settings, "ctrl+o opens the settings modal");
     drain_frame(&mut app);
 
-    settle_clean(&mut app, 30).await;
+    settle_clean(&mut app).await;
 }
 
 /// The always-on ambient wave: a session showing the sidebar never goes

--- a/late-ssh/src/test_helpers.rs
+++ b/late-ssh/src/test_helpers.rs
@@ -45,6 +45,11 @@ use tokio::sync::{Semaphore, broadcast, watch};
 use tokio::time::{Duration, Instant, sleep};
 use uuid::Uuid;
 
+/// Watchdog for exact asynchronous test conditions backed by real Postgres.
+/// CI runs several migration-heavy test databases concurrently, so startup
+/// can legitimately take longer than the condition itself needs once ready.
+const ASYNC_TEST_TIMEOUT: Duration = Duration::from_secs(15);
+
 pub async fn new_test_db() -> TestDb {
     test_db().await
 }
@@ -700,7 +705,7 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = bool>,
 {
-    let deadline = Instant::now() + Duration::from_secs(3);
+    let deadline = Instant::now() + ASYNC_TEST_TIMEOUT;
     while Instant::now() < deadline {
         if predicate().await {
             return;
@@ -734,7 +739,7 @@ pub async fn chat_compose_app(name: &str) -> (TestDb, App) {
 }
 
 pub async fn wait_for_render_contains(app: &mut App, needle: &str) {
-    let deadline = Instant::now() + Duration::from_secs(3);
+    let deadline = Instant::now() + ASYNC_TEST_TIMEOUT;
     let mut last_plain = String::new();
     while Instant::now() < deadline {
         app.tick();


### PR DESCRIPTION
- Settle based on elapsed clean time instead of tick counts
- Synchronize chat wake assertions with message creation events