### PR TITLE
feat: Allow dropping items to make room for loot in A Dark Room

### DIFF
--- a/late-ssh/src/app/door/darkroom/event.rs
+++ b/late-ssh/src/app/door/darkroom/event.rs
@@ -1035,7 +1035,7 @@ fn roll_loot(table: &'static [Loot], rng: &mut impl Rng) -> Vec<LootRow> {
 }
 
 /// The weapons the pack can actually swing, fists last if there is nothing
-/// else (upstream falls back to punching).
+/// else or if no damaging weapons have ammunition (upstream falls back to punching).
 pub fn available_weapons(look: &Look<'_>) -> Vec<Weapon> {
     let mut weapons: Vec<Weapon> = Weapon::ALL
         .into_iter()
@@ -1045,7 +1045,12 @@ pub fn available_weapons(look: &Look<'_>) -> Vec<Weapon> {
             None => false,
         })
         .collect();
-    if weapons.is_empty() {
+    // Upstream adds fists if numWeapons (usable damaging weapons) is 0.
+    let usable_damaging = weapons.iter().any(|&w| match w.damage() {
+        Damage::Hits(h) if h > 0 => weapon_loaded(w, look),
+        _ => false,
+    });
+    if !usable_damaging && !weapons.contains(&Weapon::Fists) {
         weapons.push(Weapon::Fists);
     }
     weapons

--- a/late-ssh/src/app/door/darkroom/event.rs
+++ b/late-ssh/src/app/door/darkroom/event.rs
@@ -314,7 +314,7 @@ impl Look<'_> {
     }
 
     /// Free space in the pack. At home there is no pack, so nothing binds.
