### PR TITLE
First-visit tour walks every page, bartender pour becomes a hidden treasure

### DIFF
--- a/late-core/src/models/drinks.rs
+++ b/late-core/src/models/drinks.rs
@@ -113,68 +113,62 @@ impl UserDrinks {
         drunk_level(self.effective_points(now))
     }
 
-    /// Shared upsert behind [`Self::record_purchase`] and
-    /// [`Self::record_free_pour`]: decay the stored buzz to now, add `buzz`,
-    /// cap, and bump the tallies. `tab` is the chips actually charged (0 for a
-    /// comped pour), tracked apart from `buzz` so a free round lights the glow
-    /// without inflating `lifetime_spent`. One statement, so concurrent buys
-    /// from two sessions can't double-count the decay window. Every numeric
-    /// parameter is cast to bigint so Postgres never infers a `LEAST`/
-    /// `GREATEST` argument as text.
-    async fn record(
-        client: &impl GenericClient,
-        user_id: Uuid,
-        buzz: i64,
-        tab: i64,
-    ) -> Result<Self> {
-        let row = client
-            .query_one(
-                "INSERT INTO user_drinks
-                    (user_id, drunk_points, lifetime_spent, drink_count, last_drink_at)
-                 VALUES ($1, LEAST($2::bigint, $5::bigint), $3::bigint, 1, current_timestamp)
-                 ON CONFLICT (user_id) DO UPDATE SET
-                    drunk_points = LEAST(
-                        GREATEST(
-                            user_drinks.drunk_points
-                                - (EXTRACT(EPOCH FROM (current_timestamp - user_drinks.last_drink_at))::bigint * $4::bigint / 3600),
-                            0
-                        ) + $2::bigint,
-                        $5::bigint
-                    ),
-                    lifetime_spent = user_drinks.lifetime_spent + $3::bigint,
-                    drink_count = user_drinks.drink_count + 1,
-                    last_drink_at = current_timestamp,
-                    updated = current_timestamp
-                 RETURNING *",
-                &[
-                    &user_id,
-                    &buzz,
-                    &tab,
-                    &DRUNK_DECAY_PER_HOUR,
-                    &MAX_DRUNK_POINTS,
-                ],
-            )
-            .await?;
-        Ok(Self::from(row))
-    }
-
-    /// Record a paid drink: `price` chips become both buzz and tab.
+    /// Record a paid drink: `price` chips become both buzz and tab. Decays
+    /// the stored buzz to now, adds the pour, caps, and bumps the tallies.
+    /// One statement, so concurrent buys from two sessions can't
+    /// double-count the decay window. Every numeric parameter is cast to
+    /// bigint so Postgres never infers a `LEAST`/`GREATEST` argument as text.
     pub async fn record_purchase(
         client: &impl GenericClient,
         user_id: Uuid,
         price: i64,
     ) -> Result<Self> {
-        Self::record(client, user_id, price, price).await
+        let row = client
+            .query_one(
+                "INSERT INTO user_drinks
+                    (user_id, drunk_points, lifetime_spent, drink_count, last_drink_at)
+                 VALUES ($1, LEAST($2::bigint, $4::bigint), $2::bigint, 1, current_timestamp)
+                 ON CONFLICT (user_id) DO UPDATE SET
+                    drunk_points = LEAST(
+                        GREATEST(
+                            user_drinks.drunk_points
+                                - (EXTRACT(EPOCH FROM (current_timestamp - user_drinks.last_drink_at))::bigint * $3::bigint / 3600),
+                            0
+                        ) + $2::bigint,
+                        $4::bigint
+                    ),
+                    lifetime_spent = user_drinks.lifetime_spent + $2::bigint,
+                    drink_count = user_drinks.drink_count + 1,
+                    last_drink_at = current_timestamp,
+                    updated = current_timestamp
+                 RETURNING *",
+                &[&user_id, &price, &DRUNK_DECAY_PER_HOUR, &MAX_DRUNK_POINTS],
+            )
+            .await?;
+        Ok(Self::from(row))
     }
 
