### PR TITLE
fix(lateania): loot slots, pet skills, Sunderlakes tier, ability name, docs

### DIFF
--- a/late-ssh/src/app/door/lateania/abilities.rs
+++ b/late-ssh/src/app/door/lateania/abilities.rs
@@ -751,7 +751,7 @@ pub const ABILITIES: &[Ability] = &[
     },
     Ability {
         id: 504,
-        name: "Mend Companion",
+        name: "Field Dressing",
         desc: "Tend your own hurts with the field-craft of a thousand camps.",
         class: Class::Ranger,
         level_req: 16,

--- a/late-ssh/src/app/door/lateania/items.rs
+++ b/late-ssh/src/app/door/lateania/items.rs
@@ -1648,18 +1648,15 @@ pub fn kaelmyr_loot(tier: usize) -> &'static [u32] {
 }
 
 fn generated_loot_tables(base_id: u32, tiers: usize) -> Vec<Vec<u32>> {
+    // Each tier's 10 ids are the 8 gear pieces (offsets 0-7, in WEARABLE order:
+    // Weapon, Head, Chest, Legs, Hands, Feet, Ring, Trinket) plus a draught (8)
+    // and a sellable relic (9). Drop the whole block so every slot can progress -
+    // the earlier hand-picked subset skipped offsets 3/5/7, which are exactly
+    // Legs/Feet/Trinket, leaving those slots stuck on their starting gear.
     (0..tiers as u32)
         .map(|t| {
             let base = base_id + t * 10;
-            vec![
-                base,
-                base + 1,
-                base + 2,
-                base + 4,
-                base + 6,
-                base + 8,
-                base + 9,
-            ]
+            (0..10).map(|i| base + i).collect()
         })
         .collect()
 }

--- a/late-ssh/src/app/door/lateania/items_test.rs
+++ b/late-ssh/src/app/door/lateania/items_test.rs
@@ -378,3 +378,21 @@ fn frontier_relics_state_they_are_not_combat_items() {
         );
     }
 }
+
+#[test]
+fn generated_loot_covers_the_previously_dropped_gear_slots() {
+    // Offsets 3/5/7 in each tier block are Legs/Feet/Trinket; the old loot table
+    // skipped them, so those two-plus slots never progressed from drops. Guard
+    // that every tier now drops the full gear block (offsets 0..=7).
+    let tables = super::generated_loot_tables(super::FRONTIER_ITEM_BASE, super::FRONTIER_TIERS);
+    assert_eq!(tables.len(), super::FRONTIER_TIERS);
+    for (t, table) in tables.iter().enumerate() {
+        let base = super::FRONTIER_ITEM_BASE + t as u32 * 10;
+        for offset in 0u32..8 {
+            assert!(
+                table.contains(&(base + offset)),
+                "tier {t} loot table missing gear offset {offset}"
+            );
+        }
+    }
+}

--- a/late-ssh/src/app/door/lateania/taming.rs
+++ b/late-ssh/src/app/door/lateania/taming.rs
@@ -11,8 +11,9 @@
 //     cooldown on a failed tame).
 //   * The taming success mechanic (`tame_chance`), driven by how far the tamer's
 //     Animal Taming level exceeds the beast's required level.
-//   * The pet **auto-skills** - abilities keyed to a pet's level (by size class)
-//     that fire automatically in the combat round (see `svc.rs`).
+//   * The pet **auto-skills** - abilities keyed to a pet's level, firing
+//     automatically in the combat round (see `svc.rs`). Their raw power scales
+//     with the pet's own attack, so a bigger beast hits harder on the same rung.
 //
 // The world wiring (the taming action, the panel, and the pet auto-skill combat
 // step) lives in `svc.rs` / `state.rs` / `ui.rs`; only the data and the pure
