### PR TITLE
fix: slash command detection

### DIFF
--- a/late-ssh/src/app/chat/state.rs
+++ b/late-ssh/src/app/chat/state.rs
@@ -4181,13 +4181,15 @@ impl ChatState {
         let bytes = text.as_bytes();
         let mut trigger = None;
         for i in (0..bytes.len()).rev() {
-            if matches!(bytes[i], b'@' | b'/') {
-                // Valid if at start or preceded by whitespace (space or newline)
-                if i == 0 || bytes[i - 1].is_ascii_whitespace() {
-                    trigger = Some((i, bytes[i]));
-                }
+            // Valid if at start or preceded by whitespace (space or newline)
+            let is_mention =
+                matches!(bytes[i], b'@') && (i == 0 || bytes[i - 1].is_ascii_whitespace());
+            let is_command = matches!(bytes[i], b'/') && i == 0;
+            if is_mention || is_command {
+                trigger = Some((i, bytes[i]));
                 break;
             }
+
             // Stop scanning if we hit whitespace (no @ in this word)
             if bytes[i].is_ascii_whitespace() {
                 break;


### PR DESCRIPTION
<img width="938" height="709" alt="image" src="https://github.com/user-attachments/assets/a97e566e-a783-4bd7-bb8c-86c0f99b1a82" />

slash command detection should only trigger if slash is the first character in message