-    /// Comp a drink on the house: `points` of buzz with no chips charged, so
-    /// `lifetime_spent` stays put. Backs the tutorial's welcome round.
-    pub async fn record_free_pour(
+    /// Comp the newcomer's welcome round: `points` of buzz with no chips
+    /// charged, insert-only so it lands at most once per user ever. `None`
+    /// when a `user_drinks` row already exists (they have drunk before, the
+    /// welcome is spent), which lets the caller re-fire safely across
+    /// sessions without double-comping.
+    pub async fn record_welcome_pour(
         client: &impl GenericClient,
         user_id: Uuid,
         points: i64,
-    ) -> Result<Self> {
-        Self::record(client, user_id, points, 0).await
+    ) -> Result<Option<Self>> {
+        let row = client
+            .query_opt(
+                "INSERT INTO user_drinks
+                    (user_id, drunk_points, lifetime_spent, drink_count, last_drink_at)
+                 VALUES ($1, LEAST($2::bigint, $3::bigint), 0, 1, current_timestamp)
+                 ON CONFLICT (user_id) DO NOTHING
+                 RETURNING *",
+                &[&user_id, &points, &MAX_DRUNK_POINTS],
+            )
+            .await?;
+        Ok(row.map(Self::from))
     }
 
     pub async fn find(client: &Client, user_id: Uuid) -> Result<Option<Self>> {

--- a/late-ssh/src/app/ai/ghost.rs
+++ b/late-ssh/src/app/ai/ghost.rs
@@ -975,12 +975,12 @@ const GREETINGS: [&str; 8] = [
     "One comped pour for the newest regular. Don't get used to it.",
 ];
 
-/// The clubhouse tutorial's one-shot bartender welcome, comping the newcomer's
-/// first drink. Scripted and local: it is drawn straight into the walker's own
-/// bartender banner and never posted to #lounge, so the room is not made to
-/// watch every first-timer get their free pour, and the line lands the instant
-/// they reach the bar instead of waiting on a model. It stays pure flavor: the
-/// "press i to talk" mechanic is taught by the BarLesson popup that follows.
+/// The tour's hidden treasure: the one-shot bartender welcome comping the
+/// newcomer's first drink when they walk up to the glowing bar. Scripted and
+/// local: it is drawn straight into the walker's own bartender banner and
+/// never posted to #lounge, so the room is not made to watch every
+/// first-timer get their free pour, and the line lands the instant they
+/// reach the counter instead of waiting on a model.
 pub fn bartender_tutorial_greeting(username: &str) -> String {
     let mut rng = TinyRng::seeded();
     format!("@{username} {}", GREETINGS[rng.next_usize(GREETINGS.len())])

--- a/late-ssh/src/app/clubhouse/CONTEXT.md
+++ b/late-ssh/src/app/clubhouse/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Domain: the Late Lounge tavern, top-level screen `0`, the landing screen for every session
-- Last updated: 2026-08-03 (first-visit tutorial became the page tour: the door box now leads into a forced walk of every top-level page in number order, ends back in the tavern, and the bartender's comped welcome pour moved out of the route to become the hidden treasure behind the pulsing bar sign; the comp is now guarded once-ever in the DB)
+- Last updated: 2026-08-03 (the first-visit page tour is now FORCED: while it runs, an input gate in `app/input.rs` swallows every input except the single key the current centered box names, plus quitting; the route walks pages 1-6 then 0 home, ends in the tavern, and the bartender's comped welcome pour stays the hidden treasure behind the pulsing bar sign, guarded once-ever in the DB)
 - Status: Active
 
 ## 1. Summary
@@ -111,31 +111,31 @@ room is the chat surface, and the full history lives in #lounge on Home.
 
 - Armed by `!extract_clubhouse_tutorial_done(user.settings)`
   (`users.settings.clubhouse_tutorial_done`, late-core). Fires once on the
-  first clubhouse entry: spawns the player at the door (`Tutorial::Welcome`,
-  walk keys + Ctrl+O), first step moves to `Wander` (a pinned nudge naming
-  `1`), then the tour walks every top-level page in number order:
-  `VisitChat` (1) -> `VisitArcade` (2) -> `VisitGames` (3) ->
+  first clubhouse entry: a centered box at the door pitches what late.sh is
+  (`Tutorial::Welcome`), then the tour walks every top-level page in number
+  order: `VisitChat` (1) -> `VisitArcade` (2) -> `VisitGames` (3) ->
   `VisitArtboard` (4) -> `VisitDirectory` (5) -> `VisitLeaderboard` (6) ->
-  `Homecoming` (0, back in the tavern). Each stop advances only when its
-  page is entered (`State::tutorial_screen_entered`, hooked in
-  `App::set_screen`), so digits and Tab both work and a detour never skips
-  a stop; the pitch box for the current stop pins top-right on its own page
-  (`ui::draw_tour_overlay`, called from `render.rs` on non-clubhouse
-  screens and from the clubhouse's `draw_tutorial` when a mid-tour player
-  wanders home early), a one-line nudge names the expected key anywhere
-  else. `Homecoming`'s Enter finishes the tour in place: the player stays
-  in the tavern.
-- Enter only advances the homecoming popup (`tutorial_capturing_keys`);
-  there is no Esc skip. Completion persists once via
-  `ProfileService::set_clubhouse_tutorial_done` (fire-and-forget, failure
-  only logged: worst case the tour runs again next session).
+  `Homecoming` (0, back in the tavern). Each stop draws a centered pitch
+  box over the real page (`ui::draw_tour_overlay`, called from `render.rs`)
+  ending in the next key; `Homecoming`'s Enter finishes the tour in place
+  and frees input: the player stays in the tavern.
+- **The tour is forced.** While `State::tutorial_forced_step` is `Some`,
+  `handle_tour_gate` in `app/input.rs` (sitting above the reserved chords,
+  below the quit-confirm modal) swallows every input, mouse and chords
+  included, except the named digit (which runs `set_screen`; the stage
+  advances in `State::tutorial_screen_entered`, hooked there), the
+  homecoming Enter, and `q` (quitting always works; Esc's lone-byte path
+  can still arm the quit confirm). There is no skip. Completion persists
+  once via `ProfileService::set_clubhouse_tutorial_done` (fire-and-forget,
+  failure only logged: worst case the tour runs again next session).
 - **The hidden treasure:** the bartender is deliberately absent from the
   route. His scripted welcome (`ghost::bartender_tutorial_greeting`, local
   banner only, never posted to #lounge) plus the comped welcome pour fire
-  the first time the newcomer walks up to the counter in the tour session
-  (`State::welcome_pour_due`), whenever that happens. After `Homecoming`
-  the bar sign pulses until the pour is claimed (`State::bar_glow`), the
-  only pointer at it. The once-ever guarantee is
+  the first time the newcomer walks up to the counter
+  (`State::welcome_pour_due`); since walking is gated until the homecoming
+  Enter, in practice that is after the send-off. The homecoming box ends
+  with a whispered pointer at it, and the bar sign pulses until the pour is
+  claimed (`State::bar_glow`). The once-ever guarantee is
   `UserDrinks::record_welcome_pour`, an insert-only comp that returns
   `None` for anyone who has ever drunk, so tour reruns after a mid-tour
   disconnect can't double-comp.

--- a/late-ssh/src/app/clubhouse/CONTEXT.md
+++ b/late-ssh/src/app/clubhouse/CONTEXT.md
@@ -2,7 +2,7 @@
 
 ## Metadata
 - Domain: the Late Lounge tavern, top-level screen `0`, the landing screen for every session
-- Last updated: 2026-07-27 (bartender only ever pours for the patron who mentions him: the `gift` action and the `@bartender round` house-round command are removed, since both forced the drunk-text shuffle onto someone who never chose to drink; he now points anyone buying for someone else at `/gift @user <n>` instead, which moves chips only, not a buzz)
+- Last updated: 2026-08-03 (first-visit tutorial became the page tour: the door box now leads into a forced walk of every top-level page in number order, ends back in the tavern, and the bartender's comped welcome pour moved out of the route to become the hidden treasure behind the pulsing bar sign; the comp is now guarded once-ever in the DB)
 - Status: Active
 
 ## 1. Summary
@@ -107,25 +107,38 @@ room is the chat surface, and the full history lives in #lounge on Home.
   them. The lounge is still pinned as the visible chat room for read cursors
   (`sync_visible_chat_room`).
 
-## 5. First-visit tutorial
+## 5. First-visit tour
 
 - Armed by `!extract_clubhouse_tutorial_done(user.settings)`
   (`users.settings.clubhouse_tutorial_done`, late-core). Fires once on the
-  first clubhouse entry: spawns the player at the door (`Tutorial::Welcome`),
-  advances to `GoToBar` on first step (bar sign pulses, small pinned hint),
-  reaching the counter triggers `BarLesson` plus a one-shot @bartender
-  greeting posted to #lounge (`App::send_clubhouse_bartender_greeting`):
-  AI-generated in his voice when the AI service is up, falling back to a
-  scripted line on disabled AI, errors, or a 6s timeout
-  (`ghost::bartender_tutorial_greeting`); either way it must tell them to
-  press `i`. Then `SendOff` lists the walkable landmarks (arcade 2, heavy
-  door 3, easel 4) plus Ctrl+G (the Lobby modal); its
-  Enter finishes the tour and drops the player onto the dashboard (#lounge
-  on Home, page 1) so they land in the chat.
-- Enter advances popups (`tutorial_capturing_keys`); Esc anywhere skips
-  (arm in `dispatch_escape`). Completion persists once via
+  first clubhouse entry: spawns the player at the door (`Tutorial::Welcome`,
+  walk keys + Ctrl+O), first step moves to `Wander` (a pinned nudge naming
+  `1`), then the tour walks every top-level page in number order:
+  `VisitChat` (1) -> `VisitArcade` (2) -> `VisitGames` (3) ->
+  `VisitArtboard` (4) -> `VisitDirectory` (5) -> `VisitLeaderboard` (6) ->
+  `Homecoming` (0, back in the tavern). Each stop advances only when its
+  page is entered (`State::tutorial_screen_entered`, hooked in
+  `App::set_screen`), so digits and Tab both work and a detour never skips
+  a stop; the pitch box for the current stop pins top-right on its own page
+  (`ui::draw_tour_overlay`, called from `render.rs` on non-clubhouse
+  screens and from the clubhouse's `draw_tutorial` when a mid-tour player
+  wanders home early), a one-line nudge names the expected key anywhere
+  else. `Homecoming`'s Enter finishes the tour in place: the player stays
+  in the tavern.
+- Enter only advances the homecoming popup (`tutorial_capturing_keys`);
+  there is no Esc skip. Completion persists once via
   `ProfileService::set_clubhouse_tutorial_done` (fire-and-forget, failure
   only logged: worst case the tour runs again next session).
+- **The hidden treasure:** the bartender is deliberately absent from the
+  route. His scripted welcome (`ghost::bartender_tutorial_greeting`, local
+  banner only, never posted to #lounge) plus the comped welcome pour fire
+  the first time the newcomer walks up to the counter in the tour session
+  (`State::welcome_pour_due`), whenever that happens. After `Homecoming`
+  the bar sign pulses until the pour is claimed (`State::bar_glow`), the
+  only pointer at it. The once-ever guarantee is
+  `UserDrinks::record_welcome_pour`, an insert-only comp that returns
+  `None` for anyone who has ever drunk, so tour reruns after a mid-tour
+  disconnect can't double-comp.
 - The Ctrl+O profile nudge lives here on purpose: the old
   "open settings on connect" behavior was removed in favor of this beat.
 

--- a/late-ssh/src/app/clubhouse/input.rs
+++ b/late-ssh/src/app/clubhouse/input.rs
@@ -28,14 +28,12 @@ pub fn handle_event(app: &mut App, event: &ParsedInput) -> bool {
     }
 
     if let Some(byte) = event_byte(event) {
-        // A tutorial popup wants Enter before anything else. There is no Esc
-        // skip: the tour only ends by reaching the bartender.
+        // The homecoming popup wants Enter before anything else. There is no
+        // Esc skip: the tour only ends back here, settling in. The player
+        // stays in the tavern; the glowing bar is theirs to find.
         if matches!(byte, b'\r' | b'\n') && app.clubhouse.tutorial_capturing_keys() {
             if app.clubhouse.tutorial_advance() {
                 app.persist_clubhouse_tutorial_done();
-                // The last box sends them off to the chat: land on the
-                // dashboard (#lounge on Home), page 1.
-                app.set_screen(Screen::Dashboard);
             }
             return true;
         }
@@ -117,7 +115,7 @@ fn handle_walk(app: &mut App, event: &ParsedInput) -> bool {
     // any locally-handled key would on the chat screens.
     app.music_prefix_armed = false;
     app.clubhouse.walk(dx, dy);
-    if app.clubhouse.tutorial_reached_bar() {
+    if app.clubhouse.welcome_pour_due() {
         app.show_clubhouse_bartender_welcome();
     }
     true

--- a/late-ssh/src/app/clubhouse/input.rs
+++ b/late-ssh/src/app/clubhouse/input.rs
@@ -27,17 +27,10 @@ pub fn handle_event(app: &mut App, event: &ParsedInput) -> bool {
         return handle_click(app, mouse);
     }
 
+    // The first-visit tour never reaches this handler: while it runs, the
+    // forced gate in `app/input.rs` (`handle_tour_gate`) owns all input,
+    // including the homecoming Enter.
     if let Some(byte) = event_byte(event) {
-        // The homecoming popup wants Enter before anything else. There is no
-        // Esc skip: the tour only ends back here, settling in. The player
-        // stays in the tavern; the glowing bar is theirs to find.
-        if matches!(byte, b'\r' | b'\n') && app.clubhouse.tutorial_capturing_keys() {
-            if app.clubhouse.tutorial_advance() {
-                app.persist_clubhouse_tutorial_done();
-            }
-            return true;
-        }
-
         match byte {
             b'i' | b'I' => {
                 if let Some(lounge_id) = app.chat.lounge_room_id() {

--- a/late-ssh/src/app/clubhouse/state.rs
+++ b/late-ssh/src/app/clubhouse/state.rs
@@ -88,23 +88,22 @@ struct BannerEntry {
 }
 
 /// The first-visit tour. `Pending` arms it until the screen is first opened;
-/// the door box teaches walking, then the tour walks every top-level page in
-/// number order (each stop advances when the expected page is entered, so
-/// digits and Tab both work), ends back in the tavern, and `Done` is
-/// persisted once on the homecoming Enter. There is no Esc skip, so a stray
-/// keypress can't cut it short. The bartender is deliberately absent from
-/// the route: his comped welcome pour stays a hidden treasure for whoever
-/// walks up to the glowing bar (see [`State::welcome_pour_due`]).
+/// then the tour is FORCED: while it runs, the input gate in `app/input.rs`
+/// (`handle_tour_gate`) swallows everything except the single key the
+/// current box names (`State::tutorial_forced_step`) and the quit keys. The
+/// route walks every top-level page in number order, ends back in the
+/// tavern, and `Done` is persisted once on the homecoming Enter. The
+/// bartender is deliberately absent from the route: his comped welcome pour
+/// stays a hidden treasure for whoever walks up to the glowing bar after
+/// the send-off (see [`State::welcome_pour_due`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tutorial {
     /// Nothing to run (returning user).
     Off,
     /// Armed, fires on the first clubhouse entry this session.
     Pending,
-    /// Box over your head at the door: how to walk.
+    /// Centered box at the door: what late.sh is, then `1`.
     Welcome,
-    /// Stepped off the mat; a nudge points at `1` until they leave.
-    Wander,
     /// On Home: the chat pitch, then `2`.
     VisitChat,
     /// On The Arcade: dailies and high scores, then `3`.
@@ -117,9 +116,17 @@ pub enum Tutorial {
     VisitDirectory,
     /// On the Leaderboards: the last stop, then `0` home.
     VisitLeaderboard,
-    /// Back in the tavern: the send-off box, Enter settles in.
+    /// Back in the tavern: the send-off box, Enter sets them free.
     Homecoming,
     Done,
+}
+
+/// The one input the forced tour accepts right now: a page digit and the
+/// screen it leads to, or Enter on the homecoming box.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TourStep {
+    Page(u8, Screen),
+    Enter,
 }
 
 #[derive(Debug)]
@@ -372,7 +379,7 @@ impl State {
     }
 
     /// Try to walk one step; the first step frees your seat in the shared
-    /// lobby. Also advances the tutorial off the welcome box.
+    /// lobby.
     pub fn walk(&mut self, dx: i32, dy: i32) {
         if let Some(lobby) = &self.lobby {
             let (x, y) = lobby.walk(self.user_id, &self.username, dx, dy);
@@ -386,9 +393,6 @@ impl State {
                 self.player_x = nx;
                 self.player_y = ny;
             }
-        }
-        if self.tutorial == Tutorial::Welcome {
-            self.tutorial = Tutorial::Wander;
         }
     }
 
@@ -467,14 +471,13 @@ impl State {
     }
 
     /// Advance the page tour when a top-level screen is entered. Each stop
-    /// waits for exactly the page it points at, so a detour (a different
-    /// digit, a landmark Enter) never skips a stop: the nudge keeps naming
-    /// the expected key until it is pressed. Both digits and Tab land here
-    /// (`App::set_screen`), and Tab happens to walk the same order.
+    /// waits for exactly the page it points at; the input gate only lets the
+    /// matching digit through, but the state machine guards the order on its
+    /// own so a stray `set_screen` (a landmark Enter, a slash command) can
+    /// never skip a stop.
     pub fn tutorial_screen_entered(&mut self, screen: Screen) {
         self.tutorial = match (self.tutorial, screen) {
-            // A brave soul may leave the mat by digit without ever walking.
-            (Tutorial::Welcome | Tutorial::Wander, Screen::Dashboard) => Tutorial::VisitChat,
+            (Tutorial::Welcome, Screen::Dashboard) => Tutorial::VisitChat,
             (Tutorial::VisitChat, Screen::Arcade) => Tutorial::VisitArcade,
             (Tutorial::VisitArcade, Screen::Games) => Tutorial::VisitGames,
             (Tutorial::VisitGames, Screen::Artboard) => Tutorial::VisitArtboard,
@@ -485,10 +488,28 @@ impl State {
         };
     }
 
+    /// The single input the forced tour accepts right now, or `None` when
+    /// input is free (no tour, or the tour is done). The gate in
+    /// `app/input.rs` swallows everything else while this is `Some`.
+    pub fn tutorial_forced_step(&self) -> Option<TourStep> {
+        match self.tutorial {
+            Tutorial::Off | Tutorial::Pending | Tutorial::Done => None,
+            Tutorial::Welcome => Some(TourStep::Page(b'1', Screen::Dashboard)),
+            Tutorial::VisitChat => Some(TourStep::Page(b'2', Screen::Arcade)),
+            Tutorial::VisitArcade => Some(TourStep::Page(b'3', Screen::Games)),
+            Tutorial::VisitGames => Some(TourStep::Page(b'4', Screen::Artboard)),
+            Tutorial::VisitArtboard => Some(TourStep::Page(b'5', Screen::Pinstar)),
+            Tutorial::VisitDirectory => Some(TourStep::Page(b'6', Screen::Leaderboard)),
+            Tutorial::VisitLeaderboard => Some(TourStep::Page(b'0', Screen::Clubhouse)),
+            Tutorial::Homecoming => Some(TourStep::Enter),
+        }
+    }
+
     /// The hidden treasure: the bartender comps a welcome pour the first
-    /// time the newcomer walks up to the counter, any time during or after
-    /// the tour. Returns true exactly once per session; the once-ever
-    /// guarantee is the DB insert behind the comp.
+    /// time the newcomer walks up to the counter. Walking only unlocks
+    /// after the homecoming Enter (the gate swallows movement mid-tour), so
+    /// in practice this fires after the send-off. Returns true exactly once
+    /// per session; the once-ever guarantee is the DB insert behind the comp.
     pub fn welcome_pour_due(&mut self) -> bool {
         if self.tutorial != Tutorial::Off
             && !self.welcome_pour_claimed
@@ -506,8 +527,8 @@ impl State {
         matches!(self.tutorial, Tutorial::Homecoming | Tutorial::Done) && !self.welcome_pour_claimed
     }
 
-    /// Advance past the homecoming popup (Enter). Returns true when the
-    /// tour just finished and should be persisted.
+    /// Advance past the homecoming popup (Enter, via the input gate).
+    /// Returns true when the tour just finished and should be persisted.
     pub fn tutorial_advance(&mut self) -> bool {
         match self.tutorial {
             Tutorial::Homecoming => {
@@ -516,11 +537,6 @@ impl State {
             }
             _ => false,
         }
-    }
-
-    /// True while a tutorial popup wants Enter before anything else.
-    pub fn tutorial_capturing_keys(&self) -> bool {
-        self.tutorial == Tutorial::Homecoming
     }
 }
 

--- a/late-ssh/src/app/clubhouse/state.rs
+++ b/late-ssh/src/app/clubhouse/state.rs
@@ -12,6 +12,8 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use late_core::models::chat_message::ChatMessage;
 use uuid::Uuid;
 
+use crate::app::common::primitives::Screen;
+
 use super::lobby::{Emote, LobbySnapshot, SharedLobby};
 use super::map;
 
@@ -85,23 +87,38 @@ struct BannerEntry {
     shown_tick: u64,
 }
 
-/// The first-visit walkthrough. `Pending` arms it until the screen is first
-/// opened; it ends by walking up to the bartender (no Esc skip, so a stray
-/// keypress can't cut it short), and `Done` is persisted once.
+/// The first-visit tour. `Pending` arms it until the screen is first opened;
+/// the door box teaches walking, then the tour walks every top-level page in
+/// number order (each stop advances when the expected page is entered, so
+/// digits and Tab both work), ends back in the tavern, and `Done` is
+/// persisted once on the homecoming Enter. There is no Esc skip, so a stray
+/// keypress can't cut it short. The bartender is deliberately absent from
+/// the route: his comped welcome pour stays a hidden treasure for whoever
+/// walks up to the glowing bar (see [`State::welcome_pour_due`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Tutorial {
     /// Nothing to run (returning user).
     Off,
     /// Armed, fires on the first clubhouse entry this session.
     Pending,
-    /// Box over your head at the door: how to walk, go see the bartender.
+    /// Box over your head at the door: how to walk.
     Welcome,
-    /// Walking; a hint points at the bar until you reach it.
-    GoToBar,
-    /// At the bar: the chat lesson popup.
-    BarLesson,
-    /// Last box: the landmarks and Ctrl+O, then you're on your own.
-    SendOff,
+    /// Stepped off the mat; a nudge points at `1` until they leave.
+    Wander,
+    /// On Home: the chat pitch, then `2`.
+    VisitChat,
+    /// On The Arcade: dailies and high scores, then `3`.
+    VisitArcade,
+    /// On the Games hub: the heavy-door pitch, then `4`.
+    VisitGames,
+    /// On the Artboard: the shared canvas, then `5`.
+    VisitArtboard,
+    /// On the Directory: people and profiles, then `6`.
+    VisitDirectory,
+    /// On the Leaderboards: the last stop, then `0` home.
+    VisitLeaderboard,
+    /// Back in the tavern: the send-off box, Enter settles in.
+    Homecoming,
     Done,
 }
 
@@ -127,6 +144,10 @@ pub struct State {
     seen_primed: bool,
     pub door_events: VecDeque<DoorEvent>,
     pub tutorial: Tutorial,
+    /// The hidden welcome pour fired this session, so walking back to the
+    /// bar doesn't repeat the bartender's scripted welcome. The once-ever
+    /// guarantee lives in the DB (`UserDrinks::record_welcome_pour`).
+    welcome_pour_claimed: bool,
     /// The bartender banner plays his lines one at a time: the pinned line,
     /// the ids waiting their turn, and the newest `created` already taken
     /// from the tail (so each line enqueues exactly once).
@@ -166,6 +187,7 @@ impl State {
             banner_queue: VecDeque::new(),
             banner_watermark: None,
             hit_layout: RefCell::new(Vec::new()),
+            welcome_pour_claimed: false,
             tutorial: if tutorial_pending {
                 Tutorial::Pending
             } else {
@@ -366,7 +388,7 @@ impl State {
             }
         }
         if self.tutorial == Tutorial::Welcome {
-            self.tutorial = Tutorial::GoToBar;
+            self.tutorial = Tutorial::Wander;
         }
     }
 
@@ -444,26 +466,51 @@ impl State {
             .unwrap_or_default()
     }
 
-    /// GoToBar -> BarLesson when the player reaches the counter. Returns
-    /// true exactly once, so the caller can trigger the bartender greeting.
-    pub fn tutorial_reached_bar(&mut self) -> bool {
-        if self.tutorial == Tutorial::GoToBar && self.nearby() == Some(map::Interactive::Bartender)
+    /// Advance the page tour when a top-level screen is entered. Each stop
+    /// waits for exactly the page it points at, so a detour (a different
+    /// digit, a landmark Enter) never skips a stop: the nudge keeps naming
+    /// the expected key until it is pressed. Both digits and Tab land here
+    /// (`App::set_screen`), and Tab happens to walk the same order.
+    pub fn tutorial_screen_entered(&mut self, screen: Screen) {
+        self.tutorial = match (self.tutorial, screen) {
+            // A brave soul may leave the mat by digit without ever walking.
+            (Tutorial::Welcome | Tutorial::Wander, Screen::Dashboard) => Tutorial::VisitChat,
+            (Tutorial::VisitChat, Screen::Arcade) => Tutorial::VisitArcade,
+            (Tutorial::VisitArcade, Screen::Games) => Tutorial::VisitGames,
+            (Tutorial::VisitGames, Screen::Artboard) => Tutorial::VisitArtboard,
+            (Tutorial::VisitArtboard, Screen::Pinstar) => Tutorial::VisitDirectory,
+            (Tutorial::VisitDirectory, Screen::Leaderboard) => Tutorial::VisitLeaderboard,
+            (Tutorial::VisitLeaderboard, Screen::Clubhouse) => Tutorial::Homecoming,
+            (stage, _) => stage,
+        };
+    }
+
+    /// The hidden treasure: the bartender comps a welcome pour the first
+    /// time the newcomer walks up to the counter, any time during or after
+    /// the tour. Returns true exactly once per session; the once-ever
+    /// guarantee is the DB insert behind the comp.
+    pub fn welcome_pour_due(&mut self) -> bool {
+        if self.tutorial != Tutorial::Off
+            && !self.welcome_pour_claimed
+            && self.nearby() == Some(map::Interactive::Bartender)
         {
-            self.tutorial = Tutorial::BarLesson;
+            self.welcome_pour_claimed = true;
             return true;
         }
         false
     }
 
-    /// Advance past the current tutorial popup (Enter). Returns true when
-    /// the tutorial just finished and should be persisted.
+    /// The bar sign pulses once the tour has come home and the welcome pour
+    /// is still unclaimed: the only pointer at the hidden treasure.
+    pub fn bar_glow(&self) -> bool {
+        matches!(self.tutorial, Tutorial::Homecoming | Tutorial::Done) && !self.welcome_pour_claimed
+    }
+
+    /// Advance past the homecoming popup (Enter). Returns true when the
+    /// tour just finished and should be persisted.
     pub fn tutorial_advance(&mut self) -> bool {
         match self.tutorial {
-            Tutorial::BarLesson => {
-                self.tutorial = Tutorial::SendOff;
-                false
-            }
-            Tutorial::SendOff => {
+            Tutorial::Homecoming => {
                 self.tutorial = Tutorial::Done;
                 true
             }
@@ -473,7 +520,7 @@ impl State {
 
     /// True while a tutorial popup wants Enter before anything else.
     pub fn tutorial_capturing_keys(&self) -> bool {
-        matches!(self.tutorial, Tutorial::BarLesson | Tutorial::SendOff)
+        self.tutorial == Tutorial::Homecoming
     }
 }
 

--- a/late-ssh/src/app/clubhouse/state_test.rs
+++ b/late-ssh/src/app/clubhouse/state_test.rs
@@ -84,7 +84,7 @@ fn walking_moves_and_respects_walls() {
 }
 
 #[test]
-fn tutorial_runs_welcome_to_done() {
+fn tutorial_tours_every_page_then_comes_home() {
     let mut state = state_with_lobby(true);
     assert_eq!(state.tutorial, Tutorial::Pending);
     state.enter_screen();
@@ -92,23 +92,105 @@ fn tutorial_runs_welcome_to_done() {
     assert_eq!((state.player_x, state.player_y), map::SPAWN);
 
     state.walk(0, -1);
-    assert_eq!(state.tutorial, Tutorial::GoToBar);
+    assert_eq!(state.tutorial, Tutorial::Wander);
 
-    // Not at the bar yet: no transition.
-    assert!(!state.tutorial_reached_bar());
+    // A wrong page never advances a stop; the route waits for its page.
+    state.tutorial_screen_entered(Screen::Leaderboard);
+    assert_eq!(state.tutorial, Tutorial::Wander);
+
+    state.tutorial_screen_entered(Screen::Dashboard);
+    assert_eq!(state.tutorial, Tutorial::VisitChat);
+    state.tutorial_screen_entered(Screen::Arcade);
+    assert_eq!(state.tutorial, Tutorial::VisitArcade);
+    state.tutorial_screen_entered(Screen::Games);
+    assert_eq!(state.tutorial, Tutorial::VisitGames);
+    state.tutorial_screen_entered(Screen::Artboard);
+    assert_eq!(state.tutorial, Tutorial::VisitArtboard);
+    state.tutorial_screen_entered(Screen::Pinstar);
+    assert_eq!(state.tutorial, Tutorial::VisitDirectory);
+
+    // Coming home early does not end the tour.
+    state.tutorial_screen_entered(Screen::Clubhouse);
+    assert_eq!(state.tutorial, Tutorial::VisitDirectory);
+
+    state.tutorial_screen_entered(Screen::Leaderboard);
+    assert_eq!(state.tutorial, Tutorial::VisitLeaderboard);
+    state.tutorial_screen_entered(Screen::Clubhouse);
+    assert_eq!(state.tutorial, Tutorial::Homecoming);
+
+    // Only the homecoming popup captures Enter, and it finishes the tour.
+    assert!(state.tutorial_capturing_keys());
+    assert!(state.tutorial_advance());
+    assert_eq!(state.tutorial, Tutorial::Done);
+    assert!(!state.tutorial_capturing_keys());
+}
+
+#[test]
+fn tutorial_skips_the_welcome_walk_when_leaving_by_digit() {
+    let mut state = state_with_lobby(true);
+    state.enter_screen();
+    assert_eq!(state.tutorial, Tutorial::Welcome);
+    // Pressing 1 straight from the welcome mat still joins the route.
+    state.tutorial_screen_entered(Screen::Dashboard);
+    assert_eq!(state.tutorial, Tutorial::VisitChat);
+}
+
+#[test]
+fn welcome_pour_fires_once_at_the_counter_during_the_tour_session() {
+    let mut state = state_with_lobby(true);
+    state.enter_screen();
+    state.walk(0, -1);
+
+    // Not at the bar: nothing pours, and the bar does not glow mid-tour.
+    assert!(!state.welcome_pour_due());
+    assert!(!state.bar_glow());
 
     // Teleport next to the counter (test-only shortcut via the lobby).
     state.player_x = 28;
     state.player_y = 12;
-    assert!(state.tutorial_reached_bar());
-    assert_eq!(state.tutorial, Tutorial::BarLesson);
-    // Only fires once.
-    assert!(!state.tutorial_reached_bar());
+    assert!(state.welcome_pour_due());
+    // Only fires once per session.
+    assert!(!state.welcome_pour_due());
+    assert!(!state.bar_glow());
+}
 
-    assert!(!state.tutorial_advance());
-    assert_eq!(state.tutorial, Tutorial::SendOff);
+#[test]
+fn bar_glows_after_homecoming_until_the_pour_is_claimed() {
+    let mut state = state_with_lobby(true);
+    state.enter_screen();
+    state.walk(0, -1);
+    for screen in [
+        Screen::Dashboard,
+        Screen::Arcade,
+        Screen::Games,
+        Screen::Artboard,
+        Screen::Pinstar,
+        Screen::Leaderboard,
+        Screen::Clubhouse,
+    ] {
+        state.tutorial_screen_entered(screen);
+    }
+    assert_eq!(state.tutorial, Tutorial::Homecoming);
+    assert!(state.bar_glow());
     assert!(state.tutorial_advance());
-    assert_eq!(state.tutorial, Tutorial::Done);
+    // Done, pour unclaimed: the glow keeps pointing at the treasure.
+    assert!(state.bar_glow());
+
+    state.player_x = 28;
+    state.player_y = 12;
+    assert!(state.welcome_pour_due());
+    assert!(!state.bar_glow());
+}
+
+#[test]
+fn returning_users_never_pour_or_glow() {
+    let mut state = state_with_lobby(false);
+    state.enter_screen();
+    assert_eq!(state.tutorial, Tutorial::Off);
+    state.player_x = 28;
+    state.player_y = 12;
+    assert!(!state.welcome_pour_due());
+    assert!(!state.bar_glow());
 }
 
 const BARTENDER: u128 = 9;

--- a/late-ssh/src/app/clubhouse/state_test.rs
+++ b/late-ssh/src/app/clubhouse/state_test.rs
@@ -87,78 +87,45 @@ fn walking_moves_and_respects_walls() {
 fn tutorial_tours_every_page_then_comes_home() {
     let mut state = state_with_lobby(true);
     assert_eq!(state.tutorial, Tutorial::Pending);
+    assert_eq!(state.tutorial_forced_step(), None);
     state.enter_screen();
     assert_eq!(state.tutorial, Tutorial::Welcome);
     assert_eq!((state.player_x, state.player_y), map::SPAWN);
 
-    state.walk(0, -1);
-    assert_eq!(state.tutorial, Tutorial::Wander);
+    // Every stop forces exactly one key, and its screen advances the route.
+    for (expected_key, screen, next_stage) in [
+        (b'1', Screen::Dashboard, Tutorial::VisitChat),
+        (b'2', Screen::Arcade, Tutorial::VisitArcade),
+        (b'3', Screen::Games, Tutorial::VisitGames),
+        (b'4', Screen::Artboard, Tutorial::VisitArtboard),
+        (b'5', Screen::Pinstar, Tutorial::VisitDirectory),
+        (b'6', Screen::Leaderboard, Tutorial::VisitLeaderboard),
+        (b'0', Screen::Clubhouse, Tutorial::Homecoming),
+    ] {
+        assert_eq!(
+            state.tutorial_forced_step(),
+            Some(TourStep::Page(expected_key, screen))
+        );
+        // A wrong page never advances a stop; the route waits for its page.
+        state.tutorial_screen_entered(Screen::Games);
+        state.tutorial_screen_entered(screen);
+        assert_eq!(state.tutorial, next_stage);
+    }
 
-    // A wrong page never advances a stop; the route waits for its page.
-    state.tutorial_screen_entered(Screen::Leaderboard);
-    assert_eq!(state.tutorial, Tutorial::Wander);
-
-    state.tutorial_screen_entered(Screen::Dashboard);
-    assert_eq!(state.tutorial, Tutorial::VisitChat);
-    state.tutorial_screen_entered(Screen::Arcade);
-    assert_eq!(state.tutorial, Tutorial::VisitArcade);
-    state.tutorial_screen_entered(Screen::Games);
-    assert_eq!(state.tutorial, Tutorial::VisitGames);
-    state.tutorial_screen_entered(Screen::Artboard);
-    assert_eq!(state.tutorial, Tutorial::VisitArtboard);
-    state.tutorial_screen_entered(Screen::Pinstar);
-    assert_eq!(state.tutorial, Tutorial::VisitDirectory);
-
-    // Coming home early does not end the tour.
-    state.tutorial_screen_entered(Screen::Clubhouse);
-    assert_eq!(state.tutorial, Tutorial::VisitDirectory);
-
-    state.tutorial_screen_entered(Screen::Leaderboard);
-    assert_eq!(state.tutorial, Tutorial::VisitLeaderboard);
-    state.tutorial_screen_entered(Screen::Clubhouse);
-    assert_eq!(state.tutorial, Tutorial::Homecoming);
-
-    // Only the homecoming popup captures Enter, and it finishes the tour.
-    assert!(state.tutorial_capturing_keys());
+    // The homecoming box forces Enter, and it finishes the tour.
+    assert_eq!(state.tutorial_forced_step(), Some(TourStep::Enter));
     assert!(state.tutorial_advance());
     assert_eq!(state.tutorial, Tutorial::Done);
-    assert!(!state.tutorial_capturing_keys());
-}
-
-#[test]
-fn tutorial_skips_the_welcome_walk_when_leaving_by_digit() {
-    let mut state = state_with_lobby(true);
-    state.enter_screen();
-    assert_eq!(state.tutorial, Tutorial::Welcome);
-    // Pressing 1 straight from the welcome mat still joins the route.
-    state.tutorial_screen_entered(Screen::Dashboard);
-    assert_eq!(state.tutorial, Tutorial::VisitChat);
-}
-
-#[test]
-fn welcome_pour_fires_once_at_the_counter_during_the_tour_session() {
-    let mut state = state_with_lobby(true);
-    state.enter_screen();
-    state.walk(0, -1);
-
-    // Not at the bar: nothing pours, and the bar does not glow mid-tour.
-    assert!(!state.welcome_pour_due());
-    assert!(!state.bar_glow());
-
-    // Teleport next to the counter (test-only shortcut via the lobby).
-    state.player_x = 28;
-    state.player_y = 12;
-    assert!(state.welcome_pour_due());
-    // Only fires once per session.
-    assert!(!state.welcome_pour_due());
-    assert!(!state.bar_glow());
+    assert_eq!(state.tutorial_forced_step(), None);
 }
 
 #[test]
 fn bar_glows_after_homecoming_until_the_pour_is_claimed() {
     let mut state = state_with_lobby(true);
     state.enter_screen();
-    state.walk(0, -1);
+    // Mid-tour: nothing pours at a distance, and the bar does not glow yet.
+    assert!(!state.welcome_pour_due());
+    assert!(!state.bar_glow());
     for screen in [
         Screen::Dashboard,
         Screen::Arcade,
@@ -176,9 +143,12 @@ fn bar_glows_after_homecoming_until_the_pour_is_claimed() {
     // Done, pour unclaimed: the glow keeps pointing at the treasure.
     assert!(state.bar_glow());
 
+    // Teleport next to the counter (test-only shortcut via the lobby).
     state.player_x = 28;
     state.player_y = 12;
     assert!(state.welcome_pour_due());
+    // Only fires once per session, and claiming kills the glow.
+    assert!(!state.welcome_pour_due());
     assert!(!state.bar_glow());
 }
 

--- a/late-ssh/src/app/clubhouse/ui.rs
+++ b/late-ssh/src/app/clubhouse/ui.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 use unicode_width::UnicodeWidthChar;
 use uuid::Uuid;
 
+use crate::app::common::primitives::Screen;
 use crate::app::common::theme;
 use crate::app::common::username_effect::{NameStyle, char_color};
 use late_core::api_types::NowPlaying;
@@ -512,9 +513,9 @@ fn animate(cells: &mut Cells, view: &ClubhouseView<'_>) {
         }
     }
 
-    // The tutorial's "find the bar" beat pulses the bar sign so the goal
-    // reads from across the room.
-    if view.state.tutorial == Tutorial::GoToBar {
+    // Once the tour has come home, the bar sign pulses until the newcomer
+    // claims the hidden welcome pour: the only pointer at the treasure.
+    if view.state.bar_glow() {
         let pulse = if (t / 8).is_multiple_of(2) {
             theme::AMBER_GLOW()
         } else {
@@ -1196,8 +1197,11 @@ fn draw_bartender_banner(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_
     );
 }
 
-/// The first-visit walkthrough boxes. Returns true when a tutorial overlay
-/// owned the frame (prop popovers wait their turn).
+/// The first-visit tour's tavern boxes: the welcome mat, the wander nudge,
+/// and the homecoming send-off. The page stops between them live in
+/// [`draw_tour_overlay`], which also renders a reminder here when a mid-tour
+/// player wanders home early. Returns true when a tutorial overlay owned the
+/// frame (prop popovers wait their turn).
 fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bool {
     let key = Style::default()
         .fg(theme::AMBER_GLOW())
@@ -1225,14 +1229,23 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
                 ]),
                 Line::default(),
                 Line::from(Span::styled(
-                    "the bartender is waving you over, head northwest to the bar.",
+                    "take a step and we'll walk the house.",
                     text,
                 )),
             ],
         ),
-        Tutorial::BarLesson => (
-            " O the bartender leans in ",
+        Tutorial::Homecoming => (
+            " ☾ make yourself at home ☽ ",
             vec![
+                Line::from(Span::styled(
+                    "that was the house. this room is its map:",
+                    text,
+                )),
+                Line::from(Span::styled(
+                    "walk up to anything and press Enter to step through.",
+                    text,
+                )),
+                Line::default(),
                 Line::from(vec![
                     Span::styled("[i] ", key),
                     Span::styled("say something, it floats over your head", text),
@@ -1242,69 +1255,30 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
                     Span::styled("wave · ", text),
                     Span::styled("[x] ", key),
                     Span::styled("dance · ", text),
-                    Span::styled("[t] ", key),
-                    Span::styled("talk to the bartender", text),
-                ]),
-                Line::default(),
-                Line::from(vec![
-                    Span::styled("[Ctrl+/] ", key),
-                    Span::styled("jump to any room or DM", text),
-                ]),
-                Line::from(vec![
-                    Span::styled("[Ctrl+]] ", key),
-                    Span::styled("pick an icon, spice up your words", text),
-                ]),
-                Line::default(),
-                Line::from(vec![
-                    Span::styled("[Enter] ", key),
-                    Span::styled("got it", dim),
-                ]),
-            ],
-        ),
-        Tutorial::SendOff => (
-            " ☾ make yourself at home ☽ ",
-            vec![
-                Line::from(Span::styled(
-                    "the room is a map of the house, walk up and press Enter:",
-                    text,
-                )),
-                Line::default(),
-                Line::from(Span::styled("arcade cabinet (2) · artboard (4)", text)),
-                Line::from(Span::styled(
-                    "heavy door (3): real NetHack, Green Dragon reborn",
-                    text,
-                )),
-                Line::from(Span::styled(
-                    "jukebox picks the music · the dog is a dog",
-                    text,
-                )),
-                Line::default(),
-                Line::from(vec![
                     Span::styled("[Ctrl+G] ", key),
-                    Span::styled("the lobby: house tables + daily games", text),
-                ]),
-                Line::from(vec![
-                    Span::styled("[/shop] ", key),
-                    Span::styled("the shop: cosmetics, companions, effects", text),
+                    Span::styled("the lobby", text),
                 ]),
                 Line::from(vec![
                     Span::styled("[?] ", key),
                     Span::styled("the full guide, any time", text),
                 ]),
                 Line::default(),
+                Line::from(Span::styled("the bar glows late for new faces.", dim)),
+                Line::default(),
                 Line::from(vec![
                     Span::styled("[Enter] ", key),
-                    Span::styled("head to the chat", dim),
+                    Span::styled("settle in", dim),
                 ]),
             ],
         ),
-        Tutorial::GoToBar => {
+        Tutorial::Wander => {
             // A small nudge, pinned bottom-left, out of the walking path.
-            let lines = vec![Line::from(Span::styled(
-                "find the glowing bar, northwest",
-                text,
-            ))];
-            let width = (34u16).min(inner.width.saturating_sub(2));
+            let lines = vec![Line::from(vec![
+                Span::styled("when you're ready, press ", text),
+                Span::styled("[1]", key),
+                Span::styled(": the chat", text),
+            ])];
+            let width = (38u16).min(inner.width.saturating_sub(2));
             let height = 3u16.min(inner.height);
             let rect = Rect {
                 x: inner.x + 1,
@@ -1318,13 +1292,23 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
                     Block::default()
                         .borders(Borders::ALL)
                         .border_style(border)
-                        .title(Span::styled(" ↖ the bar ", border)),
+                        .title(Span::styled(" ✦ the tour ", border)),
                 ),
                 rect,
             );
             return false;
         }
-        _ => return false,
+        Tutorial::VisitChat
+        | Tutorial::VisitArcade
+        | Tutorial::VisitGames
+        | Tutorial::VisitArtboard
+        | Tutorial::VisitDirectory
+        | Tutorial::VisitLeaderboard => {
+            // Wandered home mid-tour: the nudge keeps naming the next page.
+            draw_tour_overlay(frame, inner, view.state.tutorial, Screen::Clubhouse);
+            return false;
+        }
+        Tutorial::Off | Tutorial::Pending | Tutorial::Done => return false,
     };
 
     let width = (lines
@@ -1354,6 +1338,176 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
         rect,
     );
     true
+}
+
+/// The page stops of the first-visit tour. `render.rs` calls this on every
+/// non-clubhouse screen; the clubhouse calls it from [`draw_tutorial`] when
+/// a mid-tour player wanders home early. On the stop's own page the full
+/// pitch box pins top-right; on any other screen a one-line nudge keeps
+/// naming the key that resumes the route. Off-tour stages draw nothing.
+pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen: Screen) {
+    let key = Style::default()
+        .fg(theme::AMBER_GLOW())
+        .add_modifier(Modifier::BOLD);
+    let text = Style::default().fg(theme::TEXT());
+    let border = Style::default().fg(theme::AMBER());
+
+    let (home, title, pitch, next_key, next_label): (Screen, &str, Vec<Line>, &str, &str) =
+        match stage {
+            Tutorial::VisitChat => (
+                Screen::Dashboard,
+                " ✦ the tour · home ",
+                vec![
+                    Line::from(Span::styled(
+                        "every room, thread and DM on late.sh lives here.",
+                        text,
+                    )),
+                    Line::from(vec![
+                        Span::styled("[i] ", key),
+                        Span::styled("write · ", text),
+                        Span::styled("[Ctrl+/] ", key),
+                        Span::styled("switch rooms · ", text),
+                        Span::styled("[Ctrl+]] ", key),
+                        Span::styled("pick an icon", text),
+                    ]),
+                ],
+                "2",
+                "the arcade",
+            ),
+            Tutorial::VisitArcade => (
+                Screen::Arcade,
+                " ✦ the tour · the arcade ",
+                vec![
+                    Line::from(Span::styled(
+                        "solo games: Lateris, Snake, 2048, Sudoku, Solitaire...",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "daily puzzles pay chips; quests and streaks stack up top.",
+                        text,
+                    )),
+                ],
+                "3",
+                "the heavy door",
+            ),
+            Tutorial::VisitGames => (
+                Screen::Games,
+                " ✦ the tour · the games ",
+                vec![
+                    Line::from(Span::styled(
+                        "the big ones live behind this door:",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "Lateania, our own MMO. NetHack, the real thing.",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "DCSS, the most played roguelike alive. Green Dragon reborn.",
+                        text,
+                    )),
+                ],
+                "4",
+                "the artboard",
+            ),
+            Tutorial::VisitArtboard => (
+                Screen::Artboard,
+                " ✦ the tour · the artboard ",
+                vec![
+                    Line::from(Span::styled(
+                        "one shared canvas, the whole house draws at once.",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "leave a mark, someone will draw beside it by morning.",
+                        text,
+                    )),
+                ],
+                "5",
+                "the directory",
+            ),
+            Tutorial::VisitDirectory => (
+                Screen::Pinstar,
+                " ✦ the tour · the directory ",
+                vec![
+                    Line::from(Span::styled(
+                        "the people: profiles, projects, what everyone builds.",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "your profile gets a public page on the web.",
+                        text,
+                    )),
+                ],
+                "6",
+                "the leaderboards",
+            ),
+            Tutorial::VisitLeaderboard => (
+                Screen::Leaderboard,
+                " ✦ the tour · the leaderboards ",
+                vec![
+                    Line::from(Span::styled(
+                        "every game keeps score: chips, wins, streaks.",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "your name lands here sooner than you think.",
+                        text,
+                    )),
+                ],
+                "0",
+                "home to the lounge",
+            ),
+            Tutorial::Off
+            | Tutorial::Pending
+            | Tutorial::Welcome
+            | Tutorial::Wander
+            | Tutorial::Homecoming
+            | Tutorial::Done => return,
+        };
+
+    let lines: Vec<Line> = if screen == home {
+        let mut lines = pitch;
+        lines.push(Line::default());
+        lines.push(Line::from(vec![
+            Span::styled(format!("[{next_key}] "), key),
+            Span::styled(format!("next: {next_label}"), text),
+        ]));
+        lines
+    } else {
+        vec![Line::from(vec![
+            Span::styled("the tour waits: ", text),
+            Span::styled(format!("[{next_key}] "), key),
+            Span::styled(next_label.to_string(), text),
+        ])]
+    };
+
+    let width = (lines
+        .iter()
+        .map(Line::width)
+        .max()
+        .unwrap_or(0)
+        .max(title.chars().count())
+        + 4)
+    .min(usize::from(area.width).saturating_sub(2)) as u16;
+    let height = (lines.len() as u16 + 2).min(area.height);
+    let rect = Rect {
+        x: area.x + area.width.saturating_sub(width + 1),
+        y: area.y + 1,
+        width,
+        height,
+    };
+
+    frame.render_widget(Clear, rect);
+    frame.render_widget(
+        Paragraph::new(lines).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(border)
+                .title(Span::styled(title, border.add_modifier(Modifier::BOLD))),
+        ),
+        rect,
+    );
 }
 
 fn draw_popover(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) {

--- a/late-ssh/src/app/clubhouse/ui.rs
+++ b/late-ssh/src/app/clubhouse/ui.rs
@@ -1214,10 +1214,15 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
         Tutorial::Welcome => (
             " ☾ welcome to the late lounge ☽ ",
             vec![
-                Line::from(Span::styled(
-                    "late.sh: a late-night clubhouse that lives in a terminal.",
-                    text,
-                )),
+                Line::from(vec![
+                    Span::styled(
+                        "late.sh",
+                        Style::default()
+                            .fg(theme::TEXT_BRIGHT())
+                            .add_modifier(Modifier::BOLD),
+                    ),
+                    Span::styled(": a late-night clubhouse that lives in a terminal.", text),
+                ]),
                 Line::from(Span::styled(
                     "one tavern and six pages: chat, games, a shared canvas,",
                     text,
@@ -1340,6 +1345,11 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
         .fg(theme::AMBER_GLOW())
         .add_modifier(Modifier::BOLD);
     let text = Style::default().fg(theme::TEXT());
+    // Proper nouns (game names, late.sh, Late Chips) pop out of the prose so
+    // a skimming eye still catches the roster.
+    let name = Style::default()
+        .fg(theme::TEXT_BRIGHT())
+        .add_modifier(Modifier::BOLD);
     let border = Style::default().fg(theme::AMBER());
 
     let (home, title, pitch, next_key, next_label): (Screen, &str, Vec<Line>, &str, &str) =
@@ -1348,10 +1358,11 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                 Screen::Dashboard,
                 " ✦ the tour · home ",
                 vec![
-                    Line::from(Span::styled(
-                        "every room, thread and DM on late.sh lives here.",
-                        text,
-                    )),
+                    Line::from(vec![
+                        Span::styled("every room, thread and DM on ", text),
+                        Span::styled("late.sh", name),
+                        Span::styled(" lives here.", text),
+                    ]),
                     Line::default(),
                     Line::from(vec![
                         Span::styled("[i] ", key),
@@ -1371,7 +1382,9 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                     ]),
                     Line::from(vec![
                         Span::styled("[/private #room] ", key),
-                        Span::styled("invite-only · your Mentions wait in the rail", text),
+                        Span::styled("invite-only · your ", text),
+                        Span::styled("Mentions", name),
+                        Span::styled(" wait in the rail", text),
                     ]),
                 ],
                 "2",
@@ -1381,14 +1394,16 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                 Screen::Arcade,
                 " ✦ the tour · the arcade ",
                 vec![
-                    Line::from(Span::styled(
-                        "solo games: Lateris, Snake, 2048, Sudoku, Solitaire...",
-                        text,
-                    )),
-                    Line::from(Span::styled(
-                        "daily puzzles pay Late Chips; quests and streaks stack up top.",
-                        text,
-                    )),
+                    Line::from(vec![
+                        Span::styled("solo games: ", text),
+                        Span::styled("Lateris, Snake, 2048, Sudoku, Solitaire", name),
+                        Span::styled("...", text),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("daily puzzles pay ", text),
+                        Span::styled("Late Chips", name),
+                        Span::styled("; quests and streaks stack up top.", text),
+                    ]),
                     Line::default(),
                     Line::from(vec![
                         Span::styled("chips buy things. ", text),
@@ -1404,18 +1419,19 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                         Span::styled("[Ctrl+G] ", key),
                         Span::styled("the lobby, the busiest room in the house:", text),
                     ]),
-                    Line::from(Span::styled(
-                        "live tables: Poker, Blackjack, Asterion, Tron, Super Snake,",
-                        text,
-                    )),
-                    Line::from(Span::styled(
-                        "plus seven daily duels: chess, battleship, connect four,",
-                        text,
-                    )),
-                    Line::from(Span::styled(
-                        "reversi, checkers, backgammon, briscola. challenge someone,",
-                        text,
-                    )),
+                    Line::from(vec![
+                        Span::styled("live tables: ", text),
+                        Span::styled("Poker, Blackjack, Asterion, Tron, Super Snake", name),
+                        Span::styled(",", text),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("plus seven daily duels: ", text),
+                        Span::styled("chess, battleship, connect four,", name),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("reversi, checkers, backgammon, briscola", name),
+                        Span::styled(". challenge someone,", text),
+                    ]),
                     Line::from(Span::styled(
                         "walk away, play a move whenever; 24h on the clock per move.",
                         text,
@@ -1433,34 +1449,34 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                         text,
                     )),
                     Line::default(),
-                    Line::from(Span::styled(
-                        "Lateania: our own MMO. one shared world, bosses, mounts.",
-                        text,
-                    )),
-                    Line::from(Span::styled(
-                        "NetHack: the legend itself, decades deep. the DevTeam",
-                        text,
-                    )),
+                    Line::from(vec![
+                        Span::styled("Lateania", name),
+                        Span::styled(": our own MMO. one shared world, bosses, mounts.", text),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("NetHack", name),
+                        Span::styled(": the legend itself, decades deep. the DevTeam", text),
+                    ]),
                     Line::from(Span::styled(
                         "thought of everything; an ascension here is earned.",
                         text,
                     )),
-                    Line::from(Span::styled(
-                        "DCSS: the most played roguelike alive. pick a species,",
-                        text,
-                    )),
+                    Line::from(vec![
+                        Span::styled("DCSS", name),
+                        Span::styled(": the most played roguelike alive. pick a species,", text),
+                    ]),
                     Line::from(Span::styled(
                         "pick a god, dive for the Orb.",
                         text,
                     )),
-                    Line::from(Span::styled(
-                        "Brogue: the most beautiful dungeon ASCII ever drew.",
-                        text,
-                    )),
-                    Line::from(Span::styled(
-                        "Green Dragon: the legendary BBS door, reborn.",
-                        text,
-                    )),
+                    Line::from(vec![
+                        Span::styled("Brogue", name),
+                        Span::styled(": the most beautiful dungeon ASCII ever drew.", text),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("Green Dragon", name),
+                        Span::styled(": the legendary BBS door, reborn.", text),
+                    ]),
                     Line::default(),
                     Line::from(Span::styled(
                         "and much more; your wins stick to your name.",

--- a/late-ssh/src/app/clubhouse/ui.rs
+++ b/late-ssh/src/app/clubhouse/ui.rs
@@ -1444,10 +1444,7 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                 Screen::Games,
                 " ✦ the tour · the games ",
                 vec![
-                    Line::from(Span::styled(
-                        "the big ones live behind this door:",
-                        text,
-                    )),
+                    Line::from(Span::styled("the big ones live behind this door:", text)),
                     Line::default(),
                     Line::from(vec![
                         Span::styled("Lateania", name),
@@ -1465,10 +1462,7 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                         Span::styled("DCSS", name),
                         Span::styled(": the most played roguelike alive. pick a species,", text),
                     ]),
-                    Line::from(Span::styled(
-                        "pick a god, dive for the Orb.",
-                        text,
-                    )),
+                    Line::from(Span::styled("pick a god, dive for the Orb.", text)),
                     Line::from(vec![
                         Span::styled("Brogue", name),
                         Span::styled(": the most beautiful dungeon ASCII ever drew.", text),

--- a/late-ssh/src/app/clubhouse/ui.rs
+++ b/late-ssh/src/app/clubhouse/ui.rs
@@ -1215,23 +1215,27 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
             " ☾ welcome to the late lounge ☽ ",
             vec![
                 Line::from(Span::styled(
-                    "you're on the welcome mat, the house is live.",
+                    "late.sh: a late-night clubhouse that lives in a terminal.",
                     text,
                 )),
-                Line::default(),
-                Line::from(vec![
-                    Span::styled("[arrows/hjkl] ", key),
-                    Span::styled("walk around", text),
-                ]),
-                Line::from(vec![
-                    Span::styled("[Ctrl+O] ", key),
-                    Span::styled("introduce yourself first", text),
-                ]),
+                Line::from(Span::styled(
+                    "one tavern and six pages: chat, games, a shared canvas,",
+                    text,
+                )),
+                Line::from(Span::styled(
+                    "the people, the scores. everyone you'll see here is real.",
+                    text,
+                )),
                 Line::default(),
                 Line::from(Span::styled(
-                    "take a step and we'll walk the house.",
+                    "you're on the welcome mat. let's take the tour.",
                     text,
                 )),
+                Line::default(),
+                Line::from(vec![
+                    Span::styled("[1] ", key),
+                    Span::styled("first stop: the chat", text),
+                ]),
             ],
         ),
         Tutorial::Homecoming => (
@@ -1247,6 +1251,10 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
                 )),
                 Line::default(),
                 Line::from(vec![
+                    Span::styled("[arrows/hjkl] ", key),
+                    Span::styled("walk around", text),
+                ]),
+                Line::from(vec![
                     Span::styled("[i] ", key),
                     Span::styled("say something, it floats over your head", text),
                 ]),
@@ -1259,11 +1267,20 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
                     Span::styled("the lobby", text),
                 ]),
                 Line::from(vec![
+                    Span::styled("[Ctrl+O] ", key),
+                    Span::styled("introduce yourself · ", text),
                     Span::styled("[?] ", key),
-                    Span::styled("the full guide, any time", text),
+                    Span::styled("the full guide", text),
                 ]),
                 Line::default(),
-                Line::from(Span::styled("the bar glows late for new faces.", dim)),
+                Line::from(Span::styled(
+                    "psst: see the bar glowing, northwest? walk over.",
+                    dim,
+                )),
+                Line::from(Span::styled(
+                    "the bartender pours every new face their first drink.",
+                    dim,
+                )),
                 Line::default(),
                 Line::from(vec![
                     Span::styled("[Enter] ", key),
@@ -1271,44 +1288,18 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
                 ]),
             ],
         ),
-        Tutorial::Wander => {
-            // A small nudge, pinned bottom-left, out of the walking path.
-            let lines = vec![Line::from(vec![
-                Span::styled("when you're ready, press ", text),
-                Span::styled("[1]", key),
-                Span::styled(": the chat", text),
-            ])];
-            let width = (38u16).min(inner.width.saturating_sub(2));
-            let height = 3u16.min(inner.height);
-            let rect = Rect {
-                x: inner.x + 1,
-                y: inner.y + inner.height.saturating_sub(height),
-                width,
-                height,
-            };
-            frame.render_widget(Clear, rect);
-            frame.render_widget(
-                Paragraph::new(lines).block(
-                    Block::default()
-                        .borders(Borders::ALL)
-                        .border_style(border)
-                        .title(Span::styled(" ✦ the tour ", border)),
-                ),
-                rect,
-            );
-            return false;
-        }
+        // Mid-loop stages never render in the tavern: the forced gate only
+        // lets the route's digits through, and `0` lands straight on
+        // Homecoming.
         Tutorial::VisitChat
         | Tutorial::VisitArcade
         | Tutorial::VisitGames
         | Tutorial::VisitArtboard
         | Tutorial::VisitDirectory
-        | Tutorial::VisitLeaderboard => {
-            // Wandered home mid-tour: the nudge keeps naming the next page.
-            draw_tour_overlay(frame, inner, view.state.tutorial, Screen::Clubhouse);
-            return false;
-        }
-        Tutorial::Off | Tutorial::Pending | Tutorial::Done => return false,
+        | Tutorial::VisitLeaderboard
+        | Tutorial::Off
+        | Tutorial::Pending
+        | Tutorial::Done => return false,
     };
 
     let width = (lines
@@ -1340,11 +1331,10 @@ fn draw_tutorial(frame: &mut Frame, inner: Rect, view: &ClubhouseView<'_>) -> bo
     true
 }
 
-/// The page stops of the first-visit tour. `render.rs` calls this on every
-/// non-clubhouse screen; the clubhouse calls it from [`draw_tutorial`] when
-/// a mid-tour player wanders home early. On the stop's own page the full
-/// pitch box pins top-right; on any other screen a one-line nudge keeps
-/// naming the key that resumes the route. Off-tour stages draw nothing.
+/// The page stops of the first-visit tour, drawn centered over the page
+/// they pitch (`render.rs` calls this on every non-clubhouse screen). The
+/// forced gate guarantees the current screen is the stop's own page, so a
+/// mismatch, like off-tour stages, draws nothing.
 pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen: Screen) {
     let key = Style::default()
         .fg(theme::AMBER_GLOW())
@@ -1362,13 +1352,26 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                         "every room, thread and DM on late.sh lives here.",
                         text,
                     )),
+                    Line::default(),
                     Line::from(vec![
                         Span::styled("[i] ", key),
                         Span::styled("write · ", text),
                         Span::styled("[Ctrl+/] ", key),
-                        Span::styled("switch rooms · ", text),
+                        Span::styled("jump anywhere, type ?query to search", text),
+                    ]),
+                    Line::from(vec![
                         Span::styled("[Ctrl+]] ", key),
-                        Span::styled("pick an icon", text),
+                        Span::styled("pick an icon to sign your messages", text),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("[/dm @user] ", key),
+                        Span::styled("direct message · ", text),
+                        Span::styled("[/public #room] ", key),
+                        Span::styled("open a room", text),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("[/private #room] ", key),
+                        Span::styled("invite-only · your Mentions wait in the rail", text),
                     ]),
                 ],
                 "2",
@@ -1383,7 +1386,38 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                         text,
                     )),
                     Line::from(Span::styled(
-                        "daily puzzles pay chips; quests and streaks stack up top.",
+                        "daily puzzles pay Late Chips; quests and streaks stack up top.",
+                        text,
+                    )),
+                    Line::default(),
+                    Line::from(vec![
+                        Span::styled("chips buy things. ", text),
+                        Span::styled("[/shop] ", key),
+                        Span::styled("badges, flags, 24h name effects,", text),
+                    ]),
+                    Line::from(Span::styled(
+                        "a pet companion to feed, an aquarium with real fish.",
+                        text,
+                    )),
+                    Line::default(),
+                    Line::from(vec![
+                        Span::styled("[Ctrl+G] ", key),
+                        Span::styled("the lobby, the busiest room in the house:", text),
+                    ]),
+                    Line::from(Span::styled(
+                        "live tables: Poker, Blackjack, Asterion, Tron, Super Snake,",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "plus seven daily duels: chess, battleship, connect four,",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "reversi, checkers, backgammon, briscola. challenge someone,",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "walk away, play a move whenever; 24h on the clock per move.",
                         text,
                     )),
                 ],
@@ -1398,12 +1432,38 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                         "the big ones live behind this door:",
                         text,
                     )),
+                    Line::default(),
                     Line::from(Span::styled(
-                        "Lateania, our own MMO. NetHack, the real thing.",
+                        "Lateania: our own MMO. one shared world, bosses, mounts.",
                         text,
                     )),
                     Line::from(Span::styled(
-                        "DCSS, the most played roguelike alive. Green Dragon reborn.",
+                        "NetHack: the legend itself, decades deep. the DevTeam",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "thought of everything; an ascension here is earned.",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "DCSS: the most played roguelike alive. pick a species,",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "pick a god, dive for the Orb.",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "Brogue: the most beautiful dungeon ASCII ever drew.",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "Green Dragon: the legendary BBS door, reborn.",
+                        text,
+                    )),
+                    Line::default(),
+                    Line::from(Span::styled(
+                        "and much more; your wins stick to your name.",
                         text,
                     )),
                 ],
@@ -1419,9 +1479,22 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                         text,
                     )),
                     Line::from(Span::styled(
-                        "leave a mark, someone will draw beside it by morning.",
+                        "everything stays, and every glyph remembers who drew it.",
                         text,
                     )),
+                    Line::default(),
+                    Line::from(vec![
+                        Span::styled("[i] ", key),
+                        Span::styled("or a click starts drawing · ", text),
+                        Span::styled("[Ctrl+]] ", key),
+                        Span::styled("the glyph picker", text),
+                    ]),
+                    Line::from(vec![
+                        Span::styled("[g] ", key),
+                        Span::styled("time-travel the snapshots · ", text),
+                        Span::styled("[?] ", key),
+                        Span::styled("the local guide, here and everywhere", text),
+                    ]),
                 ],
                 "5",
                 "the directory",
@@ -1431,13 +1504,18 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                 " ✦ the tour · the directory ",
                 vec![
                     Line::from(Span::styled(
-                        "the people: profiles, projects, what everyone builds.",
+                        "the people: profiles, the projects they ship, pinned work.",
                         text,
                     )),
                     Line::from(Span::styled(
                         "your profile gets a public page on the web.",
                         text,
                     )),
+                    Line::default(),
+                    Line::from(vec![
+                        Span::styled("[Ctrl+O] ", key),
+                        Span::styled("fill yours in: bio, links, what you're building.", text),
+                    ]),
                 ],
                 "6",
                 "the leaderboards",
@@ -1447,9 +1525,18 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
                 " ✦ the tour · the leaderboards ",
                 vec![
                     Line::from(Span::styled(
-                        "every game keeps score: chips, wins, streaks.",
+                        "every game keeps score: chips, wins, streaks, high scores,",
                         text,
                     )),
+                    Line::from(Span::styled(
+                        "monthly and all-time. each month's top three wear badges",
+                        text,
+                    )),
+                    Line::from(Span::styled(
+                        "beside their name in chat, for everyone to see.",
+                        text,
+                    )),
+                    Line::default(),
                     Line::from(Span::styled(
                         "your name lands here sooner than you think.",
                         text,
@@ -1461,26 +1548,24 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
             Tutorial::Off
             | Tutorial::Pending
             | Tutorial::Welcome
-            | Tutorial::Wander
             | Tutorial::Homecoming
             | Tutorial::Done => return,
         };
 
-    let lines: Vec<Line> = if screen == home {
-        let mut lines = pitch;
-        lines.push(Line::default());
-        lines.push(Line::from(vec![
-            Span::styled(format!("[{next_key}] "), key),
-            Span::styled(format!("next: {next_label}"), text),
-        ]));
-        lines
-    } else {
-        vec![Line::from(vec![
-            Span::styled("the tour waits: ", text),
-            Span::styled(format!("[{next_key}] "), key),
-            Span::styled(next_label.to_string(), text),
-        ])]
-    };
+    if screen != home {
+        return;
+    }
+    let dim = Style::default().fg(theme::TEXT_DIM());
+    let mut lines = pitch;
+    lines.push(Line::default());
+    lines.push(Line::from(Span::styled(
+        "take it in; everything above unlocks when the tour ends.",
+        dim,
+    )));
+    lines.push(Line::from(vec![
+        Span::styled(format!("[{next_key}] "), key),
+        Span::styled(format!("next: {next_label}"), text),
+    ]));
 
     let width = (lines
         .iter()
@@ -1490,10 +1575,10 @@ pub fn draw_tour_overlay(frame: &mut Frame, area: Rect, stage: Tutorial, screen:
         .max(title.chars().count())
         + 4)
     .min(usize::from(area.width).saturating_sub(2)) as u16;
-    let height = (lines.len() as u16 + 2).min(area.height);
+    let height = (lines.len() as u16 + 2).min(area.height.saturating_sub(1));
     let rect = Rect {
-        x: area.x + area.width.saturating_sub(width + 1),
-        y: area.y + 1,
+        x: area.x + (area.width.saturating_sub(width)) / 2,
+        y: area.y + (area.height.saturating_sub(height)) / 3,
         width,
         height,
     };

--- a/late-ssh/src/app/games/chips/svc.rs
+++ b/late-ssh/src/app/games/chips/svc.rs
@@ -131,10 +131,16 @@ impl ChipService {
 
     /// Comp the newcomer's welcome pour: record the buzz with no chip debit
     /// (it's on the house) and hand back the fresh buzz so the clubhouse glow
-    /// can light up immediately.
-    pub async fn grant_free_drink(&self, user_id: Uuid, points: i64) -> anyhow::Result<UserDrinks> {
+    /// can light up immediately. At most once per user ever, guarded by the
+    /// `user_drinks` insert; `None` means they have drunk before and the
+    /// welcome is spent.
+    pub async fn grant_free_drink(
+        &self,
+        user_id: Uuid,
+        points: i64,
+    ) -> anyhow::Result<Option<UserDrinks>> {
         let client = self.db.get().await?;
-        UserDrinks::record_free_pour(&client, user_id, points).await
+        UserDrinks::record_welcome_pour(&client, user_id, points).await
     }
 
     pub async fn credit_payout(&self, user_id: Uuid, amount: i64) -> anyhow::Result<i64> {

--- a/late-ssh/src/app/games/chips/svc_test.rs
+++ b/late-ssh/src/app/games/chips/svc_test.rs
@@ -242,5 +242,8 @@ async fn welcome_pour_never_comps_a_prior_drinker() {
         .grant_free_drink(user.id, late_core::models::drinks::WELCOME_DRINK_POINTS)
         .await
         .expect("comp call succeeds");
-    assert!(comp.is_none(), "a prior drinker never gets the welcome pour");
+    assert!(
+        comp.is_none(),
+        "a prior drinker never gets the welcome pour"
+    );
 }

--- a/late-ssh/src/app/games/chips/svc_test.rs
+++ b/late-ssh/src/app/games/chips/svc_test.rs
@@ -184,3 +184,63 @@ async fn transfer_chips_leaves_unrelated_users_untouched() {
         .get(0);
     assert_eq!(ledger_rows, 0);
 }
+
+#[tokio::test]
+async fn welcome_pour_comps_only_the_first_drink_ever() {
+    let test_db = new_test_db().await;
+    let user = create_test_user(&test_db.db, "welcome-pour").await;
+    let chips = ChipService::new(test_db.db.clone());
+
+    let first = chips
+        .grant_free_drink(user.id, late_core::models::drinks::WELCOME_DRINK_POINTS)
+        .await
+        .expect("first comp succeeds")
+        .expect("first comp pours");
+    assert_eq!(
+        first.drunk_points,
+        late_core::models::drinks::WELCOME_DRINK_POINTS
+    );
+    assert_eq!(first.lifetime_spent, 0);
+
+    // A tour rerun after a mid-tour disconnect: the welcome is spent.
+    let second = chips
+        .grant_free_drink(user.id, late_core::models::drinks::WELCOME_DRINK_POINTS)
+        .await
+        .expect("second comp succeeds");
+    assert!(second.is_none());
+
+    // The comp stayed off the tab: one drink, no lifetime spend.
+    let client = test_db.db.get().await.expect("db client");
+    let row = client
+        .query_one(
+            "SELECT drunk_points, lifetime_spent, drink_count
+             FROM user_drinks WHERE user_id = $1",
+            &[&user.id],
+        )
+        .await
+        .expect("drinks row");
+    assert_eq!(
+        row.get::<_, i64>("drunk_points"),
+        late_core::models::drinks::WELCOME_DRINK_POINTS
+    );
+    assert_eq!(row.get::<_, i64>("lifetime_spent"), 0);
+    assert_eq!(row.get::<_, i64>("drink_count"), 1);
+}
+
+#[tokio::test]
+async fn welcome_pour_never_comps_a_prior_drinker() {
+    let test_db = new_test_db().await;
+    let user = create_test_user(&test_db.db, "welcome-pour-veteran").await;
+    let client = test_db.db.get().await.expect("db client");
+    late_core::models::drinks::UserDrinks::record_purchase(&client, user.id, 200)
+        .await
+        .expect("paid drink");
+    drop(client);
+
+    let chips = ChipService::new(test_db.db.clone());
+    let comp = chips
+        .grant_free_drink(user.id, late_core::models::drinks::WELCOME_DRINK_POINTS)
+        .await
+        .expect("comp call succeeds");
+    assert!(comp.is_none(), "a prior drinker never gets the welcome pour");
+}

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -807,12 +807,20 @@ fn handle_parsed_input_inner(app: &mut App, event: ParsedInput) {
         return;
     }
 
-    if handle_reserved_global_chord(app, &event) {
+    // The forced first-visit tour outranks even the reserved chords: a
+    // newcomer mid-route cannot open settings or the lobby, only follow the
+    // named key or quit. The quit-confirm modal stays above it so `y`/`n`
+    // keep working once quitting is on the table.
+    if app.show_quit_confirm {
+        quit_confirm::input::handle_input(app, event);
         return;
     }
 
-    if app.show_quit_confirm {
-        quit_confirm::input::handle_input(app, event);
+    if handle_tour_gate(app, &event) {
+        return;
+    }
+
+    if handle_reserved_global_chord(app, &event) {
         return;
     }
 
@@ -3786,6 +3794,43 @@ pub(crate) fn trigger_global_quit(app: &mut App) {
             app.running = false;
         }
     }
+}
+
+/// The forced first-visit tour: while a tour box names a key
+/// (`clubhouse::state::State::tutorial_forced_step`), that key and quitting
+/// are the only inputs that do anything. Everything else, mouse, arrows,
+/// and chords included, dies here so no modal, composer, or game can hijack
+/// a newcomer mid-route. Returns true when the event was consumed.
+fn handle_tour_gate(app: &mut App, event: &ParsedInput) -> bool {
+    use crate::app::clubhouse::state::TourStep;
+
+    let Some(step) = app.clubhouse.tutorial_forced_step() else {
+        return false;
+    };
+    let byte = match event {
+        ParsedInput::Byte(byte) => *byte,
+        ParsedInput::Char(ch) if ch.is_ascii() => *ch as u8,
+        // Arrows, mouse, pastes: swallowed while the tour runs.
+        _ => return true,
+    };
+    match step {
+        TourStep::Page(expected, screen) if byte == expected => {
+            // `set_screen` runs `tutorial_screen_entered`, which advances
+            // the tour to the next stop.
+            app.set_screen(screen);
+        }
+        TourStep::Enter if matches!(byte, b'\r' | b'\n') => {
+            if app.clubhouse.tutorial_advance() {
+                app.persist_clubhouse_tutorial_done();
+            }
+        }
+        TourStep::Page(..) | TourStep::Enter => match byte {
+            // The way out is always open.
+            b'q' | b'Q' => trigger_global_quit(app),
+            _ => {}
+        },
+    }
+    true
 }
 
 fn handle_reserved_global_chord(app: &mut App, event: &ParsedInput) -> bool {

--- a/late-ssh/src/app/input_flow_test.rs
+++ b/late-ssh/src/app/input_flow_test.rs
@@ -1314,3 +1314,50 @@ async fn clicking_the_mentions_hud_text_opens_mentions() {
     app.handle_input(format!("\x1b[<0;{};1M", mentions_col + 1).as_bytes());
     wait_for_render_contains(&mut app, "mentioned you in").await;
 }
+
+#[tokio::test]
+async fn forced_tour_gates_input_until_each_named_key() {
+    use crate::app::clubhouse::state::Tutorial;
+    use crate::app::common::primitives::Screen;
+
+    let test_db = new_test_db().await;
+    let user = create_test_user(&test_db.db, "tour-gate-it").await;
+    let mut app = make_app(test_db.db.clone(), user.id, "tour-gate-flow-it");
+
+    // Arm the tour the way a first-ever session does: land in the tavern
+    // with the walkthrough pending.
+    app.set_screen(Screen::Clubhouse);
+    app.clubhouse.tutorial = Tutorial::Pending;
+    app.clubhouse.enter_screen();
+    assert_eq!(app.clubhouse.tutorial, Tutorial::Welcome);
+
+    // The gate swallows everything but the named key: no page hopping, no
+    // Tab, no help modal, no reserved chords, no composer.
+    for bytes in [&b"2"[..], b"\t", b"?", b"\x0f", b"\x07", b"i"] {
+        app.handle_input(bytes);
+    }
+    assert_eq!(app.screen, Screen::Clubhouse);
+    assert!(!app.show_help);
+    assert_eq!(app.clubhouse.tutorial, Tutorial::Welcome);
+
+    // The named digits walk the route in order, nothing else moves it.
+    for (bytes, screen) in [
+        (&b"1"[..], Screen::Dashboard),
+        (b"2", Screen::Arcade),
+        (b"3", Screen::Games),
+        (b"4", Screen::Artboard),
+        (b"5", Screen::Pinstar),
+        (b"6", Screen::Leaderboard),
+        (b"0", Screen::Clubhouse),
+    ] {
+        app.handle_input(bytes);
+        assert_eq!(app.screen, screen);
+    }
+    assert_eq!(app.clubhouse.tutorial, Tutorial::Homecoming);
+
+    // Enter settles in, and input is free again.
+    app.handle_input(b"\r");
+    assert_eq!(app.clubhouse.tutorial, Tutorial::Done);
+    app.handle_input(b"2");
+    assert_eq!(app.screen, Screen::Arcade);
+}

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -1545,6 +1545,18 @@ impl App {
             terminal_images.clear();
         }
 
+        // The first-visit tour's page-stop box (top-right). The clubhouse
+        // draws its own tutorial overlays; toasts draw after, so they win
+        // the corner while they last.
+        if screen != Screen::Clubhouse {
+            crate::app::clubhouse::ui::draw_tour_overlay(
+                frame,
+                inner,
+                ctx.clubhouse_state.tutorial,
+                screen,
+            );
+        }
+
         // Toast banner overlay at top of content area
         let banner = if ctx.is_draining {
             Some(Banner {

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -2018,6 +2018,9 @@ impl App {
         if self.screen == Screen::Clubhouse {
             self.clubhouse.enter_screen();
         }
+        // The first-visit tour advances on page entry, so digits and Tab
+        // both move it along.
+        self.clubhouse.tutorial_screen_entered(screen);
         self.sync_visible_chat_room();
     }
 
@@ -2348,14 +2351,14 @@ impl App {
         self.show_profile_modal = true;
     }
 
-    /// The tutorial's @bartender welcome: a scripted line pinned in the
-    /// newcomer's own bartender banner (see `ghost::bartender_tutorial_greeting`).
-    /// It stays on this client, so #lounge is not made to watch every
-    /// first-timer collect their comped pour.
+    /// The hidden treasure at the end of the tour: a scripted @bartender
+    /// welcome pinned in the newcomer's own bartender banner (see
+    /// `ghost::bartender_tutorial_greeting`) plus the comped first pour. It
+    /// stays on this client, so #lounge is not made to watch every
+    /// first-timer collect their free drink. Fires on the first walk up to
+    /// the counter in the tour session (`State::welcome_pour_due`); the
+    /// once-ever guarantee is the DB insert behind the comp.
     pub(crate) fn show_clubhouse_bartender_welcome(&mut self) {
-        // Reaching the bar is the tutorial's finish line: the welcome round is
-        // on the house, so lock the walkthrough in as done and comp the pour.
-        self.persist_clubhouse_tutorial_done();
         let username = self.profile_state.profile().username.clone();
         self.clubhouse.show_local_bartender_line(
             crate::app::ai::ghost::bartender_tutorial_greeting(&username),
@@ -2371,11 +2374,14 @@ impl App {
                 .grant_free_drink(target, late_core::models::drinks::WELCOME_DRINK_POINTS)
                 .await
             {
-                Ok(drinks) => {
+                Ok(Some(drinks)) => {
                     if let Some(lobby) = lobby {
                         lobby.record_drink(target, drinks.drunk_points, drinks.last_drink_at);
                     }
                 }
+                // They have drunk before (a tour rerun after a mid-tour
+                // disconnect): the line is just flavor, nothing to glow.
+                Ok(None) => {}
                 Err(err) => {
                     tracing::warn!(error = ?err, user_id = %target, "welcome drink comp failed");
                 }

--- a/late-ssh/src/ssh_test.rs
+++ b/late-ssh/src/ssh_test.rs
@@ -272,18 +272,26 @@ async fn closing_token_exec_channel_does_not_close_interactive_shell() {
         .expect("dismiss splash after token close");
     expect_shell_data_contains(&mut shell_channel, b"welcome to the late lounge").await;
 
+    // A brand-new account runs the forced tour: only the named digit works,
+    // so follow the route (1 chat, 2 arcade, ...).
+    shell_channel
+        .data(&b"1"[..])
+        .await
+        .expect("send shell input after token close");
     shell_channel
         .data(&b"2"[..])
         .await
         .expect("send shell input after token close");
     expect_shell_data_contains(&mut shell_channel, b"The Arcade").await;
 
-    // A second post-close interaction proves the first frame was not merely
+    // A further post-close interaction proves the first frame was not merely
     // the render loop's final draw while shutting down.
-    shell_channel
-        .data(&b"5"[..])
-        .await
-        .expect("send second shell input after token close");
+    for key in [&b"3"[..], b"4", b"5"] {
+        shell_channel
+            .data(key)
+            .await
+            .expect("send tour input after token close");
+    }
     expect_shell_data_contains(&mut shell_channel, b"Directory").await;
 
     client


### PR DESCRIPTION
## Summary
- Replaces the old clubhouse tutorial (welcome box, walk to the bar, chat lesson, send-off) with a forced guided tour that walks a newcomer through every top-level page in number order: Home chat (1) → Arcade (2) → Games (3) → Artboard (4) → Directory (5) → Leaderboards (6) → back home to the tavern (0), where Enter on the homecoming box ends the tour and frees input.
- The bartender is deliberately removed from the route. His scripted welcome plus the comped first drink become a hidden treasure: after homecoming the bar sign pulses until the newcomer walks up to the counter, and the homecoming box only whispers a pointer at it.
- The comp is now guaranteed once per user ever at the DB level: `UserDrinks::record_welcome_pour` is an insert-only comp (`ON CONFLICT DO NOTHING`) that returns `None` for anyone who has ever drunk, so a tour rerun after a mid-tour disconnect can't double-comp.

## Changes
- **Forced input gate** (`late-ssh/src/app/input.rs`, `handle_tour_gate`): while the tour runs, every input dies except the single key the current box names, plus `q` to quit. That includes mouse, arrows, Tab, reserved chords, the help modal, and the composer. The gate sits above the reserved chords but below the quit-confirm modal, so `y`/`n` keep working once quitting is on the table. There is no Esc skip anymore.
- **Tour state machine** (`clubhouse/state.rs`): `Tutorial` gains one `Visit*` stage per page plus `Homecoming`; `tutorial_screen_entered` (hooked in `App::set_screen`) advances the route only when exactly the expected page is entered, so a stray `set_screen` can never skip a stop. `tutorial_forced_step` tells the gate which key is live.
- **Page-stop overlays** (`clubhouse/ui.rs::draw_tour_overlay`, called from `render.rs` on non-clubhouse screens): each stop draws a centered pitch box over the real page, ending with the next key. The tavern keeps its own welcome and homecoming boxes; the old GoToBar/BarLesson/SendOff boxes are gone.
- **Welcome pour rework**: `welcome_pour_due` fires the bartender greeting and comp on the first walk to the counter (per session; the once-ever guard is the DB insert), `bar_glow` drives the pulsing sign, and completion now persists on the homecoming Enter instead of on reaching the bar. `ChipService::grant_free_drink` returns `Option<UserDrinks>` and the `Ok(None)` arm leaves the greeting as pure flavor.
- **Drinks model** (`late-core/src/models/drinks.rs`): the shared `record` helper is folded back into `record_purchase`; `record_free_pour` is replaced by the insert-only `record_welcome_pour`.

## Behavior notes
- The tour is intentionally unskippable; quitting is always available. Completion persistence stays fire-and-forget, so worst case the tour reruns next session, but the pour cannot double-comp thanks to the DB guard.
- Returning users (any existing `user_drinks` row) never see the glow or get the comp, even if the tour re-arms.
- The welcome pour keeps `lifetime_spent` at 0, so a comped round still doesn't inflate the tab.

## Feature flags
- None.

## Screenshots / Video
- Not included in this draft; attach before review (the tour overlay boxes and the pulsing bar sign are visible TUI changes).

## Testing
- Automated: `clubhouse/state_test.rs` rewritten to walk the full route, assert wrong pages never advance a stop, and cover glow/claim semantics for new and returning users; new `input_flow_test.rs` case drives the forced gate end to end against a real DB; new `chips/svc_test.rs` cases prove the comp lands at most once ever and never for a prior drinker; `ssh_test.rs` updated to follow the forced route. Not run in this draft.
- Manual: Not run; the flow only triggers for brand-new accounts.