@@ -582,11 +583,12 @@ pub fn tame_xp(beast: &PetSpecies) -> i32 {
 // ---- Pet auto-skills ------------------------------------------------------
 //
 // A companion (bought or tamed) unlocks abilities as it gains levels, and they
-// fire automatically in the combat round on their own cooldowns. The set a pet
-// gets is keyed to its **size class** (derived from base health), so a hare
-// learns light, quick tricks and a wyrm learns devastating ones - but every pet
-// walks the same unlock ladder (L3 / L8 / L15 / L22 / L30) surfaced in the pet
-// view so the player sees what is coming.
+// fire automatically in the combat round on their own cooldowns. Every pet walks
+// the same unlock ladder, keyed to its **level** (L2 / L4 / L6 / L8 / L10,
+// surfaced in the pet view so the player sees what is coming). The skills aren't
+// varied by species; instead each one's power scales with the pet's own attack
+// in `svc.rs`, so a wyrm's Savage Bite lands far harder than a hare's on the
+// same rung.
 
 /// What an auto-skill does when it fires in the combat round. Resolved in
 /// `svc.rs` against the existing combat machinery (bonus damage, mob DoTs via
@@ -619,40 +621,41 @@ pub struct PetSkill {
     pub power: i32,
 }
 
-/// The unlock ladder shared by every companion. The five rungs unlock at L3, L8,
-/// L15, L22 and L30. (Pets currently cap at level 10 via loyalty, so the higher
-/// rungs reward the most-fed, most-loyal companions.)
+/// The unlock ladder shared by every companion. The five rungs unlock at L2, L4,
+/// L6, L8 and L10, so a well-fed, loyal companion reaches all five within the
+/// `PET_MAX_LEVEL` (10) loyalty cap. (They previously unlocked at 3/8/15/22/30,
+/// which left the top three rungs dead content behind the cap.)
 pub const PET_SKILLS: &[PetSkill] = &[
     PetSkill {
-        level: 3,
+        level: 2,
         name: "Savage Bite",
         effect: PetSkillEffect::SavageBite,
         cooldown: 3,
         power: 6,
     },
     PetSkill {
-        level: 8,
+        level: 4,
         name: "Rend",
         effect: PetSkillEffect::Rend,
         cooldown: 4,
         power: 4,
     },
     PetSkill {
-        level: 15,
+        level: 6,
         name: "Intimidating Roar",
         effect: PetSkillEffect::Roar,
         cooldown: 6,
         power: 5,
     },
     PetSkill {
-        level: 22,
+        level: 8,
         name: "Loyal Guard",
         effect: PetSkillEffect::Guard,
         cooldown: 6,
         power: 12,
     },
     PetSkill {
-        level: 30,
+        level: 10,
         name: "Killing Pounce",
         effect: PetSkillEffect::Pounce,
         cooldown: 7,

--- a/late-ssh/src/app/door/lateania/taming_test.rs
+++ b/late-ssh/src/app/door/lateania/taming_test.rs
@@ -78,12 +78,19 @@ fn tame_chance_rises_with_surplus_and_refuses_under_level() {
 
 #[test]
 fn pet_skills_unlock_on_the_ladder() {
-    assert_eq!(pet_skills_at(1).count(), 0, "no skills before level 3");
-    assert_eq!(pet_skills_at(3).count(), 1, "savage bite at 3");
-    assert_eq!(pet_skills_at(8).count(), 2, "rend at 8");
-    assert_eq!(pet_skills_at(15).count(), 3, "roar at 15");
-    assert_eq!(pet_skills_at(22).count(), 4, "guard at 22");
-    assert_eq!(pet_skills_at(30).count(), PET_SKILLS.len(), "pounce at 30");
+    assert_eq!(pet_skills_at(1).count(), 0, "no skills before level 2");
+    assert_eq!(pet_skills_at(2).count(), 1, "savage bite at 2");
+    assert_eq!(pet_skills_at(4).count(), 2, "rend at 4");
+    assert_eq!(pet_skills_at(6).count(), 3, "roar at 6");
+    assert_eq!(pet_skills_at(8).count(), 4, "guard at 8");
+    assert_eq!(pet_skills_at(10).count(), PET_SKILLS.len(), "pounce at 10");
+    // Every rung is reachable within the pet level cap.
+    assert!(
+        PET_SKILLS
+            .iter()
+            .all(|s| s.level <= super::super::pets::PET_MAX_LEVEL),
+        "all pet skills unlock at or below PET_MAX_LEVEL"
+    );
     // Unlock levels are strictly increasing.
     for w in PET_SKILLS.windows(2) {
         assert!(w[1].level > w[0].level, "pet skill unlocks climb");

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -4980,12 +4980,14 @@ fn tune_spawn_balance(spawns: &mut [MobSpawn]) {
         // Kaelmyr (mob ids 960000+) rides the same endgame multipliers; its
         // authored base stats simply sit a full continent higher on the curve.
         let reaches = (REACHES_SPAWN_ID_START..KAELMYR_SPAWN_ID_START).contains(&spawn.id);
-        // Kaelmyr owns 960000+, but later peaceful/mid continents (the lakes at
-        // 980000+, Broceliande at 990000+) sit above it. The lakes and archipelago
-        // ride the endgame band with deliberately tiny base stats; Broceliande is
-        // its own moderate green continent, so it is excluded here and keeps the
-        // gentle overworld multipliers instead of the endgame ones.
-        let kaelmyr = (KAELMYR_SPAWN_ID_START..BROCELIANDE_SPAWN_ID_START).contains(&spawn.id);
+        // Kaelmyr owns 960000+ and the deadly archipelago (970000+) rides the same
+        // endgame band. The later continents sit above them but are NOT endgame:
+        // the Sunderlakes (980000+) are a peaceful fishing country and Broceliande
+        // (990000+) a moderate green continent, so both are excluded here and keep
+        // the gentle overworld multipliers instead of the endgame ones. (The lakes
+        // used to ride the endgame band, which made a "peaceful" region hit like
+        // Kaelmyr - the bug this range fixes.)
+        let kaelmyr = (KAELMYR_SPAWN_ID_START..LAKES_SPAWN_ID_START).contains(&spawn.id);
         let endgame = frontier || reaches || kaelmyr;
         let living_dark = is_living_dark_spawn(spawn.id);
         let (hp_num, hp_den, dmg_num, dmg_den, xp_num, xp_den) =

--- a/late-ssh/src/app/door/lateania/world_test.rs
+++ b/late-ssh/src/app/door/lateania/world_test.rs
@@ -1431,3 +1431,27 @@ fn yssgar_out_toughens_and_out_earns_the_frontier_king() {
     );
     assert!(yssgar.xp > king.xp, "Yssgar should out-reward the King");
 }
+
+#[test]
+fn sunderlakes_mobs_are_peaceful_not_endgame_scaled() {
+    let world = seed_world();
+    let hp_of = |pred: fn(RoomId) -> bool| -> Vec<i32> {
+        world
+            .spawns
+            .iter()
+            .filter(|s| !s.boss && pred(s.home))
+            .map(|s| s.max_hp)
+            .collect()
+    };
+    let lakes = hp_of(is_lakes_room);
+    let kaelmyr = hp_of(is_kaelmyr_room);
+    assert!(!lakes.is_empty() && !kaelmyr.is_empty());
+    // The Sunderlakes are peaceful mid-game: their toughest regular mob must be
+    // weaker than the softest Kaelmyr (endgame) mob, i.e. no scaling overlap.
+    let lakes_max = *lakes.iter().max().unwrap();
+    let kaelmyr_min = *kaelmyr.iter().min().unwrap();
+    assert!(
+        lakes_max < kaelmyr_min,
+        "toughest Sunderlakes mob ({lakes_max} hp) should be weaker than the softest Kaelmyr mob ({kaelmyr_min} hp)"
+    );
+}


### PR DESCRIPTION
Five Lateania bugs from mason's playtest, all verified against the code and fixed.

1. **Legs/Feet/Trinket gear never drops.** `generated_loot_tables` emitted per-tier offsets `0,1,2,4,6,8,9` — it skipped `3,5,7`, which are exactly Legs/Feet/Trinket in the `WEARABLE` order. So three equipment slots never progressed from generated drops anywhere in the game. Now drops the whole tier block (all 8 gear pieces + draught + relic).

2. **Three of five pet auto-skills were unreachable.** The ladder unlocked at 3/8/15/22/30, but pets cap at `PET_MAX_LEVEL = 10`, so Intimidating Roar / Loyal Guard / Killing Pounce were dead content. Compressed to **2/4/6/8/10** so a well-fed, loyal companion earns all five within the cap.

3. **The peaceful Sunderlakes rode endgame multipliers.** `LAKES_SPAWN_ID_START` (980000) sat inside the Kaelmyr endgame band (960000..990000) in `tune_spawn_balance`, giving a fishing region ×2 hp / ×1.9 dmg endgame scaling. Ended the band at the lakes, so they keep the gentle overworld multipliers; Kaelmyr and the *deadly* archipelago stay endgame.

4. **"Mend Companion" heals the caster, not the companion.** The Ranger ability's `effect` is `HealOverTime` and its desc already reads "tend your *own* hurts." mason liked the player-heal, so rather than bolt on a pet-heal I renamed it **"Field Dressing"** so name, desc, and effect agree. (If a real companion-heal is wanted, that's a clean new ability.)

5. **Pet-skill docs claimed "size class"; the code keys to level.** `pet_skills_at` filters purely by level and `PET_SKILLS` is one ladder shared by every companion — each skill's *power* scales with the pet's own attack, not its size class. Corrected the doc comments to match.

## Tests
Updated the pet-ladder test to the new levels and to assert every rung is `<= PET_MAX_LEVEL`; added a guard that generated loot covers every gear slot (offsets 0..8); added a guard that the toughest Sunderlakes mob is weaker than the softest Kaelmyr mob (no scaling overlap). 242 Lateania tests pass; clippy/fmt clean.

Thanks @mpiorowski for late.sh, and to mason for the sharp bug report.
