### PR TITLE
Make the desktop MPRIS player controllable for mute and volume

### DIFF
--- a/late-cli/CONTEXT.md
+++ b/late-cli/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: `late-cli` - companion CLI for late.sh (plus the sibling `late-webview` helper crate)
 - Primary audience: LLM agents working on the CLI, human contributors
-- Last updated: 2026-07-29 (Linux MPRIS publication: the CLI consumes queue, Icecast, and radio metadata snapshots from pair-WS and publishes the user's selected source as a read-only desktop media player; missing session D-Bus fails open)
+- Last updated: 2026-07-30 (Linux MPRIS publication: the CLI consumes queue, Icecast, and radio metadata snapshots from pair-WS and publishes the user's selected source as a desktop media player whose transport commands map onto the local mute flag; missing session D-Bus fails open)
 - Status: Active
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change often.
 
@@ -85,7 +85,7 @@ OpenSSH mode differs slightly: it authenticates and fetches the token first thro
 - `src/clipboard.rs` - paired `/paste-image` clipboard read, Wayland/X clipboard backend use, PNG encoding, and local size guards. Clipboard support is only advertised on Linux, macOS, and Windows; Android/Termux builds do not depend on `arboard`.
 - `src/config.rs` - flags, env vars, defaults, logging
 - `src/identity.rs` - dedicated key discovery/generation
-- `src/mpris.rs` - Linux read-only MPRIS service and track metadata projection; other platforms compile a no-op publisher
+- `src/mpris.rs` - Linux MPRIS service, track metadata projection, and the transport-to-mute mapping; other platforms compile a no-op publisher
 - `src/ssh.rs` - native SSH, OpenSSH ControlMaster mode, legacy PTY subprocess mode, token parsing, resize forwarding
 - `src/pty.rs` - terminal size/PTY helpers
 - `src/raw_mode.rs` - local raw-mode guard for modes where CLI owns terminal forwarding
@@ -356,7 +356,10 @@ Platform notes:
 - Stream URL normalization trims trailing slashes, preserves `/stream`, `/stream/...`, and direct `.mp3`/`.m4a`/`.aac` URLs, and appends `/stream` only for base URLs.
 - Stream probing scans up to 64 KiB for MP3 sync/ID3 before probing.
 - Initial volume is 30%. Enabled desktop audio boots muted until the pair WebSocket delivers the user's initial mute/source state; if pairing repeatedly fails, the CLI releases startup mute after the 10 failed pair attempts. Volume uses squared scaling.
-- On Linux, the pair client consumes `queue_update`, `now_playing_update`, and `radio_meta_update` snapshots and publishes the currently selected source through `org.mpris.MediaPlayer2`. YouTube includes title/channel/duration, watch URL, thumbnail, and wall-clock-derived initial position; Icecast and radio select the metadata entry matching `set_playback_source.station`. Missing metadata falls back to the source/station label. MPRIS is intentionally read-only (`CanControl=false`) because source and playback controls remain owned by the paired TUI.
+- On Linux, the pair client consumes `queue_update`, `now_playing_update`, and `radio_meta_update` snapshots and publishes the currently selected source through `org.mpris.MediaPlayer2`. YouTube includes title/channel/duration, watch URL, thumbnail, and wall-clock-derived initial position; Icecast and radio select the metadata entry matching `set_playback_source.station`. Missing metadata falls back to the source/station label.
+- MPRIS is controllable, but only over mute. `Play`/`Pause`/`PlayPause`/`Stop` all resolve to the CLI's local `muted` atomic through `TransportCommand`, and `SetVolume` writes `volume_percent` (raising it off zero also unmutes). `CanPlay`/`CanPause`/`CanControl` are therefore true, `CanSeek`/`CanGoNext`/`CanGoPrevious` false. Muted publishes as `Paused` rather than a zeroed volume, which is what a desktop widget draws a play button for. Reporting the read-only truth (`CanControl=false`) is spec-correct but makes the player invisible to **playerctl**, which skips any player whose `can-play` is false, and with it waybar/polybar, since those link `libplayerctl`.
+- Desktop writes are announced on a `control_writes` watch epoch: the publisher republishes, and the pair WS loop pushes a fresh `client_state` so the server and TUI follow a mute that started at the widget. Without that the server never hears about it, because client-to-server pair traffic carries no control events, only status.
+- **Known gap:** this reaches only the audio the CLI decodes itself (Icecast and radio). YouTube plays in the separate `late-webview` helper, which holds its own pair WS and obeys `ToggleMute` from the *server*, so an MPRIS pause leaves it playing. Closing that needs a new client-to-server control event in `late-ssh/src/api.rs` plus fan-out to paired clients.
 - MPRIS startup and update errors fail open. Headless Linux, WSL, containers, and other environments without a usable session D-Bus continue SSH/audio normally without desktop publication.
 - The playback queue caps at roughly two seconds of output samples.
 - Analyzer cadence is about 15 Hz with a 1024-sample FFT and 8 log-spaced bands.

--- a/late-cli/CONTEXT.md
+++ b/late-cli/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: `late-cli` - companion CLI for late.sh (plus the sibling `late-webview` helper crate)
 - Primary audience: LLM agents working on the CLI, human contributors
-- Last updated: 2026-07-30 (Linux MPRIS publication: the CLI consumes queue, Icecast, and radio metadata snapshots from pair-WS and publishes the user's selected source as a desktop media player whose transport commands map onto the local mute flag; missing session D-Bus fails open)
+- Last updated: 2026-07-31 (Linux MPRIS publication: the CLI publishes the selected source as a desktop media player; widget transport/volume commands go up the pair WS as `set_muted`/`set_volume` and the server fans them to every paired client, YouTube's webview helper included; missing session D-Bus fails open)
 - Status: Active
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change often.
 
@@ -62,7 +62,8 @@ flowchart LR
     DEC --> OUT["cpal output"]
     OUT --> ANA["playback analyzer"]
     ANA -->|"viz frames"| API
-    API -->|"toggle_mute / volume_up / volume_down"| CLI
+    API -->|"toggle_mute / volume_up / volume_down / set_muted / set_volume"| CLI
+    CLI -->|"set_muted / set_volume (MPRIS)"| API
     SSH -->|"session token"| CLI
 ```
 
@@ -85,7 +86,7 @@ OpenSSH mode differs slightly: it authenticates and fetches the token first thro
 - `src/clipboard.rs` - paired `/paste-image` clipboard read, Wayland/X clipboard backend use, PNG encoding, and local size guards. Clipboard support is only advertised on Linux, macOS, and Windows; Android/Termux builds do not depend on `arboard`.
 - `src/config.rs` - flags, env vars, defaults, logging
 - `src/identity.rs` - dedicated key discovery/generation
-- `src/mpris.rs` - Linux MPRIS service, track metadata projection, and the transport-to-mute mapping; other platforms compile a no-op publisher
+- `src/mpris.rs` - Linux MPRIS service, track metadata projection, and the desktop command queue (transport/volume mapped to server-routed `set_muted`/`set_volume`); other platforms compile a no-op publisher
 - `src/ssh.rs` - native SSH, OpenSSH ControlMaster mode, legacy PTY subprocess mode, token parsing, resize forwarding
 - `src/pty.rs` - terminal size/PTY helpers
 - `src/raw_mode.rs` - local raw-mode guard for modes where CLI owns terminal forwarding
@@ -251,6 +252,13 @@ Client to server:
 }
 ```
 
+Client to server, from the Linux desktop MPRIS surface (widget play/pause, media keys, volume slider). The server fans the matching `set_muted`/`set_volume` control back to every paired client on the token:
+
+```json
+{ "event": "set_muted", "muted": true }
+{ "event": "set_volume", "volume_percent": 45 }
+```
+
 Server to client:
 
 ```json
@@ -263,6 +271,11 @@ Server to client:
 
 ```json
 { "event": "volume_down" }
+```
+
+```json
+{ "event": "set_muted", "muted": true }
+{ "event": "set_volume", "volume_percent": 45 }
 ```
 
 ```json
@@ -357,9 +370,8 @@ Platform notes:
 - Stream probing scans up to 64 KiB for MP3 sync/ID3 before probing.
 - Initial volume is 30%. Enabled desktop audio boots muted until the pair WebSocket delivers the user's initial mute/source state; if pairing repeatedly fails, the CLI releases startup mute after the 10 failed pair attempts. Volume uses squared scaling.
 - On Linux, the pair client consumes `queue_update`, `now_playing_update`, and `radio_meta_update` snapshots and publishes the currently selected source through `org.mpris.MediaPlayer2`. YouTube includes title/channel/duration, watch URL, thumbnail, and wall-clock-derived initial position; Icecast and radio select the metadata entry matching `set_playback_source.station`. Missing metadata falls back to the source/station label.
-- MPRIS is controllable, but only over mute. `Play`/`Pause`/`PlayPause`/`Stop` all resolve to the CLI's local `muted` atomic through `TransportCommand`, and `SetVolume` writes `volume_percent` (raising it off zero also unmutes). `CanPlay`/`CanPause`/`CanControl` are therefore true, `CanSeek`/`CanGoNext`/`CanGoPrevious` false. Muted publishes as `Paused` rather than a zeroed volume, which is what a desktop widget draws a play button for. Reporting the read-only truth (`CanControl=false`) is spec-correct but makes the player invisible to **playerctl**, which skips any player whose `can-play` is false, and with it waybar/polybar, since those link `libplayerctl`.
-- Desktop writes are announced on a `control_writes` watch epoch: the publisher republishes, and the pair WS loop pushes a fresh `client_state` so the server and TUI follow a mute that started at the widget. Without that the server never hears about it, because client-to-server pair traffic carries no control events, only status.
-- **Known gap:** this reaches only the audio the CLI decodes itself (Icecast and radio). YouTube plays in the separate `late-webview` helper, which holds its own pair WS and obeys `ToggleMute` from the *server*, so an MPRIS pause leaves it playing. Closing that needs a new client-to-server control event in `late-ssh/src/api.rs` plus fan-out to paired clients.
+- MPRIS is controllable, but only over mute and volume. `Play`/`Pause`/`PlayPause`/`Stop` resolve through `TransportCommand` to an absolute mute target, and `SetVolume` maps the slider to a percent (raising it off zero also unmutes). `CanPlay`/`CanPause`/`CanControl` are therefore true, `CanSeek`/`CanGoNext`/`CanGoPrevious` false. Muted publishes as `Paused` rather than a zeroed volume, which is what a desktop widget draws a play button for. Reporting the read-only truth (`CanControl=false`) is spec-correct but makes the player invisible to **playerctl**, which skips any player whose `can-play` is false, and with it waybar/polybar, since those link `libplayerctl`.
+- Desktop writes are not applied locally. The MPRIS interface queues a `DesktopCommand`, the pair WS loop sends it as a `set_muted`/`set_volume` event, and the server fans the result back to every paired client (`PairControlMessage::SetMuted`/`SetVolume`), exactly like a TUI `m` keypress. That round trip is what lets a widget pause reach YouTube, which plays in the separate `late-webview` helper on its own pair WS, and it keeps CLI, helper, and sidebar convergent. It also means controls need a live pair socket, and the widget updates when the fan-out lands rather than instantly.
 - MPRIS startup and update errors fail open. Headless Linux, WSL, containers, and other environments without a usable session D-Bus continue SSH/audio normally without desktop publication.
 - The playback queue caps at roughly two seconds of output samples.
 - Analyzer cadence is about 15 Hz with a 1024-sample FFT and 8 log-spaced bands.

--- a/late-cli/src/main.rs
+++ b/late-cli/src/main.rs
@@ -293,10 +293,11 @@ async fn run_ws_pairing(config: &Config, token: String, audio: &AudioRuntime) {
     let sample_rate = audio.sample_rate;
     let mut webview = WebviewPlaybackController::new(api_base_url.clone(), token.clone());
     let mut voice = voice::VoiceRuntimeState::default();
-    let mut desktop_media = mpris::DesktopMedia::new(mpris::AudioControls {
-        muted: Arc::clone(&muted),
-        volume_percent: Arc::clone(&volume_percent),
-    });
+    let (mut desktop_media, mut desktop_commands) =
+        mpris::DesktopMedia::new(mpris::AudioControls {
+            muted: Arc::clone(&muted),
+            volume_percent: Arc::clone(&volume_percent),
+        });
 
     let playback = PlaybackState {
         played_samples: &played_samples,
@@ -321,6 +322,7 @@ async fn run_ws_pairing(config: &Config, token: String, audio: &AudioRuntime) {
             &mut webview,
             &mut voice,
             &mut desktop_media,
+            &mut desktop_commands,
         )
         .await
         {

--- a/late-cli/src/main.rs
+++ b/late-cli/src/main.rs
@@ -293,7 +293,10 @@ async fn run_ws_pairing(config: &Config, token: String, audio: &AudioRuntime) {
     let sample_rate = audio.sample_rate;
     let mut webview = WebviewPlaybackController::new(api_base_url.clone(), token.clone());
     let mut voice = voice::VoiceRuntimeState::default();
-    let mut desktop_media = mpris::DesktopMedia::new();
+    let mut desktop_media = mpris::DesktopMedia::new(mpris::AudioControls {
+        muted: Arc::clone(&muted),
+        volume_percent: Arc::clone(&volume_percent),
+    });
 
     let playback = PlaybackState {
         played_samples: &played_samples,

--- a/late-cli/src/mpris.rs
+++ b/late-cli/src/mpris.rs
@@ -4,12 +4,12 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 #[cfg(target_os = "linux")]
 use std::time::{SystemTime, UNIX_EPOCH};
-use tokio::sync::watch;
+use tokio::sync::{mpsc, watch};
 
-/// The mute and volume the CLI is actually playing at. MPRIS both reports
-/// these and writes them: a desktop widget's play/pause button and the
-/// keyboard's media keys drive the same atomics the pair WebSocket does, and
-/// the 1s client-state heartbeat carries the result back to the server.
+/// Read handles onto the mute and volume the CLI is actually playing at.
+/// MPRIS reports these but never writes them: a desktop client's control
+/// travels as a [`DesktopCommand`] up the pair WebSocket, and the atomics only
+/// change when the server's fan-out comes back on the socket path.
 #[derive(Clone)]
 pub(super) struct AudioControls {
     pub(super) muted: Arc<AtomicBool>,
@@ -18,9 +18,10 @@ pub(super) struct AudioControls {
 
 /// The MPRIS transport commands a desktop client can send us. Playback itself
 /// is the server's, and pause/resume of a live stream is not a thing, so mute
-/// is the one control the CLI owns locally and every command maps onto it.
+/// is the one thing a command can mean and every one resolves to a target
+/// mute state.
 ///
-/// Gated with the rest of the write path: only a real MPRIS server issues
+/// Gated with the rest of the command path: only a real MPRIS server issues
 /// these, so off-Linux they are dead code and `-D warnings` fails the build.
 #[cfg(target_os = "linux")]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -42,22 +43,25 @@ impl TransportCommand {
     }
 }
 
+/// One audio control issued by a desktop media client (a widget's play/pause,
+/// media keys, a volume slider). Not applied locally: the pair WebSocket loop
+/// sends it to the server, which fans the resulting `set_muted`/`set_volume`
+/// out to every paired client, this CLI and the webview helper alike. That
+/// round trip is what makes a widget press reach YouTube, which plays in the
+/// helper process, exactly like a TUI `m` keypress does.
 #[cfg(target_os = "linux")]
-impl AudioControls {
-    pub(super) fn apply_transport(&self, command: TransportCommand) {
-        let muted = command.mutes(self.muted.load(Ordering::Relaxed));
-        self.muted.store(muted, Ordering::Relaxed);
-    }
-
-    /// A widget dragging the slider off zero means "and unmute", which is the
-    /// only way back from `Pause` for clients that only expose a slider.
-    pub(super) fn set_volume_percent(&self, percent: u8) {
-        self.volume_percent.store(percent, Ordering::Relaxed);
-        if percent > 0 {
-            self.muted.store(false, Ordering::Relaxed);
-        }
-    }
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DesktopCommand {
+    SetMuted { muted: bool },
+    SetVolume { volume_percent: u8 },
 }
+
+/// Only a real MPRIS server produces desktop commands and off-Linux there is
+/// none, so the twin is uninhabited: the channel and the pair loop's send path
+/// compile unchanged, while "a command arrived" stays unrepresentable.
+#[cfg(not(target_os = "linux"))]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DesktopCommand {}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct TrackMetadata {
@@ -127,18 +131,18 @@ pub(super) struct RadioTrack {
     pub(super) title: String,
 }
 
+/// Capacity of the desktop command queue between the MPRIS interface and the
+/// pair WebSocket loop. Commands are single key presses; a loop that stops
+/// draining for longer than a handful of them is reconnecting, and commands
+/// dropped then are presses the user will simply repeat.
+const DESKTOP_COMMAND_QUEUE_CAP: usize = 8;
+
 pub(super) struct DesktopMedia {
     /// Only the projected track travels: mute and volume are read live from
     /// [`AudioControls`] at publish time, so there is one source of truth no
     /// matter which side changed them. Dropping this ends the publisher task,
     /// whose `changed()` returns `Err` once the last sender is gone.
     track: watch::Sender<Option<TrackMetadata>>,
-    /// Bumped by the MPRIS interface whenever a desktop client writes mute or
-    /// volume. The publisher watches it to republish, and the pair WebSocket
-    /// loop watches it to push a fresh `client_state`: a locally originated
-    /// mute reaches the server no other way, so without this the TUI keeps
-    /// showing sound that is no longer playing.
-    control_writes: watch::Sender<u64>,
     source: Option<MediaSource>,
     station: Option<String>,
     stream_url: Option<String>,
@@ -154,31 +158,23 @@ impl DesktopMedia {
     /// bus: an unreachable or wedged bus would stall audio control with
     /// nothing in the logs pointing at MPRIS.
     ///
-    /// The task republishes on two edges: a new track from the pair socket,
-    /// and `control_writes`, which the MPRIS interface bumps after a desktop
-    /// client writes mute or volume. Both re-read the controls, so a
-    /// play/pause from a widget and one from the TUI converge on the same
-    /// published state.
-    pub(super) fn new(controls: AudioControls) -> Self {
+    /// Also returns the receiving end of the desktop command queue. The pair
+    /// WebSocket loop drains it and forwards each command to the server; the
+    /// state the MPRIS interface reports only changes when the server's
+    /// fan-out lands back on the socket and [`Self::republish_audio_state`]
+    /// nudges the task, so a play/pause from a widget and one from the TUI
+    /// converge through the same path.
+    pub(super) fn new(controls: AudioControls) -> (Self, mpsc::Receiver<DesktopCommand>) {
         let (track, mut track_rx) = watch::channel(None);
-        let (control_writes, mut writes_rx) = watch::channel(0_u64);
+        let (commands, commands_rx) = mpsc::channel(DESKTOP_COMMAND_QUEUE_CAP);
         let task_controls = controls.clone();
-        let interface_writes = control_writes.clone();
         tokio::spawn(async move {
-            let publisher = MprisPublisher::new(controls, interface_writes).await;
-            loop {
-                // The track sender lives in `DesktopMedia`, so its `Err` is
-                // what ends this task. `writes_rx` never closes: the interface
-                // holding its sender is owned by this same task.
-                tokio::select! {
-                    changed = track_rx.changed() => {
-                        if changed.is_err() {
-                            break;
-                        }
-                    }
-                    _ = writes_rx.changed() => {}
-                }
-                let track = track_rx.borrow().clone();
+            let publisher = MprisPublisher::new(controls, commands).await;
+            // The track sender lives in `DesktopMedia`, so its `Err` is what
+            // ends this task. A `watch` send notifies even when the value is
+            // unchanged, which is what lets `republish_audio_state` reuse it.
+            while track_rx.changed().await.is_ok() {
+                let track = track_rx.borrow_and_update().clone();
                 publisher
                     .update(
                         track.as_ref(),
@@ -188,16 +184,16 @@ impl DesktopMedia {
                     .await;
             }
         });
-        Self {
+        let media = Self {
             track,
-            control_writes,
             source: None,
             station: None,
             stream_url: None,
             youtube_current: None,
             icecast_tracks: HashMap::new(),
             radio_tracks: HashMap::new(),
-        }
+        };
+        (media, commands_rx)
     }
 
     /// No publisher task, so sends land in a channel nobody reads. Tests here
@@ -205,10 +201,8 @@ impl DesktopMedia {
     #[cfg(test)]
     fn for_test() -> Self {
         let (track, _) = watch::channel(None);
-        let (control_writes, _) = watch::channel(0_u64);
         Self {
             track,
-            control_writes,
             source: None,
             station: None,
             stream_url: None,
@@ -252,17 +246,10 @@ impl DesktopMedia {
     }
 
     /// Mute and volume are read from [`AudioControls`] by the publisher, so a
-    /// change to either only needs to nudge the task. The track is unchanged,
-    /// which a `watch` would swallow, hence the explicit send.
+    /// change to either only needs to nudge the task; a `watch` send notifies
+    /// its receiver even when the track it carries is unchanged.
     pub(super) fn republish_audio_state(&self) {
         self.publish();
-    }
-
-    /// Fires when a desktop client writes mute or volume. The pair WebSocket
-    /// loop sends `client_state` on each tick so the server and TUI follow a
-    /// change that started at the widget rather than at the terminal.
-    pub(super) fn subscribe_control_writes(&self) -> watch::Receiver<u64> {
-        self.control_writes.subscribe()
     }
 
     /// A closed receiver means the publisher task has ended (no session bus,
@@ -375,7 +362,7 @@ fn nonblank(value: Option<&str>) -> Option<&str> {
 
 #[cfg(target_os = "linux")]
 mod platform {
-    use super::{AudioControls, TrackMetadata, TransportCommand};
+    use super::{AudioControls, DesktopCommand, TrackMetadata, TransportCommand};
     use mpris_server::{
         LoopStatus, Metadata, PlaybackRate, PlaybackStatus, PlayerInterface, Property,
         RootInterface, Server, Time, TrackId, Volume,
@@ -389,7 +376,7 @@ mod platform {
             atomic::{AtomicI64, AtomicU8, AtomicU64, Ordering},
         },
     };
-    use tokio::sync::watch;
+    use tokio::sync::mpsc;
 
     const STATUS_STOPPED: u8 = 0;
     const STATUS_PLAYING: u8 = 1;
@@ -405,30 +392,34 @@ mod platform {
         volume_bits: AtomicU64,
         position_micros: AtomicI64,
         controls: AudioControls,
-        control_writes: watch::Sender<u64>,
+        commands: mpsc::Sender<DesktopCommand>,
     }
 
     impl MprisInterface {
-        /// Desktop clients write mute and volume straight into the atomics the
-        /// audio thread reads, then wake the publisher so the new state is
-        /// announced without waiting for the next track change.
+        /// Every transport command resolves to the absolute mute state it
+        /// targets, read against the flag the CLI is actually playing with.
+        /// Absolute rather than a toggle so all paired clients converge even
+        /// if one had drifted.
         fn transport(&self, command: TransportCommand) {
-            self.controls.apply_transport(command);
-            self.announce();
+            let muted = command.mutes(self.controls.muted.load(Ordering::Relaxed));
+            self.send_command(DesktopCommand::SetMuted { muted });
         }
 
-        /// Wakes both watchers of the control epoch: the publisher, so the
-        /// desktop sees the new state, and the pair socket, so the server does.
-        fn announce(&self) {
-            self.control_writes
-                .send_modify(|writes| *writes = writes.wrapping_add(1));
+        /// `try_send` because a D-Bus handler must never wait on the pair
+        /// loop: a full queue means the loop is wedged or reconnecting, and
+        /// a dropped press is one the user will repeat, unlike a stalled
+        /// session bus.
+        fn send_command(&self, command: DesktopCommand) {
+            if let Err(err) = self.commands.try_send(command) {
+                tracing::warn!(?command, error = %err, "dropping desktop media command");
+            }
         }
     }
 
     impl Publisher {
         pub(super) async fn new(
             controls: AudioControls,
-            control_writes: watch::Sender<u64>,
+            commands: mpsc::Sender<DesktopCommand>,
         ) -> ZbusResult<Self> {
             let suffix = format!("late.instance{}", std::process::id());
             let server = Server::new(
@@ -439,7 +430,7 @@ mod platform {
                     volume_bits: AtomicU64::new(1.0_f64.to_bits()),
                     position_micros: AtomicI64::new(0),
                     controls,
-                    control_writes,
+                    commands,
                 },
             )
             .await?;
@@ -501,6 +492,13 @@ mod platform {
                 ])
                 .await
         }
+    }
+
+    /// MPRIS volume is a double in 0.0..=1.0; the wire carries a percent.
+    /// Clamped before scaling, so this lands in 0..=100 and the cast cannot
+    /// truncate or lose a sign (a NaN write saturates to 0).
+    pub(super) fn volume_percent_from_mpris(volume: Volume) -> u8 {
+        (volume.clamp(0.0, 1.0) * 100.0).round() as u8
     }
 
     pub(super) fn metadata_for_track(track: &TrackMetadata) -> Metadata {
@@ -668,12 +666,11 @@ mod platform {
         async fn set_volume(&self, volume: Volume) -> ZbusResult<()> {
             // Advertising CanControl means clients may write this, so honour
             // it rather than accepting the call and dropping it. Raising the
-            // slider off zero is also how a widget expects to unmute.
-            // Clamped before scaling, so this lands in 0..=100 and the cast
-            // cannot truncate or lose a sign.
-            let percent = (volume.clamp(0.0, 1.0) * 100.0).round() as u8;
-            self.controls.set_volume_percent(percent);
-            self.announce();
+            // slider off zero is also how a widget expects to unmute; every
+            // client applies that on the `set_volume` fan-out.
+            self.send_command(DesktopCommand::SetVolume {
+                volume_percent: volume_percent_from_mpris(volume),
+            });
             Ok(())
         }
 
@@ -719,23 +716,24 @@ mod platform {
 
 #[cfg(not(target_os = "linux"))]
 mod platform {
-    use super::{AudioControls, TrackMetadata};
+    use super::{AudioControls, DesktopCommand, TrackMetadata};
     use std::{
         convert::Infallible,
         future::{Ready, ready},
     };
-    use tokio::sync::watch;
+    use tokio::sync::mpsc;
 
     pub(super) struct Publisher;
 
     /// These mirror the Linux publisher's awaited signatures so the shared
     /// wrapper needs no `cfg`, but there is nothing to await off-Linux. They
     /// return a ready future rather than being `async fn` so no suppression
-    /// is needed for a future that completes immediately.
+    /// is needed for a future that completes immediately. Dropping the
+    /// command sender here is what closes the pair loop's receiver.
     impl Publisher {
         pub(super) fn new(
             _controls: AudioControls,
-            _control_writes: watch::Sender<u64>,
+            _commands: mpsc::Sender<DesktopCommand>,
         ) -> Ready<Result<Self, Infallible>> {
             ready(Ok(Self))
         }
@@ -756,8 +754,11 @@ pub(super) struct MprisPublisher {
 }
 
 impl MprisPublisher {
-    pub(super) async fn new(controls: AudioControls, control_writes: watch::Sender<u64>) -> Self {
-        match platform::Publisher::new(controls, control_writes).await {
+    pub(super) async fn new(
+        controls: AudioControls,
+        commands: mpsc::Sender<DesktopCommand>,
+    ) -> Self {
+        match platform::Publisher::new(controls, commands).await {
             Ok(publisher) => {
                 #[cfg(target_os = "linux")]
                 tracing::info!("desktop MPRIS publisher ready");
@@ -787,11 +788,6 @@ impl MprisPublisher {
         if let Err(err) = publisher.update(track, muted, volume_percent).await {
             tracing::warn!(error = %err, "failed to update desktop MPRIS state");
         }
-    }
-
-    #[cfg(test)]
-    pub(super) const fn disabled() -> Self {
-        Self { publisher: None }
     }
 }
 

--- a/late-cli/src/mpris.rs
+++ b/late-cli/src/mpris.rs
@@ -1,8 +1,63 @@
 use serde::Deserialize;
 use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 #[cfg(target_os = "linux")]
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::sync::watch;
+
+/// The mute and volume the CLI is actually playing at. MPRIS both reports
+/// these and writes them: a desktop widget's play/pause button and the
+/// keyboard's media keys drive the same atomics the pair WebSocket does, and
+/// the 1s client-state heartbeat carries the result back to the server.
+#[derive(Clone)]
+pub(super) struct AudioControls {
+    pub(super) muted: Arc<AtomicBool>,
+    pub(super) volume_percent: Arc<AtomicU8>,
+}
+
+/// The MPRIS transport commands a desktop client can send us. Playback itself
+/// is the server's, and pause/resume of a live stream is not a thing, so mute
+/// is the one control the CLI owns locally and every command maps onto it.
+///
+/// Gated with the rest of the write path: only a real MPRIS server issues
+/// these, so off-Linux they are dead code and `-D warnings` fails the build.
+#[cfg(target_os = "linux")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum TransportCommand {
+    Play,
+    Pause,
+    PlayPause,
+    Stop,
+}
+
+#[cfg(target_os = "linux")]
+impl TransportCommand {
+    fn mutes(self, currently_muted: bool) -> bool {
+        match self {
+            Self::Play => false,
+            Self::Pause | Self::Stop => true,
+            Self::PlayPause => !currently_muted,
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+impl AudioControls {
+    pub(super) fn apply_transport(&self, command: TransportCommand) {
+        let muted = command.mutes(self.muted.load(Ordering::Relaxed));
+        self.muted.store(muted, Ordering::Relaxed);
+    }
+
+    /// A widget dragging the slider off zero means "and unmute", which is the
+    /// only way back from `Pause` for clients that only expose a slider.
+    pub(super) fn set_volume_percent(&self, percent: u8) {
+        self.volume_percent.store(percent, Ordering::Relaxed);
+        if percent > 0 {
+            self.muted.store(false, Ordering::Relaxed);
+        }
+    }
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct TrackMetadata {
@@ -72,20 +127,18 @@ pub(super) struct RadioTrack {
     pub(super) title: String,
 }
 
-/// One published state of the desktop player. The publisher only ever cares
-/// about the latest one, which is what makes a `watch` the right channel: a
-/// burst of queue updates collapses to the track that survived it.
-#[derive(Debug, Clone, PartialEq, Eq)]
-struct MediaUpdate {
-    track: Option<TrackMetadata>,
-    muted: bool,
-    volume_percent: u8,
-}
-
 pub(super) struct DesktopMedia {
-    /// Dropping this ends the publisher task: its `changed()` returns `Err`
-    /// once the last sender is gone.
-    updates: watch::Sender<MediaUpdate>,
+    /// Only the projected track travels: mute and volume are read live from
+    /// [`AudioControls`] at publish time, so there is one source of truth no
+    /// matter which side changed them. Dropping this ends the publisher task,
+    /// whose `changed()` returns `Err` once the last sender is gone.
+    track: watch::Sender<Option<TrackMetadata>>,
+    /// Bumped by the MPRIS interface whenever a desktop client writes mute or
+    /// volume. The publisher watches it to republish, and the pair WebSocket
+    /// loop watches it to push a fresh `client_state`: a locally originated
+    /// mute reaches the server no other way, so without this the TUI keeps
+    /// showing sound that is no longer playing.
+    control_writes: watch::Sender<u64>,
     source: Option<MediaSource>,
     station: Option<String>,
     stream_url: Option<String>,
@@ -100,23 +153,44 @@ impl DesktopMedia {
     /// mute/volume and voice control, so it must never block on the session
     /// bus: an unreachable or wedged bus would stall audio control with
     /// nothing in the logs pointing at MPRIS.
-    pub(super) fn new() -> Self {
-        let (updates, mut rx) = watch::channel(MediaUpdate {
-            track: None,
-            muted: false,
-            volume_percent: 0,
-        });
+    ///
+    /// The task republishes on two edges: a new track from the pair socket,
+    /// and `control_writes`, which the MPRIS interface bumps after a desktop
+    /// client writes mute or volume. Both re-read the controls, so a
+    /// play/pause from a widget and one from the TUI converge on the same
+    /// published state.
+    pub(super) fn new(controls: AudioControls) -> Self {
+        let (track, mut track_rx) = watch::channel(None);
+        let (control_writes, mut writes_rx) = watch::channel(0_u64);
+        let task_controls = controls.clone();
+        let interface_writes = control_writes.clone();
         tokio::spawn(async move {
-            let publisher = MprisPublisher::new().await;
-            while rx.changed().await.is_ok() {
-                let update = rx.borrow_and_update().clone();
+            let publisher = MprisPublisher::new(controls, interface_writes).await;
+            loop {
+                // The track sender lives in `DesktopMedia`, so its `Err` is
+                // what ends this task. `writes_rx` never closes: the interface
+                // holding its sender is owned by this same task.
+                tokio::select! {
+                    changed = track_rx.changed() => {
+                        if changed.is_err() {
+                            break;
+                        }
+                    }
+                    _ = writes_rx.changed() => {}
+                }
+                let track = track_rx.borrow().clone();
                 publisher
-                    .update(update.track.as_ref(), update.muted, update.volume_percent)
+                    .update(
+                        track.as_ref(),
+                        task_controls.muted.load(Ordering::Relaxed),
+                        task_controls.volume_percent.load(Ordering::Relaxed),
+                    )
                     .await;
             }
         });
         Self {
-            updates,
+            track,
+            control_writes,
             source: None,
             station: None,
             stream_url: None,
@@ -130,13 +204,11 @@ impl DesktopMedia {
     /// cover metadata projection, which is pure.
     #[cfg(test)]
     fn for_test() -> Self {
-        let (updates, _) = watch::channel(MediaUpdate {
-            track: None,
-            muted: false,
-            volume_percent: 0,
-        });
+        let (track, _) = watch::channel(None);
+        let (control_writes, _) = watch::channel(0_u64);
         Self {
-            updates,
+            track,
+            control_writes,
             source: None,
             station: None,
             stream_url: None,
@@ -151,66 +223,54 @@ impl DesktopMedia {
         source: MediaSource,
         station: Option<String>,
         stream_url: Option<String>,
-        muted: bool,
-        volume_percent: u8,
     ) {
         self.source = Some(source);
         self.station = station;
         self.stream_url = stream_url;
-        self.publish(muted, volume_percent);
+        self.publish();
     }
 
-    pub(super) fn update_youtube(
-        &mut self,
-        current: Option<YoutubeTrack>,
-        muted: bool,
-        volume_percent: u8,
-    ) {
+    pub(super) fn update_youtube(&mut self, current: Option<YoutubeTrack>) {
         self.youtube_current = current;
         if self.source == Some(MediaSource::Youtube) {
-            self.publish(muted, volume_percent);
+            self.publish();
         }
     }
 
-    pub(super) fn update_icecast(
-        &mut self,
-        mounts: HashMap<String, IcecastTrack>,
-        muted: bool,
-        volume_percent: u8,
-    ) {
+    pub(super) fn update_icecast(&mut self, mounts: HashMap<String, IcecastTrack>) {
         self.icecast_tracks = mounts;
         if self.source == Some(MediaSource::Icecast) {
-            self.publish(muted, volume_percent);
+            self.publish();
         }
     }
 
-    pub(super) fn update_radio(
-        &mut self,
-        stations: HashMap<String, RadioTrack>,
-        muted: bool,
-        volume_percent: u8,
-    ) {
+    pub(super) fn update_radio(&mut self, stations: HashMap<String, RadioTrack>) {
         self.radio_tracks = stations;
         if self.source == Some(MediaSource::Radio) {
-            self.publish(muted, volume_percent);
+            self.publish();
         }
     }
 
-    pub(super) fn update_audio_state(&self, muted: bool, volume_percent: u8) {
-        self.publish(muted, volume_percent);
+    /// Mute and volume are read from [`AudioControls`] by the publisher, so a
+    /// change to either only needs to nudge the task. The track is unchanged,
+    /// which a `watch` would swallow, hence the explicit send.
+    pub(super) fn republish_audio_state(&self) {
+        self.publish();
+    }
+
+    /// Fires when a desktop client writes mute or volume. The pair WebSocket
+    /// loop sends `client_state` on each tick so the server and TUI follow a
+    /// change that started at the widget rather than at the terminal.
+    pub(super) fn subscribe_control_writes(&self) -> watch::Receiver<u64> {
+        self.control_writes.subscribe()
     }
 
     /// A closed receiver means the publisher task has ended (no session bus,
     /// or the runtime is shutting down). There is nothing to publish to and
     /// nothing the pair loop can do about it, so the send result is dropped
     /// deliberately rather than logged on every track change.
-    fn publish(&self, muted: bool, volume_percent: u8) {
-        let update = MediaUpdate {
-            track: self.current_track(),
-            muted,
-            volume_percent,
-        };
-        drop(self.updates.send(update));
+    fn publish(&self) {
+        drop(self.track.send(self.current_track()));
     }
 
     fn current_track(&self) -> Option<TrackMetadata> {
@@ -315,7 +375,7 @@ fn nonblank(value: Option<&str>) -> Option<&str> {
 
 #[cfg(target_os = "linux")]
 mod platform {
-    use super::TrackMetadata;
+    use super::{AudioControls, TrackMetadata, TransportCommand};
     use mpris_server::{
         LoopStatus, Metadata, PlaybackRate, PlaybackStatus, PlayerInterface, Property,
         RootInterface, Server, Time, TrackId, Volume,
@@ -329,9 +389,11 @@ mod platform {
             atomic::{AtomicI64, AtomicU8, AtomicU64, Ordering},
         },
     };
+    use tokio::sync::watch;
 
     const STATUS_STOPPED: u8 = 0;
     const STATUS_PLAYING: u8 = 1;
+    const STATUS_PAUSED: u8 = 2;
 
     pub(super) struct Publisher {
         server: Server<MprisInterface>,
@@ -342,10 +404,32 @@ mod platform {
         status: AtomicU8,
         volume_bits: AtomicU64,
         position_micros: AtomicI64,
+        controls: AudioControls,
+        control_writes: watch::Sender<u64>,
+    }
+
+    impl MprisInterface {
+        /// Desktop clients write mute and volume straight into the atomics the
+        /// audio thread reads, then wake the publisher so the new state is
+        /// announced without waiting for the next track change.
+        fn transport(&self, command: TransportCommand) {
+            self.controls.apply_transport(command);
+            self.announce();
+        }
+
+        /// Wakes both watchers of the control epoch: the publisher, so the
+        /// desktop sees the new state, and the pair socket, so the server does.
+        fn announce(&self) {
+            self.control_writes
+                .send_modify(|writes| *writes = writes.wrapping_add(1));
+        }
     }
 
     impl Publisher {
-        pub(super) async fn new() -> ZbusResult<Self> {
+        pub(super) async fn new(
+            controls: AudioControls,
+            control_writes: watch::Sender<u64>,
+        ) -> ZbusResult<Self> {
             let suffix = format!("late.instance{}", std::process::id());
             let server = Server::new(
                 &suffix,
@@ -354,6 +438,8 @@ mod platform {
                     status: AtomicU8::new(STATUS_STOPPED),
                     volume_bits: AtomicU64::new(1.0_f64.to_bits()),
                     position_micros: AtomicI64::new(0),
+                    controls,
+                    control_writes,
                 },
             )
             .await?;
@@ -367,16 +453,15 @@ mod platform {
             volume_percent: u8,
         ) -> ZbusResult<()> {
             let metadata = track.map_or_else(Metadata::new, metadata_for_track);
-            let status = if track.is_some() {
-                PlaybackStatus::Playing
-            } else {
-                PlaybackStatus::Stopped
+            // Muted is reported as Paused rather than a zeroed volume: it is
+            // what a desktop widget draws a play button for, and it round
+            // trips through `pause`/`play` back to the same mute flag.
+            let status = match (track.is_some(), muted) {
+                (false, _) => PlaybackStatus::Stopped,
+                (true, true) => PlaybackStatus::Paused,
+                (true, false) => PlaybackStatus::Playing,
             };
-            let volume = if muted {
-                0.0
-            } else {
-                f64::from(volume_percent) / 100.0
-            };
+            let volume = f64::from(volume_percent) / 100.0;
             let position_micros = track
                 .map(TrackMetadata::position_ms)
                 .unwrap_or_default()
@@ -392,10 +477,10 @@ mod platform {
                 *current = metadata.clone();
             }
             self.server.imp().status.store(
-                if status == PlaybackStatus::Playing {
-                    STATUS_PLAYING
-                } else {
-                    STATUS_STOPPED
+                match status {
+                    PlaybackStatus::Playing => STATUS_PLAYING,
+                    PlaybackStatus::Paused => STATUS_PAUSED,
+                    PlaybackStatus::Stopped => STATUS_STOPPED,
                 },
                 Ordering::Relaxed,
             );
@@ -505,18 +590,22 @@ mod platform {
         }
 
         async fn pause(&self) -> fdo::Result<()> {
+            self.transport(TransportCommand::Pause);
             Ok(())
         }
 
         async fn play_pause(&self) -> fdo::Result<()> {
+            self.transport(TransportCommand::PlayPause);
             Ok(())
         }
 
         async fn stop(&self) -> fdo::Result<()> {
+            self.transport(TransportCommand::Stop);
             Ok(())
         }
 
         async fn play(&self) -> fdo::Result<()> {
+            self.transport(TransportCommand::Play);
             Ok(())
         }
 
@@ -576,7 +665,15 @@ mod platform {
             Ok(f64::from_bits(self.volume_bits.load(Ordering::Relaxed)))
         }
 
-        async fn set_volume(&self, _volume: Volume) -> ZbusResult<()> {
+        async fn set_volume(&self, volume: Volume) -> ZbusResult<()> {
+            // Advertising CanControl means clients may write this, so honour
+            // it rather than accepting the call and dropping it. Raising the
+            // slider off zero is also how a widget expects to unmute.
+            // Clamped before scaling, so this lands in 0..=100 and the cast
+            // cannot truncate or lose a sign.
+            let percent = (volume.clamp(0.0, 1.0) * 100.0).round() as u8;
+            self.controls.set_volume_percent(percent);
+            self.announce();
             Ok(())
         }
 
@@ -603,11 +700,11 @@ mod platform {
         }
 
         async fn can_play(&self) -> fdo::Result<bool> {
-            Ok(false)
+            Ok(true)
         }
 
         async fn can_pause(&self) -> fdo::Result<bool> {
-            Ok(false)
+            Ok(true)
         }
 
         async fn can_seek(&self) -> fdo::Result<bool> {
@@ -615,18 +712,19 @@ mod platform {
         }
 
         async fn can_control(&self) -> fdo::Result<bool> {
-            Ok(false)
+            Ok(true)
         }
     }
 }
 
 #[cfg(not(target_os = "linux"))]
 mod platform {
-    use super::TrackMetadata;
+    use super::{AudioControls, TrackMetadata};
     use std::{
         convert::Infallible,
         future::{Ready, ready},
     };
+    use tokio::sync::watch;
 
     pub(super) struct Publisher;
 
@@ -635,7 +733,10 @@ mod platform {
     /// return a ready future rather than being `async fn` so no suppression
     /// is needed for a future that completes immediately.
     impl Publisher {
-        pub(super) fn new() -> Ready<Result<Self, Infallible>> {
+        pub(super) fn new(
+            _controls: AudioControls,
+            _control_writes: watch::Sender<u64>,
+        ) -> Ready<Result<Self, Infallible>> {
             ready(Ok(Self))
         }
 
@@ -655,8 +756,8 @@ pub(super) struct MprisPublisher {
 }
 
 impl MprisPublisher {
-    pub(super) async fn new() -> Self {
-        match platform::Publisher::new().await {
+    pub(super) async fn new(controls: AudioControls, control_writes: watch::Sender<u64>) -> Self {
+        match platform::Publisher::new(controls, control_writes).await {
             Ok(publisher) => {
                 #[cfg(target_os = "linux")]
                 tracing::info!("desktop MPRIS publisher ready");

--- a/late-cli/src/mpris_test.rs
+++ b/late-cli/src/mpris_test.rs
@@ -92,63 +92,35 @@ fn projection_entry_points_stay_synchronous() {
     media.republish_audio_state();
 }
 
-#[cfg(target_os = "linux")]
-fn test_controls(muted: bool, volume_percent: u8) -> AudioControls {
-    AudioControls {
-        muted: Arc::new(AtomicBool::new(muted)),
-        volume_percent: Arc::new(AtomicU8::new(volume_percent)),
-    }
-}
-
-/// Desktop transport commands land on the same mute flag the TUI's `m` key
-/// and the pair socket drive, so a widget's play button and the terminal
-/// never disagree about whether sound is coming out.
+/// Every transport command resolves to the absolute mute state sent to the
+/// server, read against the current flag: pause and stop mean muted, play
+/// means unmuted, and PlayPause, which is what media keys send, has to read
+/// the flag rather than assume a direction.
 #[cfg(target_os = "linux")]
 #[test]
-fn transport_commands_drive_the_shared_mute_flag() {
-    let controls = test_controls(false, 70);
-
-    controls.apply_transport(TransportCommand::Pause);
-    assert!(controls.muted.load(Ordering::Relaxed), "pause mutes");
-
-    controls.apply_transport(TransportCommand::Play);
-    assert!(!controls.muted.load(Ordering::Relaxed), "play unmutes");
-
-    // PlayPause is the one that media keys send, so it has to read the
-    // current flag rather than assume a direction.
-    controls.apply_transport(TransportCommand::PlayPause);
-    assert!(controls.muted.load(Ordering::Relaxed), "play_pause mutes");
-    controls.apply_transport(TransportCommand::PlayPause);
-    assert!(
-        !controls.muted.load(Ordering::Relaxed),
-        "play_pause unmutes again"
-    );
-
+fn transport_commands_resolve_to_absolute_mute_targets() {
+    assert!(TransportCommand::Pause.mutes(false), "pause mutes");
+    assert!(TransportCommand::Pause.mutes(true), "pause keeps muted");
     // Stop has no separate meaning for a live stream: it is a mute.
-    controls.apply_transport(TransportCommand::Stop);
-    assert!(controls.muted.load(Ordering::Relaxed), "stop mutes");
-
-    // Volume is untouched throughout, so unmuting restores the same level.
-    assert_eq!(controls.volume_percent.load(Ordering::Relaxed), 70);
+    assert!(TransportCommand::Stop.mutes(false), "stop mutes");
+    assert!(!TransportCommand::Play.mutes(true), "play unmutes");
+    assert!(!TransportCommand::Play.mutes(false), "play keeps unmuted");
+    assert!(TransportCommand::PlayPause.mutes(false), "play_pause mutes");
+    assert!(
+        !TransportCommand::PlayPause.mutes(true),
+        "play_pause unmutes"
+    );
 }
 
-/// Some widgets only expose a slider, so raising it off zero is their only
-/// way back from a muted state.
+/// The MPRIS volume double is clamped before scaling to a wire percent, so
+/// out-of-range writes from a misbehaving client cannot truncate or wrap.
 #[cfg(target_os = "linux")]
 #[test]
-fn raising_volume_off_zero_also_unmutes() {
-    let controls = test_controls(true, 0);
-
-    controls.set_volume_percent(0);
-    assert!(
-        controls.muted.load(Ordering::Relaxed),
-        "a zero write is not an unmute"
-    );
-
-    controls.set_volume_percent(45);
-    assert_eq!(controls.volume_percent.load(Ordering::Relaxed), 45);
-    assert!(
-        !controls.muted.load(Ordering::Relaxed),
-        "raising the slider unmutes"
-    );
+fn mpris_volume_scales_and_clamps_to_percent() {
+    assert_eq!(platform::volume_percent_from_mpris(0.0), 0);
+    assert_eq!(platform::volume_percent_from_mpris(0.454), 45);
+    assert_eq!(platform::volume_percent_from_mpris(1.0), 100);
+    assert_eq!(platform::volume_percent_from_mpris(1.7), 100);
+    assert_eq!(platform::volume_percent_from_mpris(-0.3), 0);
+    assert_eq!(platform::volume_percent_from_mpris(f64::NAN), 0);
 }

--- a/late-cli/src/mpris_test.rs
+++ b/late-cli/src/mpris_test.rs
@@ -85,15 +85,70 @@ fn metadata_includes_track_details() {
 #[test]
 fn projection_entry_points_stay_synchronous() {
     let mut media = DesktopMedia::for_test();
-    media.select_source(
-        MediaSource::Radio,
-        Some("chillsynth".to_string()),
-        None,
-        false,
-        70,
+    media.select_source(MediaSource::Radio, Some("chillsynth".to_string()), None);
+    media.update_youtube(None);
+    media.update_icecast(HashMap::new());
+    media.update_radio(HashMap::new());
+    media.republish_audio_state();
+}
+
+#[cfg(target_os = "linux")]
+fn test_controls(muted: bool, volume_percent: u8) -> AudioControls {
+    AudioControls {
+        muted: Arc::new(AtomicBool::new(muted)),
+        volume_percent: Arc::new(AtomicU8::new(volume_percent)),
+    }
+}
+
+/// Desktop transport commands land on the same mute flag the TUI's `m` key
+/// and the pair socket drive, so a widget's play button and the terminal
+/// never disagree about whether sound is coming out.
+#[cfg(target_os = "linux")]
+#[test]
+fn transport_commands_drive_the_shared_mute_flag() {
+    let controls = test_controls(false, 70);
+
+    controls.apply_transport(TransportCommand::Pause);
+    assert!(controls.muted.load(Ordering::Relaxed), "pause mutes");
+
+    controls.apply_transport(TransportCommand::Play);
+    assert!(!controls.muted.load(Ordering::Relaxed), "play unmutes");
+
+    // PlayPause is the one that media keys send, so it has to read the
+    // current flag rather than assume a direction.
+    controls.apply_transport(TransportCommand::PlayPause);
+    assert!(controls.muted.load(Ordering::Relaxed), "play_pause mutes");
+    controls.apply_transport(TransportCommand::PlayPause);
+    assert!(
+        !controls.muted.load(Ordering::Relaxed),
+        "play_pause unmutes again"
     );
-    media.update_youtube(None, false, 70);
-    media.update_icecast(HashMap::new(), false, 70);
-    media.update_radio(HashMap::new(), true, 0);
-    media.update_audio_state(false, 30);
+
+    // Stop has no separate meaning for a live stream: it is a mute.
+    controls.apply_transport(TransportCommand::Stop);
+    assert!(controls.muted.load(Ordering::Relaxed), "stop mutes");
+
+    // Volume is untouched throughout, so unmuting restores the same level.
+    assert_eq!(controls.volume_percent.load(Ordering::Relaxed), 70);
+}
+
+/// Some widgets only expose a slider, so raising it off zero is their only
+/// way back from a muted state.
+#[cfg(target_os = "linux")]
+#[test]
+fn raising_volume_off_zero_also_unmutes() {
+    let controls = test_controls(true, 0);
+
+    controls.set_volume_percent(0);
+    assert!(
+        controls.muted.load(Ordering::Relaxed),
+        "a zero write is not an unmute"
+    );
+
+    controls.set_volume_percent(45);
+    assert_eq!(controls.volume_percent.load(Ordering::Relaxed), 45);
+    assert!(
+        !controls.muted.load(Ordering::Relaxed),
+        "raising the slider unmutes"
+    );
 }

--- a/late-cli/src/ws.rs
+++ b/late-cli/src/ws.rs
@@ -26,7 +26,7 @@ use tracing::{debug, info, warn};
 
 use super::{
     clipboard,
-    mpris::{DesktopMedia, IcecastTrack, MediaSource, RadioTrack, YoutubeTrack},
+    mpris::{DesktopCommand, DesktopMedia, IcecastTrack, MediaSource, RadioTrack, YoutubeTrack},
     voice::VoiceRuntimeState,
 };
 
@@ -54,6 +54,16 @@ enum PairControlMessage {
     ToggleMute,
     VolumeUp,
     VolumeDown,
+    /// Absolute mute/volume fan-out. The server relays a paired client's own
+    /// `set_muted`/`set_volume` event (this CLI's MPRIS surface) to everyone
+    /// on the token, so the command that started at a desktop widget comes
+    /// back here as the state to apply.
+    SetMuted {
+        muted: bool,
+    },
+    SetVolume {
+        volume_percent: u8,
+    },
     RequestClipboardImage {
         /// Echoed back in the clipboard payload so the server can match the
         /// response to this exact request. None from older servers.
@@ -633,6 +643,7 @@ pub(super) async fn run_pair_ws(
     webview: &mut WebviewPlaybackController,
     voice: &mut VoiceRuntimeState,
     desktop_media: &mut DesktopMedia,
+    desktop_commands: &mut tokio::sync::mpsc::Receiver<DesktopCommand>,
 ) -> Result<()> {
     let ws_url = pair_ws_url(api_base_url, token)?;
     debug!("connecting pair websocket");
@@ -644,7 +655,6 @@ pub(super) async fn run_pair_ws(
     let mut heartbeat = interval(Duration::from_secs(1));
     let mut voice_state_heartbeat = interval(Duration::from_secs(15));
     let mut voice_speaking_poll = interval(Duration::from_millis(250));
-    let mut desktop_control_writes = desktop_media.subscribe_control_writes();
     send_client_state(&mut ws, client, playback).await?;
     if voice.joined {
         send_voice_state(&mut ws, voice).await?;
@@ -668,12 +678,13 @@ pub(super) async fn run_pair_ws(
                     playback.volume_percent.load(Ordering::Relaxed),
                 );
             }
-            // A desktop media client (play/pause from a widget, a media key)
-            // writes mute or volume locally. The server only ever learns those
-            // from `client_state`, so without this the TUI would keep showing
-            // the pre-mute state.
-            Ok(()) = desktop_control_writes.changed() => {
-                send_client_state(&mut ws, client, playback).await?;
+            // A desktop media client (widget play/pause, a media key, the
+            // volume slider) issued a control. It is not applied locally: the
+            // server fans the resulting set_muted/set_volume back to every
+            // paired client, this CLI and the webview helper alike, which is
+            // what lets a widget press mute YouTube too.
+            Some(command) = desktop_commands.recv() => {
+                send_desktop_command(&mut ws, command).await?;
             }
             _ = voice_state_heartbeat.tick(), if voice.joined => {
                 send_voice_state(&mut ws, voice).await?;
@@ -753,7 +764,9 @@ async fn handle_pair_control(
     match control {
         audio_control @ (PairControlMessage::ToggleMute
         | PairControlMessage::VolumeUp
-        | PairControlMessage::VolumeDown) => {
+        | PairControlMessage::VolumeDown
+        | PairControlMessage::SetMuted { .. }
+        | PairControlMessage::SetVolume { .. }) => {
             apply_audio_pair_control(audio_control, playback.muted, playback.volume_percent);
             desktop_media.republish_audio_state();
             Ok(true)
@@ -895,6 +908,42 @@ async fn handle_pair_control(
     }
 }
 
+/// Forward a desktop media command (MPRIS play/pause, media keys, the volume
+/// slider) to the server as its pair-WS event. The server fans the result
+/// back to every paired client; nothing is applied locally here.
+#[cfg(target_os = "linux")]
+async fn send_desktop_command(
+    ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    command: DesktopCommand,
+) -> Result<()> {
+    let payload = match command {
+        DesktopCommand::SetMuted { muted } => json!({
+            "event": "set_muted",
+            "muted": muted,
+        }),
+        DesktopCommand::SetVolume { volume_percent } => json!({
+            "event": "set_volume",
+            "volume_percent": volume_percent,
+        }),
+    };
+    ws.send(Message::Text(payload.to_string().into())).await?;
+    Ok(())
+}
+
+/// Off-Linux `DesktopCommand` is uninhabited, so this can never be reached;
+/// the empty match proves it to the compiler and keeps the pair loop cfg-free.
+#[cfg(not(target_os = "linux"))]
+async fn send_desktop_command(
+    _ws: &mut tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >,
+    command: DesktopCommand,
+) -> Result<()> {
+    match command {}
+}
+
 fn set_stream_url(stream_url: &Mutex<String>, stream_generation: &AtomicU64, url: &str) -> bool {
     let mut current = stream_url
         .lock()
@@ -942,6 +991,22 @@ fn apply_audio_pair_control(
         PairControlMessage::VolumeDown => {
             let new_volume = bump_volume(volume_percent, -5);
             info!(volume_percent = new_volume, "applied paired volume down");
+        }
+        PairControlMessage::SetMuted { muted: new_muted } => {
+            muted.store(new_muted, Ordering::Relaxed);
+            info!(muted = new_muted, "applied paired mute set");
+        }
+        PairControlMessage::SetVolume {
+            volume_percent: new_volume,
+        } => {
+            volume_percent.store(new_volume, Ordering::Relaxed);
+            // A slider dragged off zero is a widget's only way back from
+            // pause, so a non-zero volume also unmutes; the webview helper
+            // applies the same rule to its own fan-out copy.
+            if new_volume > 0 {
+                muted.store(false, Ordering::Relaxed);
+            }
+            info!(volume_percent = new_volume, "applied paired volume set");
         }
         PairControlMessage::SetPlaybackSource { .. }
         | PairControlMessage::QueueUpdate { .. }

--- a/late-cli/src/ws.rs
+++ b/late-cli/src/ws.rs
@@ -644,6 +644,7 @@ pub(super) async fn run_pair_ws(
     let mut heartbeat = interval(Duration::from_secs(1));
     let mut voice_state_heartbeat = interval(Duration::from_secs(15));
     let mut voice_speaking_poll = interval(Duration::from_millis(250));
+    let mut desktop_control_writes = desktop_media.subscribe_control_writes();
     send_client_state(&mut ws, client, playback).await?;
     if voice.joined {
         send_voice_state(&mut ws, voice).await?;
@@ -666,6 +667,13 @@ pub(super) async fn run_pair_ws(
                     playback.muted.load(Ordering::Relaxed),
                     playback.volume_percent.load(Ordering::Relaxed),
                 );
+            }
+            // A desktop media client (play/pause from a widget, a media key)
+            // writes mute or volume locally. The server only ever learns those
+            // from `client_state`, so without this the TUI would keep showing
+            // the pre-mute state.
+            Ok(()) = desktop_control_writes.changed() => {
+                send_client_state(&mut ws, client, playback).await?;
             }
             _ = voice_state_heartbeat.tick(), if voice.joined => {
                 send_voice_state(&mut ws, voice).await?;
@@ -747,10 +755,7 @@ async fn handle_pair_control(
         | PairControlMessage::VolumeUp
         | PairControlMessage::VolumeDown) => {
             apply_audio_pair_control(audio_control, playback.muted, playback.volume_percent);
-            desktop_media.update_audio_state(
-                playback.muted.load(Ordering::Relaxed),
-                playback.volume_percent.load(Ordering::Relaxed),
-            );
+            desktop_media.republish_audio_state();
             Ok(true)
         }
         PairControlMessage::SetPlaybackSource {
@@ -818,33 +823,19 @@ async fn handle_pair_control(
                 source.into(),
                 station,
                 local_stream_url.map(str::to_string),
-                playback.muted.load(Ordering::Relaxed),
-                playback.volume_percent.load(Ordering::Relaxed),
             );
             Ok(false)
         }
         PairControlMessage::QueueUpdate { current } => {
-            desktop_media.update_youtube(
-                current,
-                playback.muted.load(Ordering::Relaxed),
-                playback.volume_percent.load(Ordering::Relaxed),
-            );
+            desktop_media.update_youtube(current);
             Ok(false)
         }
         PairControlMessage::NowPlayingUpdate { mounts } => {
-            desktop_media.update_icecast(
-                mounts,
-                playback.muted.load(Ordering::Relaxed),
-                playback.volume_percent.load(Ordering::Relaxed),
-            );
+            desktop_media.update_icecast(mounts);
             Ok(false)
         }
         PairControlMessage::RadioMetaUpdate { stations } => {
-            desktop_media.update_radio(
-                stations,
-                playback.muted.load(Ordering::Relaxed),
-                playback.volume_percent.load(Ordering::Relaxed),
-            );
+            desktop_media.update_radio(stations);
             Ok(false)
         }
         PairControlMessage::RequestClipboardImage { request_id } => {

--- a/late-cli/src/ws_test.rs
+++ b/late-cli/src/ws_test.rs
@@ -37,6 +37,84 @@ fn apply_pair_control_adjusts_volume() {
 }
 
 #[test]
+fn apply_pair_control_sets_absolute_mute() {
+    let muted = AtomicBool::new(false);
+    let volume_percent = AtomicU8::new(50);
+
+    apply_audio_pair_control(
+        PairControlMessage::SetMuted { muted: true },
+        &muted,
+        &volume_percent,
+    );
+    assert!(muted.load(Ordering::Relaxed));
+
+    // Absolute, not a toggle: applying the same state again keeps it.
+    apply_audio_pair_control(
+        PairControlMessage::SetMuted { muted: true },
+        &muted,
+        &volume_percent,
+    );
+    assert!(muted.load(Ordering::Relaxed));
+
+    apply_audio_pair_control(
+        PairControlMessage::SetMuted { muted: false },
+        &muted,
+        &volume_percent,
+    );
+    assert!(!muted.load(Ordering::Relaxed));
+    assert_eq!(
+        volume_percent.load(Ordering::Relaxed),
+        50,
+        "mute leaves volume untouched"
+    );
+}
+
+#[test]
+fn apply_pair_control_set_volume_off_zero_unmutes() {
+    let muted = AtomicBool::new(true);
+    let volume_percent = AtomicU8::new(30);
+
+    apply_audio_pair_control(
+        PairControlMessage::SetVolume { volume_percent: 0 },
+        &muted,
+        &volume_percent,
+    );
+    assert_eq!(volume_percent.load(Ordering::Relaxed), 0);
+    assert!(
+        muted.load(Ordering::Relaxed),
+        "a zero write is not an unmute"
+    );
+
+    apply_audio_pair_control(
+        PairControlMessage::SetVolume { volume_percent: 45 },
+        &muted,
+        &volume_percent,
+    );
+    assert_eq!(volume_percent.load(Ordering::Relaxed), 45);
+    assert!(!muted.load(Ordering::Relaxed), "raising the slider unmutes");
+}
+
+/// Wire contract with the server's fan-out: the CLI parses the same event
+/// names its own `set_muted`/`set_volume` requests carry upstream.
+#[test]
+fn set_controls_deserialize_from_wire_names() {
+    let muted = serde_json::from_str::<PairControlMessage>(r#"{"event":"set_muted","muted":true}"#)
+        .unwrap();
+    assert!(matches!(
+        muted,
+        PairControlMessage::SetMuted { muted: true }
+    ));
+
+    let volume =
+        serde_json::from_str::<PairControlMessage>(r#"{"event":"set_volume","volume_percent":45}"#)
+            .unwrap();
+    assert!(matches!(
+        volume,
+        PairControlMessage::SetVolume { volume_percent: 45 }
+    ));
+}
+
+#[test]
 fn queue_update_deserializes_track_details() {
     let message = serde_json::from_str::<PairControlMessage>(
         r#"{

--- a/late-ssh/src/api.rs
+++ b/late-ssh/src/api.rs
@@ -66,6 +66,15 @@ enum WsPayload {
         muted: bool,
         volume_percent: u8,
     },
+    /// Audio control initiated on a paired client (the CLI's desktop MPRIS
+    /// surface: a widget's play/pause, media keys, a volume slider). The
+    /// server fans it back out to every paired client on the token, exactly
+    /// like a TUI keypress, so the CLI, the webview helper, and the sidebar
+    /// all converge on the same state.
+    #[serde(rename = "set_muted")]
+    SetMuted { muted: bool },
+    #[serde(rename = "set_volume")]
+    SetVolume { volume_percent: u8 },
     #[serde(rename = "clipboard_image")]
     ClipboardImage {
         data_base64: String,
@@ -659,6 +668,22 @@ async fn handle_socket(mut socket: WebSocket, token: String, state: State, clien
                                         applied_initial_mute = true;
                                     }
                                 }
+                                continue;
+                            }
+                            WsPayload::SetMuted { muted } => {
+                                state.paired_client_registry.send_control(
+                                    &token,
+                                    crate::paired_clients::PairControlMessage::SetMuted { muted },
+                                );
+                                continue;
+                            }
+                            WsPayload::SetVolume { volume_percent } => {
+                                state.paired_client_registry.send_control(
+                                    &token,
+                                    crate::paired_clients::PairControlMessage::SetVolume {
+                                        volume_percent: volume_percent.min(100),
+                                    },
+                                );
                                 continue;
                             }
                             WsPayload::ClipboardImage {

--- a/late-ssh/src/api_internal_test.rs
+++ b/late-ssh/src/api_internal_test.rs
@@ -165,6 +165,23 @@ fn ws_payload_openssh_client_state_parses() {
     }
 }
 
+/// Wire contract with the CLI's desktop media commands (MPRIS play/pause and
+/// volume): the event names must match what `late-cli`'s pair loop sends.
+#[test]
+fn ws_payload_set_muted_and_set_volume_parse() {
+    let muted =
+        serde_json::from_str::<WsPayload>(r#"{"event": "set_muted", "muted": true}"#).unwrap();
+    assert!(matches!(muted, WsPayload::SetMuted { muted: true }));
+
+    let volume =
+        serde_json::from_str::<WsPayload>(r#"{"event": "set_volume", "volume_percent": 45}"#)
+            .unwrap();
+    assert!(matches!(
+        volume,
+        WsPayload::SetVolume { volume_percent: 45 }
+    ));
+}
+
 #[test]
 fn ws_payload_unknown_event_fails() {
     let json = r#"{"event": "unknown"}"#;

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -1481,7 +1481,8 @@ Now playing on your desktop (Linux)
   The paired CLI publishes the current track over MPRIS, the D-Bus standard your desktop already uses for media players.
   GNOME's top bar, KDE's tray, lock screens, and panel applets pick it up on their own. There is nothing to switch on: it appears once `late` is running and paired.
   Every source reports title and artist. YouTube tracks add duration, the video thumbnail, and a watch link; Icecast adds track length.
-  It is read only. Playback stays owned by this terminal, so the widget's buttons and your keyboard's media keys will not drive it.
+  Play/pause from the widget, or your keyboard's media keys, mutes and unmutes the paired client, the same as pressing m here. The volume slider works too.
+  That covers Icecast and radio, which the CLI plays itself. YouTube runs in a separate webview and only this terminal can mute it, so use m for that.
   Machines with no session bus (headless boxes, containers, some WSL setups) simply get nothing. Audio and everything else carry on as normal.
 
 Global keys (work anywhere)

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -1482,7 +1482,7 @@ Now playing on your desktop (Linux)
   GNOME's top bar, KDE's tray, lock screens, and panel applets pick it up on their own. There is nothing to switch on: it appears once `late` is running and paired.
   Every source reports title and artist. YouTube tracks add duration, the video thumbnail, and a watch link; Icecast adds track length.
   Play/pause from the widget, or your keyboard's media keys, mutes and unmutes the paired client, the same as pressing m here. The volume slider works too.
-  That covers Icecast and radio, which the CLI plays itself. YouTube runs in a separate webview and only this terminal can mute it, so use m for that.
+  The controls travel through the server to every paired player, so they cover all sources, YouTube included, and this terminal always agrees with the widget.
   Machines with no session bus (headless boxes, containers, some WSL setups) simply get nothing. Audio and everything else carry on as normal.
 
 Global keys (work anywhere)

--- a/late-ssh/src/paired_clients.rs
+++ b/late-ssh/src/paired_clients.rs
@@ -30,6 +30,16 @@ pub enum PairControlMessage {
     ToggleMute,
     VolumeUp,
     VolumeDown,
+    /// Absolute mute/volume writes, relayed from a paired client's own
+    /// `set_muted`/`set_volume` pair-WS events (a desktop MPRIS widget, media
+    /// keys). Absolute rather than a toggle so every paired client converges
+    /// on the same state even if one of them had drifted.
+    SetMuted {
+        muted: bool,
+    },
+    SetVolume {
+        volume_percent: u8,
+    },
     /// Ask a capable CLI to read its clipboard image. `request_id` is echoed
     /// back in the `clipboard_image`/`clipboard_image_failed` payload so a
     /// late response to a timed-out request can't satisfy a newer one. Old
@@ -544,3 +554,7 @@ fn token_hint(token: &str) -> String {
     let prefix: String = token.chars().take(8).collect();
     format!("{prefix}..({})", token.len())
 }
+
+#[cfg(test)]
+#[path = "paired_clients_test.rs"]
+mod paired_clients_test;

--- a/late-ssh/src/paired_clients_test.rs
+++ b/late-ssh/src/paired_clients_test.rs
@@ -1,4 +1,4 @@
-use crate::paired_clients::*;
+use super::*;
 use crate::app::audio::client_state::{ClientKind, ClientPlatform, ClientSshMode};
 
 fn expected_source(source: AudioSource) -> PairControlMessage {
@@ -14,12 +14,14 @@ fn expected_source(source: AudioSource) -> PairControlMessage {
 fn paired_client_send_control_delivers_message() {
     let registry = PairedClientRegistry::new("https://audio.late.sh");
     let (tx, mut rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    registry.register(
-        "tok1".to_string(),
-        tx,
-        Uuid::now_v7(),
-        AudioSource::default(),
-    ).expect("paired register");
+    registry
+        .register(
+            "tok1".to_string(),
+            tx,
+            Uuid::now_v7(),
+            AudioSource::default(),
+        )
+        .expect("paired register");
 
     assert!(registry.send_control("tok1", PairControlMessage::ToggleMute));
     assert_eq!(rx.try_recv().unwrap(), PairControlMessage::ToggleMute);
@@ -30,18 +32,22 @@ fn paired_client_unregister_if_match_removes_only_matching_entry() {
     let registry = PairedClientRegistry::new("https://audio.late.sh");
     let (tx1, mut rx1) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
     let (tx2, mut rx2) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let first = registry.register(
-        "tok1".to_string(),
-        tx1,
-        Uuid::now_v7(),
-        AudioSource::default(),
-    ).expect("paired register");
-    let second = registry.register(
-        "tok1".to_string(),
-        tx2,
-        Uuid::now_v7(),
-        AudioSource::default(),
-    ).expect("paired register");
+    let first = registry
+        .register(
+            "tok1".to_string(),
+            tx1,
+            Uuid::now_v7(),
+            AudioSource::default(),
+        )
+        .expect("paired register");
+    let second = registry
+        .register(
+            "tok1".to_string(),
+            tx2,
+            Uuid::now_v7(),
+            AudioSource::default(),
+        )
+        .expect("paired register");
 
     registry.unregister_if_match("tok1", first);
 
@@ -58,12 +64,14 @@ fn paired_client_unregister_if_match_removes_only_matching_entry() {
 fn paired_client_snapshot_tracks_latest_state() {
     let registry = PairedClientRegistry::new("https://audio.late.sh");
     let (tx, _rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let registration_id = registry.register(
-        "tok1".to_string(),
-        tx,
-        Uuid::now_v7(),
-        AudioSource::default(),
-    ).expect("paired register");
+    let registration_id = registry
+        .register(
+            "tok1".to_string(),
+            tx,
+            Uuid::now_v7(),
+            AudioSource::default(),
+        )
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         registration_id,
@@ -93,7 +101,9 @@ fn voice_cli_detection_ignores_webview_preferred_snapshot() {
     let user_id = Uuid::now_v7();
 
     let (cli_tx, _cli_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::default()).expect("paired register");
+    let cli_id = registry
+        .register("tok1".to_string(), cli_tx, user_id, AudioSource::default())
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         cli_id,
@@ -109,12 +119,14 @@ fn voice_cli_detection_ignores_webview_preferred_snapshot() {
     );
 
     let (webview_tx, _webview_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let webview_id = registry.register(
-        "tok1".to_string(),
-        webview_tx,
-        user_id,
-        AudioSource::Youtube,
-    ).expect("paired register");
+    let webview_id = registry
+        .register(
+            "tok1".to_string(),
+            webview_tx,
+            user_id,
+            AudioSource::Youtube,
+        )
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         webview_id,
@@ -144,12 +156,14 @@ fn cli_muted_tracks_cli_entry_and_ignores_webview_entries() {
     assert_eq!(registry.cli_muted("tok1"), None);
 
     let (webview_tx, _webview_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let webview_id = registry.register(
-        "tok1".to_string(),
-        webview_tx,
-        user_id,
-        AudioSource::Youtube,
-    ).expect("paired register");
+    let webview_id = registry
+        .register(
+            "tok1".to_string(),
+            webview_tx,
+            user_id,
+            AudioSource::Youtube,
+        )
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         webview_id,
@@ -166,7 +180,9 @@ fn cli_muted_tracks_cli_entry_and_ignores_webview_entries() {
     assert_eq!(registry.cli_muted("tok1"), None);
 
     let (cli_tx, _cli_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::Youtube).expect("paired register");
+    let cli_id = registry
+        .register("tok1".to_string(), cli_tx, user_id, AudioSource::Youtube)
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         cli_id,
@@ -203,12 +219,14 @@ fn paired_client_request_clipboard_image_reaches_cli_not_webview() {
     let registry = PairedClientRegistry::new("https://audio.late.sh");
 
     let (cli_tx, mut cli_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let cli_id = registry.register(
-        "tok1".to_string(),
-        cli_tx,
-        Uuid::now_v7(),
-        AudioSource::default(),
-    ).expect("paired register");
+    let cli_id = registry
+        .register(
+            "tok1".to_string(),
+            cli_tx,
+            Uuid::now_v7(),
+            AudioSource::default(),
+        )
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         cli_id,
@@ -224,12 +242,14 @@ fn paired_client_request_clipboard_image_reaches_cli_not_webview() {
     );
 
     let (webview_tx, mut webview_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let webview_entry_id = registry.register(
-        "tok1".to_string(),
-        webview_tx,
-        Uuid::now_v7(),
-        AudioSource::default(),
-    ).expect("paired register");
+    let webview_entry_id = registry
+        .register(
+            "tok1".to_string(),
+            webview_tx,
+            Uuid::now_v7(),
+            AudioSource::default(),
+        )
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         webview_entry_id,
@@ -256,12 +276,14 @@ fn paired_client_request_clipboard_image_reaches_cli_not_webview() {
 fn paired_client_request_clipboard_image_false_when_only_webview() {
     let registry = PairedClientRegistry::new("https://audio.late.sh");
     let (webview_tx, mut webview_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let webview_entry_id = registry.register(
-        "tok1".to_string(),
-        webview_tx,
-        Uuid::now_v7(),
-        AudioSource::default(),
-    ).expect("paired register");
+    let webview_entry_id = registry
+        .register(
+            "tok1".to_string(),
+            webview_tx,
+            Uuid::now_v7(),
+            AudioSource::default(),
+        )
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         webview_entry_id,
@@ -286,12 +308,14 @@ fn paired_client_clipboard_request_consumed_once() {
     let registry = PairedClientRegistry::new("https://audio.late.sh");
 
     let (cli_tx, mut cli_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let cli_id = registry.register(
-        "tok1".to_string(),
-        cli_tx,
-        Uuid::now_v7(),
-        AudioSource::default(),
-    ).expect("paired register");
+    let cli_id = registry
+        .register(
+            "tok1".to_string(),
+            cli_tx,
+            Uuid::now_v7(),
+            AudioSource::default(),
+        )
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         cli_id,
@@ -349,7 +373,9 @@ fn state_update_never_sends_pair_control_message() {
     let user_id = Uuid::now_v7();
 
     let (cli_tx, mut cli_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::Youtube).expect("paired register");
+    let cli_id = registry
+        .register("tok1".to_string(), cli_tx, user_id, AudioSource::Youtube)
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         cli_id,
@@ -372,7 +398,9 @@ fn set_audio_source_pushes_playback_source_to_every_entry() {
     let user_id = Uuid::now_v7();
 
     let (cli_tx, mut cli_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let cli_id = registry.register("tok1".to_string(), cli_tx, user_id, AudioSource::Icecast).expect("paired register");
+    let cli_id = registry
+        .register("tok1".to_string(), cli_tx, user_id, AudioSource::Icecast)
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         cli_id,
@@ -387,12 +415,14 @@ fn set_audio_source_pushes_playback_source_to_every_entry() {
         },
     );
     let (webview_tx, mut webview_rx) = tokio::sync::mpsc::channel(PAIR_CONTROL_QUEUE_CAP);
-    let webview_entry_id = registry.register(
-        "tok1".to_string(),
-        webview_tx,
-        user_id,
-        AudioSource::Icecast,
-    ).expect("paired register");
+    let webview_entry_id = registry
+        .register(
+            "tok1".to_string(),
+            webview_tx,
+            user_id,
+            AudioSource::Icecast,
+        )
+        .expect("paired register");
     registry.update_state_and_enforce_mute_policy(
         "tok1",
         webview_entry_id,
@@ -454,4 +484,19 @@ fn paired_client_register_rejects_past_per_token_cap() {
     registry
         .register("tok2".to_string(), tx, user_id, AudioSource::default())
         .expect("other tokens still register");
+}
+
+/// Wire contract with both paired clients: `late-cli` and `late-webview`
+/// deserialize these exact event names when the server fans a desktop media
+/// command back out.
+#[test]
+fn set_control_messages_serialize_to_wire_names() {
+    assert_eq!(
+        serde_json::to_string(&PairControlMessage::SetMuted { muted: true }).unwrap(),
+        r#"{"event":"set_muted","muted":true}"#
+    );
+    assert_eq!(
+        serde_json::to_string(&PairControlMessage::SetVolume { volume_percent: 45 }).unwrap(),
+        r#"{"event":"set_volume","volume_percent":45}"#
+    );
 }

--- a/late-webview/src/pair.rs
+++ b/late-webview/src/pair.rs
@@ -47,6 +47,12 @@ enum ServerMessage {
     ToggleMute,
     VolumeUp,
     VolumeDown,
+    SetMuted {
+        muted: bool,
+    },
+    SetVolume {
+        volume_percent: u8,
+    },
     LoadVideo {
         item_id: String,
         video_id: String,
@@ -109,6 +115,28 @@ impl AudioSettings {
             std::env::var("LATE_WEBVIEW_INITIAL_MUTED").ok().as_deref(),
             std::env::var("LATE_WEBVIEW_INITIAL_VOLUME").ok().as_deref(),
         )
+    }
+
+    /// Absolute mute write from the server's `set_muted` fan-out. Returns true
+    /// when this was an unmute, the edge that must re-load the current track
+    /// at the live server position.
+    fn set_muted(&mut self, muted: bool) -> bool {
+        let was_muted = self.muted;
+        self.muted = muted;
+        was_muted && !muted
+    }
+
+    /// Absolute volume write from the server's `set_volume` fan-out. A
+    /// non-zero volume also clears mute (a slider dragged off zero is the only
+    /// way back from pause on widgets without a play button), so this too can
+    /// be an unmute. Returns true on that edge.
+    fn set_volume(&mut self, volume_percent: u8) -> bool {
+        self.volume_percent = volume_percent;
+        if volume_percent > 0 {
+            self.set_muted(false)
+        } else {
+            false
+        }
     }
 }
 
@@ -550,6 +578,24 @@ fn handle_server_text(
             ServerTextResult {
                 send_client_state: true,
                 ..ServerTextResult::default()
+            }
+        }
+        ServerMessage::SetMuted { muted } => {
+            let resumed = audio_settings.set_muted(muted);
+            send_audio_settings(proxy, *audio_settings);
+            if resumed {
+                unmute_resume_result(proxy, current_item, current_snapshot.as_ref())
+            } else {
+                client_state_only()
+            }
+        }
+        ServerMessage::SetVolume { volume_percent } => {
+            let resumed = audio_settings.set_volume(volume_percent);
+            send_audio_settings(proxy, *audio_settings);
+            if resumed {
+                unmute_resume_result(proxy, current_item, current_snapshot.as_ref())
+            } else {
+                client_state_only()
             }
         }
         ServerMessage::LoadVideo {

--- a/late-webview/src/pair_test.rs
+++ b/late-webview/src/pair_test.rs
@@ -227,3 +227,58 @@ fn initial_audio_settings_fall_back_to_defaults_on_missing_or_invalid_values() {
     assert!(settings.muted);
     assert_eq!(settings.volume_percent, defaults.volume_percent);
 }
+
+/// Only the muted-to-unmuted edge resumes playback: the webview stops
+/// downloading while muted, so that transition must re-load the track, while
+/// re-asserting an existing state must not.
+#[test]
+fn set_muted_reports_only_the_unmute_edge_as_resume() {
+    let mut settings = AudioSettings {
+        muted: false,
+        volume_percent: 40,
+    };
+
+    assert!(!settings.set_muted(true), "muting is not a resume");
+    assert!(settings.muted);
+    assert!(!settings.set_muted(true), "re-muting is not a resume");
+    assert!(settings.set_muted(false), "unmuting resumes");
+    assert!(!settings.muted);
+    assert!(!settings.set_muted(false), "re-unmuting is not a resume");
+}
+
+/// A slider dragged off zero is a widget's only way back from pause, so a
+/// non-zero absolute volume also unmutes and resumes; a zero write only sets
+/// the level.
+#[test]
+fn set_volume_off_zero_unmutes_and_resumes() {
+    let mut settings = AudioSettings {
+        muted: true,
+        volume_percent: 30,
+    };
+
+    assert!(!settings.set_volume(0), "a zero write is not an unmute");
+    assert_eq!(settings.volume_percent, 0);
+    assert!(settings.muted);
+
+    assert!(settings.set_volume(45), "raising the slider resumes");
+    assert_eq!(settings.volume_percent, 45);
+    assert!(!settings.muted);
+
+    assert!(!settings.set_volume(50), "already unmuted is not a resume");
+}
+
+/// Wire contract with the server's `PairControlMessage` fan-out.
+#[test]
+fn set_events_parse_from_wire_names() {
+    let muted =
+        serde_json::from_str::<ServerMessage>(r#"{"event":"set_muted","muted":true}"#).unwrap();
+    assert!(matches!(muted, ServerMessage::SetMuted { muted: true }));
+
+    let volume =
+        serde_json::from_str::<ServerMessage>(r#"{"event":"set_volume","volume_percent":45}"#)
+            .unwrap();
+    assert!(matches!(
+        volume,
+        ServerMessage::SetVolume { volume_percent: 45 }
+    ));
+}


### PR DESCRIPTION
## Summary
The Linux MPRIS surface shipped in #488 was read-only (`CanControl=false`). That is spec-correct but leaves the player effectively invisible: **playerctl** skips any player whose `can-play` is false, and waybar/polybar link `libplayerctl`, so the whole point of publishing metadata was lost on the most common desktop setups. This branch makes the player controllable over the two things a paired client actually owns, mute and volume, and wires those controls back through the server so every paired client converges.

Widget play/pause, media keys, and the volume slider now behave like pressing `m` in the TUI, including for YouTube, which plays in the separate `late-webview` helper process.

## Changes
- **MPRIS is controllable (`late-cli/src/mpris.rs`).** `CanPlay`/`CanPause`/`CanControl` are now true; `CanSeek`/`CanGoNext`/`CanGoPrevious` stay false. `Play`/`Pause`/`PlayPause`/`Stop` resolve through a `TransportCommand` enum to an *absolute* mute target read against the current flag, and `SetVolume` maps the slider double to a wire percent (clamped, NaN saturates to 0). Muted now publishes as `Paused` instead of a zeroed volume, which is what a widget draws a play button for.
- **Controls are not applied locally.** The D-Bus handler queues a `DesktopCommand` (bounded at 8, `try_send`, dropped with a warning so a wedged pair loop can never stall the session bus). The pair WS loop forwards it as a `set_muted`/`set_volume` event; the server fans the matching `PairControlMessage` back to every paired client. Same path as a TUI keypress.
- **New pair-WS events on both directions** (`late-ssh/src/api.rs`, `paired_clients.rs`): `set_muted { muted }` and `set_volume { volume_percent }`, client-to-server and server-to-client. The server clamps `volume_percent` to 100 on ingest. Absolute rather than toggles, so a drifted client re-converges.
- **`late-cli` applies the fan-out** (`ws.rs`): absolute mute write; a non-zero `set_volume` also unmutes, since a slider dragged off zero is a widget's only way back from pause on panels with no play button.
- **`late-webview` applies the same rules** (`pair.rs`): `AudioSettings::set_muted`/`set_volume` return whether this was the muted-to-unmuted edge, which is the one transition that must re-load the current track at the live server position (the helper stops downloading while muted).
- **`DesktopMedia` refactor.** The `watch` channel now carries only the projected track; mute and volume are read live from shared `AudioControls` atomics at publish time, so there is a single source of truth regardless of which side changed them. All four projection entry points lost their `muted`/`volume_percent` parameters, and `update_audio_state` became `republish_audio_state`.
- **Docs:** `late-cli/CONTEXT.md` (wire protocol + platform notes) and the in-app help modal's "Now playing on your desktop" section, which previously told users the widget's buttons would not work.

## Behavior notes
- Controls need a live pair socket, and the widget reflects a press when the server's fan-out lands rather than instantly. That round trip is deliberate: it is what lets a widget pause reach YouTube in the helper process and keeps CLI, helper, and TUI sidebar in agreement.
- Off-Linux, `DesktopCommand` is an uninhabited enum, so the command channel and the pair loop's send path compile unchanged while "a command arrived" stays unrepresentable (`match command {}`). No `cfg` leaked into the pair loop's select.
- Missing/wedged session D-Bus still fails open: headless boxes, containers, and WSL get no publication and carry on normally.
- `late-ssh/src/paired_clients_test.rs` existed on `main` but was never declared in any module, so none of it compiled or ran. This branch wires it in with `#[cfg(test)] #[path = ...] mod paired_clients_test;` and reformats the file. Reviewers should expect previously-dormant tests to start running.

## Feature flags
None. Linux-only by target, no config gate.

## Screenshots / Video
Not included in this draft; attach before review (a waybar/GNOME widget showing play/pause and the volume slider driving the paired client would be the useful one).

## Testing
- **Automated:** new tests on all three sides of the wire. `late-cli`: transport-command to absolute-mute mapping, MPRIS volume scaling/clamping (including out-of-range and NaN), absolute `set_muted` application, `set_volume` off zero unmuting, and event-name deserialization. `late-ssh`: `WsPayload` parse and `PairControlMessage` serialize contracts for the exact wire names. `late-webview`: unmute-edge-only resume for both setters, plus wire-name parsing. Targeted runs are not recorded here; reviewers can run `ARGS="-p late-cli -E 'test(mpris) + test(pair_control)'" make test-llm` and the equivalents for `late-ssh` / `late-webview`, with `make check` as the pre-merge gate.
- **Manual:** not recorded. Worth verifying on a real Linux desktop: `playerctl -l` now lists the player, `playerctl play-pause` and a waybar volume slider mute/unmute the paired CLI, and the same actions pause YouTube playing through the webview helper.