### PR TITLE
feat: interaction mode (keyboard / mouse / hybrid) with first-run prompt + mouse clickability

### DIFF
--- a/late-core/src/models/user.rs
+++ b/late-core/src/models/user.rs
@@ -41,6 +41,52 @@ impl AudioSource {
     }
 }
 
+/// How a session is driven. Chosen on first entry (see the onboarding prompt),
+/// then editable in settings. The key behavioural lever is whether the terminal
+/// mouse reporting is turned on: off in `Keyboard` so native selection/copy keep
+/// working; on in `Mouse` and `Hybrid`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum InteractionMode {
+    /// Keyboard only, the classic terminal/programmer experience; mouse
+    /// reporting stays off so the terminal's own text selection works.
+    Keyboard,
+    /// Mouse-first, Discord-like: everything is clickable, mouse reporting on.
+    Mouse,
+    /// Both keyboard shortcuts and the mouse work. The safe default.
+    #[default]
+    Hybrid,
+}
+
+impl InteractionMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Keyboard => "keyboard",
+            Self::Mouse => "mouse",
+            Self::Hybrid => "hybrid",
+        }
+    }
+
+    pub fn from_settings_str(value: &str) -> Self {
+        match value {
+            "keyboard" => Self::Keyboard,
+            "mouse" => Self::Mouse,
+            _ => Self::Hybrid,
+        }
+    }
+
+    /// Whether the terminal's mouse reporting should be enabled in this mode.
+    pub fn mouse_enabled(self) -> bool {
+        matches!(self, Self::Mouse | Self::Hybrid)
+    }
+
+    /// Whether keyboard shortcuts are the primary/expected input (for which set
+    /// of on-screen hints to show). Both keyboard-only and hybrid say yes.
+    pub fn keyboard_primary(self) -> bool {
+        matches!(self, Self::Keyboard | Self::Hybrid)
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum IcecastStream {
@@ -305,6 +351,7 @@ pub fn normalize_right_sidebar_components(
 
 const IGNORED_USER_IDS_KEY: &str = "ignored_user_ids";
 const FRIEND_USER_IDS_KEY: &str = "friend_user_ids";
+const INTERACTION_MODE_KEY: &str = "interaction_mode";
 const THEME_ID_KEY: &str = "theme_id";
 const AUDIO_SOURCE_KEY: &str = "audio_source";
 const ICECAST_STREAM_KEY: &str = "icecast_stream";
@@ -749,6 +796,28 @@ impl User {
         Ok(())
     }
 
+    /// Persist the chosen interaction mode (keyboard / mouse / hybrid).
+    pub async fn set_interaction_mode(
+        client: &Client,
+        user_id: Uuid,
+        mode: InteractionMode,
+    ) -> Result<()> {
+        let value = mode.as_str();
+        let updated = client
+            .execute(
+                "UPDATE users
+                 SET settings = settings || jsonb_build_object($1::text, $2::text),
+                     updated = current_timestamp
+                 WHERE id = $3",
+                &[&INTERACTION_MODE_KEY, &value, &user_id],
+            )
+            .await?;
+        if updated == 0 {
+            bail!("user not found");
+        }
+        Ok(())
+    }
+
     /// Persist whether the aquarium tray is open so it survives reconnects.
     pub async fn set_show_aquarium_tray(client: &Client, user_id: Uuid, shown: bool) -> Result<()> {
         let updated = client
@@ -1086,6 +1155,17 @@ pub fn extract_birthday(settings: &Value) -> Option<String> {
         .get(BIRTHDAY_KEY)
         .and_then(Value::as_str)
         .and_then(crate::models::birthday::normalize_birthday)
+}
+
+/// The chosen interaction mode, or `None` if the user has never picked one -
+/// which is the signal to show the first-run onboarding prompt.
+pub fn extract_interaction_mode(settings: &Value) -> Option<InteractionMode> {
+    settings
+        .get(INTERACTION_MODE_KEY)
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(InteractionMode::from_settings_str)
 }
 
 pub fn extract_theme_id(settings: &Value) -> Option<String> {

--- a/late-core/src/models/user_internal_test.rs
+++ b/late-core/src/models/user_internal_test.rs
@@ -245,3 +245,29 @@ fn truncate_to_boundary_respects_char_boundaries() {
     assert_eq!(truncate_to_boundary("abcdef", 4), "abcd");
     assert_eq!(truncate_to_boundary("żółw", 3), "żół");
 }
+
+#[test]
+fn interaction_mode_absent_signals_first_run() {
+    // No key = never chosen = show the onboarding prompt.
+    assert_eq!(extract_interaction_mode(&json!({})), None);
+}
+
+#[test]
+fn interaction_mode_round_trips_and_gates_the_mouse() {
+    for (stored, mode, mouse) in [
+        ("keyboard", InteractionMode::Keyboard, false),
+        ("mouse", InteractionMode::Mouse, true),
+        ("hybrid", InteractionMode::Hybrid, true),
+    ] {
+        let settings = json!({ "interaction_mode": stored });
+        assert_eq!(extract_interaction_mode(&settings), Some(mode));
+        assert_eq!(mode.as_str(), stored);
+        assert_eq!(mode.mouse_enabled(), mouse, "mouse gate for {stored}");
+    }
+    // Unknown / garbage falls back to the safe both-work default.
+    assert_eq!(
+        extract_interaction_mode(&json!({ "interaction_mode": "wat" })),
+        Some(InteractionMode::Hybrid)
+    );
+    assert!(InteractionMode::default().mouse_enabled());
+}

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -812,6 +812,13 @@ fn handle_parsed_input_inner(app: &mut App, event: ParsedInput) {
         return;
     }
 
+    // The one-time first-run prompt blocks the app until a mode is chosen (but
+    // reserved chords above, like quit, still work).
+    if app.needs_interaction_onboarding {
+        crate::app::onboarding::input::handle_input(app, event);
+        return;
+    }
+
     if app.show_quit_confirm {
         quit_confirm::input::handle_input(app, event);
         return;

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -1050,6 +1050,12 @@ fn handle_parsed_input_inner(app: &mut App, event: ParsedInput) {
         // Mouse events feed global hit tests first, then vertical wheel
         // fallback for screens that scroll outside richer local handlers.
         ParsedInput::Mouse(mouse) => {
+            // Keyboard-only mode ignores the mouse entirely, so the terminal's
+            // own selection/copy is untouched (belt-and-suspenders: capture is
+            // also off at the terminal, but a client may still send reports).
+            if !app.interaction_mode.mouse_enabled() {
+                return;
+            }
             if handle_mouse_click(app, ctx.screen, mouse) {
                 return;
             }
@@ -3580,6 +3586,8 @@ fn open_settings_modal_globally(app: &mut App) {
     let device_rails = app.rail_modes();
     app.settings_modal_state
         .open_from_profile(app.profile_state.profile(), device_rails);
+    app.settings_modal_state
+        .set_interaction_mode_display(app.interaction_mode);
     app.show_settings = true;
 }
 

--- a/late-ssh/src/app/mod.rs
+++ b/late-ssh/src/app/mod.rs
@@ -27,6 +27,7 @@ mod input_flow_test;
 pub mod lobby;
 pub(crate) mod mod_modal;
 pub(crate) mod notify;
+pub(crate) mod onboarding;
 pub mod pet;
 pub mod pinstar;
 pub mod profile;

--- a/late-ssh/src/app/onboarding/input.rs
+++ b/late-ssh/src/app/onboarding/input.rs
@@ -1,0 +1,62 @@
+use ratatui::layout::Rect;
+
+use crate::app::{
+    input::{MouseButton, MouseEventKind, ParsedInput},
+    state::App,
+};
+
+use super::ui::OPTIONS;
+
+/// Handle input while the first-run interaction-mode prompt is up. Any pick
+/// applies the mode (flipping the mouse live), persists it, and dismisses the
+/// prompt for good.
+pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
+    match event {
+        ParsedInput::Byte(b'1') | ParsedInput::Char('1') => choose(app, 0),
+        ParsedInput::Byte(b'2') | ParsedInput::Char('2') => choose(app, 1),
+        ParsedInput::Byte(b'3') | ParsedInput::Char('3') => choose(app, 2),
+        ParsedInput::Arrow(b'A') => {
+            app.onboarding_selected = app.onboarding_selected.saturating_sub(1);
+        }
+        ParsedInput::Arrow(b'B') => {
+            app.onboarding_selected = (app.onboarding_selected + 1).min(OPTIONS.len() - 1);
+        }
+        ParsedInput::Byte(b'\r') | ParsedInput::Byte(b'\n') | ParsedInput::Byte(b' ') => {
+            choose(app, app.onboarding_selected);
+        }
+        ParsedInput::Mouse(mouse)
+            if mouse.kind == MouseEventKind::Down && mouse.button == Some(MouseButton::Left) =>
+        {
+            if let Some(i) = option_at(app, mouse.x, mouse.y) {
+                choose(app, i);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn choose(app: &mut App, index: usize) {
+    let Some((mode, _, _)) = OPTIONS.get(index).copied() else {
+        return;
+    };
+    // Applies live (flips the mouse if needed) and persists on change; also
+    // persist unconditionally so choosing the default still records a value and
+    // the prompt never returns.
+    app.set_interaction_mode(mode);
+    app.profile_state
+        .service()
+        .set_interaction_mode(app.user_id, mode);
+    app.needs_interaction_onboarding = false;
+}
+
+fn option_at(app: &App, x: u16, y: u16) -> Option<usize> {
+    let rects = app.onboarding_option_rects.get();
+    rects.iter().position(|rect| {
+        rect.is_some_and(|r: Rect| {
+            x >= r.x
+                && x < r.x.saturating_add(r.width)
+                && y >= r.y
+                && y < r.y.saturating_add(r.height)
+        })
+    })
+}

--- a/late-ssh/src/app/onboarding/mod.rs
+++ b/late-ssh/src/app/onboarding/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod input;
+pub(crate) mod ui;

--- a/late-ssh/src/app/onboarding/ui.rs
+++ b/late-ssh/src/app/onboarding/ui.rs
@@ -1,0 +1,153 @@
+use std::cell::Cell;
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph},
+};
+
+use crate::app::common::theme;
+use late_core::models::user::InteractionMode;
+
+/// The three choices, in display order. The first is the highlighted default.
+pub(crate) const OPTIONS: [(InteractionMode, &str, &str); 3] = [
+    (
+        InteractionMode::Hybrid,
+        "Both",
+        "Keyboard shortcuts and the mouse both work. (recommended)",
+    ),
+    (
+        InteractionMode::Mouse,
+        "Mouse",
+        "Click everything, like Discord.",
+    ),
+    (
+        InteractionMode::Keyboard,
+        "Keyboard",
+        "Classic terminal; mouse off so your own copy/paste works.",
+    ),
+];
+
+const WIDTH: u16 = 66;
+const HEIGHT: u16 = 13;
+
+/// Draw the one-time first-run prompt and record each option's rect (so a click
+/// can pick it). `selected` is the keyboard-highlighted row.
+pub(crate) fn draw(
+    frame: &mut Frame,
+    area: Rect,
+    selected: usize,
+    option_rects: &Cell<[Option<Rect>; 3]>,
+) {
+    let popup = centered_rect(WIDTH, HEIGHT, area);
+    frame.render_widget(Clear, popup);
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Welcome to late.sh ")
+        .border_style(
+            Style::default()
+                .fg(theme::AMBER_GLOW())
+                .add_modifier(Modifier::BOLD),
+        );
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    let rows = Layout::vertical([
+        Constraint::Length(1), // prompt
+        Constraint::Length(1), // blank
+        Constraint::Length(1), // option 0
+        Constraint::Length(1), // option 1
+        Constraint::Length(1), // option 2
+        Constraint::Min(0),    // spacer
+        Constraint::Length(1), // footer
+    ])
+    .split(inner);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "How do you want to get around?",
+            Style::default().fg(theme::TEXT_BRIGHT()),
+        ))),
+        rows[0],
+    );
+
+    let mut rects = [None; 3];
+    for (i, (_, label, desc)) in OPTIONS.iter().enumerate() {
+        let row = rows[2 + i];
+        rects[i] = Some(row);
+        let chosen = i == selected;
+        let (marker, style) = if chosen {
+            (
+                "▶ ",
+                Style::default()
+                    .fg(theme::SUCCESS())
+                    .add_modifier(Modifier::BOLD),
+            )
+        } else {
+            ("  ", Style::default().fg(theme::TEXT_DIM()))
+        };
+        frame.render_widget(
+            Paragraph::new(Line::from(vec![
+                Span::styled(format!("{marker}{}. ", i + 1), style),
+                Span::styled(
+                    format!("{label}  "),
+                    if chosen {
+                        style
+                    } else {
+                        Style::default().fg(theme::TEXT_BRIGHT())
+                    },
+                ),
+                Span::styled(
+                    (*desc).to_string(),
+                    Style::default().fg(theme::TEXT_FAINT()),
+                ),
+            ])),
+            row,
+        );
+    }
+    option_rects.set(rects);
+
+    frame.render_widget(
+        Paragraph::new(Line::from(Span::styled(
+            "1-3 or click to choose · ↑↓ then Enter · change it later in Settings",
+            Style::default().fg(theme::TEXT_FAINT()),
+        ))),
+        rows[6],
+    );
+}
+
+fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {
+    let [row] = Layout::vertical([Constraint::Length(height)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [cell] = Layout::horizontal([Constraint::Length(width)])
+        .flex(Flex::Center)
+        .areas(row);
+    cell
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OPTIONS;
+    use late_core::models::user::InteractionMode;
+
+    #[test]
+    fn options_cover_every_mode_with_hybrid_first() {
+        assert_eq!(OPTIONS.len(), 3);
+        assert_eq!(
+            OPTIONS[0].0,
+            InteractionMode::Hybrid,
+            "recommended default leads"
+        );
+        let modes: Vec<_> = OPTIONS.iter().map(|(m, _, _)| *m).collect();
+        for m in [
+            InteractionMode::Keyboard,
+            InteractionMode::Mouse,
+            InteractionMode::Hybrid,
+        ] {
+            assert!(modes.contains(&m), "every mode is offered: {m:?}");
+        }
+    }
+}

--- a/late-ssh/src/app/profile/svc.rs
+++ b/late-ssh/src/app/profile/svc.rs
@@ -450,6 +450,28 @@ impl ProfileService {
         );
     }
 
+    /// Persist the chosen interaction mode (keyboard / mouse / hybrid).
+    pub fn set_interaction_mode(
+        &self,
+        user_id: Uuid,
+        mode: late_core::models::user::InteractionMode,
+    ) {
+        let service = self.clone();
+        tokio::spawn(
+            async move {
+                let result = async {
+                    let client = service.db.get().await?;
+                    User::set_interaction_mode(&client, user_id, mode).await
+                }
+                .await;
+                if let Err(e) = result {
+                    tracing::warn!(error = ?e, "failed to persist interaction mode");
+                }
+            }
+            .instrument(info_span!("profile.interaction_mode_task", user_id = %user_id)),
+        );
+    }
+
     pub fn delete_account(&self, user_id: Uuid) {
         let service = self.clone();
         tokio::spawn(

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -221,6 +221,9 @@ struct DrawContext<'a> {
     show_settings: bool,
     settings_modal_state: &'a settings_modal::state::SettingsModalState,
     show_quit_confirm: bool,
+    needs_interaction_onboarding: bool,
+    onboarding_selected: usize,
+    onboarding_option_rects: &'a std::cell::Cell<[Option<Rect>; 3]>,
     show_mod_modal: bool,
     show_hub_modal: bool,
     show_aquarium_tray: bool,
@@ -1006,6 +1009,9 @@ impl App {
                         show_settings: self.show_settings,
                         settings_modal_state: &self.settings_modal_state,
                         show_quit_confirm: self.show_quit_confirm,
+                        needs_interaction_onboarding: self.needs_interaction_onboarding,
+                        onboarding_selected: self.onboarding_selected,
+                        onboarding_option_rects: &self.onboarding_option_rects,
                         show_mod_modal: self.show_mod_modal,
                         show_hub_modal: self.show_hub_modal,
                         show_aquarium_tray: self.show_aquarium_tray,
@@ -1662,6 +1668,16 @@ impl App {
                 inner,
                 ctx.terminal_image_protocol,
                 terminal_images,
+            );
+        }
+
+        // The one-time first-run prompt draws over everything.
+        if ctx.needs_interaction_onboarding {
+            crate::app::onboarding::ui::draw(
+                frame,
+                inner,
+                ctx.onboarding_selected,
+                ctx.onboarding_option_rects,
             );
         }
 

--- a/late-ssh/src/app/room_info_modal/input.rs
+++ b/late-ssh/src/app/room_info_modal/input.rs
@@ -15,6 +15,18 @@ pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
         return;
     }
 
+    // A click on a field focuses it; other mouse events are swallowed so they
+    // don't leak to the app behind the modal.
+    if let ParsedInput::Mouse(mouse) = event {
+        use crate::app::input::{MouseButton, MouseEventKind};
+        if mouse.kind == MouseEventKind::Down && mouse.button == Some(MouseButton::Left) {
+            if let Some(field) = app.room_info_modal_state.field_at(mouse.x, mouse.y) {
+                app.room_info_modal_state.set_focus(field);
+            }
+        }
+        return;
+    }
+
     let focus = app.room_info_modal_state.focus();
     let max = focus.max_len();
     let field = app.room_info_modal_state.field_mut(focus);

--- a/late-ssh/src/app/room_info_modal/input.rs
+++ b/late-ssh/src/app/room_info_modal/input.rs
@@ -19,10 +19,11 @@ pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
     // don't leak to the app behind the modal.
     if let ParsedInput::Mouse(mouse) = event {
         use crate::app::input::{MouseButton, MouseEventKind};
-        if mouse.kind == MouseEventKind::Down && mouse.button == Some(MouseButton::Left) {
-            if let Some(field) = app.room_info_modal_state.field_at(mouse.x, mouse.y) {
-                app.room_info_modal_state.set_focus(field);
-            }
+        if mouse.kind == MouseEventKind::Down
+            && mouse.button == Some(MouseButton::Left)
+            && let Some(field) = app.room_info_modal_state.field_at(mouse.x, mouse.y)
+        {
+            app.room_info_modal_state.set_focus(field);
         }
         return;
     }

--- a/late-ssh/src/app/room_info_modal/state.rs
+++ b/late-ssh/src/app/room_info_modal/state.rs
@@ -74,6 +74,9 @@ pub(crate) struct RoomInfoModalState {
     owner_label: String,
     topic: TextArea<'static>,
     rules: TextArea<'static>,
+    /// Screen rects of the two fields (Topic, Rules), recorded each frame so a
+    /// click can focus the field under the pointer.
+    field_rects: std::cell::Cell<[Option<ratatui::layout::Rect>; 2]>,
 }
 
 impl RoomInfoModalState {
@@ -87,6 +90,33 @@ impl RoomInfoModalState {
 
     pub(crate) fn focus(&self) -> Field {
         self.focus
+    }
+
+    pub(crate) fn set_focus(&mut self, field: Field) {
+        self.focus = field;
+    }
+
+    /// Record a field's screen rect during draw (for click-to-focus).
+    pub(crate) fn record_field_rect(&self, field: Field, rect: ratatui::layout::Rect) {
+        let mut rects = self.field_rects.get();
+        rects[field as usize] = Some(rect);
+        self.field_rects.set(rects);
+    }
+
+    /// The field whose rect contains `(x, y)`, if a click landed on one.
+    pub(crate) fn field_at(&self, x: u16, y: u16) -> Option<Field> {
+        let rects = self.field_rects.get();
+        for (i, rect) in rects.iter().enumerate() {
+            if let Some(r) = rect
+                && x >= r.x
+                && x < r.x + r.width
+                && y >= r.y
+                && y < r.y + r.height
+            {
+                return Some(if i == 0 { Field::Topic } else { Field::Rules });
+            }
+        }
+        None
     }
 
     pub(crate) fn room_label(&self) -> &str {

--- a/late-ssh/src/app/room_info_modal/ui.rs
+++ b/late-ssh/src/app/room_info_modal/ui.rs
@@ -107,6 +107,7 @@ fn draw_field(
     field: Field,
     label: &str,
 ) {
+    state.record_field_rect(field, area);
     let focused = state.focus() == field;
     let [label_row, text_rows] =
         Layout::vertical([Constraint::Length(1), Constraint::Min(1)]).areas(area);

--- a/late-ssh/src/app/room_search_modal/input.rs
+++ b/late-ssh/src/app/room_search_modal/input.rs
@@ -52,11 +52,11 @@ pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
             use crate::app::input::{MouseButton, MouseEventKind};
             match mouse.kind {
                 MouseEventKind::Down if mouse.button == Some(MouseButton::Left) => {
-                    if !message_mode {
-                        if let Some(index) = app.room_search_modal_state.item_at(mouse.y) {
-                            app.room_search_modal_state.set_selected(index);
-                            submit(app);
-                        }
+                    if !message_mode
+                        && let Some(index) = app.room_search_modal_state.item_at(mouse.y)
+                    {
+                        app.room_search_modal_state.set_selected(index);
+                        submit(app);
                     }
                 }
                 MouseEventKind::ScrollDown => app.room_search_modal_state.move_selection(1, len),

--- a/late-ssh/src/app/room_search_modal/input.rs
+++ b/late-ssh/src/app/room_search_modal/input.rs
@@ -45,6 +45,25 @@ pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
         ParsedInput::PageDown => app.room_search_modal_state.move_selection(8, len),
         ParsedInput::PageUp => app.room_search_modal_state.move_selection(-8, len),
         ParsedInput::Char(ch) => app.room_search_modal_state.push(ch),
+        // Click a result row to select and jump to it; wheel moves the cursor.
+        // (Room list only; message-mode hits render as context and aren't 1:1
+        // with rows, so a click there just moves through them.)
+        ParsedInput::Mouse(mouse) => {
+            use crate::app::input::{MouseButton, MouseEventKind};
+            match mouse.kind {
+                MouseEventKind::Down if mouse.button == Some(MouseButton::Left) => {
+                    if !message_mode {
+                        if let Some(index) = app.room_search_modal_state.item_at(mouse.y) {
+                            app.room_search_modal_state.set_selected(index);
+                            submit(app);
+                        }
+                    }
+                }
+                MouseEventKind::ScrollDown => app.room_search_modal_state.move_selection(1, len),
+                MouseEventKind::ScrollUp => app.room_search_modal_state.move_selection(-1, len),
+                _ => {}
+            }
+        }
         ParsedInput::Byte(byte) if byte.is_ascii_graphic() || byte == b' ' => {
             app.room_search_modal_state.push(byte as char);
         }

--- a/late-ssh/src/app/room_search_modal/state.rs
+++ b/late-ssh/src/app/room_search_modal/state.rs
@@ -31,6 +31,9 @@ pub(crate) struct RoomSearchModalState {
     /// The `(scope, text)` of the last fired search, so an unchanged query
     /// never refires.
     last_fired_key: Option<(Option<Uuid>, String)>,
+    /// Screen-y → item index for each result row drawn this frame, so a click
+    /// can select the room under the pointer. Interior-mutable (render has `&`).
+    item_rows: std::cell::RefCell<Vec<(u16, usize)>>,
 }
 
 impl RoomSearchModalState {
@@ -72,6 +75,29 @@ impl RoomSearchModalState {
 
     pub(crate) fn selected(&self) -> usize {
         self.selected
+    }
+
+    pub(crate) fn set_selected(&mut self, index: usize) {
+        self.selected = index;
+    }
+
+    /// Clear last frame's clickable rows (call before recording this frame's).
+    pub(crate) fn clear_item_rows(&self) {
+        self.item_rows.borrow_mut().clear();
+    }
+
+    /// Record that a result row for `index` is drawn at screen row `y`.
+    pub(crate) fn record_item_row(&self, y: u16, index: usize) {
+        self.item_rows.borrow_mut().push((y, index));
+    }
+
+    /// The item index drawn at screen row `y`, if a click landed on one.
+    pub(crate) fn item_at(&self, y: u16) -> Option<usize> {
+        self.item_rows
+            .borrow()
+            .iter()
+            .find(|(row_y, _)| *row_y == y)
+            .map(|(_, index)| *index)
     }
 
     pub(crate) fn push(&mut self, ch: char) {

--- a/late-ssh/src/app/room_search_modal/ui.rs
+++ b/late-ssh/src/app/room_search_modal/ui.rs
@@ -144,7 +144,8 @@ fn draw_results(
     let mut lines: Vec<Line<'static>> = Vec::new();
     let rows = result_rows(&items);
     let start = result_view_start(&rows, selected, height);
-    for row in rows.iter().skip(start).take(height) {
+    state.clear_item_rows();
+    for (offset, row) in rows.iter().skip(start).take(height).enumerate() {
         match *row {
             ResultRow::Header(favorite) => {
                 let label = if favorite { "favorites" } else { "rooms" };
@@ -156,6 +157,7 @@ fn draw_results(
                 )));
             }
             ResultRow::Item(index) => {
+                state.record_item_row(area.y + offset as u16, index);
                 lines.push(result_item_line(&items[index], index == selected, width));
             }
         }

--- a/late-ssh/src/app/scratchpad/input.rs
+++ b/late-ssh/src/app/scratchpad/input.rs
@@ -25,6 +25,21 @@ pub(crate) fn handle_event(app: &mut App, event: &ParsedInput) -> bool {
     let Some(state) = app.scratchpad.as_mut() else {
         return false;
     };
+    // Mouse: click positions the caret; the wheel pages through the buffer.
+    if let ParsedInput::Mouse(mouse) = event {
+        use crate::app::input::{MouseButton, MouseEventKind};
+        match mouse.kind {
+            MouseEventKind::Down if mouse.button == Some(MouseButton::Left) => {
+                if state.click_to_cursor(mouse.x, mouse.y) {
+                    state.publish();
+                }
+            }
+            MouseEventKind::ScrollUp => state.scroll_lines(true),
+            MouseEventKind::ScrollDown => state.scroll_lines(false),
+            _ => {}
+        }
+        return true;
+    }
     // Ctrl+L cycles the shared highlighting language. Unbound anywhere else
     // in this app (root CONTEXT.md notes it's no longer a global help key),
     // so it's free to use here without colliding with a reserved chord.

--- a/late-ssh/src/app/scratchpad/input.rs
+++ b/late-ssh/src/app/scratchpad/input.rs
@@ -28,15 +28,15 @@ pub(crate) fn handle_event(app: &mut App, event: &ParsedInput) -> bool {
     // Mouse: click positions the caret; the wheel pages through the buffer.
     if let ParsedInput::Mouse(mouse) = event {
         use crate::app::input::{MouseButton, MouseEventKind};
-        match mouse.kind {
-            MouseEventKind::Down if mouse.button == Some(MouseButton::Left) => {
-                if state.click_to_cursor(mouse.x, mouse.y) {
-                    state.publish();
-                }
-            }
-            MouseEventKind::ScrollUp => state.scroll_lines(true),
-            MouseEventKind::ScrollDown => state.scroll_lines(false),
-            _ => {}
+        let clicked = mouse.kind == MouseEventKind::Down
+            && mouse.button == Some(MouseButton::Left)
+            && state.click_to_cursor(mouse.x, mouse.y);
+        if clicked {
+            state.publish();
+        } else if mouse.kind == MouseEventKind::ScrollUp {
+            state.scroll_lines(true);
+        } else if mouse.kind == MouseEventKind::ScrollDown {
+            state.scroll_lines(false);
         }
         return true;
     }

--- a/late-ssh/src/app/scratchpad/state.rs
+++ b/late-ssh/src/app/scratchpad/state.rs
@@ -35,9 +35,49 @@ pub(crate) struct ScratchpadState {
     /// once), and the app is only ever touched under its own mutex, so there
     /// is no contention to speak of.
     highlight_cache: RefCell<HighlightCache>,
+    /// The editor's content area plus its (vscroll, hscroll), recorded each
+    /// frame so a click can be mapped to a text row/column. `None` until drawn.
+    editor_viewport: std::cell::Cell<Option<(ratatui::layout::Rect, usize, usize)>>,
 }
 
 impl ScratchpadState {
+    /// Record the editor's content area and scroll offsets for click mapping
+    /// (called from the render pass, which only holds `&self`).
+    pub(crate) fn record_viewport(
+        &self,
+        content_area: ratatui::layout::Rect,
+        vscroll: usize,
+        hscroll: usize,
+    ) {
+        self.editor_viewport
+            .set(Some((content_area, vscroll, hscroll)));
+    }
+
+    /// Move the caret to where a click landed in the editor. Returns whether the
+    /// click was inside the editor's content area.
+    pub(crate) fn click_to_cursor(&mut self, x: u16, y: u16) -> bool {
+        let Some((area, vscroll, hscroll)) = self.editor_viewport.get() else {
+            return false;
+        };
+        if x < area.x || x >= area.x + area.width || y < area.y || y >= area.y + area.height {
+            return false;
+        }
+        let row = vscroll + (y - area.y) as usize;
+        let col = hscroll + (x - area.x) as usize;
+        self.editor
+            .move_cursor(CursorMove::Jump(row as u16, col as u16));
+        true
+    }
+
+    /// Scroll the view by moving the caret (the viewport tracks the caret), so
+    /// a wheel over the editor pages through the buffer.
+    pub(crate) fn scroll_lines(&mut self, up: bool) {
+        for _ in 0..3 {
+            self.editor
+                .move_cursor(if up { CursorMove::Up } else { CursorMove::Down });
+        }
+    }
+
     pub(crate) fn new(
         registry: SharedScratchpadRegistry,
         shared: SharedScratchpad,
@@ -65,6 +105,7 @@ impl ScratchpadState {
             last_seen_revision,
             partner_cursor,
             highlight_cache: RefCell::new(HighlightCache::default()),
+            editor_viewport: std::cell::Cell::new(None),
         }
     }
 

--- a/late-ssh/src/app/scratchpad/state_test.rs
+++ b/late-ssh/src/app/scratchpad/state_test.rs
@@ -146,3 +146,20 @@ fn cycle_language_is_visible_to_the_partner_without_a_separate_sync_step() {
         "both sides share one buffer, so bob sees alice's cycle immediately"
     );
 }
+
+#[test]
+fn a_click_moves_the_caret_to_that_cell() {
+    use ratatui::layout::Rect;
+    let (mut alice, _bob) = paired(Uuid::new_v4(), Uuid::new_v4());
+    alice.editor.insert_str("abc\ndefgh\nij");
+    // Editor drawn at the origin with no scroll.
+    alice.record_viewport(Rect::new(0, 0, 20, 10), 0, 0);
+    assert!(alice.click_to_cursor(3, 1), "click inside lands");
+    assert_eq!(alice.editor.cursor(), (1, 3), "row 1, col 3");
+    // A click past the content area is ignored.
+    assert!(!alice.click_to_cursor(50, 50));
+    // With a vertical scroll, the click row is offset by it.
+    alice.record_viewport(Rect::new(0, 0, 20, 10), 1, 0);
+    assert!(alice.click_to_cursor(0, 0));
+    assert_eq!(alice.editor.cursor().0, 1, "vscroll shifts the clicked row");
+}

--- a/late-ssh/src/app/scratchpad/ui.rs
+++ b/late-ssh/src/app/scratchpad/ui.rs
@@ -84,6 +84,8 @@ pub(crate) fn draw(frame: &mut Frame, area: Rect, state: &ScratchpadState) {
         content_area,
     );
 
+    state.record_viewport(content_area, vscroll, hscroll);
+
     let cursor_row_in_view = cursor.row.saturating_sub(vscroll);
     let cursor_col_in_view = cursor.col.saturating_sub(hscroll);
     if cursor_row_in_view < visible_height && cursor_col_in_view < visible_width {

--- a/late-ssh/src/app/settings_modal/input.rs
+++ b/late-ssh/src/app/settings_modal/input.rs
@@ -605,13 +605,47 @@ fn handle_picker_input(app: &mut App, event: ParsedInput) {
 /// was one of the two rail rows. The modal owns the account default; the device
 /// layout is the app's, so the sync lives here rather than inside the modal.
 fn toggle_tweak(app: &mut App) {
+    if apply_interaction_mode_row(app, true) {
+        return;
+    }
     app.settings_modal_state.toggle_selected_tweak();
     app.sync_device_rails_from_settings();
 }
 
 fn cycle_tweak(app: &mut App, forward: bool) {
+    if apply_interaction_mode_row(app, forward) {
+        return;
+    }
     app.settings_modal_state.cycle_selected_tweak(forward);
     app.sync_device_rails_from_settings();
+}
+
+/// If the Input row is selected, cycle the interaction mode on the app (which
+/// flips the mouse live and persists) and mirror it into the modal for display.
+/// Returns whether it handled the row.
+fn apply_interaction_mode_row(app: &mut App, forward: bool) -> bool {
+    use late_core::models::user::InteractionMode;
+    if app.settings_modal_state.selected_tweak_row() != TweakRow::InteractionMode {
+        return false;
+    }
+    let order = [
+        InteractionMode::Keyboard,
+        InteractionMode::Mouse,
+        InteractionMode::Hybrid,
+    ];
+    let cur = order
+        .iter()
+        .position(|m| *m == app.interaction_mode)
+        .unwrap_or(0);
+    let next = if forward {
+        (cur + 1) % order.len()
+    } else {
+        (cur + order.len() - 1) % order.len()
+    };
+    app.set_interaction_mode(order[next]);
+    app.settings_modal_state
+        .set_interaction_mode_display(order[next]);
+    true
 }
 
 #[cfg(test)]

--- a/late-ssh/src/app/settings_modal/state.rs
+++ b/late-ssh/src/app/settings_modal/state.rs
@@ -106,10 +106,12 @@ pub(crate) enum TweakRow {
     StartWithMusicMuted,
     FlagFallback,
     LandOnHome,
+    // Input group.
+    InteractionMode,
 }
 
 impl TweakRow {
-    pub(crate) const ALL: [TweakRow; 9] = [
+    pub(crate) const ALL: [TweakRow; 10] = [
         TweakRow::BackgroundColor,
         TweakRow::TextBrightness,
         TweakRow::RightSidebar,
@@ -119,6 +121,7 @@ impl TweakRow {
         TweakRow::StartWithMusicMuted,
         TweakRow::FlagFallback,
         TweakRow::LandOnHome,
+        TweakRow::InteractionMode,
     ];
 }
 
@@ -486,6 +489,11 @@ pub(crate) struct SettingsModalState {
     /// scroll-wheel events to the body, so the wheel doesn't move the
     /// row cursor when the pointer is hovering over the tab strip or footer.
     body_area: Cell<Rect>,
+    /// The live interaction mode (keyboard / mouse / hybrid), mirrored here for
+    /// the Input row to display. Seeded from the app when the modal opens; the
+    /// input handler applies changes on the app itself (they persist + flip the
+    /// mouse there), so this is display-only.
+    interaction_mode: late_core::models::user::InteractionMode,
 }
 
 impl SettingsModalState {
@@ -535,7 +543,21 @@ impl SettingsModalState {
             gem: GemState::new(),
             tab_rects: Cell::new([None; Tab::ALL.len()]),
             body_area: Cell::new(Rect::new(0, 0, 0, 0)),
+            interaction_mode: late_core::models::user::InteractionMode::default(),
         }
+    }
+
+    /// The interaction mode shown on the Input row.
+    pub(crate) fn interaction_mode(&self) -> late_core::models::user::InteractionMode {
+        self.interaction_mode
+    }
+
+    /// Sync the displayed interaction mode from the app (on open and on change).
+    pub(crate) fn set_interaction_mode_display(
+        &mut self,
+        mode: late_core::models::user::InteractionMode,
+    ) {
+        self.interaction_mode = mode;
     }
 
     /// The rail modes the two Appearance rows are editing: this device's, not
@@ -801,6 +823,11 @@ impl SettingsModalState {
             }
             TweakRow::LandOnHome => {
                 self.draft.land_on_home ^= true;
+            }
+            TweakRow::InteractionMode => {
+                // Applied on the app (it flips the mouse live and persists on its
+                // own), so there's nothing to save through the profile draft.
+                return;
             }
         }
         self.save();

--- a/late-ssh/src/app/settings_modal/ui.rs
+++ b/late-ssh/src/app/settings_modal/ui.rs
@@ -686,6 +686,9 @@ fn draw_tweaks_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
         Constraint::Length(1),                // breathing
         Constraint::Length(1),                // Startup subsection heading
         Constraint::Length(1),                // land on home row
+        Constraint::Length(1),                // breathing
+        Constraint::Length(1),                // Input subsection heading
+        Constraint::Length(1),                // interaction mode row
         Constraint::Min(0),                   // flex spacer
         Constraint::Length(gem_strip_height), // gem
     ])
@@ -793,12 +796,24 @@ fn draw_tweaks_tab(frame: &mut Frame, area: Rect, state: &SettingsModalState) {
         sections[17],
     );
 
+    frame.render_widget(Paragraph::new(section_heading("Input")), sections[19]);
+    frame.render_widget(
+        Paragraph::new(tweak_row_line(
+            state,
+            TweakRow::InteractionMode,
+            width,
+            "Interaction mode",
+            interaction_mode_span(state.interaction_mode()),
+        )),
+        sections[20],
+    );
+
     if gem_strip_height > 0 {
         // Pad 2 cols off each side and lift the gem 1 row off the bottom
         // border so it doesn't crowd the dialog frame.
         const PAD_X: u16 = 2;
         const PAD_BOTTOM: u16 = 1;
-        let strip = sections[19];
+        let strip = sections[22];
         let pad_x = PAD_X.min(strip.width / 2);
         let pad_bottom = PAD_BOTTOM.min(strip.height);
         let gem_area = Rect::new(
@@ -2483,6 +2498,28 @@ fn toggle_span(enabled: bool) -> ValueSpan {
             text: "○ off".to_string(),
             style: Style::default().fg(theme::TEXT_FAINT()),
         }
+    }
+}
+
+fn interaction_mode_span(mode: late_core::models::user::InteractionMode) -> ValueSpan {
+    use late_core::models::user::InteractionMode;
+    match mode {
+        InteractionMode::Keyboard => ValueSpan {
+            text: "○ keyboard".to_string(),
+            style: Style::default().fg(theme::AMBER()),
+        },
+        InteractionMode::Mouse => ValueSpan {
+            text: "● mouse".to_string(),
+            style: Style::default()
+                .fg(theme::SUCCESS())
+                .add_modifier(Modifier::BOLD),
+        },
+        InteractionMode::Hybrid => ValueSpan {
+            text: "◐ hybrid".to_string(),
+            style: Style::default()
+                .fg(theme::SUCCESS())
+                .add_modifier(Modifier::BOLD),
+        },
     }
 }
 

--- a/late-ssh/src/app/sheet_modal/input.rs
+++ b/late-ssh/src/app/sheet_modal/input.rs
@@ -57,6 +57,11 @@ pub(crate) fn handle_input(app: &mut App, event: ParsedInput) {
         ParsedInput::Mouse(mouse) => match mouse.kind {
             MouseEventKind::ScrollUp => app.sheet_modal_state.scroll_body(-3),
             MouseEventKind::ScrollDown => app.sheet_modal_state.scroll_body(3),
+            MouseEventKind::Down if mouse.button == Some(crate::app::input::MouseButton::Left) => {
+                if let Some(field) = app.sheet_modal_state.field_at(mouse.x, mouse.y) {
+                    app.sheet_modal_state.set_focus(field);
+                }
+            }
             _ => {}
         },
         _ => {}

--- a/late-ssh/src/app/sheet_modal/state.rs
+++ b/late-ssh/src/app/sheet_modal/state.rs
@@ -33,6 +33,9 @@ pub(crate) struct SheetModalState {
     /// Last committed name, restored when a name edit is cancelled.
     committed_name: String,
     pending_save: Option<SheetSaveRequest>,
+    /// Screen rects of the Name and Body fields, recorded each frame so a click
+    /// can focus the field under the pointer.
+    field_rects: std::cell::Cell<[Option<ratatui::layout::Rect>; 2]>,
 }
 
 impl SheetModalState {
@@ -47,7 +50,35 @@ impl SheetModalState {
             body_input: new_body_textarea(),
             committed_name: String::new(),
             pending_save: None,
+            field_rects: std::cell::Cell::new([None; 2]),
         }
+    }
+
+    /// Record a field's screen rect during draw (for click-to-focus).
+    pub(crate) fn record_field_rect(&self, field: SheetField, rect: ratatui::layout::Rect) {
+        let mut rects = self.field_rects.get();
+        rects[field as usize] = Some(rect);
+        self.field_rects.set(rects);
+    }
+
+    /// The field whose rect contains `(x, y)`, if a click landed on one.
+    pub(crate) fn field_at(&self, x: u16, y: u16) -> Option<SheetField> {
+        let rects = self.field_rects.get();
+        for (i, rect) in rects.iter().enumerate() {
+            if let Some(r) = rect
+                && x >= r.x
+                && x < r.x + r.width
+                && y >= r.y
+                && y < r.y + r.height
+            {
+                return Some(if i == 0 {
+                    SheetField::Name
+                } else {
+                    SheetField::Body
+                });
+            }
+        }
+        None
     }
 
     pub(crate) fn open(&mut self, request: SheetOpenRequest) {

--- a/late-ssh/src/app/sheet_modal/ui.rs
+++ b/late-ssh/src/app/sheet_modal/ui.rs
@@ -39,6 +39,10 @@ pub(crate) fn draw(frame: &mut Frame, area: Rect, state: &SheetModalState) {
     ])
     .split(inner);
 
+    // Record the two fields so a click can focus one. The Name field spans its
+    // row plus the label above it; the Body spans its header + text area.
+    state.record_field_rect(SheetField::Name, layout[1]);
+    state.record_field_rect(SheetField::Body, layout[2].union(layout[3]));
     draw_name_row(frame, layout[1], state);
     draw_body_header(frame, layout[2], state);
     frame.render_widget(state.body_input(), layout[3].inner(Margin::new(2, 0)));

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -313,6 +313,9 @@ pub struct SessionConfig {
 
     /// Display config
     pub initial_theme_id: String,
+    /// The user's saved interaction mode (keyboard / mouse / hybrid), or `None`
+    /// if they've never chosen one - which triggers the first-run prompt.
+    pub initial_interaction_mode: Option<late_core::models::user::InteractionMode>,
     /// Initial audio source for the paired client, loaded from
     /// `users.settings.audio_source` (default `Icecast`). v+x mutates this and
     /// persists the new value.
@@ -482,6 +485,11 @@ pub struct App {
     pub(crate) paired_source: late_core::models::user::AudioSource,
     pub(crate) selected_icecast_stream: late_core::models::user::IcecastStream,
     pub(crate) selected_radio_station: late_core::models::user::RadioStation,
+
+    /// How this session is driven (keyboard / mouse / hybrid). Gates whether the
+    /// mouse is live; editable in settings. `None` at load means the user has
+    /// never chosen (first run); resolved to the default here.
+    pub(crate) interaction_mode: late_core::models::user::InteractionMode,
 
     pub(crate) music_prefix_armed: bool,
     pub(crate) room_section_prefix_armed: bool,
@@ -1237,6 +1245,7 @@ impl App {
             paired_source: config.initial_audio_source,
             selected_icecast_stream: config.initial_icecast_stream,
             selected_radio_station: config.initial_radio_station,
+            interaction_mode: config.initial_interaction_mode.unwrap_or_default(),
             music_prefix_armed: false,
             room_section_prefix_armed: false,
             afk: None,
@@ -2609,7 +2618,10 @@ impl App {
         self.terminal_image_render_state = TerminalImageRenderState::default();
     }
 
-    pub fn enter_alt_screen() -> Vec<u8> {
+    /// Terminal setup bytes. `mouse` gates the mouse-tracking DECSET sequences:
+    /// in keyboard-only mode they're withheld so the terminal keeps its own text
+    /// selection and copy. Bracketed paste stays on regardless.
+    pub fn enter_alt_screen(mouse: bool) -> Vec<u8> {
         let mut buf = Vec::new();
         // If a prior session was killed mid-OSC image payload, recover the
         // terminal parser before sending normal alt-screen setup.
@@ -2628,8 +2640,12 @@ impl App {
         // 1003h = any-event mouse tracking (motion reports with or without a
         // button held). Dartboard needs drag + hover parity with standalone.
         // 1006h = SGR extended encoding (ESC[< sequences instead of legacy X11)
-        // 2004h = bracketed paste mode (ESC[200~ ... ESC[201~)
-        buf.extend_from_slice(b"\x1b[?1000h\x1b[?1003h\x1b[?1006h\x1b[?2004h");
+        // Withheld in keyboard-only mode so native terminal selection survives.
+        if mouse {
+            buf.extend_from_slice(b"\x1b[?1000h\x1b[?1003h\x1b[?1006h");
+        }
+        // 2004h = bracketed paste mode (ESC[200~ ... ESC[201~) - always on.
+        buf.extend_from_slice(b"\x1b[?2004h");
         buf.extend_from_slice(&crate::app::files::terminal_image::xtversion_probe());
         buf.extend_from_slice(&iterm2_capabilities_probe());
         // DA1 last: nearly every terminal answers it, and replies arrive in

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -1948,6 +1948,29 @@ impl App {
         self.pending_terminal_commands.push(sequence.to_vec());
     }
 
+    /// Change the interaction mode: flip terminal mouse reporting live if the
+    /// mouse-enabled state changed (so keyboard mode restores native selection
+    /// immediately), and persist the choice. No-op if the mode is unchanged.
+    pub(crate) fn set_interaction_mode(&mut self, mode: late_core::models::user::InteractionMode) {
+        if self.interaction_mode == mode {
+            return;
+        }
+        let was_mouse = self.interaction_mode.mouse_enabled();
+        self.interaction_mode = mode;
+        if mode.mouse_enabled() != was_mouse {
+            // 1000/1003/1006 h = enable, l = disable the mouse-tracking triplet.
+            let seq: &[u8] = if mode.mouse_enabled() {
+                b"\x1b[?1000h\x1b[?1003h\x1b[?1006h"
+            } else {
+                b"\x1b[?1006l\x1b[?1003l\x1b[?1000l"
+            };
+            self.pending_terminal_commands.push(seq.to_vec());
+        }
+        self.profile_state
+            .service()
+            .set_interaction_mode(self.user_id, mode);
+    }
+
     pub(crate) fn apply_terminal_env_hint(&mut self, name: &str, value: &str) {
         self.apply_inline_image_symbol_mode(InlineImageSymbolMode::from_env_hint(name, value));
         if self.terminal_images_disabled {

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -490,6 +490,13 @@ pub struct App {
     /// mouse is live; editable in settings. `None` at load means the user has
     /// never chosen (first run); resolved to the default here.
     pub(crate) interaction_mode: late_core::models::user::InteractionMode,
+    /// True until the user picks a mode for the first time: shows the one-time
+    /// onboarding prompt over the app after they enter.
+    pub(crate) needs_interaction_onboarding: bool,
+    /// Highlighted row in that prompt, and the on-screen rect of each option
+    /// (recorded by the renderer so a click can pick one).
+    pub(crate) onboarding_selected: usize,
+    pub(crate) onboarding_option_rects: std::cell::Cell<[Option<ratatui::layout::Rect>; 3]>,
 
     pub(crate) music_prefix_armed: bool,
     pub(crate) room_section_prefix_armed: bool,
@@ -1246,6 +1253,9 @@ impl App {
             selected_icecast_stream: config.initial_icecast_stream,
             selected_radio_station: config.initial_radio_station,
             interaction_mode: config.initial_interaction_mode.unwrap_or_default(),
+            needs_interaction_onboarding: config.initial_interaction_mode.is_none(),
+            onboarding_selected: 0,
+            onboarding_option_rects: std::cell::Cell::new([None; 3]),
             music_prefix_armed: false,
             room_section_prefix_armed: false,
             afk: None,

--- a/late-ssh/src/app/state_internal_test.rs
+++ b/late-ssh/src/app/state_internal_test.rs
@@ -57,7 +57,7 @@ fn leave_alt_screen_resets_cursor_shape() {
 
 #[test]
 fn alt_screen_boundaries_recover_terminal_string_state() {
-    assert!(App::enter_alt_screen().starts_with(terminal_string_terminator()));
+    assert!(App::enter_alt_screen(true).starts_with(terminal_string_terminator()));
     assert!(App::leave_alt_screen().starts_with(terminal_string_terminator()));
 }
 
@@ -104,4 +104,23 @@ fn voice_toggle_intent_switches_to_active_voice_room() {
         voice_toggle_intent(Some(joined), Some(active)),
         VoiceToggleIntent::JoinOrSwitch
     );
+}
+
+#[test]
+fn enter_alt_screen_withholds_mouse_tracking_in_keyboard_mode() {
+    let with_mouse = App::enter_alt_screen(true);
+    let no_mouse = App::enter_alt_screen(false);
+    // The mouse-tracking DECSET triplet appears only when mouse is enabled.
+    let has = |buf: &[u8], seq: &[u8]| buf.windows(seq.len()).any(|w| w == seq);
+    assert!(
+        has(&with_mouse, b"\x1b[?1000h"),
+        "mouse mode enables tracking"
+    );
+    assert!(
+        !has(&no_mouse, b"\x1b[?1000h"),
+        "keyboard mode leaves it off"
+    );
+    // Bracketed paste stays on in both so paste still works.
+    assert!(has(&with_mouse, b"\x1b[?2004h"));
+    assert!(has(&no_mouse, b"\x1b[?2004h"));
 }

--- a/late-ssh/src/session_bootstrap.rs
+++ b/late-ssh/src/session_bootstrap.rs
@@ -504,6 +504,7 @@ pub async fn build_session_config(state: &State, inputs: SessionBootstrapInputs)
         land_on_home: late_core::models::user::extract_land_on_home(&user.settings),
         initial_theme_id: late_core::models::user::extract_theme_id(&user.settings)
             .unwrap_or_else(|| theme::DEFAULT_ID.to_string()),
+        initial_interaction_mode: late_core::models::user::extract_interaction_mode(&user.settings),
         initial_audio_source: late_core::models::user::extract_audio_source(&user.settings),
         initial_icecast_stream: late_core::models::user::extract_icecast_stream(&user.settings),
         initial_radio_station: late_core::models::user::extract_radio_station(&user.settings),

--- a/late-ssh/src/ssh.rs
+++ b/late-ssh/src/ssh.rs
@@ -1021,6 +1021,9 @@ impl russh::server::Handler for ClientHandler {
 
             // Display config
             initial_theme_id: late_ssh_theme_id(&user.settings),
+            initial_interaction_mode: late_core::models::user::extract_interaction_mode(
+                &user.settings,
+            ),
             initial_audio_source: late_core::models::user::extract_audio_source(&user.settings),
             initial_icecast_stream: late_core::models::user::extract_icecast_stream(&user.settings),
             initial_radio_station: late_core::models::user::extract_radio_station(&user.settings),
@@ -1163,7 +1166,11 @@ impl russh::server::Handler for ClientHandler {
                 .await;
             }
 
-            let init = App::enter_alt_screen();
+            // Keyboard-only sessions never turn on mouse reporting, so the
+            // terminal keeps its own selection/copy. First-run (unchosen) users
+            // default to mouse-on so the onboarding prompt itself is clickable.
+            let mouse_on = app.lock().await.interaction_mode.mouse_enabled();
+            let init = App::enter_alt_screen(mouse_on);
             let _ = timeout(Duration::from_millis(50), handle.data(channel_id, init)).await;
 
             let app = Arc::clone(app);

--- a/late-ssh/src/test_helpers.rs
+++ b/late-ssh/src/test_helpers.rs
@@ -542,6 +542,7 @@ fn make_app_with_chat_service_and_permissions(
         land_on_home: false,
         is_draining: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         initial_theme_id: "contrast".to_string(),
+        initial_interaction_mode: None,
         initial_audio_source: late_core::models::user::AudioSource::default(),
         initial_icecast_stream: late_core::models::user::IcecastStream::default(),
         initial_radio_station: late_core::models::user::RadioStation::default(),
@@ -730,6 +731,7 @@ pub fn make_app_with_paired_client(
         initial_icecast_stream: late_core::models::user::IcecastStream::default(),
         initial_radio_station: late_core::models::user::RadioStation::default(),
         initial_theme_id: "contrast".to_string(),
+        initial_interaction_mode: None,
         initial_audio_source: late_core::models::user::AudioSource::default(),
     })
     .expect("app");


### PR DESCRIPTION
Lets each person choose how they drive late.sh: keyboard-only (the classic terminal/programmer feel), mouse-first (Discord-like, click everything), or hybrid (both). A one-time prompt asks on first entry, then it lives in Settings.

## Interaction mode
- `InteractionMode` (keyboard / mouse / hybrid) persisted per-user in `users.settings` (`interaction_mode` key), following the existing theme/audio pattern; threaded through `SessionConfig` into `App`.
- **Mouse gate:** in keyboard mode the mouse-tracking DECSET sequences are withheld at session start (`enter_alt_screen`), so the terminal keeps its own text selection and copy; bracketed paste stays on. Mouse is on for mouse/hybrid.
- **Live toggle:** changing the mode flips terminal mouse reporting immediately (pushed onto the existing `pending_terminal_commands` queue) and persists, no reconnect needed. The top-level mouse dispatch also drops mouse events in keyboard mode as a belt-and-suspenders.
- **Settings:** Tweaks gains an "Input" row that cycles keyboard / mouse / hybrid.

## First-run prompt
After a new user enters late.sh (no saved mode), a one-time overlay asks how they want to get around: Both (default), Mouse, or Keyboard. Pick with 1-3, arrows + Enter, or a click (the mouse is live at first run so the prompt itself is clickable). It applies live, persists, and never returns; editable afterwards in Settings. New lightweight `app/onboarding/` module mirroring the quit-confirm pattern.

## Mouse clickability
Filled gaps so the common surfaces are fully mouse-driven (most already were):
- **Scratchpad:** click to place the caret, wheel to page the buffer.
- **Room search:** click a result to select and jump to that room.
- **Room info form:** click the Topic or Rules field to focus it.
- **Character sheet modal:** click Name/Body to focus.

Left keyboard-first by design: the mod modal (a command-typing interface), and the house-table card games + Green Dragon door — both render through wrapping/scrolling game panels where a click doesn't map cleanly to a menu row, and both are fully keyboard-playable.

## Tests
Cover the settings round-trip + mouse gate, the DECSET withholding, the onboarding options, and the scratchpad click-to-cell mapping. fmt + clippy clean; the whole suite passes bar the pre-existing DB-backed integration tests that need TEST_DATABASE_URL.

Thanks @mpiorowski for late.sh.