### PR TITLE
feat(lateania): world map - path-into-fog hints + land/terrain/gather/champion indicators

### DIFF
--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -284,6 +284,7 @@ fn draw_world_map(frame: &mut Frame, area: Rect, state: &State, view: &PlayerVie
                     Tile::Empty => (" ".to_string(), Style::default()),
                     Tile::LinkH => ("\u{2500}".to_string(), link_style), // ─
                     Tile::LinkV => ("\u{2502}".to_string(), link_style), // │
+                    Tile::Hint(ch) => (ch.to_string(), Style::default().fg(theme::TEXT_FAINT())),
                     Tile::Room(id) if *id == player_room => ("@".to_string(), player_style),
                     Tile::Room(id) => match poi(*id) {
                         Some(p) if p.boss.is_some() => ("\u{2605}".to_string(), boss_style),
@@ -389,7 +390,9 @@ fn draw_world_map(frame: &mut Frame, area: Rect, state: &State, view: &PlayerVie
             Span::styled("\u{2665}", Style::default().fg(Color::Rgb(230, 140, 160))),
             Span::styled(" tame  ", Style::default().fg(theme::TEXT_DIM())),
             Span::styled("\u{2192}", Style::default().fg(theme::AMBER_DIM())),
-            Span::styled(" off-map", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(" off-map  ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled("\u{2192}", Style::default().fg(theme::TEXT_FAINT())),
+            Span::styled(" path", Style::default().fg(theme::TEXT_DIM())),
         ])),
         rows[3],
     );

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -172,6 +172,14 @@ fn map_fits(area: Rect) -> bool {
 }
 
 /// Per-biome map glyph and colour for the overhead world map.
+/// A short land name for the map overlay: the atlas carries full titles like
+/// "Embergate & the King's Road", but a map label wants just "Embergate". Drop
+/// any " & ..." or ", ..." tail so the name fits a clear run and reads at a glance.
+fn land_label(name: &str) -> &str {
+    let name = name.split(" & ").next().unwrap_or(name);
+    name.split(", ").next().unwrap_or(name)
+}
+
 fn biome_style(biome: super::world::Biome) -> (char, Color) {
     use super::world::Biome;
     match biome {
@@ -214,7 +222,8 @@ fn draw_world_map(frame: &mut Frame, area: Rect, state: &State, view: &PlayerVie
         Constraint::Length(1), // header
         Constraint::Min(1),    // map body
         Constraint::Length(2), // cell inspector (crosshair target)
-        Constraint::Length(1), // controls + legend
+        Constraint::Length(1), // controls + marker legend
+        Constraint::Length(1), // terrain key (biomes in view)
     ])
     .split(area);
 
@@ -274,6 +283,12 @@ fn draw_world_map(frame: &mut Frame, area: Rect, state: &State, view: &PlayerVie
     let tame_style = Style::default()
         .fg(Color::Rgb(230, 140, 160))
         .add_modifier(Modifier::BOLD);
+    let gather_style = Style::default()
+        .fg(Color::Rgb(150, 200, 120))
+        .add_modifier(Modifier::BOLD);
+    let elite_style = Style::default()
+        .fg(Color::Rgb(210, 120, 90))
+        .add_modifier(Modifier::BOLD);
     let link_style = Style::default().fg(theme::BORDER_DIM());
 
     let mut cells: Vec<Vec<(String, Style)>> = canvas
@@ -289,6 +304,8 @@ fn draw_world_map(frame: &mut Frame, area: Rect, state: &State, view: &PlayerVie
                     Tile::Room(id) => match poi(*id) {
                         Some(p) if p.boss.is_some() => ("\u{2605}".to_string(), boss_style),
                         Some(p) if p.tameable.is_some() => ("\u{2665}".to_string(), tame_style),
+                        Some(p) if p.elite_foe.is_some() => ("\u{25c6}".to_string(), elite_style),
+                        Some(p) if p.gather.is_some() => ("\u{2692}".to_string(), gather_style),
                         _ => {
                             let (g, color) = biome_style(super::world::biome_of(*id));
                             (g.to_string(), Style::default().fg(color))
@@ -304,6 +321,72 @@ fn draw_world_map(frame: &mut Frame, area: Rect, state: &State, view: &PlayerVie
         if let Some(cell) = cells.get_mut(arrow.row).and_then(|r| r.get_mut(arrow.col)) {
             let style = if arrow.boss { boss_style } else { tame_style };
             *cell = (arrow.glyph.to_string(), style);
+        }
+    }
+
+    // Land labels: name each explored region once, near the centroid of its
+    // rooms in view, so you can see which land is which at a glance. Only lands
+    // you've set foot in are drawn (canvas already holds only seen rooms), and
+    // the text lands only in empty cells so it never hides a room or a marker.
+    let mut land_centroids: std::collections::HashMap<&'static str, (i32, i32, i32)> =
+        std::collections::HashMap::new();
+    for (r, row) in canvas.iter().enumerate() {
+        for (c, tile) in row.iter().enumerate() {
+            if let Tile::Room(id) = tile
+                && let Some((name, _)) = region_atlas_entry(*id)
+            {
+                let e = land_centroids.entry(name).or_insert((0, 0, 0));
+                e.0 += r as i32;
+                e.1 += c as i32;
+                e.2 += 1;
+            }
+        }
+    }
+    let label_style = Style::default()
+        .fg(theme::AMBER_DIM())
+        .add_modifier(Modifier::ITALIC);
+    let rows_n = cells.len();
+    for (name, (sum_r, sum_c, count)) in land_centroids {
+        // A stray room or two shouldn't plant a label; wait for a real presence.
+        if count < 3 {
+            continue;
+        }
+        let text: Vec<char> = land_label(name).chars().collect();
+        let len = text.len();
+        let mid_r = sum_r / count;
+        let ideal_c = ((sum_c / count) - (len as i32) / 2).max(0);
+
+        // Find a clear horizontal run of `len` cells near the centroid so the
+        // name reads whole rather than being chopped up by rooms and corridors.
+        // Scan rows outward from the centroid, nudging left/right a little; if
+        // nothing clear turns up, drop the label - better absent than garbled.
+        let is_clear = |cells: &[Vec<(String, Style)>], r: usize, c0: usize| {
+            c0 + len <= cols as usize && (0..len).all(|i| cells[r][c0 + i].0 == " ")
+        };
+        let mut spot = None;
+        'search: for dr in 0..=5i32 {
+            for r in [mid_r - dr, mid_r + dr] {
+                if r < 0 || r as usize >= rows_n {
+                    continue;
+                }
+                let r = r as usize;
+                for dc in 0..=10i32 {
+                    for c in [ideal_c + dc, ideal_c - dc] {
+                        if c >= 0 && is_clear(&cells, r, c as usize) {
+                            spot = Some((r, c as usize));
+                            break 'search;
+                        }
+                    }
+                }
+                if dr == 0 {
+                    break; // mid_r - 0 == mid_r + 0; don't scan it twice
+                }
+            }
+        }
+        if let Some((r, c0)) = spot {
+            for (i, ch) in text.iter().enumerate() {
+                cells[r][c0 + i] = (ch.to_string(), label_style);
+            }
         }
     }
 
@@ -357,6 +440,9 @@ fn draw_world_map(frame: &mut Frame, area: Rect, state: &State, view: &PlayerVie
             if let Some(t) = p.tameable {
                 parts.push(format!("tame {t}"));
             }
+            if let Some(g) = p.gather {
+                parts.push(format!("gather {g}"));
+            }
             if !p.monsters.is_empty() {
                 parts.push(format!("foes {}", p.monsters.join(", ")));
             }
@@ -378,24 +464,66 @@ fn draw_world_map(frame: &mut Frame, area: Rect, state: &State, view: &PlayerVie
     }
     frame.render_widget(Paragraph::new(inspect), rows[2]);
 
-    // Footer: controls + marker legend.
+    // Footer line 1: controls + marker legend.
+    let dim = Style::default().fg(theme::TEXT_DIM());
     frame.render_widget(
         Paragraph::new(Line::from(vec![
-            Span::styled(
-                "wasd/arrows pan · <> level · Enter re-centre · m close    ",
-                Style::default().fg(theme::TEXT_DIM()),
-            ),
+            Span::styled("wasd pan · <> level · Enter re-centre · m close   ", dim),
             Span::styled("\u{2605}", Style::default().fg(Color::Rgb(250, 210, 90))),
-            Span::styled(" boss  ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(" boss ", dim),
             Span::styled("\u{2665}", Style::default().fg(Color::Rgb(230, 140, 160))),
-            Span::styled(" tame  ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(" tame ", dim),
+            Span::styled("\u{25c6}", Style::default().fg(Color::Rgb(210, 120, 90))),
+            Span::styled(" foe ", dim),
+            Span::styled("\u{2692}", Style::default().fg(Color::Rgb(150, 200, 120))),
+            Span::styled(" gather ", dim),
             Span::styled("\u{2192}", Style::default().fg(theme::AMBER_DIM())),
-            Span::styled(" off-map  ", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(" off-map ", dim),
             Span::styled("\u{2192}", Style::default().fg(theme::TEXT_FAINT())),
-            Span::styled(" path", Style::default().fg(theme::TEXT_DIM())),
+            Span::styled(" path", dim),
         ])),
         rows[3],
     );
+
+    // Footer line 2: terrain key, showing only the biomes actually in view so it
+    // stays legible instead of listing every biome in the world.
+    use super::world::Biome;
+    let mut present: Vec<Biome> = Vec::new();
+    for row in &canvas {
+        for tile in row {
+            if let Tile::Room(id) = tile {
+                let b = super::world::biome_of(*id);
+                if !present.contains(&b) {
+                    present.push(b);
+                }
+            }
+        }
+    }
+    // Fixed order so the key doesn't reshuffle as you pan.
+    const BIOME_ORDER: [(Biome, &str); 9] = [
+        (Biome::Heartland, "heartland"),
+        (Biome::Plains, "plains"),
+        (Biome::Urban, "town"),
+        (Biome::Forest, "forest"),
+        (Biome::Water, "water"),
+        (Biome::Islands, "isles"),
+        (Biome::Ash, "ash"),
+        (Biome::Cavern, "caves"),
+        (Biome::Badlands, "badlands"),
+    ];
+    let mut key: Vec<Span> = vec![Span::styled(
+        "terrain  ",
+        Style::default().fg(theme::TEXT_FAINT()),
+    )];
+    for (biome, label) in BIOME_ORDER {
+        if !present.contains(&biome) {
+            continue;
+        }
+        let (glyph, color) = biome_style(biome);
+        key.push(Span::styled(glyph.to_string(), Style::default().fg(color)));
+        key.push(Span::styled(format!(" {label}  "), dim));
+    }
+    frame.render_widget(Paragraph::new(Line::from(key)), rows[4]);
 }
 
 fn draw_class_select(frame: &mut Frame, area: Rect, view: &PlayerView, cursor: usize) {

--- a/late-ssh/src/app/door/lateania/worldmap.rs
+++ b/late-ssh/src/app/door/lateania/worldmap.rs
@@ -410,8 +410,13 @@ pub struct Poi {
     pub reward: Vec<&'static str>,
     /// Names of the mobs that spawn (can be slain) here.
     pub monsters: Vec<&'static str>,
+    /// A notable non-boss foe lairing here (epic/legendary rank), if any - the
+    /// hunt-worthy targets, distinct from trash spawns.
+    pub elite_foe: Option<&'static str>,
     /// A tameable wild beast roaming here, if any.
     pub tameable: Option<&'static str>,
+    /// A harvestable resource here (the gather trade worked at it), if any.
+    pub gather: Option<&'static str>,
 }
 
 static POIS: LazyLock<HashMap<RoomId, Poi>> = LazyLock::new(build_pois);
@@ -431,9 +436,36 @@ fn build_pois() -> HashMap<RoomId, Poi> {
             }
         }
     }
+    // Regional champions: the single toughest non-boss foe in each land. The
+    // endgame is wall-to-wall max-level mobs, so a per-room "elite" marker would
+    // carpet the map; one apex hunt per region stays rare and worth flagging.
+    let mut champ: HashMap<&'static str, (RoomId, &'static str, i32)> = HashMap::new();
+    for spawn in &world.spawns {
+        if spawn.boss {
+            continue;
+        }
+        let Some((region, _)) = super::world::region_atlas_entry(spawn.home) else {
+            continue;
+        };
+        let lvl = spawn.level();
+        champ
+            .entry(region)
+            .and_modify(|best| {
+                if lvl > best.2 {
+                    *best = (spawn.home, spawn.name, lvl);
+                }
+            })
+            .or_insert((spawn.home, spawn.name, lvl));
+    }
+    for (_region, (home, name, _)) in champ {
+        map.entry(home).or_default().elite_foe = Some(name);
+    }
     for beast in super::taming::wild_beasts() {
         map.entry(beast.home).or_default().tameable =
             Some(super::taming::TAMEABLE[beast.species].name);
+    }
+    for n in super::world::NODES {
+        map.entry(n.home).or_default().gather = Some(n.skill.key());
     }
     map
 }

--- a/late-ssh/src/app/door/lateania/worldmap.rs
+++ b/late-ssh/src/app/door/lateania/worldmap.rs
@@ -460,6 +460,11 @@ pub enum Tile {
     LinkH,
     /// A vertical corridor (north/south exit) between two rooms.
     LinkV,
+    /// A path-continuation hint: this room links to a visited room that the map
+    /// can't draw right beside it (the hand-authored core doesn't lay perfectly
+    /// flat, so some branches scatter). The arrow points the way the exit runs,
+    /// so no reachable room ever reads as a stranded island.
+    Hint(char),
 }
 
 /// Build a `cols x rows` map canvas centred on `center`, interleaving rooms
@@ -514,6 +519,24 @@ pub fn map_canvas(
         };
         for (dir, dest) in &room.exits {
             if !seen(*dest) {
+                // An exit into the fog: draw a faint arrow pointing the way the
+                // path runs so a discovered room (a boss you've found, the edge
+                // of your exploration) never reads as stranded. Direction only,
+                // into an empty adjacent cell - no spoiler of what waits there.
+                let (dx, dy) = match dir {
+                    Dir::East => (1, 0),
+                    Dir::West => (-1, 0),
+                    Dir::North => (0, -1),
+                    Dir::South => (0, 1),
+                    _ => continue, // up/down: no flat direction to point
+                };
+                let (hx, hy) = (sc + dx, sr + dy);
+                if (0..cols).contains(&hx)
+                    && (0..rows).contains(&hy)
+                    && canvas[hy as usize][hx as usize] == Tile::Empty
+                {
+                    canvas[hy as usize][hx as usize] = Tile::Hint(arrow_glyph(dx, dy));
+                }
                 continue;
             }
             let Some(&dc) = coords.get(dest) else {
@@ -527,7 +550,25 @@ pub fn map_canvas(
                 (Dir::West, -1, 0) => put(&mut canvas, sc - 1, sr, Tile::LinkH),
                 (Dir::North, 0, -1) => put(&mut canvas, sc, sr - 1, Tile::LinkV),
                 (Dir::South, 0, 1) => put(&mut canvas, sc, sr + 1, Tile::LinkV),
-                _ => {} // linked but not spatially adjacent (cross-region seam)
+                _ if dc.z == c.z => {
+                    // Linked on the same level but not in the adjacent cell (the
+                    // hand-authored core scatters some branches). Point toward the
+                    // neighbour on the dominant axis, into an empty cell only, so
+                    // no reachable room reads as a stranded island.
+                    let glyph = arrow_glyph(dc.x - c.x, dc.y - c.y);
+                    let (hx, hy) = if (dc.x - c.x).abs() >= (dc.y - c.y).abs() {
+                        (sc + (dc.x - c.x).signum(), sr)
+                    } else {
+                        (sc, sr + (dc.y - c.y).signum())
+                    };
+                    if (0..cols).contains(&hx)
+                        && (0..rows).contains(&hy)
+                        && canvas[hy as usize][hx as usize] == Tile::Empty
+                    {
+                        canvas[hy as usize][hx as usize] = Tile::Hint(glyph);
+                    }
+                }
+                _ => {} // stairs (up/down): not drawn on a flat level
             }
         }
     }

--- a/late-ssh/src/app/door/lateania/worldmap_test.rs
+++ b/late-ssh/src/app/door/lateania/worldmap_test.rs
@@ -616,3 +616,33 @@ fn a_discovered_room_ringed_by_fog_shows_exit_hints() {
         }
     }
 }
+
+// The POI index carries every marker kind the map draws, and the "notable foe"
+// marker stays rare: one regional champion per land, never a per-room carpet
+// (the endgame is wall-to-wall max-level mobs, so a level threshold would flood).
+#[test]
+fn poi_index_has_every_marker_kind_and_elite_stays_rare() {
+    let p = super::pois();
+    let has = |f: fn(&super::Poi) -> bool| p.values().filter(|x| f(x)).count();
+    assert!(has(|x| x.boss.is_some()) > 0, "bosses indexed");
+    assert!(has(|x| x.tameable.is_some()) > 0, "tameable beasts indexed");
+    assert!(has(|x| x.gather.is_some()) > 0, "gather nodes indexed");
+
+    let elite = has(|x| x.elite_foe.is_some());
+    assert!(elite > 0, "at least one regional champion");
+    // One apex per region: comfortably under any per-region-count ceiling and
+    // nowhere near the thousands a raw level threshold would mark.
+    assert!(
+        elite < 40,
+        "elite foe markers must stay rare (one per land), got {elite}"
+    );
+    // A champion room is never also a boss room (bosses take precedence).
+    for poi in p.values() {
+        if poi.elite_foe.is_some() {
+            assert!(
+                poi.boss.is_none(),
+                "a champion room must not also be a boss"
+            );
+        }
+    }
+}

--- a/late-ssh/src/app/door/lateania/worldmap_test.rs
+++ b/late-ssh/src/app/door/lateania/worldmap_test.rs
@@ -566,3 +566,53 @@ fn poi_arrows_point_off_screen_pois_to_the_border() {
         );
     }
 }
+
+// A discovered room whose neighbours are all still fog must not read as a
+// stranded island: each exit into the unknown gets a faint direction arrow so
+// the player can see a path continues that way (direction only, no spoiler).
+#[test]
+fn a_discovered_room_ringed_by_fog_shows_exit_hints() {
+    use super::Tile;
+    let world = seed_world();
+    let coords = derive_coords(&world);
+
+    // Find a room with at least one flat (N/S/E/W) exit whose neighbour sits in
+    // the adjacent cell, so the hint has an empty cell to land in.
+    let (&anchor, _) = world
+        .rooms
+        .iter()
+        .find(|(id, room)| {
+            let c = coords[*id];
+            room.exits.iter().any(|(_dir, dst)| {
+                coords
+                    .get(dst)
+                    .is_some_and(|dc| dc.z == c.z && (dc.x - c.x).abs() + (dc.y - c.y).abs() == 1)
+            })
+        })
+        .expect("world has a room with a unit-adjacent flat exit");
+
+    // Only the anchor is explored - every neighbour is fog.
+    let visited: std::collections::HashSet<_> = std::iter::once(anchor).collect();
+    let canvas = super::map_canvas(&coords, coords[&anchor], 21, 21, &visited, anchor);
+
+    let hints = canvas
+        .iter()
+        .flatten()
+        .filter(|t| matches!(t, Tile::Hint(_)))
+        .count();
+    assert!(
+        hints > 0,
+        "a discovered room surrounded by fog must sprout at least one exit hint"
+    );
+    // Hints are direction glyphs, never overwriting the player's own cell.
+    for row in &canvas {
+        for tile in row {
+            if let Tile::Hint(g) = tile {
+                assert!(
+                    "\u{2190}\u{2191}\u{2192}\u{2193}\u{2196}\u{2197}\u{2198}\u{2199}".contains(*g),
+                    "hint glyph {g:?} is not a direction arrow"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Builds on the overhead world map (#475) and the corridors/off-map-arrow follow-up (#480, now merged). Two things: a fix for markers that looked stranded, and the map indicators to answer "which land is this and what's here".

## Path-into-fog hints
In play, a boss you'd discovered could show its marker with no visible way to it. That's fog of war: the map only draws a corridor between two rooms you've *both* explored, so a landmark whose approach still lies in the fog had nothing connecting it and read as "there's a boss here but no path to him".

- An exit from a visited room into the unknown now draws a faint direction arrow in the adjacent cell. Direction only, into an empty cell, so it never spoils what waits there - a found room just shows which way its paths run instead of looking stranded.
- Same treatment for the handful of same-level links the hand-authored core scatters too far apart to draw as a straight corridor.

## More map indicators
The map coloured rooms by biome but only marked bosses and taming spots, so you couldn't tell which land you were in or what an area held.

- **Land labels** - each explored region names itself near the centroid of its rooms in view (short form, e.g. "Embergate", "The Overworld"), placed only on a clear run of empty cells so the name reads whole and never hides a room or marker. Undiscovered lands stay unnamed.
- **Terrain key** - a footer line decoding the biome glyphs, listing only the biomes actually on screen so it stays legible.
- **Gather markers** - harvestable resource rooms show a pick, indexed from the world's resource nodes.
- **Champion markers** - the single toughest non-boss foe in each land shows a diamond. The endgame is wall-to-wall max-level mobs, so a per-room "elite" marker would carpet the map (4800+ rooms); one apex per region stays rare (~11). The crosshair inspector also now names the gather trade worked at a room.

Marker precedence: boss > tame > champion > gather > terrain, so a room shows its most significant feature.

## Tests
24 worldmap unit tests (added a fog-hint regression and a marker-index regression that pins the champion marker to stay rare). fmt + clippy clean.

Thanks @mpiorowski for the door and for merging the map work.