-    fn free_space(&self) -> f64 {
+    pub fn free_space(&self) -> f64 {
         match self.trip {
             Some(trip) => self.game.capacity() - trip.load(),
             None => f64::MAX,
@@ -347,6 +347,10 @@ pub enum Phase {
     Spoils {
         leave_cooldown: f64,
     },
+    /// Selecting an item in the pack to drop in order to fit a target loot item.
+    DropFor {
+        loot_index: usize,
+    },
 }
 
 /// One row of the modal.
@@ -360,6 +364,13 @@ pub enum Row {
     Take(usize),
     /// Take everything that fits.
     TakeAll,
+    /// Drop `count` of `item` from pack to fit target loot.
+    Drop {
+        item: Resource,
+        count: i64,
+    },
+    /// Cancel drop selection and return to spoils/story.
+    DropCancel,
     Leave,
 }
 
@@ -436,7 +447,7 @@ impl Active {
     pub fn fight(&self) -> Option<&Fight> {
         match &self.phase {
             Phase::Fighting(fight) => Some(fight),
-            Phase::Story | Phase::Spoils { .. } => None,
+            Phase::Story | Phase::Spoils { .. } | Phase::DropFor { .. } => None,
         }
     }
 
@@ -493,6 +504,29 @@ impl Active {
                     rows.push(Row::Meds);
                 }
             }
+            Phase::DropFor { loot_index } => {
+                if let Some(target) = self.loot.get(*loot_index) {
+                    let needed = world_data::weight(target.item) - look.free_space();
+                    if let Some(trip) = look.trip {
+                        for item in world_data::CARRYABLE {
+                            let count = trip.carrying(item);
+                            if count > 0 && item != target.item {
+                                let item_weight = world_data::weight(item);
+                                if item_weight > 0.0 {
+                                    let num_to_drop = (needed / item_weight).ceil() as i64;
+                                    if num_to_drop <= count {
+                                        rows.push(Row::Drop {
+                                            item,
+                                            count: num_to_drop.max(1),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+                rows.push(Row::DropCancel);
+            }
             Phase::Story | Phase::Spoils { .. } => {
                 for (index, _) in self.loot.iter().enumerate() {
                     rows.push(Row::Take(index));
@@ -534,31 +568,56 @@ impl Active {
                     fight.weapon_cooldown.get(&weapon).copied().unwrap_or(0.0) <= 0.0
                         && weapon_loaded(weapon, look)
                 }
-                Phase::Story | Phase::Spoils { .. } => false,
+                Phase::Story | Phase::Spoils { .. } | Phase::DropFor { .. } => false,
             },
             Row::Eat => match &self.phase {
                 Phase::Fighting(fight) => {
                     fight.eat_cooldown <= 0.0 && look.quantity(Resource::CuredMeat) > 0
                 }
-                Phase::Story | Phase::Spoils { .. } => look.quantity(Resource::CuredMeat) > 0,
+                Phase::Story | Phase::Spoils { .. } | Phase::DropFor { .. } => {
+                    look.quantity(Resource::CuredMeat) > 0
+                }
             },
             Row::Meds => match &self.phase {
                 Phase::Fighting(fight) => {
                     fight.meds_cooldown <= 0.0 && look.quantity(Resource::Medicine) > 0
                 }
-                Phase::Story | Phase::Spoils { .. } => look.quantity(Resource::Medicine) > 0,
+                Phase::Story | Phase::Spoils { .. } | Phase::DropFor { .. } => {
+                    look.quantity(Resource::Medicine) > 0
+                }
             },
             Row::Take(index) => match self.loot.get(index) {
-                Some(row) => row.left > 0 && world_data::weight(row.item) <= look.free_space(),
+                Some(row) => {
+                    if row.left <= 0 {
+                        false
+                    } else if world_data::weight(row.item) <= look.free_space() {
+                        true
+                    } else if let Some(trip) = look.trip {
+                        let target_weight = world_data::weight(row.item);
+                        world_data::CARRYABLE.iter().any(|item| {
+                            let count = trip.carrying(*item);
+                            if count > 0 && *item != row.item {
+                                let total_item_weight = count as f64 * world_data::weight(*item);
+                                total_item_weight + look.free_space() >= target_weight
+                            } else {
+                                false
+                            }
+                        })
+                    } else {
+                        false
+                    }
+                }
                 None => false,
             },
             Row::TakeAll => self
                 .loot
                 .iter()
                 .any(|row| row.left > 0 && world_data::weight(row.item) <= look.free_space()),
+            Row::Drop { item, count } => look.quantity(item) >= count,
+            Row::DropCancel => true,
             Row::Leave => match &self.phase {
                 Phase::Spoils { leave_cooldown } => *leave_cooldown <= 0.0,
-                Phase::Story | Phase::Fighting(_) => true,
+                Phase::Story | Phase::Fighting(_) | Phase::DropFor { .. } => true,
             },
         }
     }
@@ -605,14 +664,58 @@ impl Active {
                 Outcome::Continue
             }
             Row::Take(index) => {
-                self.take_one(index, ctx);
+                let Some(target) = self.loot.get(index) else {
+                    return Outcome::Continue;
+                };
+                if world_data::weight(target.item) <= ctx.look().free_space() {
+                    self.take_one(index, ctx);
+                } else {
+                    self.phase = Phase::DropFor { loot_index: index };
+                }
                 Outcome::Continue
             }
             Row::TakeAll => {
                 for index in 0..self.loot.len() {
-                    while self.row_ready(Row::Take(index), &ctx.look()) {
-                        self.take_one(index, ctx);
+                    while let Some(target) = self.loot.get(index) {
+                        if target.left > 0
+                            && world_data::weight(target.item) <= ctx.look().free_space()
+                        {
+                            self.take_one(index, ctx);
+                        } else {
+                            break;
+                        }
                     }
+                }
+                Outcome::Continue
+            }
+            Row::Drop { item, count } => {
+                if let Phase::DropFor { loot_index } = self.phase {
+                    if let Some(trip) = &mut ctx.trip {
+                        trip.add(item, -count);
+                    }
+                    if let Some(existing) = self.loot.iter_mut().find(|r| r.item == item) {
+                        existing.left += count;
+                    } else {
+                        self.loot.push(LootRow { item, left: count });
+                    }
+                    self.take_one(loot_index, ctx);
+                    self.phase = match self.scene.combat {
+                        Some(_) => Phase::Spoils {
+                            leave_cooldown: 0.0,
+                        },
+                        None => Phase::Story,
+                    };
+                }
+                Outcome::Continue
+            }
+            Row::DropCancel => {
+                if matches!(self.phase, Phase::DropFor { .. }) {
+                    self.phase = match self.scene.combat {
+                        Some(_) => Phase::Spoils {
+                            leave_cooldown: 0.0,
+                        },
+                        None => Phase::Story,
+                    };
                 }
                 Outcome::Continue
             }
@@ -625,7 +728,7 @@ impl Active {
                         .unwrap_or(Next::End);
                     self.follow(next, ctx, rng, out)
                 }
-                Phase::Story | Phase::Fighting(_) => Outcome::Done,
+                Phase::Story | Phase::Fighting(_) | Phase::DropFor { .. } => Outcome::Done,
             },
         }
     }
@@ -752,7 +855,7 @@ impl Active {
         out: &mut Vec<String>,
     ) -> Outcome {
         match &mut self.phase {
-            Phase::Story => Outcome::Continue,
+            Phase::Story | Phase::DropFor { .. } => Outcome::Continue,
             Phase::Spoils { leave_cooldown } => {
                 *leave_cooldown = (*leave_cooldown - seconds).max(0.0);
                 Outcome::Continue

--- a/late-ssh/src/app/door/darkroom/event_test.rs
+++ b/late-ssh/src/app/door/darkroom/event_test.rs
@@ -414,3 +414,42 @@ fn cancel_drop_restores_spoils_phase_without_changes() {
     assert_eq!(trip.carrying(Resource::IronSword), 0);
     assert_eq!(active.loot[0].left, 1);
 }
+
+#[test]
+fn unusable_ranged_weapon_without_ammo_falls_back_to_fists() {
+    let mut game = game();
+    let mut trip = Expedition {
+        hp: 10,
+        water: 10,
+        ..Expedition::default()
+    };
+    trip.add(Resource::Rifle, 1);
+    assert_eq!(trip.carrying(Resource::Bullets), 0);
+
+    let beast = find(&super::scenes_encounters::ENCOUNTERS, "snarling beast");
+    let mut rng = StdRng::seed_from_u64(1);
+    let mut out = Vec::new();
+    let mut ctx = Ctx {
+        game: &mut game,
+        trip: Some(&mut trip),
+        view: View::World,
+        now: Utc.timestamp_opt(1_800_000_000, 0).unwrap(),
+    };
+
+    let weapons = event::available_weapons(&ctx.look());
+    assert!(weapons.contains(&Weapon::Rifle));
+    assert!(weapons.contains(&Weapon::Fists));
+
+    let mut active = Active::start(beast, &mut ctx, &mut rng, &mut out);
+    assert!(matches!(active.phase, Phase::Fighting(_)));
+    assert!(!active.row_ready(Row::Attack(Weapon::Rifle), &ctx.look()));
+    assert!(active.row_ready(Row::Attack(Weapon::Fists), &ctx.look()));
+
+    active.press(Row::Attack(Weapon::Fists), &mut ctx, &mut rng, &mut out);
+    assert_eq!(
+        active
+            .fight()
+            .and_then(|fight| fight.weapon_cooldown.get(&Weapon::Fists).copied()),
+        Some(2.0)
+    );
+}

--- a/late-ssh/src/app/door/darkroom/event_test.rs
+++ b/late-ssh/src/app/door/darkroom/event_test.rs
@@ -306,6 +306,7 @@ fn drop_items_to_take_heavy_loot() {
         chance: 1.0,
     }];
     static SCENE: Scene = Scene {
+        key: "start",
         loot: &LOOT,
         ..Scene::EMPTY
     };
@@ -392,6 +393,7 @@ fn cancel_drop_restores_spoils_phase_without_changes() {
         chance: 1.0,
     }];
     static SCENE: Scene = Scene {
+        key: "start",
         loot: &LOOT,
         ..Scene::EMPTY
     };

--- a/late-ssh/src/app/door/darkroom/event_test.rs
+++ b/late-ssh/src/app/door/darkroom/event_test.rs
@@ -3,7 +3,7 @@ use rand::SeedableRng;
 use rand::rngs::StdRng;
 
 use super::data::{Perk, Resource};
-use super::event::{self, Active, Ctx, Outcome, Phase, Row};
+use super::event::{self, Active, Ctx, Event, Loot, Outcome, Phase, Row, Scene};
 use super::model::{Expedition, Game, Thieves, View};
 use super::world_data::Weapon;
 
@@ -277,4 +277,140 @@ fn the_unarmed_master_punches_twice_as_fast() {
         1.0,
         "upstream halves the fists cooldown for the unarmed master"
     );
+}
+
+#[test]
+fn drop_items_to_take_heavy_loot() {
+    let mut game = game();
+    // Default capacity is 10.0. Fill it with 10 CuredMeat (weight 1.0 each).
+    let mut trip = Expedition {
+        hp: 10,
+        water: 10,
+        outfit: [(Resource::CuredMeat, 10)].into_iter().collect(),
+        ..Expedition::default()
+    };
+    let mut ctx = Ctx {
+        game: &mut game,
+        trip: Some(&mut trip),
+        view: View::World,
+        now: Utc.timestamp_opt(1_800_000_000, 0).unwrap(),
+    };
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut out = Vec::new();
+
+    // An event offering an IronSword (weight 3.0).
+    static LOOT: [Loot; 1] = [Loot {
+        item: Resource::IronSword,
+        min: 1,
+        max: 1,
+        chance: 1.0,
+    }];
+    static SCENE: Scene = Scene {
+        loot: &LOOT,
+        ..Scene::EMPTY
+    };
+    static EVENT: Event = Event {
+        key: "test loot drop",
+        title: "test",
+        available: &[],
+        scenes: &[SCENE],
+    };
+
+    let mut active = Active::start(&EVENT, &mut ctx, &mut rng, &mut out);
+    assert_eq!(active.loot.len(), 1);
+    assert_eq!(active.loot[0].item, Resource::IronSword);
+    assert_eq!(ctx.look().free_space(), 0.0);
+
+    // Row::Take(0) should be ready because dropping 3 cured meat covers the sword (weight 3.0).
+    assert!(active.row_ready(Row::Take(0), &ctx.look()));
+
+    // Pressing Take(0) when it doesn't fit transitions to Phase::DropFor { loot_index: 0 }.
+    let outcome = active.press(Row::Take(0), &mut ctx, &mut rng, &mut out);
+    assert_eq!(outcome, Outcome::Continue);
+    assert!(matches!(active.phase, Phase::DropFor { loot_index: 0 }));
+
+    // Check rows offered in DropFor phase.
+    let rows = active.rows(&ctx.look());
+    assert_eq!(
+        rows,
+        vec![
+            Row::Drop {
+                item: Resource::CuredMeat,
+                count: 3
+            },
+            Row::DropCancel
+        ]
+    );
+
+    // Press Row::Drop.
+    let outcome = active.press(
+        Row::Drop {
+            item: Resource::CuredMeat,
+            count: 3,
+        },
+        &mut ctx,
+        &mut rng,
+        &mut out,
+    );
+    assert_eq!(outcome, Outcome::Continue);
+    assert!(matches!(active.phase, Phase::Story));
+
+    // Verify outfit and loot state.
+    let trip = ctx.trip.as_ref().unwrap();
+    assert_eq!(trip.carrying(Resource::CuredMeat), 7);
+    assert_eq!(trip.carrying(Resource::IronSword), 1);
+    assert_eq!(trip.load(), 10.0);
+
+    // Ground loot should now contain the dropped CuredMeat (3 left).
+    let dropped = active.loot.iter().find(|l| l.item == Resource::CuredMeat);
+    assert!(dropped.is_some());
+    assert_eq!(dropped.unwrap().left, 3);
+}
+
+#[test]
+fn cancel_drop_restores_spoils_phase_without_changes() {
+    let mut game = game();
+    let mut trip = Expedition {
+        hp: 10,
+        water: 10,
+        outfit: [(Resource::CuredMeat, 10)].into_iter().collect(),
+        ..Expedition::default()
+    };
+    let mut ctx = Ctx {
+        game: &mut game,
+        trip: Some(&mut trip),
+        view: View::World,
+        now: Utc.timestamp_opt(1_800_000_000, 0).unwrap(),
+    };
+    let mut rng = StdRng::seed_from_u64(0);
+    let mut out = Vec::new();
+
+    static LOOT: [Loot; 1] = [Loot {
+        item: Resource::IronSword,
+        min: 1,
+        max: 1,
+        chance: 1.0,
+    }];
+    static SCENE: Scene = Scene {
+        loot: &LOOT,
+        ..Scene::EMPTY
+    };
+    static EVENT: Event = Event {
+        key: "test loot drop cancel",
+        title: "test",
+        available: &[],
+        scenes: &[SCENE],
+    };
+
+    let mut active = Active::start(&EVENT, &mut ctx, &mut rng, &mut out);
+    active.press(Row::Take(0), &mut ctx, &mut rng, &mut out);
+    assert!(matches!(active.phase, Phase::DropFor { loot_index: 0 }));
+
+    active.press(Row::DropCancel, &mut ctx, &mut rng, &mut out);
+    assert!(matches!(active.phase, Phase::Story));
+
+    let trip = ctx.trip.as_ref().unwrap();
+    assert_eq!(trip.carrying(Resource::CuredMeat), 10);
+    assert_eq!(trip.carrying(Resource::IronSword), 0);
+    assert_eq!(active.loot[0].left, 1);
 }

--- a/late-ssh/src/app/door/darkroom/state.rs
+++ b/late-ssh/src/app/door/darkroom/state.rs
@@ -1076,10 +1076,11 @@ impl State {
                 .map(|loot| format!("{} [{}]", loot.item.label(), loot.left))
                 .unwrap_or_default(),
             event::Row::TakeAll => "take everything".to_string(),
+            event::Row::Drop { item, count } => format!("drop {count} {}", item.label()),
+            event::Row::DropCancel => "cancel".to_string(),
             event::Row::Leave => "leave".to_string(),
         }
     }
-
     /// Seconds until a row's cooldown expires, if it is on one.
     pub fn row_cooldown(&self, row: Row) -> u32 {
         let Some(game) = self.game.as_ref() else {

--- a/late-ssh/src/app/door/darkroom/ui_event.rs
+++ b/late-ssh/src/app/door/darkroom/ui_event.rs
@@ -99,6 +99,12 @@ fn body_lines(state: &State) -> Vec<Line<'static>> {
                 )));
             }
         }
+        Phase::DropFor { .. } => {
+            lines.push(Line::from(Span::styled(
+                "not enough room. choose what to drop:",
+                Style::default().fg(theme::TEXT()),
+            )));
+        }
         Phase::Story | Phase::Spoils { .. } => {
             for text in active.scene.text {
                 lines.push(Line::from(Span::styled(


### PR DESCRIPTION
Added functionality to drop items from your pack to make room for new items in A Dark Room. The mechanics/logic should match the implementation from the original game.

- Added `Phase::DropFor` and `Row::Drop` / `Row::DropCancel` to the event state machine. If selected loot exceeds free pack capacity, the game prompts "not enough room. choose what to drop:" and calculates the required quantity of carried items to discard (needed / item_weight).
- Dropping pack items transfers them to the ground loot list, picks up the target item and returns to the loot/story view so any dropped items can be retrieved later (if capacity permits).
- Added tests to `event_test.rs`