### PR TITLE
Fix test overly sensitive to runner load

### DIFF
--- a/late-core/src/models/chat_room_test.rs
+++ b/late-core/src/models/chat_room_test.rs
@@ -271,7 +271,12 @@ async fn room_state_caps_the_unread_count() {
         "a room with more unread than the cap reports exactly the cap, not the true total"
     );
     assert!(
-        state.last_message_at.get(&room.id).copied().flatten().is_some(),
+        state
+            .last_message_at
+            .get(&room.id)
+            .copied()
+            .flatten()
+            .is_some(),
         "the room carries the timestamp of its newest message"
     );
 }

--- a/late-ssh/src/app/tick_test.rs
+++ b/late-ssh/src/app/tick_test.rs
@@ -1,6 +1,7 @@
 use std::time::{Duration, Instant};
 
 use late_core::models::user::RightSidebarMode;
+use late_core::models::user_ssh_key::KeyLayout;
 use tokio::time::{sleep, timeout};
 
 use crate::app::chat::svc::ChatEvent;
@@ -15,8 +16,22 @@ const CLEAN_SETTLE_TIMEOUT: Duration = Duration::from_secs(10);
 /// sidebar is visible, so a session showing it never settles by design.
 /// Settle-based tests turn the sidebar off to exercise the gate beneath;
 /// `sidebar_wave_holds_half_rate_and_paints_on_edges` covers the wave path.
+///
+/// This writes the per-device rails rather than the profile. `ProfileState::
+/// drain_snapshot` replaces the whole profile every time a `ProfileService`
+/// snapshot lands, so a profile-level edit here survives only until the
+/// session's first profile prefetch arrives. That prefetch is async: on an
+/// unloaded machine it lands before the settle loop starts, but under load it
+/// lands mid-settle, silently restores the account's `On`, and switches the
+/// wave back on -- at which point the app dirties every anim_half edge
+/// (~132ms) and can never hold the 250ms window, at any timeout. `device_rails`
+/// takes precedence over the profile in `device_rails_or_profile` and nothing
+/// async overwrites it, so the sidebar stays off for the whole test.
 fn hide_sidebar(app: &mut App) {
-    app.profile_state.profile.right_sidebar_mode = RightSidebarMode::Off;
+    app.device_rails = Some(KeyLayout {
+        room_list_mode: app.rail_modes().0,
+        right_sidebar_mode: RightSidebarMode::Off,
+    });
 }
 
 /// Mirror the render loop's frame path: a changed tick renders and drains


### PR DESCRIPTION
## How this preserves test intent while introducing runner load tolerance

The diff is one import and the helper's body. `settle_clean`'s 250ms window, its 10s budget, and every assertion in all five tests are untouched — nothing was loosened, lengthened, or retried.

Hiding the sidebar is a precondition, not the subject. These tests assert that a session settles to clean ticks; the sidebar is off only to get the always-on ambient wave out of the way, since a session showing it never settles *by design*. The fix changes how that precondition is established, not what is measured.  And the old helper wasn't asserting something stronger — it was asserting something false. When the profile prefetch won the race, the sidebar came back on and the test went on to demand that a session with a live wave settle clean, the opposite of the documented contract. The failure was the fixture evaporating, not the gate breaking.

Coverage is unchanged: `sidebar_wave_holds_half_rate_and_paints_on_edges` is the one test that deliberately skips `hide_sidebar`, and it still asserts the visible sidebar holds `ANIM_HALF_TICK` and pays edge frames but only those.  Per-device rails are also how production resolves this — a real keyed session carries a device layout; the test app has none, which is why the profile was governing at all.

