### PR TITLE
OBS streaming: `/golive obs` via a LiveKit WHIP ingress

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: late.sh - Command-Line Clubhouse for Computer People
 - Primary audience: LLM agents working on this codebase, human contributors
-- Last updated: 2026-08-11 ("watch me" streaming rooms shipped: `/golive` publishes a screen share into the streamer's permanent `#<user>-live` room's LiveKit voice channel, browser watch pages subscribe through unlisted capability URLs, the Home rail grows a `stream` section, and #lounge gets one `is live` line when media actually flows. New domain context at `late-ssh/src/app/stream/CONTEXT.md`; web pages in `late-web/src/pages/live`; the voice-scope exception is documented in `late-ssh/src/app/voice/CONTEXT.md` §7)
+- Last updated: 2026-08-12 (OBS streaming: `/golive obs [title]` publishes into the same stream room through a LiveKit WHIP ingress — new `redis` + `livekit-ingress` deployments in infra and dev compose, `whip.<domain>` ingest endpoint, video codecs enabled in the LiveKit config, liveness via a server-side ingress poll. Domain details in `late-ssh/src/app/stream/CONTEXT.md`; the Ingress API client lives in `VoiceService`, see `late-ssh/src/app/voice/CONTEXT.md` §7)
 - Status: Active
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change often.
 

--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ LATE_LIVEKIT_RTC_TCP_PORT ?= 7881
 LATE_LIVEKIT_RTC_UDP_PORT ?= 7882
 # Public LiveKit WebSocket URL sent to browsers and the CLI.
 LATE_LIVEKIT_URL ?= ws://localhost:$(LATE_LIVEKIT_HOST_PORT)
+# Server-to-server Twirp API base: late-ssh runs in a container, so it must
+# reach LiveKit by compose service name, not localhost.
+LATE_LIVEKIT_API_URL ?= http://livekit:7880
 # Local LiveKit credentials.
 LATE_LIVEKIT_API_KEY ?= devkey
 LATE_LIVEKIT_API_SECRET ?= secret
@@ -155,6 +158,7 @@ LATE_FILES_S3_SECRET_ACCESS_KEY ?=  								                        # S3/R2 secr
 	@echo "LATE_ICECAST_HOST_PORT=$(LATE_ICECAST_HOST_PORT)" >> .env
 	@echo "LATE_VOICE_ENABLED=$(LATE_VOICE_ENABLED)" >> .env
 	@echo "LATE_LIVEKIT_URL=$(LATE_LIVEKIT_URL)" >> .env
+	@echo "LATE_LIVEKIT_API_URL=$(LATE_LIVEKIT_API_URL)" >> .env
 	@echo "LATE_LIVEKIT_HOST_PORT=$(LATE_LIVEKIT_HOST_PORT)" >> .env
 	@echo "LATE_LIVEKIT_RTC_TCP_PORT=$(LATE_LIVEKIT_RTC_TCP_PORT)" >> .env
 	@echo "LATE_LIVEKIT_RTC_UDP_PORT=$(LATE_LIVEKIT_RTC_UDP_PORT)" >> .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -201,14 +201,42 @@ services:
       - ./music:/music:ro
     command: ["liquidsoap", "/etc/liquidsoap/radio.liq"]
 
+  # Message bus between livekit and livekit-ingress; nothing persists.
+  redis:
+    image: redis:7-alpine
+    container_name: ${INSTANCE}-redis
+    command: ["redis-server", "--save", "", "--appendonly", "no"]
+
   livekit:
     image: livekit/livekit-server:latest
     container_name: ${INSTANCE}-livekit
-    command: ["--dev", "--bind", "0.0.0.0"]
+    # The config file replaces the old `--dev` flag: same devkey keys and
+    # ports, plus the redis bus and WHIP base URL the OBS ingest flow needs.
+    command: ["--config", "/etc/livekit/config.yaml"]
+    depends_on:
+      - redis
+    volumes:
+      - ./infra/livekit/dev-config.yaml:/etc/livekit/config.yaml:ro
     ports:
       - "${LATE_LIVEKIT_HOST_PORT}:7880"
       - "${LATE_LIVEKIT_RTC_TCP_PORT}:7881"
       - "${LATE_LIVEKIT_RTC_UDP_PORT}:7882/udp"
+
+  # WHIP ingest for `/golive obs`. Ports are fixed (not env vars) because
+  # they must match the two dev-config.yaml files exactly.
+  livekit-ingress:
+    image: livekit/ingress:v1.4.3
+    container_name: ${INSTANCE}-livekit-ingress
+    environment:
+      INGRESS_CONFIG_FILE: /etc/livekit-ingress/config.yaml
+    depends_on:
+      - redis
+      - livekit
+    volumes:
+      - ./infra/livekit-ingress/dev-config.yaml:/etc/livekit-ingress/config.yaml:ro
+    ports:
+      - "7888:7888" # WHIP HTTP: OBS Server URL is http://localhost:7888/w
+      - "7890:7890/udp" # WHIP ICE/UDP media
 
 volumes:
   cargo-registry:

--- a/infra/defaults.tf
+++ b/infra/defaults.tf
@@ -40,6 +40,10 @@ locals {
   livekit_turn_udp_port       = tonumber(trimspace(var.LIVEKIT_TURN_UDP_PORT) != "" ? trimspace(var.LIVEKIT_TURN_UDP_PORT) : "3478")
   livekit_turn_tls_port       = tonumber(trimspace(var.LIVEKIT_TURN_TLS_PORT) != "" ? trimspace(var.LIVEKIT_TURN_TLS_PORT) : "5349")
 
+  livekit_ingress_image     = trimspace(var.LIVEKIT_INGRESS_IMAGE) != "" ? trimspace(var.LIVEKIT_INGRESS_IMAGE) : "livekit/ingress:v1.4.3"
+  livekit_whip_subdomain    = trimspace(var.LIVEKIT_WHIP_SUBDOMAIN) != "" ? trimspace(var.LIVEKIT_WHIP_SUBDOMAIN) : "whip"
+  livekit_ingress_whip_port = tonumber(trimspace(var.LIVEKIT_INGRESS_WHIP_PORT) != "" ? trimspace(var.LIVEKIT_INGRESS_WHIP_PORT) : "7888")
+
   irc_enabled                  = trimspace(var.IRC_ENABLED) != "" ? trimspace(var.IRC_ENABLED) : "0"
   irc_enabled_bool             = contains(["1", "true", "yes", "on"], lower(local.irc_enabled))
   irc_proxy_accept             = trimspace(var.IRC_PROXY_ACCEPT) != "" ? trimspace(var.IRC_PROXY_ACCEPT) : "1"

--- a/infra/livekit-ingress.tf
+++ b/infra/livekit-ingress.tf
@@ -1,0 +1,212 @@
+# =============================================================================
+# LiveKit Ingress: WHIP ingest for OBS streams (`/golive obs`)
+#
+# OBS pushes WebRTC (h264+opus) to https://whip.<domain>/w with a per-stream
+# bearer token; this service forwards it into the stream room's LiveKit
+# channel. Transcoding is disabled by the app at CreateIngress time, so this
+# stays a packet forwarder, not an encoder. It talks to livekit-server over
+# the shared redis bus (redis.tf).
+# =============================================================================
+
+locals {
+  livekit_ingress_config = yamlencode({
+    api_key    = local.livekit_api_key
+    api_secret = random_password.livekit_api_secret.result
+    ws_url     = "ws://livekit-sv"
+
+    redis = {
+      address = "redis-sv:6379"
+    }
+
+    # WHIP signaling (HTTP) behind the nginx ingress below.
+    whip_port       = local.livekit_ingress_whip_port
+    http_relay_port = local.livekit_ingress_whip_port + 1
+
+    # WHIP media: one muxed ICE/UDP port on the node (host network, same
+    # pattern as livekit itself).
+    rtc_config = {
+      udp_port        = local.livekit_ingress_whip_port + 2
+      use_external_ip = local.livekit_rtc_use_external_ip
+    }
+
+    # The RTMP listener is bound (upstream default) but inert: the app only
+    # ever creates WHIP ingresses, so no stream key routes through RTMP.
+    # Keep 1935 closed at the node firewall.
+    rtmp_port = 1935
+
+    logging = {
+      level = local.livekit_log_level
+    }
+  })
+}
+
+resource "kubernetes_secret_v1" "livekit_ingress" {
+  metadata {
+    name = "livekit-ingress"
+  }
+
+  data = {
+    "config.yaml" = local.livekit_ingress_config
+  }
+}
+
+resource "kubernetes_deployment_v1" "livekit_ingress" {
+  metadata {
+    name = "livekit-ingress"
+  }
+
+  spec {
+    replicas = 1
+
+    strategy {
+      type = "Recreate"
+    }
+
+    selector {
+      match_labels = {
+        app = "livekit-ingress"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "livekit-ingress"
+        }
+        annotations = {
+          config_hash = sha256(local.livekit_ingress_config)
+        }
+      }
+
+      spec {
+        host_network                     = true
+        dns_policy                       = "ClusterFirstWithHostNet"
+        termination_grace_period_seconds = 30
+
+        container {
+          image = local.livekit_ingress_image
+          name  = "livekit-ingress"
+
+          env {
+            name  = "INGRESS_CONFIG_FILE"
+            value = "/etc/livekit-ingress/config.yaml"
+          }
+
+          port {
+            container_port = local.livekit_ingress_whip_port
+            host_port      = local.livekit_ingress_whip_port
+            name           = "whip"
+            protocol       = "TCP"
+          }
+
+          port {
+            container_port = local.livekit_ingress_whip_port + 2
+            host_port      = local.livekit_ingress_whip_port + 2
+            name           = "whip-udp"
+            protocol       = "UDP"
+          }
+
+          resources {
+            limits = {
+              cpu    = "1000m"
+              memory = "1Gi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "256Mi"
+            }
+          }
+
+          readiness_probe {
+            tcp_socket {
+              port = "whip"
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+            failure_threshold     = 6
+          }
+
+          liveness_probe {
+            tcp_socket {
+              port = "whip"
+            }
+            initial_delay_seconds = 15
+            period_seconds        = 20
+            failure_threshold     = 5
+          }
+
+          volume_mount {
+            name       = "config"
+            mount_path = "/etc/livekit-ingress"
+            read_only  = true
+          }
+        }
+
+        volume {
+          name = "config"
+
+          secret {
+            secret_name = kubernetes_secret_v1.livekit_ingress.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "livekit_ingress" {
+  metadata {
+    name = "livekit-ingress-sv"
+  }
+
+  spec {
+    selector = {
+      app = "livekit-ingress"
+    }
+
+    port {
+      name        = "whip"
+      port        = 80
+      target_port = "whip"
+    }
+  }
+}
+
+resource "kubernetes_ingress_v1" "livekit_whip" {
+  metadata {
+    name = "livekit-whip-ingress"
+    annotations = {
+      "kubernetes.io/ingress.class"                    = "nginx"
+      "cert-manager.io/cluster-issuer"                 = "letsencrypt-prod"
+      "acme.cert-manager.io/http01-edit-in-place"      = "true"
+      "nginx.ingress.kubernetes.io/proxy-read-timeout" = "3600"
+      "nginx.ingress.kubernetes.io/proxy-send-timeout" = "3600"
+      "nginx.ingress.kubernetes.io/proxy-http-version" = "1.1"
+    }
+  }
+
+  spec {
+    tls {
+      hosts       = [local.livekit_whip_host]
+      secret_name = "livekit-whip-tls"
+    }
+
+    rule {
+      host = local.livekit_whip_host
+      http {
+        path {
+          path      = "/"
+          path_type = "Prefix"
+          backend {
+            service {
+              name = kubernetes_service_v1.livekit_ingress.metadata[0].name
+              port {
+                name = "whip"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/infra/livekit-ingress/dev-config.yaml
+++ b/infra/livekit-ingress/dev-config.yaml
@@ -1,0 +1,19 @@
+# Local dev LiveKit ingress config: WHIP ingest for `/golive obs`. OBS on
+# the host pushes to http://localhost:7888/w with the per-stream bearer
+# token. Ports here must match docker-compose.yml and
+# infra/livekit/dev-config.yaml.
+api_key: devkey
+api_secret: secret
+ws_url: ws://livekit:7880
+redis:
+  address: redis:6379
+whip_port: 7888
+http_relay_port: 7889
+# Bound but inert: the app only creates WHIP ingresses (see
+# infra/livekit-ingress.tf for the same note on prod).
+rtmp_port: 1935
+rtc_config:
+  udp_port: 7890
+  use_external_ip: false
+logging:
+  level: info

--- a/infra/livekit.tf
+++ b/infra/livekit.tf
@@ -3,8 +3,9 @@
 # =============================================================================
 
 locals {
-  livekit_host = "${local.livekit_subdomain}.${var.DOMAIN}"
-  livekit_url  = "wss://${local.livekit_host}"
+  livekit_host      = "${local.livekit_subdomain}.${var.DOMAIN}"
+  livekit_url       = "wss://${local.livekit_host}"
+  livekit_whip_host = "${local.livekit_whip_subdomain}.${var.DOMAIN}"
 
   livekit_config = yamlencode({
     port = 7880
@@ -24,6 +25,18 @@ locals {
       key_file  = "/etc/livekit-tls/tls.key"
     }
 
+    # Message bus shared with the ingress service; also where ingress
+    # definitions live. The server refuses Ingress API calls without it.
+    redis = {
+      address = "redis-sv:6379"
+    }
+
+    # Returned in IngressInfo.url by CreateIngress: the public WHIP endpoint
+    # OBS pushes to (served by the livekit-ingress deployment behind nginx).
+    ingress = {
+      whip_base_url = "https://${local.livekit_whip_host}/w"
+    }
+
     keys = {
       (local.livekit_api_key) = random_password.livekit_api_secret.result
     }
@@ -32,9 +45,18 @@ locals {
       auto_create       = true
       empty_timeout     = 300
       departure_timeout = 20
+      # Video codecs are required by the stream rooms (go-live screen share
+      # and OBS/WHIP ingest); opus-only here silently refuses every video
+      # publish at SDP negotiation.
       enabled_codecs = [
         {
           mime = "audio/opus"
+        },
+        {
+          mime = "video/h264"
+        },
+        {
+          mime = "video/vp8"
         }
       ]
     }

--- a/infra/livekit/dev-config.yaml
+++ b/infra/livekit/dev-config.yaml
@@ -1,0 +1,22 @@
+# Local dev LiveKit server config. Replaces the old `--dev` flag with the
+# same defaults (devkey keys, dev ports) plus what the OBS/WHIP ingest flow
+# needs: the redis bus shared with the livekit-ingress container and the
+# WHIP base URL returned by CreateIngress. Ports here must match
+# docker-compose.yml and infra/livekit-ingress/dev-config.yaml.
+port: 7880
+bind_addresses:
+  - "0.0.0.0"
+rtc:
+  tcp_port: 7881
+  udp_port: 7882
+  use_external_ip: false
+redis:
+  address: redis:6379
+ingress:
+  whip_base_url: http://localhost:7888/w
+keys:
+  devkey: secret
+room:
+  auto_create: true
+logging:
+  level: info

--- a/infra/redis.tf
+++ b/infra/redis.tf
@@ -1,0 +1,96 @@
+# =============================================================================
+# Redis: message bus between livekit-server and the livekit-ingress service.
+# No persistence on purpose: it only carries the psrpc bus and ingress
+# definitions, all of which are re-minted by the app (a restart just ends any
+# in-flight OBS stream, same failure tier as the in-memory stream registry).
+# =============================================================================
+
+resource "kubernetes_deployment_v1" "redis" {
+  metadata {
+    name = "redis"
+  }
+
+  spec {
+    replicas = 1
+
+    strategy {
+      type = "Recreate"
+    }
+
+    selector {
+      match_labels = {
+        app = "redis"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          app = "redis"
+        }
+      }
+
+      spec {
+        container {
+          image = "redis:7-alpine"
+          name  = "redis"
+
+          args = ["--save", "", "--appendonly", "no"]
+
+          port {
+            container_port = 6379
+            name           = "redis"
+            protocol       = "TCP"
+          }
+
+          resources {
+            limits = {
+              cpu    = "200m"
+              memory = "256Mi"
+            }
+            requests = {
+              cpu    = "50m"
+              memory = "64Mi"
+            }
+          }
+
+          readiness_probe {
+            tcp_socket {
+              port = "redis"
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 10
+            failure_threshold     = 3
+          }
+
+          liveness_probe {
+            tcp_socket {
+              port = "redis"
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 20
+            failure_threshold     = 5
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "redis_sv" {
+  metadata {
+    name = "redis-sv"
+  }
+
+  spec {
+    selector = {
+      app = "redis"
+    }
+
+    port {
+      name        = "redis"
+      port        = 6379
+      target_port = "redis"
+    }
+  }
+}

--- a/infra/redis.tf
+++ b/infra/redis.tf
@@ -1,8 +1,12 @@
 # =============================================================================
-# Redis: message bus between livekit-server and the livekit-ingress service.
-# No persistence on purpose: it only carries the psrpc bus and ingress
-# definitions, all of which are re-minted by the app (a restart just ends any
-# in-flight OBS stream, same failure tier as the in-memory stream registry).
+# Redis: the psrpc message bus shared by livekit-server and livekit-ingress.
+# Once livekit-server has redis configured it routes room lookups and its
+# server API RPCs through it, so a redis outage degrades all LiveKit control
+# plane work: voice joins, RemoveParticipant kicks, and stream teardown, not
+# just OBS ingest. Media already flowing keeps flowing.
+# No persistence on purpose: it carries the bus and ingress definitions, both
+# re-minted per stream; a restart ends in-flight OBS streams, same failure
+# tier as the in-memory stream registry.
 # =============================================================================
 
 resource "kubernetes_deployment_v1" "redis" {

--- a/infra/service-ssh.tf
+++ b/infra/service-ssh.tf
@@ -531,6 +531,12 @@ resource "kubernetes_deployment_v1" "service_ssh" {
             value = local.livekit_url
           }
           env {
+            # Server-to-server Twirp API calls go to the cluster-internal
+            # service instead of looping out through the public ingress.
+            name  = "LATE_LIVEKIT_API_URL"
+            value = "http://${kubernetes_service_v1.livekit.metadata[0].name}"
+          }
+          env {
             name = "LATE_LIVEKIT_API_KEY"
             value_from {
               secret_key_ref {

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -323,6 +323,24 @@ variable "LIVEKIT_API_KEY" {
   default     = ""
 }
 
+variable "LIVEKIT_INGRESS_IMAGE" {
+  description = "LiveKit ingress service image (WHIP ingest for OBS streams)."
+  type        = string
+  default     = ""
+}
+
+variable "LIVEKIT_WHIP_SUBDOMAIN" {
+  description = "Subdomain used for the public WHIP ingest endpoint under DOMAIN."
+  type        = string
+  default     = ""
+}
+
+variable "LIVEKIT_INGRESS_WHIP_PORT" {
+  description = "LiveKit ingress WHIP HTTP port (behind the nginx ingress)."
+  type        = string
+  default     = ""
+}
+
 variable "LIVEKIT_RTC_TCP_PORT" {
   description = "LiveKit ICE/TCP fallback port exposed directly on the node."
   type        = string

--- a/late-ssh/src/api_test.rs
+++ b/late-ssh/src/api_test.rs
@@ -114,6 +114,7 @@ async fn stream_endpoints_serve_the_watch_and_publish_flow() {
     let mut config = test_config(test_db.db.config().clone());
     config.voice = crate::app::voice::svc::VoiceConfig::enabled(
         "wss://rtc.test".to_string(),
+        "http://livekit-sv.test".to_string(),
         "test-key".to_string(),
         "test-secret".to_string(),
         "late-voice".to_string(),

--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -233,26 +233,34 @@ pub(crate) enum GoLiveCommand {
     /// `/golive [title]`: register (or re-surface) this user's stream and
     /// show the publisher URL modal.
     Start { title: Option<String> },
+    /// `/golive obs [title]`: register the stream with OBS as the
+    /// publisher and show the WHIP connection details modal.
+    StartObs { title: Option<String> },
     /// `/golive stop`: tear the stream down now.
     Stop,
 }
 
-/// `/golive` with an optional title or the `stop` subcommand. `None` means
-/// the body is not a golive command at all.
+/// `/golive` with an optional title, or the `stop` / `obs [title]`
+/// subcommands. `None` means the body is not a golive command at all.
 fn parse_golive_command(body: &str) -> Option<GoLiveCommand> {
     let trimmed = body.trim();
     let rest = trimmed.strip_prefix("/golive")?;
     if !rest.is_empty() && !rest.starts_with(' ') {
         return None;
     }
+    // Free text that ends up in the rail, the stream header, and the
+    // #lounge announcement; clamp it at the parse boundary so no downstream
+    // surface needs its own cap.
+    let clamp = |title: &str| Some(title.chars().take(GOLIVE_TITLE_MAX_CHARS).collect());
     Some(match rest.trim() {
         "" => GoLiveCommand::Start { title: None },
         "stop" => GoLiveCommand::Stop,
-        title => GoLiveCommand::Start {
-            // Free text that ends up in the rail, the stream header, and
-            // the #lounge announcement; clamp it at the boundary so no
-            // downstream surface needs its own cap.
-            title: Some(title.chars().take(GOLIVE_TITLE_MAX_CHARS).collect()),
+        "obs" => GoLiveCommand::StartObs { title: None },
+        text => match text.strip_prefix("obs ") {
+            Some(title) => GoLiveCommand::StartObs {
+                title: clamp(title.trim()),
+            },
+            None => GoLiveCommand::Start { title: clamp(text) },
         },
     })
 }

--- a/late-ssh/src/app/chat/state_internal_test.rs
+++ b/late-ssh/src/app/chat/state_internal_test.rs
@@ -3316,3 +3316,42 @@ fn the_cyberspace_section_carries_the_pane_and_the_pinned_rooms() {
         ]
     );
 }
+
+#[test]
+fn parse_golive_routes_console_obs_and_stop() {
+    assert_eq!(
+        parse_golive_command("/golive"),
+        Some(GoLiveCommand::Start { title: None })
+    );
+    assert_eq!(
+        parse_golive_command("/golive fixing the render loop"),
+        Some(GoLiveCommand::Start {
+            title: Some("fixing the render loop".to_string())
+        })
+    );
+    assert_eq!(parse_golive_command("/golive stop"), Some(GoLiveCommand::Stop));
+    assert_eq!(
+        parse_golive_command("/golive obs"),
+        Some(GoLiveCommand::StartObs { title: None })
+    );
+    assert_eq!(
+        parse_golive_command("/golive obs speedrun night"),
+        Some(GoLiveCommand::StartObs {
+            title: Some("speedrun night".to_string())
+        })
+    );
+    // Not the command at all: no space boundary after /golive.
+    assert_eq!(parse_golive_command("/golivenow"), None);
+    assert_eq!(parse_golive_command("hello"), None);
+}
+
+#[test]
+fn parse_golive_clamps_titles_at_the_boundary() {
+    let long = "x".repeat(GOLIVE_TITLE_MAX_CHARS + 20);
+    match parse_golive_command(&format!("/golive obs {long}")) {
+        Some(GoLiveCommand::StartObs { title: Some(title) }) => {
+            assert_eq!(title.chars().count(), GOLIVE_TITLE_MAX_CHARS);
+        }
+        other => panic!("expected clamped obs title, got {other:?}"),
+    }
+}

--- a/late-ssh/src/app/chat/state_internal_test.rs
+++ b/late-ssh/src/app/chat/state_internal_test.rs
@@ -3329,7 +3329,10 @@ fn parse_golive_routes_console_obs_and_stop() {
             title: Some("fixing the render loop".to_string())
         })
     );
-    assert_eq!(parse_golive_command("/golive stop"), Some(GoLiveCommand::Stop));
+    assert_eq!(
+        parse_golive_command("/golive stop"),
+        Some(GoLiveCommand::Stop)
+    );
     assert_eq!(
         parse_golive_command("/golive obs"),
         Some(GoLiveCommand::StartObs { title: None })

--- a/late-ssh/src/app/chat/svc_test.rs
+++ b/late-ssh/src/app/chat/svc_test.rs
@@ -2679,6 +2679,7 @@ async fn mod_stream_ban_ends_the_live_stream_and_persists_the_block() {
     let voice = crate::app::voice::svc::VoiceService::new(
         crate::app::voice::svc::VoiceConfig::enabled(
             "wss://rtc.test".to_string(),
+            "http://livekit-sv.test".to_string(),
             "test-key".to_string(),
             "test-secret".to_string(),
             "late-voice".to_string(),

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -481,6 +481,8 @@ pub(crate) fn chat_help_lines(keep_composer_focused: bool) -> Vec<String> {
         "  /golive [title]    stream your screen: opens a browser publisher page, the",
         "                     room shows up under the rail's `stream` section, and a",
         "                     `is live` line hits #lounge once media flows; /golive stop ends it",
+        "  /golive obs [..]   stream from OBS instead: shows a WHIP server URL + bearer",
+        "                     token to paste into OBS (Settings > Stream > Service: WHIP)",
         "  /watch @user       open someone's live stream (browser via paired CLI, else QR)",
         "  /pomodoro [m] [..] focus countdown in the top bar, 1-180 min (default 25)",
         "                     [..] names the block; /pomodoro stop cancels it",

--- a/late-ssh/src/app/help_modal/data.rs
+++ b/late-ssh/src/app/help_modal/data.rs
@@ -31,10 +31,11 @@ pub enum HelpTopic {
     Bonsai,
     Settings,
     Voice,
+    Streaming,
 }
 
 impl HelpTopic {
-    pub const ALL: [HelpTopic; 22] = [
+    pub const ALL: [HelpTopic; 23] = [
         HelpTopic::Pair,
         HelpTopic::Overview,
         HelpTopic::Chat,
@@ -56,6 +57,7 @@ impl HelpTopic {
         HelpTopic::Bonsai,
         HelpTopic::Settings,
         HelpTopic::Voice,
+        HelpTopic::Streaming,
         HelpTopic::Architecture,
     ];
 
@@ -83,6 +85,7 @@ impl HelpTopic {
             HelpTopic::Bonsai => "Bonsai",
             HelpTopic::Settings => "Settings",
             HelpTopic::Voice => "Voice",
+            HelpTopic::Streaming => "Streaming",
         }
     }
 
@@ -109,7 +112,8 @@ impl HelpTopic {
             HelpTopic::Bonsai => 18,
             HelpTopic::Settings => 19,
             HelpTopic::Voice => 20,
-            HelpTopic::Architecture => 21,
+            HelpTopic::Streaming => 21,
+            HelpTopic::Architecture => 22,
         }
     }
 }
@@ -154,6 +158,7 @@ pub(crate) fn lines_for(
         HelpTopic::Bonsai => bonsai_help_lines(),
         HelpTopic::Settings => settings_help_lines(),
         HelpTopic::Voice => voice_help_lines(),
+        HelpTopic::Streaming => streaming_help_lines(),
     }
 }
 
@@ -478,12 +483,10 @@ pub(crate) fn chat_help_lines(keep_composer_focused: bool) -> Vec<String> {
         "  /list              list public rooms",
         "  /poll              start a Home room poll with 2-3 options",
         "  /pair @user        shared live coding scratchpad (both of you must run it)",
-        "  /golive [title]    stream your screen: opens a browser publisher page, the",
-        "                     room shows up under the rail's `stream` section, and a",
-        "                     `is live` line hits #lounge once media flows; /golive stop ends it",
-        "  /golive obs [..]   stream from OBS instead: shows a WHIP server URL + bearer",
-        "                     token to paste into OBS (Settings > Stream > Service: WHIP)",
+        "  /golive [title]    stream your screen via a browser publisher page",
+        "  /golive obs [..]   stream from OBS over WHIP; /golive stop ends either",
         "  /watch @user       open someone's live stream (browser via paired CLI, else QR)",
+        "                     setup and OBS details live in the Streaming tab",
         "  /pomodoro [m] [..] focus countdown in the top bar, 1-180 min (default 25)",
         "                     [..] names the block; /pomodoro stop cancels it",
         "  /roll [NdM ...]    roll dice (default d20), e.g. /roll 3d6 2d20",
@@ -1335,6 +1338,71 @@ fn voice_help_lines() -> Vec<String> {
         "  LiveKit carries the actual audio; late.sh never relays voice media through SSH or the music stack.",
         "  late.sh only mints a short-lived LiveKit token per join and tracks who is connected, muted, or speaking for the roster.",
         "  The native CLI captures your mic and plays back the room over LiveKit, and reports its state back so the TUI roster stays in sync.",
+    ]
+    .into_iter()
+    .map(str::to_string)
+    .collect()
+}
+
+fn streaming_help_lines() -> Vec<String> {
+    [
+        "Streaming",
+        "",
+        "/golive puts you live in your own stream room: viewers watch in a browser, chat rides the room, and the room's voice channel is the stream's voice. One stream per account.",
+        "",
+        "Two ways to publish",
+        "  /golive [title]    stream your screen from a browser publisher page;",
+        "                     late.sh opens it via your paired CLI, or shows a QR",
+        "  /golive obs [..]   stream from OBS over WHIP; shows the server URL and",
+        "                     bearer token to paste into OBS",
+        "  The two kinds do not mix: to switch, /golive stop first, then start the other.",
+        "  Rerunning /golive obs while set up shows the same credentials again.",
+        "  /golive stop       end your stream (either kind)",
+        "",
+        "Watching",
+        "  /watch @user       open someone's live stream (browser via paired CLI, else QR)",
+        "  Live streams also show under the room rail's `stream` section, and an",
+        "  `is live` line hits #lounge once media flows.",
+        "  Watch pages are born silent: nothing is audible until the viewer turns sound on.",
+        "",
+        "OBS setup: Settings > Stream",
+        "  Service           WHIP",
+        "  Server            the WHIP URL from /golive obs",
+        "  Bearer Token      the token from /golive obs",
+        "",
+        "OBS setup: Settings > Output",
+        "  Video Encoder     H.264: hardware if you have it (NVENC, AMF, VAAPI,",
+        "                    Apple VT), otherwise x264",
+        "  Audio Encoder     Opus, required: WHIP cannot carry AAC",
+        "  Bitrate           whatever your upload handles; 4000-8000 Kbps is plenty",
+        "  The server forwards your encoding untouched (no re-encode), so what you",
+        "  send is exactly what viewers get.",
+        "",
+        "If OBS says \"at least one video or audio encoder is not set\"",
+        "  Switching Service to WHIP resets any encoder it cannot carry, including",
+        "  the Recording ones, and OBS refuses to save while any output has none.",
+        "  Simple output mode: set Recording Quality to \"Same as stream\".",
+        "  Advanced output mode: check the Recording tab and pick its encoders",
+        "  (\"Use stream encoder\" is fine).",
+        "  Still complaining with everything set? Restart OBS: older versions do",
+        "  not rebind encoders after the service switch until a restart.",
+        "",
+        "Credentials",
+        "  The WHIP URL and bearer token are minted per stream and die with it:",
+        "  /golive stop (or the stream ending) invalidates them, and the next",
+        "  /golive obs mints a fresh pair to paste in.",
+        "",
+        "On air and voice",
+        "  While you publish, the stream room's voice strip shows ⦿ ON AIR.",
+        "  Voice in a stream room is audible to watch-page viewers, and an OBS",
+        "  stream counts as on air the whole time it publishes, since program",
+        "  audio can carry a microphone.",
+        "",
+        "Disconnects",
+        "  OBS dropping does not kill the stream instantly: after ~30 seconds",
+        "  without media it falls to a reconnect grace, and ends ~30 seconds",
+        "  later if OBS has not come back. OBS's automatic reconnect picks the",
+        "  stream back up within that window.",
     ]
     .into_iter()
     .map(str::to_string)

--- a/late-ssh/src/app/help_modal/data_test.rs
+++ b/late-ssh/src/app/help_modal/data_test.rs
@@ -226,7 +226,10 @@ fn streaming_guide_covers_golive_and_obs_setup() {
         "born silent",
         "ON AIR",
     ] {
-        assert!(streaming.contains(expected), "streaming guide missing {expected}");
+        assert!(
+            streaming.contains(expected),
+            "streaming guide missing {expected}"
+        );
     }
     // The chat commands list stays an index and defers the details here.
     let chat = chat_help_lines(false).join("\n");

--- a/late-ssh/src/app/help_modal/data_test.rs
+++ b/late-ssh/src/app/help_modal/data_test.rs
@@ -200,6 +200,39 @@ fn chat_guide_collapses_compose_section_when_keep_composer_focused() {
     assert!(!on.contains("<<COMPOSE_SEND_LINES>>"));
 }
 
+/// OBS setup questions land on @bot, so the Streaming tab has to carry the
+/// full WHIP recipe: service fields, the Opus requirement, and the encoder
+/// reset trap that OBS springs when the service switches to WHIP.
+#[test]
+fn streaming_guide_covers_golive_and_obs_setup() {
+    assert!(
+        HelpTopic::ALL
+            .iter()
+            .any(|topic| topic.title() == "Streaming")
+    );
+    assert!(bot_app_context().contains("## Streaming\n"));
+    let streaming = lines_for(HelpTopic::Streaming, false, "").join("\n");
+    for expected in [
+        "/golive [title]",
+        "/golive obs",
+        "/golive stop",
+        "/watch @user",
+        "Service           WHIP",
+        "Bearer Token",
+        "Opus, required: WHIP cannot carry AAC",
+        "Same as stream",
+        "Restart OBS",
+        "minted per stream and die with it",
+        "born silent",
+        "ON AIR",
+    ] {
+        assert!(streaming.contains(expected), "streaming guide missing {expected}");
+    }
+    // The chat commands list stays an index and defers the details here.
+    let chat = chat_help_lines(false).join("\n");
+    assert!(chat.contains("the Streaming tab"));
+}
+
 #[test]
 fn bot_context_does_not_leak_restricted_commands() {
     let context = bot_app_context();

--- a/late-ssh/src/app/input.rs
+++ b/late-ssh/src/app/input.rs
@@ -804,7 +804,7 @@ fn handle_parsed_input_inner(app: &mut App, event: ParsedInput) {
     // Stream URL + QR modal: any key or click closes it. It sits above
     // everything except the announcements: the URL it shows was just
     // requested, so nothing else should swallow the dismissal.
-    if app.stream_qr_modal.is_some() {
+    if app.stream_modal.is_some() {
         if matches!(
             event,
             ParsedInput::Byte(_)
@@ -815,7 +815,7 @@ fn handle_parsed_input_inner(app: &mut App, event: ParsedInput) {
                     ..
                 })
         ) {
-            app.stream_qr_modal = None;
+            app.stream_modal = None;
         }
         return;
     }
@@ -2036,8 +2036,8 @@ fn dispatch_escape(app: &mut App) {
     // (it dispatches here via the pending-escape flush instead), so the
     // stream URL modal needs its own arm, first, mirroring its position
     // above everything else in that gate.
-    if app.stream_qr_modal.is_some() {
-        app.stream_qr_modal = None;
+    if app.stream_modal.is_some() {
+        app.stream_modal = None;
         return;
     }
     if app.show_quit_confirm {

--- a/late-ssh/src/app/input_flow_test.rs
+++ b/late-ssh/src/app/input_flow_test.rs
@@ -1685,24 +1685,26 @@ async fn forced_tour_gates_input_until_each_named_key() {
 }
 
 #[tokio::test]
-async fn esc_closes_the_stream_qr_modal_like_any_other_key() {
+async fn esc_closes_the_stream_modal_like_any_other_key() {
     let test_db = new_test_db().await;
     let user = create_test_user(&test_db.db, "stream-qr-esc").await;
     let mut app = make_app(test_db.db.clone(), user.id, "stream-qr-esc-it");
     wait_for_render_contains(&mut app, "Home").await;
 
-    app.stream_qr_modal = Some(crate::app::state::StreamQrModal {
-        url: "https://late.sh/golive/abc".to_string(),
-        title: "Go Live".to_string(),
-        subtitle: "scan to broadcast".to_string(),
-    });
+    app.stream_modal = Some(crate::app::state::StreamModal::Qr(
+        crate::app::state::StreamQrModal {
+            url: "https://late.sh/golive/abc".to_string(),
+            title: "Go Live".to_string(),
+            subtitle: "scan to broadcast".to_string(),
+        },
+    ));
 
     // A lone Esc dispatches via the pending-escape flush on a later tick,
     // not through the any-key gate the other keys hit.
     app.handle_input(b"\x1b");
     wait_for_esc_effect(
         &mut app,
-        |app| app.stream_qr_modal.is_none(),
+        |app| app.stream_modal.is_none(),
         "esc closes the stream qr modal",
     )
     .await;

--- a/late-ssh/src/app/render.rs
+++ b/late-ssh/src/app/render.rs
@@ -249,7 +249,7 @@ struct DrawContext<'a> {
     lobby: &'a crate::app::lobby::state::LobbyState,
     daily: &'a crate::app::lobby::daily::state::DailyState,
     login_announcements: Option<&'a announcements::LoginAnnouncements>,
-    stream_qr_modal: Option<&'a crate::app::state::StreamQrModal>,
+    stream_modal: Option<&'a crate::app::state::StreamModal>,
     show_help: bool,
     help_modal_state: &'a help_modal::state::HelpModalState,
     show_ultimate_modal: bool,
@@ -1077,7 +1077,7 @@ impl App {
                         } else {
                             None
                         },
-                        stream_qr_modal: self.stream_qr_modal.as_ref(),
+                        stream_modal: self.stream_modal.as_ref(),
                         show_help: self.show_help,
                         help_modal_state: &self.help_modal_state,
                         show_ultimate_modal: self.show_ultimate_modal,
@@ -1794,16 +1794,29 @@ impl App {
             icon_picker::picker::render(frame, area, ctx.icon_picker_state, catalog);
         }
 
-        // Stream URL + QR modal (publisher URL from `/golive`, watch URL
-        // from `/watch`): topmost, since it was just explicitly requested.
-        if let Some(modal) = ctx.stream_qr_modal {
-            crate::app::common::qr::draw_qr_overlay(
-                frame,
-                inner,
-                &modal.url,
-                &modal.title,
-                &modal.subtitle,
-            );
+        // Stream handoff modal (publisher URL from `/golive`, watch URL
+        // from `/watch`, OBS details from `/golive obs`): topmost, since it
+        // was just explicitly requested.
+        match ctx.stream_modal {
+            Some(crate::app::state::StreamModal::Qr(modal)) => {
+                crate::app::common::qr::draw_qr_overlay(
+                    frame,
+                    inner,
+                    &modal.url,
+                    &modal.title,
+                    &modal.subtitle,
+                );
+            }
+            Some(crate::app::state::StreamModal::Obs(modal)) => {
+                crate::app::stream::ui::draw_obs_overlay(
+                    frame,
+                    inner,
+                    &modal.whip_url,
+                    &modal.stream_key,
+                    &modal.watch_url,
+                );
+            }
+            None => {}
         }
     }
 }
@@ -1819,7 +1832,7 @@ fn foreground_terminal_overlay_open(ctx: &DrawContext<'_>) -> bool {
         || ctx.show_bonsai_modal
         || ctx.show_bonsai_v2_modal
         || ctx.login_announcements.is_some()
-        || ctx.stream_qr_modal.is_some()
+        || ctx.stream_modal.is_some()
         || ctx.show_help
         || ctx.show_ultimate_modal
         || ctx.news_modal.is_some()

--- a/late-ssh/src/app/state.rs
+++ b/late-ssh/src/app/state.rs
@@ -53,12 +53,26 @@ struct VoiceJoinTaskResult {
     ticket: Result<crate::app::voice::svc::VoiceJoinTicket, String>,
 }
 
-/// Full-screen URL + QR modal for stream pages, drawn over everything and
-/// dismissed by any key.
+/// Full-screen stream handoff overlay, drawn over everything and dismissed
+/// by any key.
+pub(crate) enum StreamModal {
+    /// URL + QR (publisher URL from `/golive`, watch URL from `/watch`).
+    Qr(StreamQrModal),
+    /// OBS connection details from `/golive obs`. No QR: the values are
+    /// pasted into OBS settings on a desktop, not scanned by a phone.
+    Obs(StreamObsModal),
+}
+
 pub(crate) struct StreamQrModal {
     pub url: String,
     pub title: String,
     pub subtitle: String,
+}
+
+pub(crate) struct StreamObsModal {
+    pub whip_url: String,
+    pub stream_key: String,
+    pub watch_url: String,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -508,7 +522,7 @@ pub struct App {
     pub(crate) pending_on_air_voice_confirm: Option<Uuid>,
     /// Full-screen URL + QR modal for the stream pages (`/golive` publisher
     /// URL, `/watch` for raw SSH sessions). Any key closes it.
-    pub(crate) stream_qr_modal: Option<StreamQrModal>,
+    pub(crate) stream_modal: Option<StreamModal>,
     pub(crate) user_id: Uuid,
     pub(crate) permissions: Permissions,
     pub(crate) is_admin: bool,
@@ -1297,7 +1311,7 @@ impl App {
             }),
             stream_service: config.stream_service,
             pending_on_air_voice_confirm: None,
-            stream_qr_modal: None,
+            stream_modal: None,
             user_id: config.user_id,
             permissions: config.permissions,
             is_admin: config.permissions.is_admin(),
@@ -2708,6 +2722,10 @@ impl App {
                     service.go_live_task(self.user_id, self.username.clone(), title);
                     self.banner = Some(Banner::success("Setting up your stream..."));
                 }
+                (Some(service), crate::app::chat::state::GoLiveCommand::StartObs { title }) => {
+                    service.go_live_obs_task(self.user_id, self.username.clone(), title);
+                    self.banner = Some(Banner::success("Setting up your OBS stream..."));
+                }
                 (Some(service), crate::app::chat::state::GoLiveCommand::Stop) => {
                     self.banner = Some(if service.stop(self.user_id) {
                         Banner::success("Stream ended.")
@@ -2830,11 +2848,33 @@ impl App {
                         false,
                     );
                 }
+                StreamEvent::GoLiveObsReady {
+                    user_id,
+                    whip_url,
+                    stream_key,
+                    watch_url,
+                    room_id,
+                    ..
+                } if user_id == self.user_id => {
+                    changed = true;
+                    // Same landing as the console flow: the streamer ends up
+                    // in their stream room with the header in front of them.
+                    self.chat.request_list();
+                    self.chat
+                        .select_room_slot(crate::app::chat::state::RoomSlot::Room(room_id));
+                    self.stream_modal = Some(StreamModal::Obs(StreamObsModal {
+                        whip_url,
+                        stream_key,
+                        watch_url,
+                    }));
+                }
                 StreamEvent::GoLiveFailed { user_id, message } if user_id == self.user_id => {
                     changed = true;
                     self.banner = Some(Banner::error(&message));
                 }
-                StreamEvent::GoLiveReady { .. } | StreamEvent::GoLiveFailed { .. } => {}
+                StreamEvent::GoLiveReady { .. }
+                | StreamEvent::GoLiveObsReady { .. }
+                | StreamEvent::GoLiveFailed { .. } => {}
             }
         }
 
@@ -2866,11 +2906,11 @@ impl App {
                 return;
             }
         }
-        self.stream_qr_modal = Some(StreamQrModal {
+        self.stream_modal = Some(StreamModal::Qr(StreamQrModal {
             url,
             title,
             subtitle,
-        });
+        }));
     }
 
     fn voice_leave_current_channel(&mut self) -> bool {

--- a/late-ssh/src/app/stream/CONTEXT.md
+++ b/late-ssh/src/app/stream/CONTEXT.md
@@ -169,7 +169,11 @@ Cross-domain touchpoints:
    unanswerable after the fact. An OBS stream's `EndedStream` additionally
    carries the ingress id and the same funnel deletes the ingress:
    participant removal alone leaves the stream key valid and OBS
-   auto-reconnects through it.
+   auto-reconnects through it. The delete retries with backoff (an ingress
+   is a LiveKit-side resource; a failed delete is a still-valid stream key
+   with no page to stop itself), and `reconcile_ingresses` runs at boot to
+   delete every ingress the registry does not know, since a restart wipes
+   the registry while LiveKit keeps the keys.
 
 ## 4. Consent invariants (non-negotiable, from STREAM.md)
 

--- a/late-ssh/src/app/stream/CONTEXT.md
+++ b/late-ssh/src/app/stream/CONTEXT.md
@@ -3,9 +3,11 @@
 ## Metadata
 - Domain: "watch me" streaming rooms — the `/golive` screen-share broadcast, the in-process stream registry, stream rooms, publisher/watch capability URLs, and the rail's `stream` section
 - Primary audience: LLM agents working in `late-ssh/src/app/stream`, the `/golive`/`/watch` commands, the `/api/stream/*` routes, or `late-web/src/pages/live`
-- Last updated: 2026-08-12 (stream moderation scope: `/mod kick stream`,
-  `/mod ban stream` backed by `stream_bans`, and server bans now stop the
-  broadcast too)
+- Last updated: 2026-08-12 (OBS streaming: `/golive obs` publishes through a
+  LiveKit WHIP ingress instead of the browser console; registry entries
+  carry a `StreamPublisher` kind, liveness for OBS streams comes from the
+  server-side ingress status poll, and teardown also deletes the ingress.
+  New infra: `infra/redis.tf`, `infra/livekit-ingress.tf`, `whip.<domain>`)
 - Status: Active (v1)
 - Parent context: `../../../../CONTEXT.md`
 - Related context: `../voice/CONTEXT.md` (LiveKit grants, the ONE-room audio model), `../../../../late-web/CONTEXT.md` (watch + go-live pages), `STREAM.md` at the repo root (the design seed)
@@ -24,13 +26,19 @@ it moves capability ids, registry state, and one activity line.
 Owned by this domain:
 - `registry.rs` — the process-global `StreamRegistry`: one stream per user,
   phase machine (`Pending -> Live -> Grace`), watcher heartbeats, publisher
-  heartbeats/grace, capability ids. In-memory only, single replica, dies
-  with the process (scratchpad-registry tier).
+  heartbeats/grace, capability ids, and the `StreamPublisher` kind
+  (`Console` vs `Obs(ObsIngress)` — the publisher kinds conflict instead of
+  silently rewiring; `/golive stop` switches). In-memory only, single
+  replica, dies with the process (scratchpad-registry tier).
 - `svc.rs` — `StreamService` orchestration: lazy stream-room creation,
-  ticket minting via `VoiceService`, the `WentLive` announcement, the event
-  channel back to sessions, the sweeper.
-- The `/golive [title|stop]` and `/watch @user` composer commands (parsed in
-  `chat/state.rs`, drained by `App::tick_stream` in `app/state.rs`).
+  ticket minting via `VoiceService`, WHIP ingress create/reuse/delete, the
+  `WentLive` announcement, the event channel back to sessions, the ingress
+  status poll, the sweeper.
+- `ui.rs` — the OBS handoff overlay (`/golive obs`: WHIP server URL +
+  bearer token + watch link, hand-copied into OBS, dismissed by any key).
+- The `/golive [title|stop]`, `/golive obs [title]`, and `/watch @user`
+  composer commands (parsed in `chat/state.rs`, drained by
+  `App::tick_stream` in `app/state.rs`).
 - The `/api/stream/*` routes in `api.rs` and their late-web proxies/pages.
 
 Out of scope (deliberate v1 boundaries, from STREAM.md):
@@ -47,7 +55,8 @@ Out of scope (deliberate v1 boundaries, from STREAM.md):
 late-ssh/src/app/stream/
 ├── mod.rs        # declarations only
 ├── registry.rs   # StreamRegistry state machine + snapshot watch
-└── svc.rs        # StreamService: DB, VoiceService tickets, activity, events
+├── svc.rs        # StreamService: DB, VoiceService tickets, ingress, events
+└── ui.rs         # OBS handoff overlay (WHIP URL + bearer token modal)
 ```
 
 Cross-domain touchpoints:
@@ -65,6 +74,17 @@ Cross-domain touchpoints:
   SFU grant level to `screen_share`/`screen_share_audio`/`microphone`,
   identity `stream-{user_id}` so it never collides with the CLI voice
   identity) and `stream_watch_ticket` (`canPublish=false`, `hidden=true`).
+  For OBS: the LiveKit Ingress API client (`create_whip_ingress`,
+  `delete_ingress`, `ingress_publishing`; `ingressAdmin` Twirp calls). The
+  ingress participant identity is also `stream-{user_id}`, so teardown and
+  moderation reach an OBS publisher through the exact same paths; see
+  `../voice/CONTEXT.md` §7.
+- Infra: `infra/redis.tf` (LiveKit<->ingress bus; the server refuses
+  Ingress API calls without redis), `infra/livekit-ingress.tf`
+  (`whip.<domain>`, WHIP only — no RTMP ingest is ever minted), the
+  `redis`/`livekit-ingress` docker-compose services with
+  `infra/livekit/dev-config.yaml` + `infra/livekit-ingress/dev-config.yaml`
+  (dev OBS pushes to `http://localhost:7888/w`).
 - `api.rs` — `/api/stream/publish/{token}`, `/api/stream/publish/{token}/state`,
   `/api/stream/watch/{id}`, `/api/stream/watch/{id}/grant`,
   `/api/stream/watch/{id}/heartbeat`. Capability id in the URL is the whole
@@ -118,6 +138,17 @@ Cross-domain touchpoints:
 3. Watch pages resolve `/live/{id}`, poll state (10s), heartbeat (15s;
    45s TTL drives the "N watching" count), and subscribe with an anonymous
    hidden grant. Pages are born silent; a human click opens each direction.
+3a. OBS variant: `/golive obs [title]` runs the same registration but mints
+   a WHIP ingress (reused on re-runs; a same-user race deletes the loser)
+   and shows a modal with the WHIP server URL + bearer token to paste into
+   OBS (Settings → Stream → Service: WHIP). There is no console page, so
+   liveness comes from `StreamService::poll_obs_publishers` (the 5s sweeper
+   task): `ENDPOINT_PUBLISHING` synthesizes the publisher reports the phase
+   machine already understands, fires the same one #lounge line on the
+   first hit, and marks the streamer `on air` for the whole broadcast (OBS
+   program audio may carry a mic; a possibly-audible speaker is never
+   invisible). A failed poll call skips the report (never forges a stop);
+   a truly dead ingress falls to grace via the publisher TTL.
 4. Ending: `/golive stop`, or close the tab / stop sharing → grace
    (~30s, survives a refresh) → the registry sweeps the stream, watch and
    publisher URLs die, the rail row disappears. A registered stream whose
@@ -128,6 +159,9 @@ Cross-domain touchpoints:
    identity `stream-{user_id}`), and the console itself treats a 404 on its
    state report as stream-over (unpublish + disconnect), so neither side
    can keep broadcasting into the voice channel after the stream is gone.
+   An OBS stream's `EndedStream` additionally carries the ingress id and
+   teardown deletes the ingress: participant removal alone leaves the
+   stream key valid and OBS auto-reconnects through it.
 
 ## 4. Consent invariants (non-negotiable, from STREAM.md)
 
@@ -160,7 +194,14 @@ Cross-domain touchpoints:
   heartbeat counting (including the `WATCHERS_MAX` cap), mic state,
   teardown, username lookup, the claim-once publisher lock, and all four
   TTL transitions via the clock-injected `sweep_at` (pending expiry,
-  live → grace, grace teardown, watcher pruning).
+  live → grace, grace teardown, watcher pruning). OBS side: ingress
+  stored/reused on re-runs, publisher-kind conflicts both ways, `report_obs`
+  phase transitions + on-air, and `EndedStream.ingress_id` on stop and
+  sweep.
+- `ui_test.rs` — the OBS overlay renders every hand-copied value unclipped
+  and survives a tiny terminal.
+- `chat/state_internal_test.rs` — `/golive` parse routing (console vs `obs`
+  vs `stop`) and the title clamp.
 - `activity/event_test.rs` — feed titles are mention-safe: `@` is stripped
   before a `/golive` or cyberspace title lands in a #lounge body (the
   lounge feed's "bodies never contain `@`" contract).

--- a/late-ssh/src/app/stream/mod.rs
+++ b/late-ssh/src/app/stream/mod.rs
@@ -1,2 +1,3 @@
 pub mod registry;
 pub mod svc;
+pub mod ui;

--- a/late-ssh/src/app/stream/registry.rs
+++ b/late-ssh/src/app/stream/registry.rs
@@ -50,6 +50,26 @@ pub enum StreamPhase {
     Grace,
 }
 
+/// How the stream's media reaches LiveKit.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StreamPublisher {
+    /// Browser go-live console: claim-once publish token, page state reports.
+    Console,
+    /// OBS pushing to a WHIP ingress; liveness comes from the server-side
+    /// ingress status poll, not from any page.
+    Obs(ObsIngress),
+}
+
+/// The WHIP ingress behind an OBS stream. Kept in the registry so a re-run
+/// `/golive obs` re-shows the same connection details instead of minting a
+/// second ingress, and so teardown knows what to delete.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObsIngress {
+    pub ingress_id: String,
+    pub whip_url: String,
+    pub stream_key: String,
+}
+
 struct StreamEntry {
     user_id: Uuid,
     username: String,
@@ -58,6 +78,7 @@ struct StreamEntry {
     voice_channel_id: Uuid,
     stream_id: String,
     publish_token: String,
+    publisher: StreamPublisher,
     phase: StreamPhase,
     created_at: Instant,
     last_publisher_report: Instant,
@@ -78,7 +99,57 @@ struct StreamEntry {
     watchers: HashMap<String, Instant>,
 }
 
+/// A fresh `Pending` entry with newly minted capability ids.
+fn new_entry(
+    user_id: Uuid,
+    username: &str,
+    title: &str,
+    room_id: Uuid,
+    voice_channel_id: Uuid,
+    publisher: StreamPublisher,
+) -> StreamEntry {
+    let now = Instant::now();
+    StreamEntry {
+        user_id,
+        username: username.to_string(),
+        title: title.to_string(),
+        room_id,
+        voice_channel_id,
+        stream_id: capability_id(),
+        publish_token: capability_id(),
+        publisher,
+        phase: StreamPhase::Pending,
+        created_at: now,
+        last_publisher_report: now,
+        grace_since: None,
+        announced: false,
+        publisher_claim: None,
+        watchers: HashMap::new(),
+        mic_on_air: false,
+    }
+}
+
 impl StreamEntry {
+    fn handles(&self) -> StreamHandles {
+        StreamHandles {
+            stream_id: self.stream_id.clone(),
+            publish_token: self.publish_token.clone(),
+            room_id: self.room_id,
+            voice_channel_id: self.voice_channel_id,
+        }
+    }
+
+    fn into_ended(self) -> EndedStream {
+        EndedStream {
+            user_id: self.user_id,
+            voice_channel_id: self.voice_channel_id,
+            ingress_id: match self.publisher {
+                StreamPublisher::Console => None,
+                StreamPublisher::Obs(ingress) => Some(ingress.ingress_id),
+            },
+        }
+    }
+
     fn view(&self) -> LiveStreamView {
         LiveStreamView {
             user_id: self.user_id,
@@ -144,6 +215,38 @@ pub struct StreamHandles {
     pub voice_channel_id: Uuid,
 }
 
+/// Outcome of registering a console stream.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BeginOutcome {
+    Ready(StreamHandles),
+    /// The user's registered stream publishes through OBS; `/golive stop`
+    /// first.
+    PublisherConflict,
+}
+
+/// Outcome of registering an OBS stream.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BeginObsOutcome {
+    Ready {
+        handles: StreamHandles,
+        /// The ingress actually stored on the stream. On a re-run this is
+        /// the existing one; a caller that just minted a duplicate compares
+        /// ingress ids and deletes its own.
+        ingress: ObsIngress,
+    },
+    /// The user's registered stream publishes through the browser console;
+    /// `/golive stop` first.
+    PublisherConflict,
+}
+
+/// One OBS stream as the ingress status poll sees it.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObsPublisherPoll {
+    pub user_id: Uuid,
+    pub title: String,
+    pub ingress_id: String,
+}
+
 /// Everything the publisher grant endpoint needs to mint a publish ticket.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PublisherInfo {
@@ -157,11 +260,13 @@ pub struct PublisherInfo {
 /// A stream the registry just tore down. The caller (StreamService) uses
 /// this to force-disconnect the publisher's LiveKit session: registry
 /// removal alone only kills the capability URLs, not an already-connected
-/// go-live page.
+/// go-live page. For an OBS stream, `ingress_id` is the WHIP ingress to
+/// delete: without that, the stream key stays valid and OBS reconnects.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct EndedStream {
     pub user_id: Uuid,
     pub voice_channel_id: Uuid,
+    pub ingress_id: Option<String>,
 }
 
 /// Outcome of resolving a publish token for the grant endpoint.
@@ -226,10 +331,12 @@ impl StreamRegistry {
         self.tx.subscribe()
     }
 
-    /// Register (or re-surface) the user's stream. One stream per user: a
-    /// second `/golive` while one is registered updates the title and hands
-    /// back the same capability ids, so re-running the command re-shows the
-    /// modal instead of minting a parallel stream.
+    /// Register (or re-surface) the user's console stream. One stream per
+    /// user: a second `/golive` while one is registered updates the title and
+    /// hands back the same capability ids, so re-running the command re-shows
+    /// the modal instead of minting a parallel stream. A registered OBS
+    /// stream is a conflict: a live broadcast is never silently rewired to a
+    /// different publisher.
     pub fn begin(
         &self,
         user_id: Uuid,
@@ -237,38 +344,145 @@ impl StreamRegistry {
         title: &str,
         room_id: Uuid,
         voice_channel_id: Uuid,
-    ) -> StreamHandles {
-        let handles = {
+    ) -> BeginOutcome {
+        let outcome = {
             let mut inner = self.inner.lock_recover();
-            let now = Instant::now();
-            let entry = inner.entry(user_id).or_insert_with(|| StreamEntry {
-                user_id,
-                username: username.to_string(),
-                title: title.to_string(),
-                room_id,
-                voice_channel_id,
-                stream_id: capability_id(),
-                publish_token: capability_id(),
-                phase: StreamPhase::Pending,
-                created_at: now,
-                last_publisher_report: now,
-                grace_since: None,
-                announced: false,
-                publisher_claim: None,
-                watchers: HashMap::new(),
-                mic_on_air: false,
-            });
-            entry.title = title.to_string();
-            entry.username = username.to_string();
-            StreamHandles {
-                stream_id: entry.stream_id.clone(),
-                publish_token: entry.publish_token.clone(),
-                room_id: entry.room_id,
-                voice_channel_id: entry.voice_channel_id,
+            match inner.get_mut(&user_id) {
+                Some(entry) => match &entry.publisher {
+                    StreamPublisher::Obs(_) => return BeginOutcome::PublisherConflict,
+                    StreamPublisher::Console => {
+                        entry.title = title.to_string();
+                        entry.username = username.to_string();
+                        BeginOutcome::Ready(entry.handles())
+                    }
+                },
+                None => {
+                    let entry = new_entry(
+                        user_id,
+                        username,
+                        title,
+                        room_id,
+                        voice_channel_id,
+                        StreamPublisher::Console,
+                    );
+                    let handles = entry.handles();
+                    inner.insert(user_id, entry);
+                    BeginOutcome::Ready(handles)
+                }
             }
         };
         self.publish();
-        handles
+        outcome
+    }
+
+    /// Register (or re-surface) the user's OBS stream. On a re-run the
+    /// stored ingress wins and is handed back so the same connection details
+    /// re-show; the caller compares ingress ids and deletes a freshly minted
+    /// duplicate. A registered console stream is a conflict, mirroring
+    /// [`begin`](Self::begin).
+    pub fn begin_obs(
+        &self,
+        user_id: Uuid,
+        username: &str,
+        title: &str,
+        room_id: Uuid,
+        voice_channel_id: Uuid,
+        ingress: ObsIngress,
+    ) -> BeginObsOutcome {
+        let outcome = {
+            let mut inner = self.inner.lock_recover();
+            match inner.get_mut(&user_id) {
+                Some(entry) => match &entry.publisher {
+                    StreamPublisher::Console => return BeginObsOutcome::PublisherConflict,
+                    StreamPublisher::Obs(existing) => {
+                        let existing = existing.clone();
+                        entry.title = title.to_string();
+                        entry.username = username.to_string();
+                        BeginObsOutcome::Ready {
+                            handles: entry.handles(),
+                            ingress: existing,
+                        }
+                    }
+                },
+                None => {
+                    let entry = new_entry(
+                        user_id,
+                        username,
+                        title,
+                        room_id,
+                        voice_channel_id,
+                        StreamPublisher::Obs(ingress.clone()),
+                    );
+                    let handles = entry.handles();
+                    inner.insert(user_id, entry);
+                    BeginObsOutcome::Ready { handles, ingress }
+                }
+            }
+        };
+        self.publish();
+        outcome
+    }
+
+    /// The stored ingress of the user's registered OBS stream, if any. Lets
+    /// `/golive obs` re-runs skip minting a duplicate ingress.
+    pub fn obs_ingress(&self, user_id: Uuid) -> Option<ObsIngress> {
+        let inner = self.inner.lock_recover();
+        inner.get(&user_id).and_then(|entry| match &entry.publisher {
+            StreamPublisher::Console => None,
+            StreamPublisher::Obs(ingress) => Some(ingress.clone()),
+        })
+    }
+
+    /// Every registered OBS stream, for the ingress status poll.
+    pub fn obs_streams(&self) -> Vec<ObsPublisherPoll> {
+        let inner = self.inner.lock_recover();
+        inner
+            .values()
+            .filter_map(|entry| match &entry.publisher {
+                StreamPublisher::Console => None,
+                StreamPublisher::Obs(ingress) => Some(ObsPublisherPoll {
+                    user_id: entry.user_id,
+                    title: entry.title.clone(),
+                    ingress_id: ingress.ingress_id.clone(),
+                }),
+            })
+            .collect()
+    }
+
+    /// Apply an ingress status poll result to the user's OBS stream. Mirrors
+    /// [`report_publisher`](Self::report_publisher) without the claim
+    /// machinery: the server itself is the reporter, there is no page. While
+    /// OBS publishes, the streamer counts as on air: the program audio may
+    /// carry their mic and a possibly-audible speaker is never invisible.
+    /// `Gone` covers a stream that ended (or switched publisher) since the
+    /// poll snapshot was taken.
+    pub fn report_obs(&self, user_id: Uuid, publishing: bool) -> PublisherReport {
+        let outcome = {
+            let mut inner = self.inner.lock_recover();
+            let Some(entry) = inner
+                .get_mut(&user_id)
+                .filter(|entry| matches!(entry.publisher, StreamPublisher::Obs(_)))
+            else {
+                return PublisherReport::Gone;
+            };
+            entry.last_publisher_report = Instant::now();
+            entry.mic_on_air = publishing;
+            if publishing {
+                let went_live = !entry.announced;
+                entry.announced = true;
+                entry.phase = StreamPhase::Live;
+                entry.grace_since = None;
+                PublisherReport::Live { went_live }
+            } else {
+                if entry.phase == StreamPhase::Live {
+                    entry.phase = StreamPhase::Grace;
+                    entry.grace_since = Some(Instant::now());
+                }
+                PublisherReport::Stopped
+            }
+        };
+        self.publish();
+        outcome
     }
 
     /// Tear the user's stream down now (`/golive stop`, moderation kick).
@@ -276,10 +490,7 @@ impl StreamRegistry {
     /// LiveKit session, `None` when no stream existed.
     pub fn end_for_user(&self, user_id: Uuid) -> Option<EndedStream> {
         let removed = self.inner.lock_recover().remove(&user_id);
-        let ended = removed.map(|entry| EndedStream {
-            user_id: entry.user_id,
-            voice_channel_id: entry.voice_channel_id,
-        });
+        let ended = removed.map(StreamEntry::into_ended);
         if ended.is_some() {
             self.publish();
         }
@@ -480,12 +691,7 @@ impl StreamRegistry {
                 .collect();
             let ended: Vec<EndedStream> = expired
                 .into_iter()
-                .filter_map(|user_id| {
-                    inner.remove(&user_id).map(|entry| EndedStream {
-                        user_id: entry.user_id,
-                        voice_channel_id: entry.voice_channel_id,
-                    })
-                })
+                .filter_map(|user_id| inner.remove(&user_id).map(StreamEntry::into_ended))
                 .collect();
             (changed || !ended.is_empty(), ended)
         };

--- a/late-ssh/src/app/stream/registry.rs
+++ b/late-ssh/src/app/stream/registry.rs
@@ -474,10 +474,12 @@ impl StreamRegistry {
     /// `/golive obs` re-runs skip minting a duplicate ingress.
     pub fn obs_ingress(&self, user_id: Uuid) -> Option<ObsIngress> {
         let inner = self.inner.lock_recover();
-        inner.get(&user_id).and_then(|entry| match &entry.publisher {
-            StreamPublisher::Console => None,
-            StreamPublisher::Obs(ingress) => Some(ingress.clone()),
-        })
+        inner
+            .get(&user_id)
+            .and_then(|entry| match &entry.publisher {
+                StreamPublisher::Console => None,
+                StreamPublisher::Obs(ingress) => Some(ingress.clone()),
+            })
     }
 
     /// Every registered OBS stream, for the ingress status poll.

--- a/late-ssh/src/app/stream/registry_test.rs
+++ b/late-ssh/src/app/stream/registry_test.rs
@@ -3,12 +3,34 @@ use std::time::Instant;
 use uuid::Uuid;
 
 use super::{
-    PENDING_TTL, PUBLISHER_GRACE, PUBLISHER_TTL, PublisherReport, StreamRegistry, WATCHER_TTL,
-    WATCHERS_MAX,
+    BeginObsOutcome, BeginOutcome, ObsIngress, PENDING_TTL, PUBLISHER_GRACE, PUBLISHER_TTL,
+    PublisherReport, StreamHandles, StreamRegistry, WATCHER_TTL, WATCHERS_MAX,
 };
 
 fn ids() -> (Uuid, Uuid, Uuid) {
     (Uuid::now_v7(), Uuid::now_v7(), Uuid::now_v7())
+}
+
+fn begin_ok(
+    registry: &StreamRegistry,
+    user: Uuid,
+    username: &str,
+    title: &str,
+    room: Uuid,
+    channel: Uuid,
+) -> StreamHandles {
+    match registry.begin(user, username, title, room, channel) {
+        BeginOutcome::Ready(handles) => handles,
+        BeginOutcome::PublisherConflict => panic!("unexpected publisher conflict"),
+    }
+}
+
+fn example_ingress(id: &str) -> ObsIngress {
+    ObsIngress {
+        ingress_id: id.to_string(),
+        whip_url: format!("https://whip.example/w/{id}"),
+        stream_key: format!("key-{id}"),
+    }
 }
 
 #[test]
@@ -16,8 +38,8 @@ fn begin_is_one_stream_per_user_and_updates_title() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
 
-    let first = registry.begin(user, "mat", "first title", room, channel);
-    let second = registry.begin(user, "mat", "second title", room, channel);
+    let first = begin_ok(&registry, user, "mat", "first title", room, channel);
+    let second = begin_ok(&registry, user, "mat", "second title", room, channel);
 
     assert_eq!(first.stream_id, second.stream_id);
     assert_eq!(first.publish_token, second.publish_token);
@@ -33,7 +55,7 @@ fn pending_streams_appear_in_the_snapshot_as_not_live() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
 
-    let handles = registry.begin(user, "mat", "quiet", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "quiet", room, channel);
 
     // The rail's "stream" section lists a stream from /golive on; the
     // announcement and LIVE tag key off `live`, which waits for media.
@@ -49,7 +71,7 @@ fn pending_streams_appear_in_the_snapshot_as_not_live() {
 fn first_media_report_goes_live_exactly_once() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
 
     let first = registry.report_publisher(&handles.publish_token, true, false, None);
     let second = registry.report_publisher(&handles.publish_token, true, false, None);
@@ -75,7 +97,7 @@ fn unknown_publish_token_reports_gone() {
 fn publisher_stop_keeps_the_stream_in_grace() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
     registry.report_publisher(&handles.publish_token, true, false, None);
 
     let outcome = registry.report_publisher(&handles.publish_token, false, false, None);
@@ -95,7 +117,7 @@ fn publisher_stop_keeps_the_stream_in_grace() {
 fn watch_heartbeats_drive_the_watching_count() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
     registry.report_publisher(&handles.publish_token, true, false, None);
 
     assert!(registry.watch_heartbeat(&handles.stream_id, "viewer-a"));
@@ -111,7 +133,7 @@ fn watch_heartbeats_drive_the_watching_count() {
 fn mic_state_reaches_the_view() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
 
     registry.report_publisher(&handles.publish_token, true, true, None);
     let view = registry.watch_view(&handles.stream_id).expect("watch view");
@@ -126,7 +148,7 @@ fn mic_state_reaches_the_view() {
 fn end_for_user_kills_the_watch_url() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
     registry.report_publisher(&handles.publish_token, true, false, None);
 
     // The ended stream carries the voice channel so the caller can
@@ -134,6 +156,8 @@ fn end_for_user_kills_the_watch_url() {
     let ended = registry.end_for_user(user).expect("ended stream");
     assert_eq!(ended.user_id, user);
     assert_eq!(ended.voice_channel_id, channel);
+    // A console stream has no ingress to delete.
+    assert_eq!(ended.ingress_id, None);
     assert!(registry.end_for_user(user).is_none());
 
     assert!(registry.watch_view(&handles.stream_id).is_none());
@@ -145,7 +169,7 @@ fn end_for_user_kills_the_watch_url() {
 fn stream_lookup_by_username_is_case_insensitive() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "Mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "Mat", "show", room, channel);
     registry.report_publisher(&handles.publish_token, true, false, None);
 
     let view = registry
@@ -159,7 +183,7 @@ fn stream_lookup_by_username_is_case_insensitive() {
 fn sweep_keeps_fresh_streams() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
     registry.report_publisher(&handles.publish_token, true, false, None);
     registry.watch_heartbeat(&handles.stream_id, "viewer-a");
 
@@ -174,7 +198,7 @@ fn sweep_keeps_fresh_streams() {
 fn sweep_expires_a_pending_stream_after_the_ttl() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "never shown", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "never shown", room, channel);
 
     assert!(registry.sweep_at(Instant::now()).is_empty());
     let ended = registry.sweep_at(Instant::now() + PENDING_TTL);
@@ -190,7 +214,7 @@ fn sweep_expires_a_pending_stream_after_the_ttl() {
 fn sweep_moves_a_stale_publisher_into_grace_then_tears_down() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
     registry.report_publisher(&handles.publish_token, true, false, None);
 
     // Publisher silent past its TTL: grace, still shown as live (the room
@@ -211,7 +235,7 @@ fn sweep_moves_a_stale_publisher_into_grace_then_tears_down() {
 fn sweep_prunes_stale_watchers() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
     registry.report_publisher(&handles.publish_token, true, false, None);
     registry.watch_heartbeat(&handles.stream_id, "viewer-a");
 
@@ -230,7 +254,7 @@ fn sweep_prunes_stale_watchers() {
 fn watcher_cap_bounds_the_watching_count() {
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
     registry.report_publisher(&handles.publish_token, true, false, None);
 
     for i in 0..(WATCHERS_MAX + 25) {
@@ -248,7 +272,7 @@ fn publisher_claim_locks_the_token_to_the_first_caller() {
     use super::PublisherAccess;
     let registry = StreamRegistry::new();
     let (user, room, channel) = ids();
-    let handles = registry.begin(user, "mat", "show", room, channel);
+    let handles = begin_ok(&registry, user, "mat", "show", room, channel);
 
     // First grant fetch claims the token and mints the secret.
     let secret = match registry.access_publisher(&handles.publish_token, None) {
@@ -291,7 +315,7 @@ fn publisher_claim_locks_the_token_to_the_first_caller() {
 
     // A fresh stream after a stop starts unclaimed with new ids.
     registry.end_for_user(user).expect("ended stream");
-    let fresh = registry.begin(user, "mat", "next show", room, channel);
+    let fresh = begin_ok(&registry, user, "mat", "next show", room, channel);
     assert_ne!(fresh.publish_token, handles.publish_token);
     assert!(matches!(
         registry.access_publisher(&fresh.publish_token, None),
@@ -304,4 +328,139 @@ fn publisher_claim_locks_the_token_to_the_first_caller() {
         registry.access_publisher(&handles.publish_token, None),
         PublisherAccess::Gone
     );
+}
+
+#[test]
+fn obs_begin_stores_the_ingress_and_reuses_it_on_a_rerun() {
+    let registry = StreamRegistry::new();
+    let (user, room, channel) = ids();
+
+    let first = match registry.begin_obs(
+        user,
+        "mat",
+        "obs show",
+        room,
+        channel,
+        example_ingress("in-1"),
+    ) {
+        BeginObsOutcome::Ready { handles, ingress } => {
+            assert_eq!(ingress, example_ingress("in-1"));
+            handles
+        }
+        other => panic!("expected ready, got {other:?}"),
+    };
+
+    // A re-run hands back the stored ingress, never the freshly minted
+    // duplicate, so the caller knows to delete its own.
+    match registry.begin_obs(
+        user,
+        "mat",
+        "new title",
+        room,
+        channel,
+        example_ingress("in-2"),
+    ) {
+        BeginObsOutcome::Ready { handles, ingress } => {
+            assert_eq!(handles.stream_id, first.stream_id);
+            assert_eq!(ingress, example_ingress("in-1"));
+        }
+        other => panic!("expected ready, got {other:?}"),
+    }
+    assert_eq!(registry.obs_ingress(user), Some(example_ingress("in-1")));
+    let info = registry
+        .publisher_info(&first.publish_token)
+        .expect("publisher info");
+    assert_eq!(info.title, "new title");
+}
+
+#[test]
+fn publisher_kinds_conflict_instead_of_rewiring_a_stream() {
+    let registry = StreamRegistry::new();
+    let (user, room, channel) = ids();
+
+    begin_ok(&registry, user, "mat", "console show", room, channel);
+    assert_eq!(
+        registry.begin_obs(user, "mat", "obs", room, channel, example_ingress("in-1")),
+        BeginObsOutcome::PublisherConflict
+    );
+    // The console stream is untouched by the refused OBS begin.
+    assert_eq!(registry.obs_ingress(user), None);
+
+    registry.end_for_user(user).expect("ended stream");
+    registry.begin_obs(user, "mat", "obs", room, channel, example_ingress("in-1"));
+    assert_eq!(
+        registry.begin(user, "mat", "console", room, channel),
+        BeginOutcome::PublisherConflict
+    );
+}
+
+#[test]
+fn obs_reports_drive_the_phase_machine_and_on_air() {
+    let registry = StreamRegistry::new();
+    let (user, room, channel) = ids();
+    let handles = match registry.begin_obs(
+        user,
+        "mat",
+        "obs show",
+        room,
+        channel,
+        example_ingress("in-1"),
+    ) {
+        BeginObsOutcome::Ready { handles, .. } => handles,
+        other => panic!("expected ready, got {other:?}"),
+    };
+
+    let polls = registry.obs_streams();
+    assert_eq!(polls.len(), 1);
+    assert_eq!(polls[0].user_id, user);
+    assert_eq!(polls[0].ingress_id, "in-1");
+
+    // First publishing poll goes live exactly once; while OBS publishes the
+    // streamer counts as on air (program audio may carry their mic).
+    assert_eq!(
+        registry.report_obs(user, true),
+        PublisherReport::Live { went_live: true }
+    );
+    assert_eq!(
+        registry.report_obs(user, true),
+        PublisherReport::Live { went_live: false }
+    );
+    let view = registry.watch_view(&handles.stream_id).expect("watch view");
+    assert!(view.live);
+    assert!(view.mic_on_air);
+
+    // A non-publishing poll starts grace; the stream still shows live.
+    assert_eq!(registry.report_obs(user, false), PublisherReport::Stopped);
+    let view = registry.watch_view(&handles.stream_id).expect("watch view");
+    assert!(view.live);
+    assert!(!view.mic_on_air);
+
+    // Unknown or non-OBS users report gone.
+    assert_eq!(
+        registry.report_obs(Uuid::now_v7(), true),
+        PublisherReport::Gone
+    );
+
+    // Ending carries the ingress id so teardown can delete it.
+    let ended = registry.end_for_user(user).expect("ended stream");
+    assert_eq!(ended.ingress_id, Some("in-1".to_string()));
+}
+
+#[test]
+fn obs_sweep_carries_the_ingress_id() {
+    let registry = StreamRegistry::new();
+    let (user, room, channel) = ids();
+    registry.begin_obs(
+        user,
+        "mat",
+        "never started",
+        room,
+        channel,
+        example_ingress("in-1"),
+    );
+
+    let ended = registry.sweep_at(Instant::now() + PENDING_TTL);
+
+    assert_eq!(ended.len(), 1);
+    assert_eq!(ended[0].ingress_id, Some("in-1".to_string()));
 }

--- a/late-ssh/src/app/stream/svc.rs
+++ b/late-ssh/src/app/stream/svc.rs
@@ -21,8 +21,8 @@ use uuid::Uuid;
 use crate::app::{
     activity::publisher::ActivityPublisher,
     stream::registry::{
-        EndedStream, LiveStreamView, PublisherAccess, PublisherReport, StreamRegistry,
-        StreamSnapshot,
+        BeginObsOutcome, BeginOutcome, EndedStream, LiveStreamView, ObsIngress, PublisherAccess,
+        PublisherReport, StreamRegistry, StreamSnapshot,
     },
     voice::svc::{StreamMediaTicket, VoiceService},
 };
@@ -38,8 +38,32 @@ pub enum StreamEvent {
         watch_url: String,
         room_id: Uuid,
     },
+    /// `/golive obs`: the stream is registered and OBS connection details
+    /// are ready to show. OBS pushes to `whip_url` with `stream_key` as the
+    /// bearer token; going live waits for the ingress status poll to see
+    /// media, same contract as the console's first media report.
+    GoLiveObsReady {
+        user_id: Uuid,
+        title: String,
+        whip_url: String,
+        stream_key: String,
+        watch_url: String,
+        room_id: Uuid,
+    },
     GoLiveFailed {
         user_id: Uuid,
+        message: String,
+    },
+}
+
+/// Outcome of the shared `/golive` groundwork (ban gates, room + voice
+/// channel ensured, streamer joined), before any publisher-specific step.
+enum GoLivePrep {
+    Ready {
+        room_id: Uuid,
+        voice_channel_id: Uuid,
+    },
+    Refused {
         message: String,
     },
 }
@@ -127,37 +151,59 @@ impl StreamService {
         tokio::spawn(
             async move {
                 let title = title.unwrap_or_default();
-                match service.go_live(user_id, &username, &title).await {
-                    Ok(event) => {
-                        match &event {
-                            StreamEvent::GoLiveReady { room_id, .. } => {
-                                tracing::info!(room_id = %room_id, "stream registered");
-                            }
-                            StreamEvent::GoLiveFailed { message, .. } => {
-                                tracing::info!(user_id = %user_id, reason = %message, "go live refused");
-                            }
-                        }
-                        let _ = service.evt_tx.send(event);
-                    }
-                    Err(error) => {
-                        tracing::error!(error = ?error, user_id = %user_id, "go live failed");
-                        let _ = service.evt_tx.send(StreamEvent::GoLiveFailed {
-                            user_id,
-                            message: "Could not start the stream. Try again.".to_string(),
-                        });
-                    }
-                }
+                let event = service.go_live(user_id, &username, &title).await;
+                service.send_go_live_event(user_id, event);
             }
             .instrument(span),
         );
     }
 
-    async fn go_live(
-        &self,
-        user_id: Uuid,
-        username: &str,
-        title: &str,
-    ) -> anyhow::Result<StreamEvent> {
+    /// `/golive obs [title]`: same registration flow, but the media comes
+    /// from OBS through a WHIP ingress instead of a browser console.
+    pub fn go_live_obs_task(&self, user_id: Uuid, username: String, title: Option<String>) {
+        let service = self.clone();
+        let span = info_span!("stream.go_live_obs_task", user_id = %user_id, username = %username);
+        tokio::spawn(
+            async move {
+                let title = title.unwrap_or_default();
+                let event = service.go_live_obs(user_id, &username, &title).await;
+                service.send_go_live_event(user_id, event);
+            }
+            .instrument(span),
+        );
+    }
+
+    /// The one place a `/golive` outcome is logged and delivered, whatever
+    /// the publisher kind.
+    fn send_go_live_event(&self, user_id: Uuid, event: anyhow::Result<StreamEvent>) {
+        match event {
+            Ok(event) => {
+                match &event {
+                    StreamEvent::GoLiveReady { room_id, .. } => {
+                        tracing::info!(room_id = %room_id, "stream registered");
+                    }
+                    StreamEvent::GoLiveObsReady { room_id, .. } => {
+                        tracing::info!(room_id = %room_id, "obs stream registered");
+                    }
+                    StreamEvent::GoLiveFailed { message, .. } => {
+                        tracing::info!(user_id = %user_id, reason = %message, "go live refused");
+                    }
+                }
+                let _ = self.evt_tx.send(event);
+            }
+            Err(error) => {
+                tracing::error!(error = ?error, user_id = %user_id, "go live failed");
+                let _ = self.evt_tx.send(StreamEvent::GoLiveFailed {
+                    user_id,
+                    message: "Could not start the stream. Try again.".to_string(),
+                });
+            }
+        }
+    }
+
+    /// Shared `/golive` groundwork for both publisher kinds: ban gates, the
+    /// permanent stream room, its voice channel, streamer membership.
+    async fn prepare_go_live(&self, user_id: Uuid, username: &str) -> anyhow::Result<GoLivePrep> {
         if !self.voice.config().enabled {
             anyhow::bail!("voice/LiveKit is not configured");
         }
@@ -165,8 +211,7 @@ impl StreamService {
             // Surface the block at command time: without this the stream
             // half-registers (room, rail row) and only the page's grant
             // fetch fails, as a generic error.
-            return Ok(StreamEvent::GoLiveFailed {
-                user_id,
+            return Ok(GoLivePrep::Refused {
                 message: "You have been removed from voice by a moderator.".to_string(),
             });
         }
@@ -175,8 +220,7 @@ impl StreamService {
             .await
             .context("checking stream ban")?
         {
-            return Ok(StreamEvent::GoLiveFailed {
-                user_id,
+            return Ok(GoLivePrep::Refused {
                 message: "A moderator has blocked you from streaming.".to_string(),
             });
         }
@@ -195,17 +239,119 @@ impl StreamService {
         ChatRoomMember::join(&client, room.id, user_id)
             .await
             .context("joining streamer to stream room")?;
-
-        let handles = self
-            .registry
-            .begin(user_id, username, title, room.id, voice_channel.id);
-        Ok(StreamEvent::GoLiveReady {
-            user_id,
-            title: title.to_string(),
-            publish_url: self.publish_url(&handles.publish_token),
-            watch_url: self.watch_url(&handles.stream_id),
+        Ok(GoLivePrep::Ready {
             room_id: room.id,
+            voice_channel_id: voice_channel.id,
         })
+    }
+
+    async fn go_live(
+        &self,
+        user_id: Uuid,
+        username: &str,
+        title: &str,
+    ) -> anyhow::Result<StreamEvent> {
+        let (room_id, voice_channel_id) = match self.prepare_go_live(user_id, username).await? {
+            GoLivePrep::Ready {
+                room_id,
+                voice_channel_id,
+            } => (room_id, voice_channel_id),
+            GoLivePrep::Refused { message } => {
+                return Ok(StreamEvent::GoLiveFailed { user_id, message });
+            }
+        };
+        match self
+            .registry
+            .begin(user_id, username, title, room_id, voice_channel_id)
+        {
+            BeginOutcome::Ready(handles) => Ok(StreamEvent::GoLiveReady {
+                user_id,
+                title: title.to_string(),
+                publish_url: self.publish_url(&handles.publish_token),
+                watch_url: self.watch_url(&handles.stream_id),
+                room_id,
+            }),
+            BeginOutcome::PublisherConflict => Ok(StreamEvent::GoLiveFailed {
+                user_id,
+                message: "You are set up to stream from OBS. Run /golive stop first.".to_string(),
+            }),
+        }
+    }
+
+    async fn go_live_obs(
+        &self,
+        user_id: Uuid,
+        username: &str,
+        title: &str,
+    ) -> anyhow::Result<StreamEvent> {
+        let (room_id, voice_channel_id) = match self.prepare_go_live(user_id, username).await? {
+            GoLivePrep::Ready {
+                room_id,
+                voice_channel_id,
+            } => (room_id, voice_channel_id),
+            GoLivePrep::Refused { message } => {
+                return Ok(StreamEvent::GoLiveFailed { user_id, message });
+            }
+        };
+        // Reuse the stored ingress on a re-run so the same connection
+        // details re-show; mint one only when none is registered.
+        let (ingress, minted) = match self.registry.obs_ingress(user_id) {
+            Some(existing) => (existing, false),
+            None => {
+                let created = self
+                    .voice
+                    .create_whip_ingress(voice_channel_id, user_id, username)
+                    .await
+                    .context("creating WHIP ingress")?;
+                (
+                    ObsIngress {
+                        ingress_id: created.ingress_id,
+                        whip_url: created.url,
+                        stream_key: created.stream_key,
+                    },
+                    true,
+                )
+            }
+        };
+        match self.registry.begin_obs(
+            user_id,
+            username,
+            title,
+            room_id,
+            voice_channel_id,
+            ingress.clone(),
+        ) {
+            BeginObsOutcome::Ready {
+                handles,
+                ingress: stored,
+            } => {
+                if minted && stored.ingress_id != ingress.ingress_id {
+                    // Lost a same-user race; the stored ingress wins and the
+                    // duplicate must not stay a valid stream key.
+                    self.delete_ingress_task(ingress.ingress_id);
+                }
+                Ok(StreamEvent::GoLiveObsReady {
+                    user_id,
+                    title: title.to_string(),
+                    whip_url: stored.whip_url,
+                    stream_key: stored.stream_key,
+                    watch_url: self.watch_url(&handles.stream_id),
+                    room_id,
+                })
+            }
+            BeginObsOutcome::PublisherConflict => {
+                if minted {
+                    // The refused begin must not leave a live stream key
+                    // pointed at the conflicting stream's room.
+                    self.delete_ingress_task(ingress.ingress_id);
+                }
+                Ok(StreamEvent::GoLiveFailed {
+                    user_id,
+                    message: "You are streaming from the browser console. Run /golive stop first."
+                        .to_string(),
+                })
+            }
+        }
     }
 
     /// `/golive stop` (also fired by a moderation voice kick): tear the
@@ -227,6 +373,12 @@ impl StreamService {
     /// to a short delay instead of an endless broadcast. Debug level because
     /// a pending stream's console may never have connected at all.
     fn disconnect_publisher_task(&self, ended: EndedStream) {
+        // An OBS stream's ingress dies with the stream: the participant
+        // removal below only cuts the current session, while the stream key
+        // stays valid and OBS auto-reconnects through it.
+        if let Some(ingress_id) = &ended.ingress_id {
+            self.delete_ingress_task(ingress_id.clone());
+        }
         let voice = self.voice.clone();
         tokio::spawn(async move {
             if let Err(error) = voice
@@ -238,6 +390,18 @@ impl StreamService {
                     user_id = %ended.user_id,
                     "stream publisher disconnect failed; page stops itself on the next report"
                 );
+            }
+        });
+    }
+
+    /// Fire-and-forget ingress deletion, so it logs its own failures. Warn
+    /// level: a leaked ingress is a stream key that still publishes into the
+    /// room.
+    fn delete_ingress_task(&self, ingress_id: String) {
+        let voice = self.voice.clone();
+        tokio::spawn(async move {
+            if let Err(error) = voice.delete_ingress(&ingress_id).await {
+                tracing::warn!(error = ?error, ingress_id = %ingress_id, "stream ingress delete failed");
             }
         });
     }
@@ -334,6 +498,38 @@ impl StreamService {
     pub fn watch_url_for_username(&self, username: &str) -> Option<String> {
         let view = self.registry.stream_for_username(username)?;
         view.live.then(|| self.watch_url(&view.stream_id))
+    }
+
+    /// Ingress status poll for OBS streams; run right before [`sweep`] from
+    /// the same periodic task. The poll is the OBS analogue of the go-live
+    /// page's state reports: `ENDPOINT_PUBLISHING` keeps the stream live
+    /// (and fires the one #lounge announcement on the first hit), any other
+    /// ingress state reports stopped and starts grace.
+    pub async fn poll_obs_publishers(&self) {
+        for poll in self.registry.obs_streams() {
+            let publishing = match self.voice.ingress_publishing(&poll.ingress_id).await {
+                Ok(publishing) => publishing,
+                Err(error) => {
+                    // Skip, not stop: a flaky LiveKit API call must not
+                    // shove a live stream into grace. A truly dead ingress
+                    // is caught by the publisher TTL once reports stop
+                    // landing.
+                    tracing::debug!(
+                        error = ?error,
+                        user_id = %poll.user_id,
+                        "ingress status poll failed"
+                    );
+                    continue;
+                }
+            };
+            if let PublisherReport::Live { went_live: true } =
+                self.registry.report_obs(poll.user_id, publishing)
+            {
+                tracing::info!(user_id = %poll.user_id, "stream went live via obs");
+                let title = Some(poll.title).filter(|title| !title.trim().is_empty());
+                self.activity.went_live_task(poll.user_id, title);
+            }
+        }
     }
 
     /// Registry hygiene pass; run periodically from `main.rs`. Streams the

--- a/late-ssh/src/app/stream/svc.rs
+++ b/late-ssh/src/app/stream/svc.rs
@@ -580,14 +580,13 @@ impl StreamService {
         // The polls run concurrently and the HTTP client carries a request
         // timeout, so one slow LiveKit call delays the sweep behind this by
         // at most one timeout, not one per stream.
-        let statuses =
-            futures_util::future::join_all(self.registry.obs_streams().into_iter().map(
-                |poll| async move {
-                    let publishing = self.voice.ingress_publishing(&poll.ingress_id).await;
-                    (poll, publishing)
-                },
-            ))
-            .await;
+        let statuses = futures_util::future::join_all(self.registry.obs_streams().into_iter().map(
+            |poll| async move {
+                let publishing = self.voice.ingress_publishing(&poll.ingress_id).await;
+                (poll, publishing)
+            },
+        ))
+        .await;
         for (poll, publishing) in statuses {
             let publishing = match publishing {
                 Ok(publishing) => publishing,

--- a/late-ssh/src/app/stream/svc.rs
+++ b/late-ssh/src/app/stream/svc.rs
@@ -411,16 +411,70 @@ impl StreamService {
         });
     }
 
-    /// Fire-and-forget ingress deletion, so it logs its own failures. Warn
-    /// level: a leaked ingress is a stream key that still publishes into the
-    /// room.
+    /// Fire-and-forget ingress deletion, so it logs its own failures. A
+    /// leaked ingress is a stream key OBS keeps publishing through, and OBS
+    /// has no page that stops itself the way the go-live console does, so a
+    /// transient LiveKit failure gets a few retries before giving up. The
+    /// boot reconciliation pass ([`Self::reconcile_ingresses`]) is the
+    /// backstop for an outage that outlasts them.
     fn delete_ingress_task(&self, ingress_id: String) {
         let voice = self.voice.clone();
         tokio::spawn(async move {
-            if let Err(error) = voice.delete_ingress(&ingress_id).await {
-                tracing::warn!(error = ?error, ingress_id = %ingress_id, "stream ingress delete failed");
+            let backoff = [
+                std::time::Duration::from_secs(5),
+                std::time::Duration::from_secs(30),
+            ];
+            let mut attempt = 1;
+            loop {
+                let error = match voice.delete_ingress(&ingress_id).await {
+                    Ok(()) => return,
+                    Err(error) => error,
+                };
+                match backoff.get(attempt - 1) {
+                    Some(delay) => {
+                        tracing::debug!(error = ?error, ingress_id = %ingress_id, attempt, "stream ingress delete failed; retrying");
+                        tokio::time::sleep(*delay).await;
+                        attempt += 1;
+                    }
+                    None => {
+                        tracing::warn!(error = ?error, ingress_id = %ingress_id, attempts = attempt, "stream ingress delete failed; orphan until the next boot reconciliation");
+                        return;
+                    }
+                }
             }
         });
+    }
+
+    /// Boot-time reconciliation. A WHIP ingress is a LiveKit-side resource
+    /// whose stream key outlives this process, while the registry that owns
+    /// it is process memory: after a restart, every ingress LiveKit still
+    /// holds is an orphan (a key OBS can publish through with all app-side
+    /// trace of the stream gone, which breaks the no-invisible-speaker
+    /// invariant). Delete every ingress the registry does not know.
+    pub async fn reconcile_ingresses(&self) {
+        if !self.voice.is_enabled() {
+            return;
+        }
+        let ids = match self.voice.list_ingress_ids().await {
+            Ok(ids) => ids,
+            Err(error) => {
+                tracing::warn!(error = ?error, "ingress reconciliation list failed");
+                return;
+            }
+        };
+        let known: std::collections::HashSet<String> = self
+            .registry
+            .obs_streams()
+            .into_iter()
+            .map(|poll| poll.ingress_id)
+            .collect();
+        for ingress_id in ids {
+            if known.contains(&ingress_id) {
+                continue;
+            }
+            tracing::info!(ingress_id = %ingress_id, "deleting orphaned stream ingress");
+            self.delete_ingress_task(ingress_id);
+        }
     }
 
     /// Resolve a publisher URL token into LiveKit connection details for the
@@ -523,8 +577,19 @@ impl StreamService {
     /// (and fires the one #lounge announcement on the first hit), any other
     /// ingress state reports stopped and starts grace.
     pub async fn poll_obs_publishers(&self) {
-        for poll in self.registry.obs_streams() {
-            let publishing = match self.voice.ingress_publishing(&poll.ingress_id).await {
+        // The polls run concurrently and the HTTP client carries a request
+        // timeout, so one slow LiveKit call delays the sweep behind this by
+        // at most one timeout, not one per stream.
+        let statuses =
+            futures_util::future::join_all(self.registry.obs_streams().into_iter().map(
+                |poll| async move {
+                    let publishing = self.voice.ingress_publishing(&poll.ingress_id).await;
+                    (poll, publishing)
+                },
+            ))
+            .await;
+        for (poll, publishing) in statuses {
+            let publishing = match publishing {
                 Ok(publishing) => publishing,
                 Err(error) => {
                     // Skip, not stop: a flaky LiveKit API call must not

--- a/late-ssh/src/app/stream/svc_test.rs
+++ b/late-ssh/src/app/stream/svc_test.rs
@@ -20,6 +20,7 @@ fn test_stream_service(db: late_core::db::Db) -> StreamService {
     let voice = VoiceService::new(
         VoiceConfig::enabled(
             "wss://rtc.test".to_string(),
+            "http://livekit-sv.test".to_string(),
             "test-key".to_string(),
             "test-secret".to_string(),
             "late-voice".to_string(),

--- a/late-ssh/src/app/stream/ui.rs
+++ b/late-ssh/src/app/stream/ui.rs
@@ -1,0 +1,95 @@
+//! Stream overlays. The OBS handoff modal shows the WHIP connection
+//! details from `/golive obs`; the values are hand-copied into OBS
+//! (Settings -> Stream -> Service: WHIP), so every value gets its own
+//! full-width row and nothing is ever clipped.
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Flex, Layout, Rect},
+    style::{Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
+};
+
+use crate::app::common::theme;
+
+pub fn draw_obs_overlay(
+    frame: &mut Frame,
+    area: Rect,
+    whip_url: &str,
+    stream_key: &str,
+    watch_url: &str,
+) {
+    let dim = Style::default().fg(theme::TEXT_DIM());
+    let amber = Style::default().fg(theme::AMBER());
+
+    let lines = vec![
+        Line::from(""),
+        Line::from(Span::styled(
+            "  OBS -> Settings -> Stream -> Service: WHIP",
+            dim,
+        )),
+        Line::from(""),
+        Line::from(Span::styled("  Server", dim)),
+        Line::from(Span::styled(format!("  {whip_url}"), amber)),
+        Line::from(""),
+        Line::from(Span::styled("  Bearer Token", dim)),
+        Line::from(Span::styled(format!("  {stream_key}"), amber)),
+        Line::from(""),
+        Line::from(Span::styled("  Watch link (share it)", dim)),
+        Line::from(Span::styled(format!("  {watch_url}"), amber)),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Start streaming in OBS; the room goes live when media flows.",
+            dim,
+        )),
+        Line::from(""),
+        Line::from(Span::styled("  Press any key to close.", dim)),
+        Line::from(""),
+    ];
+
+    // Wide enough for the longest value plus indent; hand-copied values must
+    // never clip. When the terminal is narrower, rows wrap instead.
+    let longest = whip_url
+        .len()
+        .max(stream_key.len())
+        .max(watch_url.len())
+        .max(58) as u16;
+    let w = longest
+        .saturating_add(6)
+        .min(area.width.saturating_sub(4))
+        .max(20);
+    let inner_w = w.saturating_sub(2).max(1);
+    let wrapped_rows: u16 = [whip_url.len(), stream_key.len(), watch_url.len()]
+        .iter()
+        .map(|len| (*len as u16 + 2).div_ceil(inner_w).saturating_sub(1))
+        .sum();
+    let h = (lines.len() as u16 + 2 + wrapped_rows).min(area.height.saturating_sub(2));
+
+    let [popup_area] = Layout::vertical([Constraint::Length(h)])
+        .flex(Flex::Center)
+        .areas(area);
+    let [popup_area] = Layout::horizontal([Constraint::Length(w)])
+        .flex(Flex::Center)
+        .areas(popup_area);
+
+    frame.render_widget(Clear, popup_area);
+
+    let block = Block::default()
+        .title(" Go Live via OBS ")
+        .title_style(
+            Style::default()
+                .fg(theme::AMBER_GLOW())
+                .add_modifier(Modifier::BOLD),
+        )
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(theme::BORDER_ACTIVE()));
+    let inner = block.inner(popup_area);
+    frame.render_widget(block, popup_area);
+
+    frame.render_widget(Paragraph::new(lines).wrap(Wrap { trim: false }), inner);
+}
+
+#[cfg(test)]
+#[path = "ui_test.rs"]
+mod ui_test;

--- a/late-ssh/src/app/stream/ui_test.rs
+++ b/late-ssh/src/app/stream/ui_test.rs
@@ -1,0 +1,54 @@
+use crate::app::stream::ui::draw_obs_overlay;
+use ratatui::{Terminal, backend::TestBackend};
+
+fn render_text(width: u16, height: u16) -> String {
+    let backend = TestBackend::new(width, height);
+    let mut terminal = Terminal::new(backend).expect("terminal");
+    terminal
+        .draw(|frame| {
+            draw_obs_overlay(
+                frame,
+                frame.area(),
+                "https://whip.late.sh/w",
+                "sk-abc123",
+                "https://late.sh/live/deadbeef",
+            )
+        })
+        .expect("draw");
+    let buffer = terminal.backend().buffer();
+    let mut text = String::new();
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            text.push_str(buffer[(x, y)].symbol());
+        }
+        text.push('\n');
+    }
+    text
+}
+
+#[test]
+fn obs_overlay_shows_every_hand_copied_value() {
+    let text = render_text(100, 32);
+
+    // The three values are copied into OBS by hand; a clipped value is a
+    // silently broken one.
+    assert!(text.contains("https://whip.late.sh/w"), "whip url:\n{text}");
+    assert!(text.contains("sk-abc123"), "stream key:\n{text}");
+    assert!(
+        text.contains("https://late.sh/live/deadbeef"),
+        "watch url:\n{text}"
+    );
+    assert!(text.contains("Service: WHIP"), "obs instructions:\n{text}");
+    assert!(
+        text.contains("Press any key to close."),
+        "dismiss hint:\n{text}"
+    );
+}
+
+#[test]
+fn obs_overlay_survives_a_tiny_terminal() {
+    // No panic and the dismiss path still hinted; values wrap instead of
+    // clipping where the width allows.
+    let text = render_text(30, 12);
+    assert!(text.contains("WHIP"), "modal renders at 30x12:\n{text}");
+}

--- a/late-ssh/src/app/voice/CONTEXT.md
+++ b/late-ssh/src/app/voice/CONTEXT.md
@@ -3,7 +3,7 @@
 ## Metadata
 - Domain: late.sh voice channels — LiveKit-backed CLI voice, SSH TUI controls/status, and pair-WS voice control
 - Primary audience: LLM agents working in `late-ssh/src/app/voice`, `late-cli/src/voice.rs`, or pair-WS voice messages
-- Last updated: 2026-08-11 (stream-room exception: `VoiceService` now also mints source-restricted publish tickets for the streamer's go-live page and hidden subscribe-only tickets for anonymous watch pages; see §7 and `../stream/CONTEXT.md`)
+- Last updated: 2026-08-12 (OBS/WHIP ingest: `VoiceService` also owns the LiveKit Ingress API client — `create_whip_ingress`/`delete_ingress`/`ingress_publishing`, Twirp calls authorized by an `ingressAdmin` token; see §7 and `../stream/CONTEXT.md`)
 - Status: Active
 - Parent context: `../../../../CONTEXT.md`
 - Related context: `../../../../late-cli/CONTEXT.md`, `../audio/CONTEXT.md`
@@ -246,6 +246,17 @@ deliberately and narrowly:
 Viewers never publish. General browser voice remains a separate, unmade
 decision.
 
+`/golive obs` adds a third, non-browser publisher: a WHIP ingress created
+through the LiveKit Ingress API (`create_whip_ingress`, with
+`delete_ingress` and `ingress_publishing` beside it; all Twirp calls on the
+LiveKit server authorized by a short-lived `ingressAdmin` admin token,
+server-to-server only, same pattern as `RemoveParticipant`). The ingress
+participant identity is `stream-{user_id}`, the same identity as the go-live
+console, so every existing teardown path finds it; transcoding is disabled
+at CreateIngress time (OBS already sends h264+opus), so the ingress service
+forwards packets instead of re-encoding. Ownership of when to create/delete
+ingresses lives entirely in `../stream` — this service only speaks the API.
+
 ---
 
 ## 8. Config, Infra, and Background Tasks
@@ -262,6 +273,13 @@ Production infra:
 - `rtc.<domain>` is the public LiveKit signaling endpoint.
 - Media ports are bound directly on the node; keep DNS/networking assumptions distinct from SSH/API/web routing.
 - `infra/service-ssh.tf` wires the voice env vars into `service-ssh`.
+- `infra/redis.tf` + `infra/livekit-ingress.tf` back the OBS/WHIP ingest:
+  redis is the LiveKit<->ingress bus (the server refuses Ingress API calls
+  without it), `whip.<domain>` is the public WHIP endpoint (nginx TLS in
+  front of the ingress service's HTTP port; ICE/UDP bound on the node).
+  The LiveKit `room.enabled_codecs` list includes `video/h264` and
+  `video/vp8`: stream rooms need them, opus-only silently refuses every
+  video publish.
 
 Background tasks:
 - `main.rs` prunes stale voice participants every 30s with `ttl = 90s`.

--- a/late-ssh/src/app/voice/CONTEXT.md
+++ b/late-ssh/src/app/voice/CONTEXT.md
@@ -263,7 +263,13 @@ ingresses lives entirely in `../stream` — this service only speaks the API.
 
 Config env vars (`late-ssh/src/config.rs`):
 - `LATE_VOICE_ENABLED` — defaults false in config parsing.
-- `LATE_LIVEKIT_URL` — required when voice is enabled.
+- `LATE_LIVEKIT_URL` — required when voice is enabled. Client-facing URL,
+  handed to browsers in join grants.
+- `LATE_LIVEKIT_API_URL` — required when voice is enabled. Server-to-server
+  Twirp base (RemoveParticipant, Ingress API). Split from the client URL:
+  in dev the browser needs `ws://localhost:7880` while late-ssh runs in a
+  container where `localhost` is itself, so it uses `http://livekit:7880`;
+  in prod it points at the cluster-internal `http://livekit-sv`.
 - `LATE_LIVEKIT_API_KEY` — required when voice is enabled.
 - `LATE_LIVEKIT_API_SECRET` — required when voice is enabled.
 - `LATE_VOICE_ROOM` — optional; default `late-voice`.

--- a/late-ssh/src/app/voice/CONTEXT.md
+++ b/late-ssh/src/app/voice/CONTEXT.md
@@ -283,6 +283,10 @@ Production infra:
   redis is the LiveKit<->ingress bus (the server refuses Ingress API calls
   without it), `whip.<domain>` is the public WHIP endpoint (nginx TLS in
   front of the ingress service's HTTP port; ICE/UDP bound on the node).
+  Note the blast radius: once livekit-server has redis configured it routes
+  room lookups and its server API RPCs through it, so redis health gates
+  voice joins, RemoveParticipant kicks, and stream teardown too, not just
+  OBS ingest. Media already flowing keeps flowing.
   The LiveKit `room.enabled_codecs` list includes `video/h264` and
   `video/vp8`: stream rooms need them, opus-only silently refuses every
   video publish.

--- a/late-ssh/src/app/voice/svc.rs
+++ b/late-ssh/src/app/voice/svc.rs
@@ -25,7 +25,14 @@ type HmacSha256 = Hmac<Sha256>;
 #[derive(Clone)]
 pub struct VoiceConfig {
     pub enabled: bool,
+    /// Client-facing LiveKit URL, handed to browsers in join grants. In dev
+    /// this is `ws://localhost:7880`, which only resolves from the host.
     pub livekit_url: Option<String>,
+    /// Server-to-server base for Twirp API calls (RemoveParticipant, the
+    /// Ingress API). Split from `livekit_url` because the two audiences
+    /// differ: in dev the browser needs `localhost` while this process runs
+    /// in a container where `localhost` is itself, not LiveKit.
+    pub livekit_api_url: Option<String>,
     pub api_key: Option<String>,
     pub api_secret: Option<String>,
     /// Base name for LiveKit rooms. Each voice channel gets its own LiveKit
@@ -38,6 +45,7 @@ impl VoiceConfig {
         Self {
             enabled: false,
             livekit_url: None,
+            livekit_api_url: None,
             api_key: None,
             api_secret: None,
             room_name: "late-voice".to_string(),
@@ -46,12 +54,16 @@ impl VoiceConfig {
 
     pub fn enabled(
         livekit_url: String,
+        livekit_api_url: String,
         api_key: String,
         api_secret: String,
         room_name: String,
     ) -> anyhow::Result<Self> {
         if livekit_url.trim().is_empty() {
             anyhow::bail!("LATE_LIVEKIT_URL must not be empty when voice is enabled");
+        }
+        if livekit_api_url.trim().is_empty() {
+            anyhow::bail!("LATE_LIVEKIT_API_URL must not be empty when voice is enabled");
         }
         if api_key.trim().is_empty() {
             anyhow::bail!("LATE_LIVEKIT_API_KEY must not be empty when voice is enabled");
@@ -65,6 +77,7 @@ impl VoiceConfig {
         Ok(Self {
             enabled: true,
             livekit_url: Some(livekit_url),
+            livekit_api_url: Some(livekit_api_url),
             api_key: Some(api_key),
             api_secret: Some(api_secret),
             room_name,
@@ -77,6 +90,7 @@ impl fmt::Debug for VoiceConfig {
         f.debug_struct("VoiceConfig")
             .field("enabled", &self.enabled)
             .field("livekit_url", &self.livekit_url)
+            .field("livekit_api_url", &self.livekit_api_url)
             .field("api_key_present", &self.api_key.is_some())
             .field("api_secret_present", &self.api_secret.is_some())
             .field("room_name", &self.room_name)
@@ -585,9 +599,9 @@ impl VoiceService {
         }
         let url = self
             .config
-            .livekit_url
+            .livekit_api_url
             .as_deref()
-            .context("voice enabled without LiveKit URL")?;
+            .context("voice enabled without LiveKit API URL")?;
         let http_base = livekit_http_base(url)?;
         let token = self.mint_livekit_token_with_grants(
             &Uuid::new_v4().to_string(),
@@ -704,9 +718,9 @@ impl VoiceService {
         }
         let url = self
             .config
-            .livekit_url
+            .livekit_api_url
             .as_deref()
-            .context("voice enabled without LiveKit URL")?;
+            .context("voice enabled without LiveKit API URL")?;
         let http_base = livekit_http_base(url)?;
         let token = self.mint_livekit_token_with_grants(
             &Uuid::new_v4().to_string(),
@@ -979,30 +993,27 @@ struct RemoveParticipantRequest<'a> {
     identity: &'a str,
 }
 
+// LiveKit's Twirp endpoints speak proto field names on the wire (snake_case:
+// `ingress_id`, `stream_key`), not protojson camelCase. Requests are parsed
+// leniently (either form works) but responses are emitted snake_case only, so
+// these structs keep the raw Rust field names with no renames.
 #[derive(Serialize)]
 struct CreateIngressRequest<'a> {
-    #[serde(rename = "inputType")]
     input_type: &'a str,
     name: &'a str,
-    #[serde(rename = "roomName")]
     room_name: &'a str,
-    #[serde(rename = "participantIdentity")]
     participant_identity: &'a str,
-    #[serde(rename = "participantName")]
     participant_name: &'a str,
-    #[serde(rename = "enableTranscoding")]
     enable_transcoding: bool,
 }
 
 #[derive(Serialize)]
 struct DeleteIngressRequest<'a> {
-    #[serde(rename = "ingressId")]
     ingress_id: &'a str,
 }
 
 #[derive(Serialize)]
 struct ListIngressRequest<'a> {
-    #[serde(rename = "ingressId")]
     ingress_id: &'a str,
 }
 
@@ -1014,9 +1025,9 @@ struct ListIngressResponse {
 
 #[derive(Deserialize)]
 struct IngressInfo {
-    #[serde(rename = "ingressId", default)]
+    #[serde(default)]
     ingress_id: String,
-    #[serde(rename = "streamKey", default)]
+    #[serde(default)]
     stream_key: String,
     #[serde(default)]
     url: String,

--- a/late-ssh/src/app/voice/svc.rs
+++ b/late-ssh/src/app/voice/svc.rs
@@ -252,8 +252,20 @@ impl VoiceService {
             db: None,
             inner: Arc::new(Mutex::new(VoiceInner::default())),
             tx,
-            http: reqwest::Client::new(),
+            // Everything through this client is a server-to-server Twirp
+            // call, and one of them runs inline in the stream sweep loop:
+            // without a timeout a wedged LiveKit connection would stall
+            // every stream TTL in the app for as long as the OS lets the
+            // socket hang.
+            http: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .expect("building reqwest client"),
         }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.config.enabled
     }
 
     pub fn with_db(mut self, db: Db) -> Self {
@@ -687,6 +699,16 @@ impl VoiceService {
             .ingress_api_call("DeleteIngress", &DeleteIngressRequest { ingress_id })
             .await?;
         Ok(())
+    }
+
+    /// Every ingress id LiveKit currently holds, publishing or not. An empty
+    /// filter lists them all: the boot reconciliation pass uses this to find
+    /// stream keys left valid by a previous process.
+    pub async fn list_ingress_ids(&self) -> anyhow::Result<Vec<String>> {
+        let resp: ListIngressResponse = self
+            .ingress_api_call("ListIngress", &ListIngressRequest { ingress_id: "" })
+            .await?;
+        Ok(resp.items.into_iter().map(|item| item.ingress_id).collect())
     }
 
     /// Whether an ingress is currently receiving and publishing media.

--- a/late-ssh/src/app/voice/svc.rs
+++ b/late-ssh/src/app/voice/svc.rs
@@ -10,7 +10,7 @@ use late_core::{
         voice_channel::{TARGET_CHAT_ROOM, VoiceChannel},
     },
 };
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::{
     collections::{HashMap, HashSet},
@@ -159,6 +159,17 @@ pub struct StreamMediaTicket {
     pub room: String,
     pub url: String,
     pub token: String,
+}
+
+/// A WHIP ingress minted for an OBS stream: OBS pushes WebRTC to `url` with
+/// `stream_key` as the bearer token, and the LiveKit ingress service
+/// republishes it into the stream room. `url` comes from the server's
+/// `ingress.whip_base_url` config.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct WhipIngress {
+    pub ingress_id: String,
+    pub url: String,
+    pub stream_key: String,
 }
 
 /// Outcome of a moderator `kick`. `changed` is whether anything actually changed
@@ -585,6 +596,7 @@ impl VoiceService {
             LiveKitTokenGrants {
                 room_admin: true,
                 room_create: false,
+                ingress_admin: false,
                 can_publish: false,
                 can_publish_sources: None,
                 can_subscribe: false,
@@ -610,6 +622,124 @@ impl VoiceService {
             anyhow::bail!("LiveKit RemoveParticipant failed: {status} {body}");
         }
         Ok(())
+    }
+
+    /// Create a WHIP ingress for an OBS stream into a stream room's LiveKit
+    /// channel. The ingress participant identity is `stream-{user_id}`, the
+    /// same identity the go-live console uses, so every existing teardown
+    /// path (`remove_stream_publisher`, moderation) finds it. Transcoding is
+    /// off: OBS already encodes WebRTC-compatible media (h264+opus) and the
+    /// ingress service forwards it as-is, so the server never re-encodes.
+    pub async fn create_whip_ingress(
+        &self,
+        room_id: Uuid,
+        user_id: Uuid,
+        username: &str,
+    ) -> anyhow::Result<WhipIngress> {
+        let room = self.livekit_room_name(room_id);
+        let info: IngressInfo = self
+            .ingress_api_call(
+                "CreateIngress",
+                &CreateIngressRequest {
+                    input_type: "WHIP_INPUT",
+                    name: &format!("obs-{user_id}"),
+                    room_name: &room,
+                    participant_identity: &format!("stream-{user_id}"),
+                    participant_name: username,
+                    enable_transcoding: false,
+                },
+            )
+            .await?;
+        if info.url.is_empty() {
+            anyhow::bail!(
+                "LiveKit returned an ingress without a WHIP URL; is ingress.whip_base_url configured on the server?"
+            );
+        }
+        if info.stream_key.is_empty() {
+            anyhow::bail!("LiveKit returned an ingress without a stream key");
+        }
+        Ok(WhipIngress {
+            ingress_id: info.ingress_id,
+            url: info.url,
+            stream_key: info.stream_key,
+        })
+    }
+
+    /// Delete an ingress. This is what actually stops OBS from reconnecting:
+    /// removing the participant alone leaves the stream key valid and OBS
+    /// auto-reconnects through it.
+    pub async fn delete_ingress(&self, ingress_id: &str) -> anyhow::Result<()> {
+        let _: serde_json::Value = self
+            .ingress_api_call("DeleteIngress", &DeleteIngressRequest { ingress_id })
+            .await?;
+        Ok(())
+    }
+
+    /// Whether an ingress is currently receiving and publishing media.
+    /// `Ok(false)` covers every non-publishing state, including an ingress
+    /// that no longer exists (deleted out of band).
+    pub async fn ingress_publishing(&self, ingress_id: &str) -> anyhow::Result<bool> {
+        let resp: ListIngressResponse = self
+            .ingress_api_call("ListIngress", &ListIngressRequest { ingress_id })
+            .await?;
+        let publishing = resp.items.iter().any(|item| {
+            item.ingress_id == ingress_id
+                && item
+                    .state
+                    .as_ref()
+                    .is_some_and(|state| state.status == "ENDPOINT_PUBLISHING")
+        });
+        Ok(publishing)
+    }
+
+    /// One Twirp call against the LiveKit Ingress API, authorized with a
+    /// short-lived `ingressAdmin` token. Server-to-server only.
+    async fn ingress_api_call<Req: Serialize, Resp: serde::de::DeserializeOwned>(
+        &self,
+        method: &str,
+        request: &Req,
+    ) -> anyhow::Result<Resp> {
+        if !self.config.enabled {
+            anyhow::bail!("voice is not configured");
+        }
+        let url = self
+            .config
+            .livekit_url
+            .as_deref()
+            .context("voice enabled without LiveKit URL")?;
+        let http_base = livekit_http_base(url)?;
+        let token = self.mint_livekit_token_with_grants(
+            &Uuid::new_v4().to_string(),
+            "late-ingress",
+            "",
+            LiveKitTokenGrants {
+                room_admin: false,
+                room_create: false,
+                ingress_admin: true,
+                can_publish: false,
+                can_publish_sources: None,
+                can_subscribe: false,
+                can_publish_data: false,
+                hidden: false,
+            },
+        )?;
+        let endpoint = format!("{http_base}/twirp/livekit.Ingress/{method}");
+        let resp = self
+            .http
+            .post(endpoint)
+            .bearer_auth(token)
+            .json(request)
+            .send()
+            .await
+            .with_context(|| format!("failed to call LiveKit {method}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            anyhow::bail!("LiveKit {method} failed: {status} {body}");
+        }
+        resp.json()
+            .await
+            .with_context(|| format!("failed to decode LiveKit {method} response"))
     }
 
     /// Publisher ticket for the streamer's go-live console page. Publishing
@@ -645,6 +775,7 @@ impl VoiceService {
             LiveKitTokenGrants {
                 room_admin: false,
                 room_create: false,
+                ingress_admin: false,
                 can_publish: true,
                 can_publish_sources: Some(&["screen_share", "screen_share_audio", "microphone"]),
                 can_subscribe: true,
@@ -681,6 +812,7 @@ impl VoiceService {
             LiveKitTokenGrants {
                 room_admin: false,
                 room_create: false,
+                ingress_admin: false,
                 can_publish: false,
                 can_publish_sources: None,
                 can_subscribe: true,
@@ -704,6 +836,7 @@ impl VoiceService {
             LiveKitTokenGrants {
                 room_admin: false,
                 room_create: false,
+                ingress_admin: false,
                 can_publish: true,
                 can_publish_sources: None,
                 can_subscribe: true,
@@ -739,8 +872,9 @@ impl VoiceService {
             exp: now + 60 * 60,
             video: LiveKitVideoGrant {
                 room,
-                room_join: !grants.room_admin,
+                room_join: !(grants.room_admin || grants.ingress_admin),
                 room_admin: grants.room_admin,
+                ingress_admin: grants.ingress_admin,
                 room_create: grants.room_create,
                 can_publish: grants.can_publish,
                 can_publish_sources: grants.can_publish_sources,
@@ -825,6 +959,9 @@ async fn ensure_user_can_join_voice(
 struct LiveKitTokenGrants {
     room_admin: bool,
     room_create: bool,
+    /// Grants the LiveKit Ingress API (create/list/delete). Admin-only
+    /// tokens minted for server-to-server calls, never handed to a client.
+    ingress_admin: bool,
     can_publish: bool,
     /// LiveKit publish-source restriction (`canPublishSources`). `None`
     /// means the grant does not restrict sources.
@@ -840,6 +977,59 @@ struct LiveKitTokenGrants {
 struct RemoveParticipantRequest<'a> {
     room: &'a str,
     identity: &'a str,
+}
+
+#[derive(Serialize)]
+struct CreateIngressRequest<'a> {
+    #[serde(rename = "inputType")]
+    input_type: &'a str,
+    name: &'a str,
+    #[serde(rename = "roomName")]
+    room_name: &'a str,
+    #[serde(rename = "participantIdentity")]
+    participant_identity: &'a str,
+    #[serde(rename = "participantName")]
+    participant_name: &'a str,
+    #[serde(rename = "enableTranscoding")]
+    enable_transcoding: bool,
+}
+
+#[derive(Serialize)]
+struct DeleteIngressRequest<'a> {
+    #[serde(rename = "ingressId")]
+    ingress_id: &'a str,
+}
+
+#[derive(Serialize)]
+struct ListIngressRequest<'a> {
+    #[serde(rename = "ingressId")]
+    ingress_id: &'a str,
+}
+
+#[derive(Deserialize)]
+struct ListIngressResponse {
+    #[serde(default)]
+    items: Vec<IngressInfo>,
+}
+
+#[derive(Deserialize)]
+struct IngressInfo {
+    #[serde(rename = "ingressId", default)]
+    ingress_id: String,
+    #[serde(rename = "streamKey", default)]
+    stream_key: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default)]
+    state: Option<IngressState>,
+}
+
+#[derive(Deserialize)]
+struct IngressState {
+    /// Proto enum as its JSON string name; `ENDPOINT_PUBLISHING` is the only
+    /// state that counts as media flowing.
+    #[serde(default)]
+    status: String,
 }
 
 #[derive(Serialize)]
@@ -865,6 +1055,8 @@ struct LiveKitVideoGrant<'a> {
     room_join: bool,
     #[serde(rename = "roomAdmin")]
     room_admin: bool,
+    #[serde(rename = "ingressAdmin", skip_serializing_if = "std::ops::Not::not")]
+    ingress_admin: bool,
     #[serde(rename = "roomCreate")]
     room_create: bool,
     #[serde(rename = "canPublish")]

--- a/late-ssh/src/app/voice/svc_test.rs
+++ b/late-ssh/src/app/voice/svc_test.rs
@@ -7,6 +7,7 @@ fn enabled_service() -> VoiceService {
     VoiceService::new(
         VoiceConfig::enabled(
             "ws://localhost:7880".to_string(),
+            "http://livekit:7880".to_string(),
             "devkey".to_string(),
             "secret".to_string(),
             "late-voice".to_string(),

--- a/late-ssh/src/config.rs
+++ b/late-ssh/src/config.rs
@@ -227,6 +227,7 @@ impl Config {
         tracing::info!(
             enabled = self.voice.enabled,
             livekit_url = ?self.voice.livekit_url,
+            livekit_api_url = ?self.voice.livekit_api_url,
             room = %self.voice.room_name,
             has_key = self.voice.api_key.is_some(),
             "voice: LiveKit RTC status"
@@ -314,6 +315,7 @@ impl Config {
         let voice = if optional_bool("LATE_VOICE_ENABLED", false)? {
             VoiceConfig::enabled(
                 required("LATE_LIVEKIT_URL")?,
+                required("LATE_LIVEKIT_API_URL")?,
                 required("LATE_LIVEKIT_API_KEY")?,
                 required("LATE_LIVEKIT_API_SECRET")?,
                 optional("LATE_VOICE_ROOM").unwrap_or_else(|| "late-voice".to_string()),

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -498,6 +498,10 @@ async fn main() -> anyhow::Result<()> {
     let stream_sweep_shutdown = singleton_shutdown.clone();
     let stream_sweep_service = state.stream_service.clone();
     tasks.spawn(async move {
+        // A restart wiped the in-memory registry, so any ingress LiveKit
+        // still holds is an orphaned stream key; collect them before the
+        // first poll can see them.
+        stream_sweep_service.reconcile_ingresses().await;
         let mut interval = tokio::time::interval(Duration::from_secs(5));
         interval.tick().await; // skip immediate first tick
         loop {

--- a/late-ssh/src/main.rs
+++ b/late-ssh/src/main.rs
@@ -504,6 +504,9 @@ async fn main() -> anyhow::Result<()> {
             tokio::select! {
                 _ = stream_sweep_shutdown.cancelled() => break,
                 _ = interval.tick() => {
+                    // The poll feeds the OBS streams' publisher reports; the
+                    // sweep right after acts on whatever state it left.
+                    stream_sweep_service.poll_obs_publishers().await;
                     stream_sweep_service.sweep();
                 }
             }


### PR DESCRIPTION
## Summary
- Adds a second way to go live: `/golive obs [title]` publishes into the same stream room via a LiveKit WHIP ingress instead of the browser go-live console, so streamers can push from OBS. Console and OBS streaming are mutually exclusive per user (`/golive stop` first to switch).
- New infra: a `redis` message bus between LiveKit and a new `livekit-ingress` deployment, and a public `whip.<domain>` ingest endpoint. Local dev gets equivalent `docker-compose.yml` services and static LiveKit/ingress config files.

## Changes
- **Command**: `/golive obs [title]` parses alongside the existing `/golive [title]`/`/golive stop` forms, with the same title clamp at the parse boundary (`late-ssh/src/app/chat/state.rs`). Help text updated (`help_modal/data.rs`).
- **Registry**: `StreamRegistry` entries now carry a `StreamPublisher` (`Console` or `Obs(ObsIngress)`). Registering a stream under the wrong publisher kind is a conflict, not a silent rewire (`begin` / `begin_obs` in `registry.rs`). A re-run of `/golive obs` reuses the stored ingress instead of minting a duplicate; a same-user race deletes the loser. Liveness for OBS streams comes from a new server-side poll (`report_obs`) rather than page state reports.
- **Service orchestration**: `StreamService::go_live_obs` shares the ban-gate/room/voice-channel groundwork with the console path (`prepare_go_live`), then creates or reuses the WHIP ingress. A new periodic `poll_obs_publishers` task (run right before the existing sweep in `main.rs`) checks each OBS stream's ingress status via `ingress_publishing`, fires the same one-time `#lounge` "went live" line, and marks the streamer on-air. Teardown (`/golive stop`, moderation, sweep) now also deletes the ingress, since removing the LiveKit participant alone leaves the stream key valid and OBS auto-reconnects through it.
- **VoiceService**: gains a LiveKit Ingress API Twirp client (`create_whip_ingress`, `delete_ingress`, `ingress_publishing`), authorized with a short-lived `ingressAdmin` token. Transcoding is disabled at creation time, so the ingress service only forwards OBS's already-WebRTC-compatible media. This introduces `LATE_LIVEKIT_API_URL`, a server-to-server Twirp base split from the existing client-facing `LATE_LIVEKIT_URL` (in dev the browser needs `localhost`, but late-ssh runs in a container where `localhost` is itself).
- **UI**: new full-screen OBS handoff overlay (`app/stream/ui.rs`) shows the WHIP server URL, bearer token, and watch link to hand-copy into OBS; replaces the single `stream_qr_modal` field with a `StreamModal` enum (`Qr` | `Obs`) covering both handoff flows.
- **Infra**: new `infra/redis.tf` (LiveKit<->ingress bus) and `infra/livekit-ingress.tf` (WHIP-only ingress deployment behind `whip.<domain>`, no RTMP ever minted); `infra/livekit.tf` gains `redis`/`ingress.whip_base_url` config and video codecs were already enabled for screen share, now also serve OBS. `infra/service-ssh.tf` wires the new `LATE_LIVEKIT_API_URL` env var to the in-cluster LiveKit service. New Terraform variables: `LIVEKIT_INGRESS_IMAGE`, `LIVEKIT_WHIP_SUBDOMAIN`, `LIVEKIT_INGRESS_WHIP_PORT`.
- **Dev environment**: `docker-compose.yml` adds `redis` and `livekit-ingress` services and switches the LiveKit container from `--dev` to a static config file (`infra/livekit/dev-config.yaml`) carrying equivalent defaults plus the new redis/ingress wiring. `Makefile` gains `LATE_LIVEKIT_API_URL` with a compose-internal default.

## Behavior notes
- A failed ingress status poll call is skipped, never treated as a stop, so a flaky LiveKit API call can't force a live OBS stream into grace; a genuinely dead ingress still falls to grace via the existing publisher TTL.
- `LATE_LIVEKIT_API_URL` is now a required config value whenever voice is enabled, alongside the existing LiveKit env vars — this affects any deployment or test harness that constructs `VoiceConfig::enabled(...)` directly (test call sites are already updated in this branch).

## Feature flags
None; gated by the existing `LATE_VOICE_ENABLED` flag, same as the rest of the streaming feature.

## Screenshots / Video
Not included in this draft; attach before review.

## Testing
- Automated: new/updated tests cover the `/golive obs` parse routing and title clamp (`chat/state_internal_test.rs`), registry publisher-conflict and ingress-reuse/race behavior, OBS liveness reporting, and ingress-id propagation through teardown/sweep (`stream/registry_test.rs`), and the OBS overlay's rendering at normal and tiny terminal sizes (`stream/ui_test.rs`). Not run in this session; see `make test-llm` guidance in `CONTEXT.md`.
- Manual: not run in this session.