### PR TITLE
Themed resist/weak profiles for every zone, plus craftable weapon oils

### DIFF
--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -4,7 +4,7 @@
 - Scope: `late-ssh/src/app/door/lateania` plus Lateania screen lifecycle in `late-ssh/src/app/door`
 - Domain: Lateania, the persistent D&D-style MUD inside late.sh
 - Primary audience: LLM agents changing the Lateania game runtime, content, UI, combat, or persistence
-- Last updated: 2026-08-20 (class rendering now derives from the `Class` enum instead of hand-kept name lists: every calling glows its key ability on the sheet and the class-select screen, carries a class accent colour, and stands under its own portrait emblem, where twelve of seventeen used to render with no attribute highlighted and seven under a nameless "Adventurer" bust; pinned by `ui_test::every_class_glows_the_ability_that_drives_its_attack` and `every_class_wears_its_own_emblem_under_the_portrait`. Also recorded in §11: four of the six ability scores are read by nothing)
+- Last updated: 2026-08-20 (weapon coats corrected after review: a coat re-seeded its DoT on every strike at the same cadence the DoT ticked, so `POISON_DOT_TICKS` stacks ran live at once and every coat was silently worth 3x its documented rider - coats now keep **one refreshing wound per attacker** (`svc::DotSource`, persisted via `SavedMobDot::from_coat`, logged once), and both coat curves are re-tuned as a share of the newly measured `svc::TIER_ATTACK_BAR` into burst-vs-sustain shapes (poison ~30% of the auto for 5 strikes and 2 herbs, oil ~20% for 12). The world pass's grind-rate budget now **derives** its rider from those constants instead of declaring a `0.15` no assertion could check; zone-boss profiles are asserted rather than skipped; six stale "bosses keep their own" table comments corrected; one Aelunor glade rethemed Resonant -> Haunted so the region has a Holy coat lane. Spec in §7's "The world resist/weak pass" section, coat mechanics in Crafting depth)
 - Status: Active
 - Parent context: `../../../../../CONTEXT.md`
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change when gameplay/content changes.
@@ -338,7 +338,9 @@ Load-bearing decisions, all of them deliberate:
 
 ### Crafting depth [VOLATILE]
 
-- **Weapon coats (poisons + oils)**: using a crafted poison (`items::poison_tier`) or one of the four **weapon oils** (`items::oil_id`/`oil_school_tier`/`OIL_SCHOOLS` = Fire/Frost/Holy/Lightning, 6 tiers each, Alchemy recipes with a school-flavored second ingredient) routes out of the normal consumable path in `use_item` and coats the weapon - `PlayerState::weapon_coat = Some((school, per_tick, charges))` (transient, one slot: any new coat replaces the last; `POISON_CHARGES = 5`, `OIL_CHARGES = 12`). Each landed melee strike seeds a DoT of the coat's school via `seed_mob_dot`, which bakes the foe's resist/weak multiplier into the per-tick up front, so a matched oil is a real matchup lever, and spends a charge; `POISON_PER_TICK`/`OIL_PER_TICK` scale by tier, six real entries each (oils half again above poison: the deliberate zone-prep coat vs the cheap burst vial). Coats seed pvp dots in duels the same way, and the active coat shows in both battle panels' `you:` effects line via `PlayerView.coat` ("fire coat x8"). Oils are always flat riders added to the Physical auto, never a conversion of its school and never a multiplier on `attack()` - that line is reserved for the planned Thundersmith class (THUNDERSMITH.md).
+- **Weapon coats (poisons + oils)**: using a crafted poison (`items::poison_tier`) or one of the four **weapon oils** (`items::oil_id`/`oil_school_tier`/`OIL_SCHOOLS` = Fire/Frost/Holy/Lightning, 6 tiers each, Alchemy recipes with a school-flavored second ingredient) routes out of the normal consumable path in `use_item` and coats the weapon - `PlayerState::weapon_coat = Some((school, per_tick, charges))` (transient, one slot: any new coat replaces the last; `POISON_CHARGES = 5`, `OIL_CHARGES = 12`). Each landed melee strike seeds a DoT of the coat's school via `seed_mob_dot`, which bakes the foe's resist/weak multiplier into the per-tick up front, so a matched oil is a real matchup lever, and spends a charge. Coats seed pvp dots in duels the same way, and the active coat shows in both battle panels' `you:` effects line via `PlayerView.coat` ("fire coat x8"). Oils are always flat riders added to the Physical auto, never a conversion of its school and never a multiplier on `attack()` - that line is reserved for the planned Thundersmith class (THUNDERSMITH.md).
+  - **One wound per coat, refreshed** (`svc::DotSource`): a coat re-seeds on every landed strike, at the very cadence its DoT ticks, so it keeps a single stack per attacker and refreshes it in place. Ability DoTs still stack, because a cooldown rations how often they can be cast. This is load-bearing, not housekeeping: while coats pushed a stack per strike, `POISON_DOT_TICKS` of them were live at once and every coat was silently worth three times its rider (`a_coat_keeps_one_refreshing_wound_however_many_swings_land`). The wound's source is persisted (`SavedMobDot::from_coat`) so a reload cannot untag a live coat and let a second stack open beside it. Only the opening of a wound is logged, never a refresh.
+  - **Two shapes, priced against the same bar**: `svc::TIER_ATTACK_BAR` is a *measured* auto-attack yardstick (a real character at each crafting gate wearing that tier's crafted weapon, pinned by `the_attack_bar_still_matches_a_real_character`), and both coat curves are written as a share of it. The oil sustains ~20% of the auto for 12 strikes; the poison bursts ~30% of it for 5, costs two herbs against the oils' three items, and owns the one school no oil covers. So a vial is roughly three quarters of an oil's damage in half the window for two thirds of the materials - cheaper, shorter, sharper, never simply worse. `the_coat_curves_stay_inside_their_share_of_the_bar` holds every tier of both curves to its band, which is what stops a curve quietly outgrowing the attack curve (it had: the oil rider was documented at 15% of output while really running three to six times that).
 - **Cooking buffs**: eating crafted food (`items::food_tier`) heals/restores as a normal consumable *and* pushes a `HealOverTime` self-effect (well-fed regen, `WELL_FED_TICKS`), reusing the ability HoT tick.
 - **Masterwork sinks**: two Legendary smithing recipes (`items::masterwork_id`, level 45) consume a heap of top-tier intermediates (8-10 mithril ingots + ironbark planks / dire leather) for gear a clear step above the tiered craftables - the endgame material sink.
 - None of this adds save state (`weapon_coat` is transient); no schema bump.
@@ -656,22 +658,33 @@ Coats are never a conversion of the auto's school and never a multiplier on
 (THUNDERSMITH.md), whose whole identity is industrializing this system.
 
 **The balance budget**, enforced by the routed grind-rate model in
-`world_test.rs` (75% auto / 25% abilities from the real roster mix / 15% oil
-rider; "before" is exactly 1.0 everywhere since regulars were `(None, None)`):
-per-zone swing within +-15%; per-class themed-zone average within +-3%; a
->=+5% best zone-and-coat answer for every class in every region (the
-meaningfulness floor); a <=+18% routed ceiling with <=12 points of spread
-between the best- and worst-served class. The mono-Holy classes top the table
-by design (holy oil stacking with their own school in Undead/Haunted lanes):
-the deliberate buff to today's weakest two.
+`world_test.rs`: 75% auto / 25% abilities from the real roster mix, plus the
+coat rider; "before" is exactly 1.0 everywhere since regulars were
+`(None, None)`. Bands: per-zone swing within +-15%; per-class themed-zone
+average within +-3%; a >=+5% best zone-and-coat answer for every class in
+every region (the meaningfulness floor); a <=+18% routed ceiling with <=12
+points of spread between the best- and worst-served class. The mono-Holy
+classes top the table by design (holy oil stacking with their own school in
+Undead/Haunted lanes): the deliberate buff to today's weakest two.
 
-**Tests** (`world_test.rs`): `every_generated_regular_wears_its_zone_theme`,
+The rider in that model is **derived from the engine, never declared**:
+`OIL_PER_TICK` over `TIER_ATTACK_BAR` (both in `svc.rs`, both pinned to a live
+character by `svc_test.rs`), converted through `AUTO_SHARE`. It lands near 14%
+of output. This is the one part of the pass that has already failed once: the
+rider was a hardcoded `0.15` while the real coat was worth three to six times
+that, and no assertion in the file could see it. A model that measures a
+constant instead of the game is not a budget.
+
+**Tests** (`world_test.rs`): `every_generated_zone_spawn_wears_its_zone_theme`
+(regulars wear the theme, zone bosses wear its weak and no resist),
 `no_regular_resists_physical_and_nothing_is_weak_to_physical`,
 `every_boss_carries_a_weakness`,
 `the_school_census_stays_inside_its_declared_bands`,
-`the_world_pass_redistributes_grind_rates_but_never_rebalances_a_class`.
-Re-theming a zone means editing its table row and letting these judge the
-census and budget; they, not prose, are the contract.
+`the_world_pass_redistributes_grind_rates_but_never_rebalances_a_class`; in
+`svc_test.rs`, `the_attack_bar_still_matches_a_real_character` and
+`the_coat_curves_stay_inside_their_share_of_the_bar`. Re-theming a zone means
+editing its table row and letting these judge the census and budget; they, not
+prose, are the contract.
 
 **Visibility**: the targeted foe's traits line (`rank · strikes with X · weak
 to Y · shrugs off Z`) in both battle surfaces, plus the per-hit log tags.

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -4,7 +4,7 @@
 - Scope: `late-ssh/src/app/door/lateania` plus Lateania screen lifecycle in `late-ssh/src/app/door`
 - Domain: Lateania, the persistent D&D-style MUD inside late.sh
 - Primary audience: LLM agents changing the Lateania game runtime, content, UI, combat, or persistence
-- Last updated: 2026-08-20 (the world resist/weak pass: every generated zone now names a `damage::ZoneTheme` and its regulars wear the theme's resist/weak while bosses keep their authored profiles, pinned by four world_test invariants incl. a routed grind-rate budget; plus the four Alchemy weapon oils - `weapon_poison` generalized to the one-slot `weapon_coat`, oils are flat school riders on the auto that ride `seed_mob_dot`'s baked-in resist/weak multiplier; spec in §7's "The world resist/weak pass" section, coat mechanics in Crafting depth)
+- Last updated: 2026-08-20 (the world resist/weak pass: every generated zone now names a `damage::ZoneTheme`, its regulars wear the theme's resist/weak, and every boss in the world carries a weakness (zone bosses inherit the theme's weak but never its resist; authored crowns keep or gained hand-picked ones) - pinned by world_test invariants incl. a routed grind-rate budget and `every_boss_carries_a_weakness`; plus the four Alchemy weapon oils - `weapon_poison` generalized to the one-slot `weapon_coat`, oils are flat school riders on the auto that ride `seed_mob_dot`'s baked-in resist/weak multiplier; spec in §7's "The world resist/weak pass" section, coat mechanics in Crafting depth)
 - Status: Active
 - Parent context: `../../../../../CONTEXT.md`
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change when gameplay/content changes.
@@ -614,9 +614,14 @@ reward; walls are events, and rare).
 in the same order: `FRONTIER/REACHES/KAELMYR/LAKES/BROCELIANDE/AELUNOR_ZONE_THEMES`
 in `world.rs`, `ISLAND_THEMES` in `archipelago.rs`; 126 themed zones. Regulars
 inherit the theme at spawn build (an Aelunor spawn wears its zone theme
-whatever affix it rolls); **bosses keep their authored profiles bit-for-bit**,
-so no crown fight moved and Physical resist survives only on bosses, where
-"bring a caster, an oil, or the smith" is the point.
+whatever affix it rolls). **Every boss carries a weakness** - bosses are the
+fights players actually prepare for, so the prep mechanic must exist there:
+generated zone bosses inherit their zone theme's weak but **never** its
+resist (a weakness is pure reward; a resist on a boss is a class tax with no
+counterplay, so boss resists stay rare authored events - the 14 Physical
+walls and the elemental crowns). Authored crowns keep their hand-picked
+profiles; the zone teaches the school, the boss is the exam, and the oil
+already in your bag is the answer.
 
 **The two hard rules** (global, no exceptions): nothing anywhere is weak to
 Physical, and no regular anywhere resists it - a Physical resist on a regular
@@ -624,6 +629,17 @@ is a zone-wide tax on the seven Physical-locked classes with no counterplay.
 The twelve authored regulars that used to resist it were re-themed
 (constructs/stone to Poison, wraiths/shades to Shadow, cold-sea creatures to
 Frost), each keeping its weakness.
+
+**The solo rule** (this is a solo game, no grouping fallback): a Physical
+resist on a boss may only guard an optional prize or sit at the low band
+where a tier-0 oil's flat rider out-punches the halving. Exactly 14 bosses
+wear one - the Elder Treant (the road's teaching fight, ~L5-8, where a 20g
+Sparkseed Oil already beats hitting a neutral boss dry), the Fallen Paladin
+(optional Sunken Citadel), and Aelunor's 12 zone bosses (optional region,
+weak Holy, so the blessed-oil rider lands at 150%). The mandatory Long Road
+past the Treant never demands a school a Physical-locked class can't bring;
+never add a Physical resist to a road crown. Pinned by
+`physical_walls_never_gate_the_long_road_past_the_treant` (`svc_test.rs`).
 
 **Census bands** (declared, test-enforced): per school 10..=30 weak zones and
 <=10 resist zones; Holy keeps >=4 resist zones (the Profane predators - without
@@ -650,6 +666,7 @@ the deliberate buff to today's weakest two.
 
 **Tests** (`world_test.rs`): `every_generated_regular_wears_its_zone_theme`,
 `no_regular_resists_physical_and_nothing_is_weak_to_physical`,
+`every_boss_carries_a_weakness`,
 `the_school_census_stays_inside_its_declared_bands`,
 `the_world_pass_redistributes_grind_rates_but_never_rebalances_a_class`.
 Re-theming a zone means editing its table row and letting these judge the

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -4,7 +4,7 @@
 - Scope: `late-ssh/src/app/door/lateania` plus Lateania screen lifecycle in `late-ssh/src/app/door`
 - Domain: Lateania, the persistent D&D-style MUD inside late.sh
 - Primary audience: LLM agents changing the Lateania game runtime, content, UI, combat, or persistence
-- Last updated: 2026-08-17 (the land map is now a drawn atlas rather than a derived trunk: every country sits at a hand-set place, the Overworld and Embergate are walled keeps each road leaves by its own wall junction, and `ROADS` is checked against `worldmap::land_links` so the picture can neither invent a road nor lose one; see §5.2 and the new gotcha in §11; the Ways no longer carry gate titles of their own - `CONTINENT_WAYSTONES` lost its third field and `svc::travel` its duplicate title check, so every title check now lives in `can_cross_progression_gate` and a waystone is offered on `waystone_is_known` alone, see §6; the overhead compass now always renders a `compass_glyph` direction + room count for a marked destination, and off-screen POI arrows are `PAN_LIMIT`-filtered rather than pointing at meaningless cross-block deltas; Aelunor, the Faewood - a twelve-zone, cavern-only forest continent of elves/high elves/druids/fae, 100 named creatures across five rarity tiers - and its own city Silvael are new, along with five more tameable beasts each carrying their own auto-skill ladder; see §1, §5.1, §6, §9, §11)
+- Last updated: 2026-08-20 (the world resist/weak pass: every generated zone now names a `damage::ZoneTheme` and its regulars wear the theme's resist/weak while bosses keep their authored profiles, pinned by four world_test invariants incl. a routed grind-rate budget; plus the four Alchemy weapon oils - `weapon_poison` generalized to the one-slot `weapon_coat`, oils are flat school riders on the auto that ride `seed_mob_dot`'s baked-in resist/weak multiplier; spec in §7's "The world resist/weak pass" section, coat mechanics in Crafting depth)
 - Status: Active
 - Parent context: `../../../../../CONTEXT.md`
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change when gameplay/content changes.
@@ -72,10 +72,10 @@ Current game scale:
 | `archipelago.rs` | The **Shattered Archipelago** data + address arithmetic: the four portal `VILLAGES` (rooms `8000+`), the 20 `ISLANDS` theme table (rooms `20000+`), `island_entrance`/`village_room`/`is_archipelago_room`/`has_waystone`, and `portal_destinations()` (the fast-travel menu). Rooms are generated in `world.rs`; the portal teleport (`travel`) lives in `svc.rs`. |
 | `pets.rs` | Combat companions. `PetSpecies` data table (`PET_SPECIES`, `pet_species_by_key`) of buyable beasts, and the live `Pet` (held on `PlayerState`, always co-located with its owner). Loyalty (earned by feeding) drives the level via a pure function; `max_hp`/`attack` scale with level. `PetSpecies` carries a `tame_level` (`0` = buyable Stable species; `>0` = the Animal Taming level a wild beast needs) and its own `skills: &'static [taming::PetSkill]` ladder (every pre-Aelunor species points at the shared `taming::PET_SKILLS`; Aelunor's five each carry their own, so different pets really do have different spells); `pet_species_by_key` searches `PET_SPECIES`, `taming::TAMEABLE`, **and** `taming::AELUNOR_TAMEABLE` so a saved pet of any kind reloads. The world wiring (buying/feeding/wounds, the bite each round, and the level-gated **pet auto-skills**) lives in `svc.rs`. Persisted by species key + loyalty (HP restored full on load). |
 | `taming.rs` | The **Animal Taming** trade. `TAMEABLE` = fifty-five tameable `PetSpecies` of Broceliande, small→large with `tame_level` rising 1..50 (harder and harder); `AELUNOR_TAMEABLE` = five more, native to Aelunor. `wild_beasts()` places every beast in **both** pools at a real safe room (Broceliande's zone forest gates, Aelunor's zone Wood-Gates, via `world::aelunor_entrances()`) and returns one combined list; `WildBeast.species` indexes the **combined** pool (`TAMEABLE` then `AELUNOR_TAMEABLE`), resolved through `beast_species(index)` rather than indexing `TAMEABLE` directly. `beasts_at(room)` filters it. `tame_chance(xp, beast)` drives the success roll (40% at the required level, +9%/surplus level, capped 95%, 0 if under-level); `tame_xp` scales the reward. **Pet auto-skills**: `PET_SKILLS` (Savage Bite L3 / Rend L8 / Intimidating Roar L15 / Loyal Guard L22 / Killing Pounce L30, `pet_skills_at(level)`) is the shared ladder every pre-Aelunor species uses; the five Aelunor species each carry a distinct `PetSkill` array of their own (see the Animal Taming section), including a `Mend` effect (a direct heal) no earlier pet had. `PetSkillEffect` is resolved in `svc.rs::fire_pet_skills`/`fire_pet_skills_pvp`, both of which now take the firing pet's own `skills` slice as a parameter rather than assuming the shared ladder. Only data + pure maths; the action/panel/combat wiring is in `svc.rs`/`state.rs`/`ui.rs`. |
-| `items.rs` | Item catalog, equipment slots, consumables, valuables, shops, generated Frontier loot. Also the **raw-material catalog** (`materials()`/`material_id`/`MATERIAL_BASE = 4000`): 5 skills x 5 tiers of gathered materials (logs/ores/fish/herbs/hides), `Valuable` kind (immediately sellable), IDs `4000..4100` (skill index x 20 + tier). The **crafted-goods catalog** (`crafted()`/`CRAFTED_BASE = 4200` + the `*_id(tier)` helpers): intermediates (ingots/planks/leather) and finished goods (weapons/armor/potions/poisons/food), IDs `4200..4500`. And the **Sunderlakes fish catalog** (`fish()`/`FISH_BASE = 4600`/`FISH_COUNT = 40`): 40 species with a wide sell-price spread, ~a third `Consumable` (edible), the rest `Valuable`; `fish_well_fed(id)` gives the well-fed regen for the legendary "special" fish. All chained into `item()`. |
+| `items.rs` | Item catalog, equipment slots, consumables, valuables, shops, generated Frontier loot. Also the **raw-material catalog** (`materials()`/`material_id`/`MATERIAL_BASE = 4000`): 5 skills x 5 tiers of gathered materials (logs/ores/fish/herbs/hides), `Valuable` kind (immediately sellable), IDs `4000..4100` (skill index x 20 + tier). The **crafted-goods catalog** (`crafted()`/`CRAFTED_BASE = 4200` + the `*_id(tier)` helpers): intermediates (ingots/planks/leather) and finished goods (weapons/armor/potions/poisons/oils/food), IDs `4200..4600` (the four oil families sit at `oil_id`, `4500..4566`). And the **Sunderlakes fish catalog** (`fish()`/`FISH_BASE = 4600`/`FISH_COUNT = 40`): 40 species with a wide sell-price spread, ~a third `Consumable` (edible), the rest `Valuable`; `fish_well_fed(id)` gives the well-fed regen for the legendary "special" fish. All chained into `item()`. |
 | `skills.rs` | **Gathering skills** (`GatherSkill`: Woodcutting/Mining/Fishing/Foraging/Skinning) and **crafting skills** (`CraftSkill`: Smithing/Woodworking/Leatherworking/Alchemy/Cooking), both on one 1-50 xp curve (`xp_for_skill_level`/`skill_level_for_xp`/`skill_progress`), independent of class level and steepening past level 10. Persisted per-player as (skill key, xp) for each set. |
 | `crafting.rs` | **Recipes** (`Recipe`/`recipes()`/`recipe(i)`/`recipe_indices_for(skill)`): inputs -> output, gated by a `CraftSkill` + level. 50 recipes (10 per tier x 5 tiers) that **chain** (ore -> ingot -> weapon). Data only; `svc::craft` resolves and applies them. Built at runtime and cached (inputs are `Vec`, not a leaked slice). |
-| `damage.rs` | Damage schools, mob resistance/weakness profiles, damage multiplier math. |
+| `damage.rs` | Damage schools, mob resistance/weakness profiles, damage multiplier math. Also `ZoneTheme`: the closed 16-variant theme vocabulary of the world resist/weak pass, each an exhaustive const mapping to `(resist, weak)` (see the Abilities and damage section). |
 | `stats.rs` | D&D-style ability scores, 4d6-drop-lowest rolls, modifiers, HP/attack bonuses. |
 | `persist.rs` | JSON schemas for durable character saves and shared world saves. Versioned (`SCHEMA_VERSION`); new fields use `#[serde(default)]` so old saves load (e.g. `board_progress`/`board_done` for quests). |
 
@@ -333,15 +333,15 @@ Load-bearing decisions, all of them deliberate:
 - Five crafting trades (`skills::CraftSkill`) - Smithing, Woodworking, Leatherworking, Alchemy, Cooking - level 1..=50 on the same curve, tracked as a separate `craft_skills` map on `PlayerState` and persisted (schema v13).
 - `world::FEATURES` places the five **craft stations** (`FeatureKind::CraftStation(CraftSkill)`) in Embergate's Market Row (room 3): a forge, workbench, tannery, alchemy lab and cooking fire. `craft_stations_at(room)` gates crafting and builds the panel. Stations read as actionable gold in the room (`ui::is_craft_station`).
 - `u` opens the **Crafting** panel (`Panel::Crafting`) where any station stands; it lists every recipe worked at the stations here, each flagged craftable/gated (station + skill level + materials). `Enter` crafts the selected recipe (`svc::craft` / `craft_task`): it consumes the inputs (`PlayerState::consume`/`item_count`), adds the output, and trains the craft skill. Recipes **chain** - smelt ore -> ingot, then forge ingot + plank -> sword.
-- Crafted outputs are ordinary items, so they equip / are consumed / sell through the existing systems (weapons & armor equip, potions & food heal/restore, poisons are sellable valuables until the depth update makes them applyable).
+- Crafted outputs are ordinary items, so they equip / are consumed / sell through the existing systems (weapons & armor equip, potions & food heal/restore, poisons and oils coat the weapon - see Crafting depth below).
 - The **Trades** block shows all ten trades (gather then craft); the recipe `inputs` are summarised as `"3x Copper Ingot, 1x Oak Plank"`.
 
 ### Crafting depth [VOLATILE]
 
-- **Applied poisons**: using a crafted poison (`items::poison_tier` routes it out of the normal consumable path in `use_item`) coats the weapon - `PlayerState::weapon_poison = Some((per_tick, charges))` (transient, `POISON_CHARGES = 5`). Each landed melee strike in the combat round seeds a `DamageType::Poison` DoT on the struck foe via the existing `seed_mob_dot` and spends a charge; `POISON_PER_TICK` scales the damage by poison tier.
+- **Weapon coats (poisons + oils)**: using a crafted poison (`items::poison_tier`) or one of the four **weapon oils** (`items::oil_id`/`oil_school_tier`/`OIL_SCHOOLS` = Fire/Frost/Holy/Lightning, 6 tiers each, Alchemy recipes with a school-flavored second ingredient) routes out of the normal consumable path in `use_item` and coats the weapon - `PlayerState::weapon_coat = Some((school, per_tick, charges))` (transient, one slot: any new coat replaces the last; `POISON_CHARGES = 5`, `OIL_CHARGES = 12`). Each landed melee strike seeds a DoT of the coat's school via `seed_mob_dot`, which bakes the foe's resist/weak multiplier into the per-tick up front, so a matched oil is a real matchup lever, and spends a charge; `POISON_PER_TICK`/`OIL_PER_TICK` scale by tier, six real entries each (oils half again above poison: the deliberate zone-prep coat vs the cheap burst vial). Coats seed pvp dots in duels the same way, and the active coat shows in both battle panels' `you:` effects line via `PlayerView.coat` ("fire coat x8"). Oils are always flat riders added to the Physical auto, never a conversion of its school and never a multiplier on `attack()` - that line is reserved for the planned Thundersmith class (THUNDERSMITH.md).
 - **Cooking buffs**: eating crafted food (`items::food_tier`) heals/restores as a normal consumable *and* pushes a `HealOverTime` self-effect (well-fed regen, `WELL_FED_TICKS`), reusing the ability HoT tick.
 - **Masterwork sinks**: two Legendary smithing recipes (`items::masterwork_id`, level 45) consume a heap of top-tier intermediates (8-10 mithril ingots + ironbark planks / dire leather) for gear a clear step above the tiered craftables - the endgame material sink.
-- None of this adds save state (`weapon_poison` is transient); no schema bump.
+- None of this adds save state (`weapon_coat` is transient); no schema bump.
 
 ### Animal Taming [VOLATILE]
 
@@ -355,7 +355,7 @@ Load-bearing decisions, all of them deliberate:
 - **First real pvp.** Before this, Lateania was pure PvE - no player could target another. `Room::pvp` (never `true` together with `safe`) marks a room as contested ground; `svc::engage_player`/`engage_player_task` let a player lock onto another adventurer standing in the same `pvp` room, mirroring `engage_mob`. The victim auto-retaliates (`pvp_target` set both ways) if they weren't already mid-fight with anything. `PlayerState::in_combat()` (`target.is_some() || pvp_target.is_some()`) is what movement/recall/mount/waypoint/travel actually gate on now - a duel holds you in place exactly like a mob fight always has.
 - **The exchange.** The tick's pvp-fighters pass (right after the mob-fighters pass) resolves one auto-attack per engaged pair per tick, reusing `attack()`/`strike_player` as-is (`strike_player`'s `mob_name` argument is just a display string, so a player-vs-player blow needed no changes there). Rogue opening strike, Berserker frenzy, and Ranger's wounded-target bonus all still apply to the attacker; armor mitigation, shields, Monk/Tank mitigation, the Warrior death-save, and veteran in-place resurrection all still apply to the victim exactly as they do against a mob.
 - **`target` and `pvp_target` are mutually exclusive, and both halves are load-bearing.** `engage_player` clears `target`; `set_target` (shared by `engage`/`engage_mob`) clears `pvp_target` and logs "You break off the duel." Every resolver reads pvp first, so a player holding both at once would have their abilities damage the rival while `Stun` landed its stun on the mob - and in the Waste, where contested ground and the mob roster share the same rooms, one auto-attack keypress used to be enough to get there (`locking_onto_a_mob_breaks_off_the_duel_so_abilities_hit_the_mob`).
-- **Abilities and pets also reach a `pvp_target` now.** `damage_target` (used by `Strike`/`Finisher`) checks `pvp_target` before `target` and routes through the new `strike_pvp_target` (a thin wrapper around `strike_player` that also handles pvp kill-crediting - shared by the auto-attack pass, abilities, pet bites, and pvp dots, so that logic lives in exactly one place). `DamageOverTime` seeds a `pvp_dots` entry (parallel to `mob_dots`, but keyed by victim id and carrying its own `DamageType` per stack, since a player's `strike_player` needs the real school every tick rather than a resist/weak multiplier baked in once); the tick resolves it the same way as mob dots, just through `strike_pvp_target`. `Stun` inserts into `pvp_stuns` (parallel to `mob_stuns`), checked at the top of each attacker's own turn in the pvp-fighters pass - a stunned adventurer skips their swing that round, same as a stunned mob does. A companion's bite and its unlockable auto-skills (`fire_pet_skills_pvp`, a pvp sibling of `fire_pet_skills`) fire against `pvp_target` too: `SavageBite`/`Pounce`/`Rend` route through `strike_pvp_target`/`seed_pvp_dot`; `Roar`/`Guard` are pure self-buffs and needed no changes. **Still auto-attack-only for mobs, not pvp:** poison-coated weapons (`weapon_poison`) still only seed a `mob_dots` entry - extending that to pvp is the one remaining gap.
+- **Abilities and pets also reach a `pvp_target` now.** `damage_target` (used by `Strike`/`Finisher`) checks `pvp_target` before `target` and routes through the new `strike_pvp_target` (a thin wrapper around `strike_player` that also handles pvp kill-crediting - shared by the auto-attack pass, abilities, pet bites, and pvp dots, so that logic lives in exactly one place). `DamageOverTime` seeds a `pvp_dots` entry (parallel to `mob_dots`, but keyed by victim id and carrying its own `DamageType` per stack, since a player's `strike_player` needs the real school every tick rather than a resist/weak multiplier baked in once); the tick resolves it the same way as mob dots, just through `strike_pvp_target`. `Stun` inserts into `pvp_stuns` (parallel to `mob_stuns`), checked at the top of each attacker's own turn in the pvp-fighters pass - a stunned adventurer skips their swing that round, same as a stunned mob does. A companion's bite and its unlockable auto-skills (`fire_pet_skills_pvp`, a pvp sibling of `fire_pet_skills`) fire against `pvp_target` too: `SavageBite`/`Pounce`/`Rend` route through `strike_pvp_target`/`seed_pvp_dot`; `Roar`/`Guard` are pure self-buffs and needed no changes. Coated weapons (`weapon_coat`, poisons and oils alike) work in duels too: the pvp auto-attack pass seeds a `pvp_dots` entry of the coat's school and spends a charge, mirroring the mob path.
 - **Death and spoils.** A real pvp kill (not a death-save or a spent veteran charge) reuses the ordinary death path unchanged - the victim becomes a corpse, keeps `CORPSE_LINGER_SECS` to be resurrected or release, and loses the same `carried_gold_death_loss` cut as any death. The only pvp-specific step is crediting that lost gold to the killer (diffed before/after the `strike_player` call, not a new field) alongside a flat xp bonus, incrementing persisted `pvp_kills: i64` (schema **v18**, `#[serde(default)]`), and awarding the reaver title track (`pvp_title_for`: Blooded → Reaver of the Waste → Dread of the Wildbound → Warlord of the Waste → Deathless Sovereign of the Waste at 1/10/50/150/500 kills) via the existing `award_title`.
 - **UI.** `OccupantView` gained `attackable`/`targeted`; the "Adventurers here" list marks a hostile row (`hostile`/`duel` tag, a `»` marker on your current target) and, only in a `pvp` room, is clickable (`ClickAction::AttackPlayer`) exactly like a foe roster row. `PlayerView.pvp`/`pvp_kills` expose the room flag and lifetime count. `OccupantView` also carries `level` now: both the "Adventurers here" list and the Follow panel prefix the name with `Lv{N}` (`roster_row`, same convention `MobView` already uses) and append a three-letter class abbreviation (`ui::class_abbrev`, hand-picked - not a naive truncation, since e.g. Warrior/Warlock would otherwise both read "WAR") into the status-tag slot, combined with any active status (`hostile·WAR`) rather than replacing it - so a foe's kit is visible before you ever engage.
 - **The continent.** `extend_wildbound` (rooms 30000+) builds three chained biomes - Duskmire Wood (cavern, levels ~13-60), the Hollowdeep (braided maze, ~44-67), the Scorched Flats (cavern, ~65-83) - each ending in one named apex boss (Wychelm Sovereign / Deathless Warden / Apex Sandwyrm, **levels 62 / 70 / 85** derived from their `boss_stats` through `Spawn::level()`; an earlier note here claimed 65/78/100, which overstated all three and wrongly implied the Sandwyrm was the world's ceiling - Kaelmyr and the deep Reaches are, see §7), carved with the same `carve_maze`/`carve_cavern` never-a-grid machinery as Broceliande. Every field room is `pvp: true`; the only havens are three small four-room gate towns (Last Watch, Barrowgate, Ashhold), one per biome, chained gate → field → next gate. Regular mobs are 20 base creature names per biome crossed with a shared five-tier affix ladder (`Lesser/·/Greater/Elder/Ancient`) - a 300-entry template pool, ~600 live spawns. Loot borrows `frontier_loot` at an offset tier per biome rather than a bespoke catalog (`broceliande_loot`'s shortcut): every table, **the apex boss's included**, is `loot_base + n`, the boss one affix ladder past its own deepest regular (tiers 5 / 12 / 18), and `wildbound_loot` clamps at `FRONTIER_TIERS - 2` so the Waste can never reach the catalog's top table. That clamp is load-bearing - the boss branch used to return `FRONTIER_TIERS - 1` outright, so all three apexes dropped the King Who Was Promised Nothing's own tier, guaranteed (`roll_loot` never rolls for a boss), off a 1500hp Duskmire mob reached by an ungated walk at gentle overworld multipliers. Pinned by `a_wildbound_apex_boss_pays_off_its_own_biome_not_the_frontier_crown`. Hung off the Sahra Wastes' `WILDBOUND_GATEWAY` (room 751, the Sand-Wyrm's Maw) by a plain walk south; `Last Watch, the Wildbound Waste` is a `CONTINENT_WAYSTONES` entry with no title gate.
@@ -576,6 +576,89 @@ Progression:
 - `DamageProfile` lets each mob deal one attack type, resist up to one incoming school, and be weak to up to one incoming school.
 - Resist halves damage, weak adds 50 percent, and minimum damage is 1.
 - Auto-attacks are physical and still pass through mob resistances.
+- Every generated zone carries a themed resist/weak profile on its regulars: see the dedicated section below, **The world resist/weak pass**.
+
+### The world resist/weak pass [STABLE]
+
+Landed 2026-08-20. Every generated zone gives its regular mobs a themed
+resist/weak profile, so school choice is a real lever across the whole Lv30-60+
+band instead of only against ~116 authored spawns. Data-only: the engine
+multipliers (resist halves, weak +50%, minimum 1) and the one-resist-one-weak
+`DamageProfile` shape are unchanged.
+
+**The theme vocabulary.** `damage::ZoneTheme` is a closed 16-variant enum; each
+variant maps exhaustively to `(resist, weak)`. Physical never appears in either
+slot, and every theme carries a weakness (weak-forward: the right school is a
+reward; walls are events, and rare).
+
+| theme | resist | weak | flavor |
+|---|---|---|---|
+| Ashen | Fire | Frost | magma-born flesh |
+| Sunscorched | - | Frost | heat without fire-born flesh |
+| Frozen | Frost | Fire | ice country |
+| Verdant | - | Fire | burnable greenwood |
+| Tidal | - | Lightning | open water, wet ground |
+| Drowned | Frost | Lightning | the cold deep |
+| Storm | Lightning | Arcane | storm-born |
+| Resonant | - | Arcane | song, echo, standing wards |
+| Undead | Shadow | Holy | barrow-flesh |
+| Haunted | - | Holy | ghosts without the flesh |
+| Profane | Holy | Shadow | god-cults, the profaned divine |
+| Fae | - | Shadow | glamour |
+| Beastwild | - | Poison | living beasts and vermin |
+| Fungal | Poison | Fire | spore and rot |
+| Construct | Poison | Lightning | bloodless made things |
+| Crystal | - | Lightning | glass and shard |
+
+**Placement.** One theme table per generated region, beside its zone data and
+in the same order: `FRONTIER/REACHES/KAELMYR/LAKES/BROCELIANDE/AELUNOR_ZONE_THEMES`
+in `world.rs`, `ISLAND_THEMES` in `archipelago.rs`; 126 themed zones. Regulars
+inherit the theme at spawn build (an Aelunor spawn wears its zone theme
+whatever affix it rolls); **bosses keep their authored profiles bit-for-bit**,
+so no crown fight moved and Physical resist survives only on bosses, where
+"bring a caster, an oil, or the smith" is the point.
+
+**The two hard rules** (global, no exceptions): nothing anywhere is weak to
+Physical, and no regular anywhere resists it - a Physical resist on a regular
+is a zone-wide tax on the seven Physical-locked classes with no counterplay.
+The twelve authored regulars that used to resist it were re-themed
+(constructs/stone to Poison, wraiths/shades to Shadow, cold-sea creatures to
+Frost), each keeping its weakness.
+
+**Census bands** (declared, test-enforced): per school 10..=30 weak zones and
+<=10 resist zones; Holy keeps >=4 resist zones (the Profane predators - without
+them the two mono-Holy classes silently win the school game); resists <= a
+third of any region; >=5 weak schools per region; no school owns more than a
+quarter of a region's weaknesses. Nothing resists Arcane.
+
+**The martial lever** is the weapon-coat family (poisons + the four Alchemy
+oils; mechanics in Crafting depth): flat, charge-limited school riders on the
+Physical auto that ride `seed_mob_dot`'s baked-in resist/weak multiplier.
+Coats are never a conversion of the auto's school and never a multiplier on
+`attack()` - both are reserved for the planned Thundersmith class
+(THUNDERSMITH.md), whose whole identity is industrializing this system.
+
+**The balance budget**, enforced by the routed grind-rate model in
+`world_test.rs` (75% auto / 25% abilities from the real roster mix / 15% oil
+rider; "before" is exactly 1.0 everywhere since regulars were `(None, None)`):
+per-zone swing within +-15%; per-class themed-zone average within +-3%; a
+>=+5% best zone-and-coat answer for every class in every region (the
+meaningfulness floor); a <=+18% routed ceiling with <=12 points of spread
+between the best- and worst-served class. The mono-Holy classes top the table
+by design (holy oil stacking with their own school in Undead/Haunted lanes):
+the deliberate buff to today's weakest two.
+
+**Tests** (`world_test.rs`): `every_generated_regular_wears_its_zone_theme`,
+`no_regular_resists_physical_and_nothing_is_weak_to_physical`,
+`the_school_census_stays_inside_its_declared_bands`,
+`the_world_pass_redistributes_grind_rates_but_never_rebalances_a_class`.
+Re-theming a zone means editing its table row and letting these judge the
+census and budget; they, not prose, are the contract.
+
+**Visibility**: the targeted foe's traits line (`rank · strikes with X · weak
+to Y · shrugs off Z`) in both battle surfaces, plus the per-hit log tags.
+Deliberately no pre-fight display: the first swing is the probe, and pre-fight
+knowledge is reserved as the future Thundersmith Ledger's territory.
 
 ### Combat rules
 

--- a/late-ssh/src/app/door/lateania/CONTEXT.md
+++ b/late-ssh/src/app/door/lateania/CONTEXT.md
@@ -4,7 +4,7 @@
 - Scope: `late-ssh/src/app/door/lateania` plus Lateania screen lifecycle in `late-ssh/src/app/door`
 - Domain: Lateania, the persistent D&D-style MUD inside late.sh
 - Primary audience: LLM agents changing the Lateania game runtime, content, UI, combat, or persistence
-- Last updated: 2026-08-20 (the world resist/weak pass: every generated zone now names a `damage::ZoneTheme`, its regulars wear the theme's resist/weak, and every boss in the world carries a weakness (zone bosses inherit the theme's weak but never its resist; authored crowns keep or gained hand-picked ones) - pinned by world_test invariants incl. a routed grind-rate budget and `every_boss_carries_a_weakness`; plus the four Alchemy weapon oils - `weapon_poison` generalized to the one-slot `weapon_coat`, oils are flat school riders on the auto that ride `seed_mob_dot`'s baked-in resist/weak multiplier; spec in §7's "The world resist/weak pass" section, coat mechanics in Crafting depth)
+- Last updated: 2026-08-20 (class rendering now derives from the `Class` enum instead of hand-kept name lists: every calling glows its key ability on the sheet and the class-select screen, carries a class accent colour, and stands under its own portrait emblem, where twelve of seventeen used to render with no attribute highlighted and seven under a nameless "Adventurer" bust; pinned by `ui_test::every_class_glows_the_ability_that_drives_its_attack` and `every_class_wears_its_own_emblem_under_the_portrait`. Also recorded in §11: four of the six ability scores are read by nothing)
 - Status: Active
 - Parent context: `../../../../../CONTEXT.md`
 - Stability note: Sections marked `[STABLE]` should change rarely. Sections marked `[VOLATILE]` are expected to change when gameplay/content changes.
@@ -561,11 +561,12 @@ Playable classes (17; the first five are the class-select `1-5` quick-pick):
 - Each of the five newcomers carries a full 1..=50 ability roster (ids 1700/1800/1900/2000/2100+) with a level-50 capstone and two archetype paths at `ARCHETYPE_LEVEL`. Progression reads as tiered: staged ability unlocks across the curve, the L10 archetype specialisation, and the shared five-level named milestones.
 
 Progression:
-- Level cap is `Class::MAX_LEVEL = 50`.
-- `xp_for_level` keeps early levels quick, then adds a much steeper post-level-8 term so midgame and Frontier progress target roughly week-scale casual play instead of a 1-2 sitting clear; `level_for_xp` caps at 50.
+- Level cap is `Class::MAX_LEVEL = 100`.
+- `xp_for_level` keeps early levels quick, then adds a much steeper post-level-8 term so midgame and Frontier progress target roughly week-scale casual play instead of a 1-2 sitting clear; `level_for_xp` caps at `MAX_LEVEL`.
 - `Class::stats_at(level)` computes HP/resource/attack/resource regen.
 - Ability scores are rolled before class selection and persist after class choice.
-- Constitution adjusts max HP by level; class primary score adjusts attack.
+- Constitution and the class's `primary_score` are the only two of the six scores wired to mechanics: CON adds max HP that grows with level (`AbilityScores::hp_bonus`), the primary score adds a flat attack modifier (`attack_bonus`). The other four are display only, see §11.
+- The sheet and the class-select screen glow the primary score's row in the class accent. Both the label (`ui::primary_label`) and the accent (`ui::class_accent`, `ui::class_emblem`) are matched exhaustively over `Class`, so a new calling breaks the build instead of rendering with no attribute highlighted and a nameless "Adventurer" bust.
 
 ### Abilities and damage
 
@@ -859,6 +860,7 @@ Put DB/service orchestration tests that cannot stay pure in adjacent `_test.rs` 
 - `view.occupants` includes other players in the room regardless of class; service follow selection only allows classed targets in the same room.
 - Boon perks apply on room entry and can spam log lines if movement loops through boon rooms.
 - Hunted game cooldowns are not persisted across process restart.
+- **Four of the six ability scores are dead weight.** Nothing outside `stats.rs` reads STR/DEX/INT/WIS/CHA unless that score happens to be the class's `primary_score`: a Berserker's INT, a Mage's CHA, a Monk's STR all decide nothing. Only CON (`hp_bonus`, level-scaled, the one score that matters to everyone) and the primary score (`attack_bonus`, a flat modifier of at most +-4, which is a rounding error against a late-game attack curve plus gear) touch a number a player feels. Class selection still rolls all six and offers `r` to reroll, so the screen promises a build decision the game does not honour. Fixing it means either giving the other four real hooks (DEX to dodge/crit, INT/WIS to resource pool or regen, CHA to prices or taming, STR to carry weight or melee riders) or cutting the roll down to the scores that are real.
 - World content is authored as Rust data. A future data-file loader should preserve the existing `World`, `Room`, `MobSpawn`, `Feature`, and `CritterSpawn` shapes.
 - **The authored core cannot level a player through itself.** Its 31 spawns hold 6,276 xp in total (about Lv11) while the Archdemon at its end wants roughly Lv40 on bare class stats, so players are pushed into the ungated side countries to level and return over-levelled. The consequence is that the run up to the Obsidian Throne plays as trivial even though its trash is correctly tuned at ~1/3 of its boss, matching every other boss on that ladder. Fixing this means raising the core's xp budget (or its late trash), not re-tuning the boss: the Archdemon's damage was already lifted 48 -> 58 to match the ladder's own ~1.6x boss-to-trash damage ratio, which he alone was missing at 1.33x. See §7 for the whole shape.
 - **No quest content bridges Lv15-30, Lv35-52, or anything past Lv78**, and none of the five side countries has a single quest, despite Aelunor and Broceliande being the de facto route from the authored core to the Archdemon. Boards exist only in the three capitals and at the Kaelmyr ash-cairn. This is the emptiest part of the game for a new player and the most likely place to lose them.

--- a/late-ssh/src/app/door/lateania/THUNDERSMITH.md
+++ b/late-ssh/src/app/door/lateania/THUNDERSMITH.md
@@ -266,105 +266,58 @@ Cheap where it counts, reusing existing patterns (all verified present):
 - Whether probe results are account-wide or per character (per character
   proposed; the ledger is the character's story).
 
-## 13. Handoff brief: the world resist/weak pass
+## 13. The world resist/weak pass (landed)
 
-A companion change, run as its own piece of work (own session, own review). This
-design works without it (the cell economy carries the class) and gets better
-with it. Everything below is code-verified as of 2026-08-20.
+Formerly a full handoff brief; the pass shipped 2026-08-20, together with the
+weapon oils (promoted from follow-up once it was clear placement alone left
+the seven Physical-locked classes a mathematically zero matchup game). **The
+spec now lives in `CONTEXT.md`, section "The world resist/weak pass"**: theme
+vocabulary and tables, the two Physical rules, census bands, the routed
+grind-rate budget, and the tests that are the contract. This section keeps
+only what it means for this class.
 
-### Why
+### What the Thundersmith inherits
 
-The recon fantasy is only as rich as the world's profile data, and today most of
-the Lv30-60 band has nothing to learn: every generated region's regulars are
-`(None, None)` (Frontier, Reaches, Kaelmyr, archipelago, lakes, Broceliande,
-Aelunor's 100 creatures). Only ~116 authored spawns vary. Meanwhile resist/weak
-already applies to all ability damage, so a placement pass hands *every* class a
-school game, not just the Thundersmith.
+- **Real ledger data everywhere.** 126 themed zones; one profile per zone for
+  regulars is now test-enforced, so the zone-keyed Ledger (§5) can never be
+  wrong about a regular. Bosses keep authored profiles, so the ledger
+  rightly does not cover them: the §4 recon dance survives exclusively for
+  bosses, exactly where it should activate.
+- **The monopoly is fenced in code.** Oils are flat riders, never a
+  conversion of the auto's school, never a multiplier on `attack()`; both
+  levers remain reserved for the cells. Everyone else plays matchups now
+  (casters: rotations; martials: oils and geography); his edge stays
+  legible as degree, not kind.
+- **Boss walls are his signature moment by contract.** Physical resist now
+  exists only on bosses, everywhere - the one wall the gun uniquely walks
+  through.
+- **The seven-cell rack is his exclusive reach** (proposed): oils cover four
+  schools deliberately; Shadow/Arcane/Poison zone weaknesses (22/18/13
+  zones) have no martial answer. Cells covering all seven schools makes
+  "he industrializes matchups" a capability gap, not just a number gap.
 
-### Locked decision: resist/weak is per zone
+### Re-price at ship time
 
-One profile per zone for regulars, derived from the zone's theme (the Frontier's
-20 zones already carry strong themes: the Ashen Wastes resist Fire and fear
-Frost, and so on). Bosses and marked elites may deviate from their zone.
+The pass moved numbers this doc still states pre-pass:
 
-Rationale: this matches how the world data already works (the three dungeons and
-three Wildbound biomes are exactly one profile per zone, and it plays fine), it
-aligns with the Thundersmith's zone-keyed Ledger, and it keeps the whole pass
-tunable as a small table instead of 400+ per-species rows.
-
-### Verified facts the brief inherits
-
-- **Everyone is an auto-attacker.** At band gear (Lv45, ~+100 attack), every
-  class including the Mage is ~75% auto damage; autos ride `attack()` and gear,
-  ability magnitudes are flat constants. "Melee vs caster" here is trait and
-  roster, not the basic attack. Nobody's school lever rides the dominant source.
-- **Flat riders decay by construction.** The existing weapon poison is
-  `POISON_PER_TICK = [4, 8, 14, 22, 34]`: flat, capped, ~10% of output at Lv45,
-  ~5% at endgame. Anything built on this pattern cannot compound with gear.
-- **Current school census (116 authored profiles):** expected multipliers Holy
-  1.140, Fire 1.057, Lightning 1.031, Arcane 1.013, Frost 0.974, Physical 0.934,
-  Shadow 0.921. Nothing resists Arcane. Nothing is weak to Physical. Holy has
-  zero resists anywhere.
-- **Resist halves, weak adds 50%, one of each per mob, minimum damage 1.** The
-  engine multipliers are fixed and stay fixed.
-
-### Design rules
-
-1. **Weak-forward on regulars.** Every zone gets a theme weakness; weaknesses
-   reward the right answer and are fun. Resists on regulars are rare, roughly a
-   third of zones at most; walls are only fun when they are events.
-2. **No Physical resist on regular mobs, ever.** Zone-wide Physical resist is a
-   50% tax on the seven Physical-locked classes with zero counterplay. Physical
-   resist lives on bosses and marked elites only, where it reads as "bring a
-   caster, an oil, or the smith" (Aelunor's bosses already do this and it plays
-   fine).
-3. **Nothing is ever weak to Physical.** Preserves the current 0/116 reality and
-   the Thundersmith's scrap-floor economics.
-4. **Holy gets predators.** Add Holy-resist zones (demonic, hallowed-corrupt
-   themes) or Cleric/Paladin quietly become the school winners. Counterpoint to
-   weigh deliberately: those are two of the weakest classes today, so a couple
-   of Holy-weak lanes could be an intentional buff. Decide on purpose, not by
-   accident.
-5. **Oils are the martial lever, and they are flat riders only.** Elemental oils
-   (fire, frost, holy, ...) via Alchemy, literally the `weapon_poison` code path
-   with a school parameter: a flat, charge-limited DoT/rider *added* to the
-   Physical auto. Never a conversion of the auto's school, never a multiplier on
-   `attack()`; both are the Thundersmith's monopoly and the line that keeps the
-   pass from breaking the game. An oil at x1.5 in the right zone is ~+5% total
-   damage: a decision lever, not a power lever.
-
-### Expected net effect (the balance argument)
-
-- Weakness zones only touch school damage; autos are Physical and nothing is
-  weak to Physical, so a matchup zone gives a caster +50% on the ~25% ability
-  slice (~+12% total) and a martial's autos nothing. The pass is a small
-  situational caster buff.
-- Physical-resist bosses tax whoever leans hardest on Physical: a Warrior's kit
-  is ~90% Physical, a Mage's ~75%. Both hurt, the martial more, exactly at the
-  fights where composition and prep should matter.
-- Baselines do not move: the neutral case (auto, Physical, unthemed foe) is
-  untouched by construction.
-
-### Don't-break-the-game protocol
-
-1. **Data-only.** No engine changes: same `DamageProfile`, same 50/150
-   multipliers, one resist + one weak per mob. The whole pass is placement in
-   the builders, reviewable as a diff of themed assignments.
-2. **Invariants as tests**, in the codebase's existing balance-test style (cf.
-   `no_beast_is_out_classed_by_an_easier_one`): no Physical resist on regulars,
-   every zone weakness derivable from its theme table, per-school resist/weak
-   counts within declared bands so Holy cannot silently stay predator-free.
-3. **A before/after sim budget.** Run a per-class grind-rate model across every
-   zone. Within a zone, matchups may swing a class up to ±15%; each class's
-   *average* across the band must stay within a few percent of today.
-   Redistribution yes, rebalancing no. A class whose average moves past the
-   budget means the placement is wrong, not the class.
-
-### What the Thundersmith gets out of it
-
-Real ledger data everywhere: every zone becomes probeable, auto-chamber fires on
-real information across the whole band, and the counter-cell lines earn their
-crafting cost. The pass also gives every other class its own smaller school
-game (casters: situational rotations; martials: oils and geography), which keeps
-the Thundersmith's edge legible as *degree*, not *kind*: everyone plays
-matchups, he industrializes them.
+- **Top-state uptime.** §9's "known weakness chambered" (+15-20%) was
+  priced against a mostly-neutral world; now every zone has a weakness and
+  auto-chamber makes it the default in known land. Re-run the sim; if the
+  fueled edge lands high, the doc's own levers apply (tier-5 multiplier or
+  shots-per-cell, never the frame).
+- **The bar moved.** The Ranger benchmark (382/tick) predates oils; an
+  oiled Ranger in a matched zone is ~+6.5%. Re-anchor §9 against the oiled
+  Ranger or the stated gap silently shrinks by a third.
+- **§3's census paragraph is stale** (Physical 4th by resist count at
+  15/116): the world is now ~5,000 profiled regulars and boss-only Physical
+  resists. The "every Aelunor boss resists Physical" line still holds.
+- **§11's cost map** says the loaded cell reuses the `weapon_poison`
+  pattern; that field is now the one-slot `weapon_coat`, and the cell must
+  be a *separate* transient - a coat legitimately rides on top of a cell
+  shot (flat rider + multiplied shot, each in its lane).
+- **Extend the routed sim, don't exempt him.** Add a Thundersmith row where
+  "routed" means fueled-and-informed and assert his band explicitly:
+  prepared edge inside the §9 targets, dry state pinned to the bottom
+  third, no state that reaches the top row without per-fight spend. The
+  contract - OP only if prepared - becomes an assertion that fails the
+  build, not a sentence in this doc.

--- a/late-ssh/src/app/door/lateania/THUNDERSMITH.md
+++ b/late-ssh/src/app/door/lateania/THUNDERSMITH.md
@@ -87,11 +87,12 @@ the gear curve instead, so tier-5 cells matter as much at the top as in the band
   the glass countries) against 6 Storm-zone resists. The brand school is
   also the best default cell, which keeps storm affinity honest.
 - **The rack covers all seven non-Physical schools, and that is the point.**
-  Oils deliberately cover four (fire/frost/holy/lightning); the Shadow,
-  Arcane, and Poison lanes (22/18/13 themed zones) have no martial answer
-  but his. His counter-lines are also multipliers where oils are flat
-  riders. Together that is the capability gap that makes "everyone plays
-  matchups, he industrializes them" literal rather than rhetorical.
+  Oils deliberately cover four (fire/frost/holy/lightning) and the poison
+  vial owns the fifth, which leaves **Shadow and Arcane** - 22 and 17 of the
+  126 themed zones, and every foe in them - with no martial answer but his.
+  His counter-lines are also multipliers where coats are flat riders.
+  Together that is the capability gap that makes "everyone plays matchups,
+  he industrializes them" literal rather than rhetorical.
 
 ## 4. The loop (provision, march, execute)
 
@@ -129,10 +130,12 @@ only pays where fights matter - and it is paid per bandolier, never once.
 Field notes, **keyed by zone, not by species** - and since the world pass
 this is the enforced data model, not a design bet: every generated zone's
 regulars share one `ZoneTheme` profile, guaranteed by
-`every_generated_regular_wears_its_zone_theme`. A zone key therefore
-captures every regular in the land. Bosses deliberately deviate and are
-**not** ledger rows: a crown is read the hard way, every character, every
-time.
+`every_generated_zone_spawn_wears_its_zone_theme`. A zone key therefore
+captures every regular in the land, and since the boss-weakness pass it
+captures the zone boss's weakness too (same test: a zone boss wears the
+theme's weak and no resist). The **authored crowns** are the deliberate
+deviation and are **not** ledger rows: a crown is read the hard way, every
+character, every time.
 
 Given that the battle panel already reads a targeted foe's profile aloud,
 what the ledger buys is **distance**: mid-fight everyone knows; only he
@@ -311,8 +314,8 @@ Cheap where it counts, reusing existing patterns (all verified present):
 - Whether ledger entries are account-wide or per character (per character
   proposed; the ledger is the character's story).
 - Whether the counter-rack ships all six lines at once, or the
-  Shadow/Arcane/Poison lines (the lanes no oil covers) unlock deeper in the
-  Smithing climb - staging his exclusivity as a late reward.
+  Shadow/Arcane lines (the two lanes no coat covers at all) unlock deeper
+  in the Smithing climb - staging his exclusivity as a late reward.
 - Fueled uptime: with every zone weak to something, the top state is the
   default in read land. If the sim says that runs hot, shots-per-cell is
   the dial that prices uptime without touching the per-shot feel.
@@ -342,8 +345,8 @@ model in §5, the oiled bar and uptime caveats in §9, the coat exclusion in
   zone bosses inherit their zone's weak lane, authored crowns carry
   bespoke ones. For him that means the rack always has a boss answer -
   there is no fight in the game where a chambered counter-cell reads
-  "nothing", and the Shadow/Arcane/Poison boss lanes are answerable by
-  casters and him alone (oils cover only fire/frost/holy/lightning).
+  "nothing", and the Shadow and Arcane boss lanes are answerable by casters
+  and him alone (the coat rack reaches the other five schools, not those).
 - **Boss walls are his signature moment by contract - but never a group
   tax.** Physical resist exists on exactly 14 bosses and zero regulars,
   everywhere, test-enforced, and every one of those bosses guards an

--- a/late-ssh/src/app/door/lateania/THUNDERSMITH.md
+++ b/late-ssh/src/app/door/lateania/THUNDERSMITH.md
@@ -1,9 +1,11 @@
 # The Thundersmith, a class design
 
-Status: design only, not implemented. Drafted 2026-08-06; revised 2026-08-20 after
-a code-verified balance pass. Every engine claim below was re-checked against
-source; the benchmark class is now the Ranger (not the Rogue), measured at the
-Lv30-60 band where the game is actually played, not at L100.
+Status: design only, not implemented. Drafted 2026-08-06; revised 2026-08-20
+twice: after a code-verified balance pass, and again the same day after the
+world resist/weak pass and the weapon oils landed (spec: `CONTEXT.md`, "The
+world resist/weak pass"). Every engine claim below reflects the landed world;
+the benchmark class is the Ranger (not the Rogue), measured at the Lv30-60
+band where the game is actually played, not at L100.
 
 *A bulky master smith with a storm-cell scattergun. He is not stronger than you.
 He is prepared, and that's worse.*
@@ -28,8 +30,9 @@ it is never a one-time unlock. If preparation can be paid once and forgotten, th
 design has failed.
 
 Not locked. The class is available at class select like any other. Access is free,
-power is gated: being good costs Smithing ~50, materials, and a survived recon
-fight per zone. An unlock gate on top adds annoyance, not depth.
+power is gated: being good costs Smithing ~50, materials, and a survived first
+walk of every land he wants in the ledger. An unlock gate on top adds
+annoyance, not depth.
 
 ## 2. Frame
 
@@ -64,7 +67,7 @@ the gear curve instead, so tier-5 cells matter as much at the top as in the band
 |---|---|---|---|
 | Scrap shot | Physical | **x0.90** | unlimited, free; the never-empty floor |
 | Storm-cells t1-t5 (signature) | Lightning | x1.10 / x1.15 / x1.20 / x1.27 / **x1.35** | crafted |
-| Counter-cells (ember / frost / holy / ...) | one line per school | one notch below the same tier's storm | crafted |
+| Counter-cells (ember / rime / blessed / gloom / rune / venom) | one line per remaining school | one notch below the same tier's storm | crafted |
 
 - Cells are consumed per shot. Combat runs one auto per 2s tick, so a 20-shot
   cell is ~40 seconds of fighting; cells therefore craft in **bandoliers**
@@ -72,48 +75,71 @@ the gear curve instead, so tier-5 cells matter as much at the top as in the band
 - Tier-5 cells require Smithing ~50 and masterwork-grade materials. This is the
   power ceiling and the crafting system's endgame consumer.
 - Scrap keeps the dry state playable but honest, and it stings twice: x0.90 on
-  the multiplier, and Physical is the worst-expectation school in the game.
-  Corrected census (116 authored profiles): Physical is 4th by resist count
-  (Frost 23, Shadow 19, Fire 18, Physical 15) but **nothing in the world is weak
-  to it** (0 of 116), giving it the near-worst expected multiplier (0.934).
-  Notably, every Aelunor boss resists Physical: an entire continent already
-  punishes the unprepared shot.
-- Why lightning as the brand holds up: resisted by 2 profiles, a weakness on 9,
-  expected multiplier 1.031, behind only Holy (1.140) and Fire (1.057). Nothing
-  resists Arcane (0 of 116), but nothing meaningfully seeks it either (weak on 3).
+  the multiplier, and Physical is the only school the world never rewards.
+  Post-pass census (test-enforced, no drift possible): nothing anywhere is
+  weak to Physical, no regular anywhere resists it, and Physical resist
+  lives on exactly 14 bosses (the Elder Treant - the game's first crown -
+  the Fallen Paladin, and Aelunor's twelve). So scrap is safe on trash but
+  worst-in-class everywhere: it misses the weakness every one of the 126
+  themed zones now carries, and it halves against the walls that matter.
+- Why lightning as the brand holds up, post-pass: Lightning is the widest
+  weak lane in the world (25 of 126 themed zones - the coasts, the lakes,
+  the glass countries) against 6 Storm-zone resists. The brand school is
+  also the best default cell, which keeps storm affinity honest.
+- **The rack covers all seven non-Physical schools, and that is the point.**
+  Oils deliberately cover four (fire/frost/holy/lightning); the Shadow,
+  Arcane, and Poison lanes (22/18/13 themed zones) have no martial answer
+  but his. His counter-lines are also multipliers where oils are flat
+  riders. Together that is the capability gap that makes "everyone plays
+  matchups, he industrializes them" literal rather than rhetorical.
 
-## 4. The loop (recon fights)
+## 4. The loop (provision, march, execute)
 
-No free information. A mob's resist/weak profile is never shown up front (true for
-everyone; the engine only reveals it via the post-hit `defense_tag` log line).
-The Thundersmith's edge is that he can *act* on what he learns.
+A correction from the landed world: **information is not the scarce good.**
+The battle panel reads a targeted foe's school/weak/resist out loud for
+everyone (`MobView.weak/resist`, both layouts), and every regular in a zone
+shares the zone theme. The original "no free information" probe dance is
+dead as designed. What stays scarce is the *answer*: having the right line
+crafted, carried, and chambered. The loop is provisioning, not spying.
 
-1. **Probe.** Each school fired reveals its result (weak / resisted / neutral),
-   reusing the existing tag machinery. Every probe round is a real combat round;
-   recon costs HP and shells. Sharp players binary-search schools; sloppy ones
-   empty a bandolier.
-2. **Fighting retreat.** Signature utility ability: a concussion blast that stuns
-   and withdraws cleanly (unlike flee's uncontrolled first-exit). Probe damage
-   persists on the mob (shared-world HP), so the return pass faces a dented foe.
-3. **Re-arm.** Swapping loaded cells from the carried bandolier is an
-   out-of-combat action, doable at the boss door. Crafting *new* cells requires a
-   craft station (forge in Embergate), so expeditions are provisioned in advance.
-4. **Execute.** Return, auto-chamber (below), shred.
+1. **Read the land.** The first engage in a new zone writes it into the
+   ledger. Mid-fight the traits line tells anyone; only the ledger remembers
+   it at the forge, forever. Walking a land once is still a real cost - a
+   survived trip, not a wiki lookup.
+2. **Provision.** Crafting new cells requires a craft station (forge in
+   Embergate), so expeditions are provisioned in advance. The ledger is the
+   shopping list: bandolier composition against the route ahead is the skill
+   expression. Swapping loaded cells from the carried bandolier stays an
+   out-of-combat action, doable at the boss door.
+3. **Fighting retreat.** Signature utility ability: a concussion blast that
+   stuns and withdraws cleanly (unlike flee's uncontrolled first-exit).
+   Dealt damage persists (shared-world HP), so the return pass faces a
+   dented foe. This is now chiefly the tool for **authored crowns**: since
+   the boss-weakness pass, a generated zone boss wears its zone's weakness
+   (the ledger already knows it), but the hand-authored crowns keep bespoke
+   profiles and hit hardest, so the first pull on one is still a read paid
+   in HP.
+4. **Execute.** Auto-chamber (below), shred.
 
-The loop self-balances: trash dies to anything, so the recon dance only activates
-on fights that matter.
+The loop self-balances: trash dies to anything, so provisioning discipline
+only pays where fights matter - and it is paid per bandolier, never once.
 
 ## 5. The Ledger
 
-Field notes, **keyed by zone, not by species.** Verified data model: resist/weak
-is per-zone in practice. Every generated region's regulars carry no profile at
-all (Frontier, Reaches, Kaelmyr, archipelago, lakes, Broceliande, Aelunor's 100
-creatures), the three dungeons and the three Wildbound biomes carry exactly one
-profile per zone, and only ~116 authored spawns vary individually. A per-species
-ledger over 426 regular foes would be almost entirely duplicate rows (the same
-clutter wall that got per-species titles removed); a zone-keyed ledger makes the
-first probe in a place a real "you've read this land" moment and shrinks the
-schema bump to a small persisted set of zone keys.
+Field notes, **keyed by zone, not by species** - and since the world pass
+this is the enforced data model, not a design bet: every generated zone's
+regulars share one `ZoneTheme` profile, guaranteed by
+`every_generated_regular_wears_its_zone_theme`. A zone key therefore
+captures every regular in the land. Bosses deliberately deviate and are
+**not** ledger rows: a crown is read the hard way, every character, every
+time.
+
+Given that the battle panel already reads a targeted foe's profile aloud,
+what the ledger buys is **distance**: mid-fight everyone knows; only he
+knows at the forge, before the march, with zero keypresses at the door. The
+ledger is §4's provisioning input and the auto-chamber key, not secret
+knowledge. Persisted as a small set of zone keys - still the only schema
+bump.
 
 **Auto-chamber (QoL):** on engage, if the zone is in the ledger and the
 counter-school is carried, it loads itself with one log line ("You know this
@@ -211,10 +237,23 @@ comparison.
 | Scrap shot (dry) | 280-300 | bottom three |
 
 The spread is the design contract: unambiguous #1 while fueled and informed,
-Druid's neighborhood while dry. Re-verify the same table at Lv55 before shipping;
-the multipliers are level-independent by construction, so drift there means a
-frame or roster bug, not a cell bug. If the fueled number lands above +25%,
-tighten the tier-5 multiplier or shots-per-cell, not the frame.
+Druid's neighborhood while dry.
+
+Two post-pass caveats on this table, both re-verified at ship time:
+
+- **The bar is now the oiled Ranger.** The 382 figure predates the oils; a
+  matched oil is worth ~+6.5%, so in exactly the zones where prepared
+  players live the bar is ~405. The stated gaps must hold against that, or
+  they silently shrink by a third.
+- **The top row's uptime is now standard, not a spike.** Every zone carries
+  a weakness and auto-chamber loads it in known land, so "known weakness
+  chambered" is his *sustained* state wherever the ledger reaches. Judge
+  the +15-20% ceiling as an hourly rate, not a lucky matchup.
+
+Re-verify the same table at Lv45 and Lv55 before shipping; the multipliers
+are level-independent by construction, so drift there means a frame or
+roster bug, not a cell bug. If the fueled number lands above +25%, tighten
+the tier-5 multiplier or shots-per-cell, not the frame.
 
 ## 10. Costs, as rates
 
@@ -226,7 +265,7 @@ Every cost is a recurring rate, never a one-time gate. Smithing ~50 is the
 | Smithing ~50 + masterwork materials | access to tier-5 cells, the ceiling |
 | Tier 2-3 upkeep | target ~10-15 min of gathering/smithing per hour of fueled combat |
 | Tier-5 upkeep | steep by design; rationed for bosses, not for grinding |
-| The recon fight, per zone | survive learning each land the hard way |
+| The first walk, per zone | survive reaching each land once to ledger it |
 | PvP | pure burn, no Scrapwright rebate |
 
 Scrapwright turns skill into margin: clean trash play runs a ~20% shell rebate,
@@ -237,8 +276,14 @@ dividend on knowledge.
 
 Cheap where it counts, reusing existing patterns (all verified present):
 
-- Loaded ammo: the `weapon_poison` transient pattern (`Some((school, mult_pct, shots)`-shaped),
-  no save state for the chambered cell; bandolier contents are inventory items.
+- Loaded ammo: its own transient field in the `weapon_coat` mold
+  (`Some((school, mult_pct, shots))`), separate from `weapon_coat` itself -
+  but **the gun never holds a coat**: using a poison or oil as a
+  Thundersmith is refused ("the shardgun's heat would cook it off").
+  Stacking a matched oil rider on top of a matched cell shot was too much
+  buff on the one class that needs none; oils stay the mundane martial's
+  lever, cells stay his, and the two never combine. No save state for the
+  chambered cell; bandolier contents are inventory items.
 - Cell application: the two auto-attack call sites (the combat round's mob strike
   and the pvp strike) swap `DamageType::Physical` for the chambered school and
   scale `attack()` by the cell's percent. Two call sites, one helper.
@@ -263,61 +308,59 @@ Cheap where it counts, reusing existing patterns (all verified present):
   notch-below rule.
 - Doorway advantage: one denied strike, or two vs non-boss. First nerf lever.
 - Scrapwright refund rate (1 shell per mob kill proposed, ~20% rebate).
-- Whether probe results are account-wide or per character (per character
+- Whether ledger entries are account-wide or per character (per character
   proposed; the ledger is the character's story).
+- Whether the counter-rack ships all six lines at once, or the
+  Shadow/Arcane/Poison lines (the lanes no oil covers) unlock deeper in the
+  Smithing climb - staging his exclusivity as a late reward.
+- Fueled uptime: with every zone weak to something, the top state is the
+  default in read land. If the sim says that runs hot, shots-per-cell is
+  the dial that prices uptime without touching the per-shot feel.
 
 ## 13. The world resist/weak pass (landed)
 
 Formerly a full handoff brief; the pass shipped 2026-08-20, together with the
 weapon oils (promoted from follow-up once it was clear placement alone left
 the seven Physical-locked classes a mathematically zero matchup game). **The
-spec now lives in `CONTEXT.md`, section "The world resist/weak pass"**: theme
+spec lives in `CONTEXT.md`, section "The world resist/weak pass"**: theme
 vocabulary and tables, the two Physical rules, census bands, the routed
-grind-rate budget, and the tests that are the contract. This section keeps
-only what it means for this class.
+grind-rate budget, and the tests that are the contract. Its consequences for
+this class are folded into the sections above (the census and the
+seven-school rack in §3, the provisioning loop in §4, the guaranteed ledger
+model in §5, the oiled bar and uptime caveats in §9, the coat exclusion in
+§11, the new knobs in §12). What remains here:
 
-### What the Thundersmith inherits
+### What the class inherits
 
-- **Real ledger data everywhere.** 126 themed zones; one profile per zone for
-  regulars is now test-enforced, so the zone-keyed Ledger (§5) can never be
-  wrong about a regular. Bosses keep authored profiles, so the ledger
-  rightly does not cover them: the §4 recon dance survives exclusively for
-  bosses, exactly where it should activate.
-- **The monopoly is fenced in code.** Oils are flat riders, never a
-  conversion of the auto's school, never a multiplier on `attack()`; both
-  levers remain reserved for the cells. Everyone else plays matchups now
-  (casters: rotations; martials: oils and geography); his edge stays
-  legible as degree, not kind.
-- **Boss walls are his signature moment by contract.** Physical resist now
-  exists only on bosses, everywhere - the one wall the gun uniquely walks
-  through.
-- **The seven-cell rack is his exclusive reach** (proposed): oils cover four
-  schools deliberately; Shadow/Arcane/Poison zone weaknesses (22/18/13
-  zones) have no martial answer. Cells covering all seven schools makes
-  "he industrializes matchups" a capability gap, not just a number gap.
+- **The monopoly is fenced in code, and the fence runs both ways.** Oils
+  are flat riders, never a conversion of the auto's school, never a
+  multiplier on `attack()`; both levers remain reserved for the cells. In
+  exchange he is the one class that cannot coat a weapon at all (§11).
+  Everyone else plays matchups now; his edge stays legible as degree, not
+  kind.
+- **Every boss carries a weakness** (`every_boss_carries_a_weakness`):
+  zone bosses inherit their zone's weak lane, authored crowns carry
+  bespoke ones. For him that means the rack always has a boss answer -
+  there is no fight in the game where a chambered counter-cell reads
+  "nothing", and the Shadow/Arcane/Poison boss lanes are answerable by
+  casters and him alone (oils cover only fire/frost/holy/lightning).
+- **Boss walls are his signature moment by contract - but never a group
+  tax.** Physical resist exists on exactly 14 bosses and zero regulars,
+  everywhere, test-enforced, and every one of those bosses guards an
+  optional prize or sits at the low band where a tier-0 oil already answers
+  the fight (the solo rule in CONTEXT.md, pinned by
+  `physical_walls_never_gate_the_long_road_past_the_treant`). An oiled
+  martial always clears the wall - slower, roughly two-thirds pace - so
+  the Thundersmith's edge here is comfort and speed, not access. Do not
+  "improve" his signature by adding Physical resists to road crowns.
 
-### Re-price at ship time
+### Verify at ship time
 
-The pass moved numbers this doc still states pre-pass:
-
-- **Top-state uptime.** §9's "known weakness chambered" (+15-20%) was
-  priced against a mostly-neutral world; now every zone has a weakness and
-  auto-chamber makes it the default in known land. Re-run the sim; if the
-  fueled edge lands high, the doc's own levers apply (tier-5 multiplier or
-  shots-per-cell, never the frame).
-- **The bar moved.** The Ranger benchmark (382/tick) predates oils; an
-  oiled Ranger in a matched zone is ~+6.5%. Re-anchor §9 against the oiled
-  Ranger or the stated gap silently shrinks by a third.
-- **§3's census paragraph is stale** (Physical 4th by resist count at
-  15/116): the world is now ~5,000 profiled regulars and boss-only Physical
-  resists. The "every Aelunor boss resists Physical" line still holds.
-- **§11's cost map** says the loaded cell reuses the `weapon_poison`
-  pattern; that field is now the one-slot `weapon_coat`, and the cell must
-  be a *separate* transient - a coat legitimately rides on top of a cell
-  shot (flat rider + multiplied shot, each in its lane).
-- **Extend the routed sim, don't exempt him.** Add a Thundersmith row where
-  "routed" means fueled-and-informed and assert his band explicitly:
-  prepared edge inside the §9 targets, dry state pinned to the bottom
-  third, no state that reaches the top row without per-fight spend. The
-  contract - OP only if prepared - becomes an assertion that fails the
-  build, not a sentence in this doc.
+- Re-run the §9 table at Lv45 and Lv55 with both §9 caveats applied (the
+  oiled-Ranger bar, top-row uptime as the sustained state). Levers if hot:
+  tier-5 multiplier, shots-per-cell, doorway advantage - never the frame.
+- Extend the routed world sim in `world_test.rs`, don't exempt him: add a
+  Thundersmith row where "routed" means fueled-and-informed, asserting the
+  prepared band inside the §9 targets, the dry state in the bottom third,
+  and no path to the top row without per-fight spend. The contract - OP
+  only if prepared - becomes an assertion that fails the build.

--- a/late-ssh/src/app/door/lateania/archipelago.rs
+++ b/late-ssh/src/app/door/lateania/archipelago.rs
@@ -55,8 +55,9 @@ pub const ARCH_SEED: u64 = 0x15_1A9D_5EED_u64;
 pub const ISLAND_COUNT: usize = ISLANDS.len();
 
 /// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
-/// island, in `ISLANDS` order. Regulars inherit the theme's profile; island
-/// bosses keep their own.
+/// island, in `ISLANDS` order. Regulars inherit the theme's profile; the
+/// island boss wears the theme's weakness but never its resist (prep is a
+/// pure reward on the fight players provision for).
 pub const ISLAND_THEMES: [ZoneTheme; ISLAND_COUNT] = [
     ZoneTheme::Crystal,   // Isle of Glass Sands
     ZoneTheme::Tidal,     // Coral Crown Atoll

--- a/late-ssh/src/app/door/lateania/archipelago.rs
+++ b/late-ssh/src/app/door/lateania/archipelago.rs
@@ -13,6 +13,7 @@
 // generation lives in `world.rs` (`extend_villages` / `extend_archipelago`), and
 // the portal fast-travel action lives in `svc.rs`.
 
+use super::damage::ZoneTheme;
 use super::world::RoomId;
 
 /// First room id of the villages block. One room per village.
@@ -52,6 +53,32 @@ pub const ARCH_SEED: u64 = 0x15_1A9D_5EED_u64;
 
 /// The number of islands.
 pub const ISLAND_COUNT: usize = ISLANDS.len();
+
+/// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
+/// island, in `ISLANDS` order. Regulars inherit the theme's profile; island
+/// bosses keep their own.
+pub const ISLAND_THEMES: [ZoneTheme; ISLAND_COUNT] = [
+    ZoneTheme::Crystal,   // Isle of Glass Sands
+    ZoneTheme::Tidal,     // Coral Crown Atoll
+    ZoneTheme::Ashen,     // Ashfall Cinderisle
+    ZoneTheme::Fae,       // Whispering Fenholm
+    ZoneTheme::Frozen,    // Frostspar Skerries
+    ZoneTheme::Verdant,   // Thornweald Isle
+    ZoneTheme::Haunted,   // Sunken Vault Isle
+    ZoneTheme::Storm,     // Stormglass Reach
+    ZoneTheme::Undead,    // Bonewhite Atoll
+    ZoneTheme::Verdant,   // Verdant Ruin Isle
+    ZoneTheme::Fae,       // Mirrorlake Isle
+    ZoneTheme::Crystal,   // Saltspire Pillars
+    ZoneTheme::Beastwild, // Duskmoth Grove
+    ZoneTheme::Crystal,   // Rustwrack Shoals
+    ZoneTheme::Resonant,  // Windsong Cliffs
+    ZoneTheme::Drowned,   // Gloomtide Trench
+    ZoneTheme::Beastwild, // Amberglow Isle
+    ZoneTheme::Fae,       // Starfall Crater
+    ZoneTheme::Storm,     // Tempest Eye Isle
+    ZoneTheme::Profane,   // Worldwound Isle
+];
 
 /// One island: (name, adjective, ground, landmark, creatures, three mob names,
 /// boss). Prose is composed by `world.rs`. Each has unique scenery.

--- a/late-ssh/src/app/door/lateania/crafting.rs
+++ b/late-ssh/src/app/door/lateania/crafting.rs
@@ -12,7 +12,7 @@
 use std::sync::OnceLock;
 
 use super::items::{
-    food_id, ingot_id, leather_armor_id, leather_id, masterwork_id, material_id, plank_id,
+    food_id, ingot_id, leather_armor_id, leather_id, masterwork_id, material_id, oil_id, plank_id,
     poison_id, potion_id, smith_armor_id, smith_weapon_id, wood_weapon_id,
 };
 use super::skills::CraftSkill;
@@ -153,6 +153,43 @@ fn build_recipes() -> Vec<Recipe> {
             level_req: gate,
             xp: craft,
             inputs: vec![ing(herb(t), 3)],
+        });
+
+        // ---- Alchemy: the four weapon oils (the martial lever of the
+        // world resist/weak pass). Each family's second ingredient ties its
+        // school to a gathering trade: ore for fire, deep fish for frost,
+        // timber resin for lightning; the blessed oil is pure herbcraft.
+        r.push(Recipe {
+            output: oil_id(0, t),
+            output_qty: 1,
+            skill: Alchemy,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(herb(t), 2), ing(ore(t), 1)],
+        });
+        r.push(Recipe {
+            output: oil_id(1, t),
+            output_qty: 1,
+            skill: Alchemy,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(herb(t), 2), ing(fish(t), 1)],
+        });
+        r.push(Recipe {
+            output: oil_id(2, t),
+            output_qty: 1,
+            skill: Alchemy,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(herb(t), 4)],
+        });
+        r.push(Recipe {
+            output: oil_id(3, t),
+            output_qty: 1,
+            skill: Alchemy,
+            level_req: gate,
+            xp: craft,
+            inputs: vec![ing(herb(t), 2), ing(log(t), 1)],
         });
 
         // ---- Cooking: a restorative meal --------------------------------

--- a/late-ssh/src/app/door/lateania/crafting.rs
+++ b/late-ssh/src/app/door/lateania/crafting.rs
@@ -146,13 +146,17 @@ fn build_recipes() -> Vec<Recipe> {
             xp: craft,
             inputs: vec![ing(herb(t), 2)],
         });
+        // Two herbs against the oils' three items: the poison is the budget
+        // coat, buying about three quarters of an oil's damage for two thirds
+        // of the materials, in a burst shape and in the one school no oil
+        // covers. Cheaper, shorter, sharper - not simply worse.
         r.push(Recipe {
             output: poison_id(t),
             output_qty: 1,
             skill: Alchemy,
             level_req: gate,
             xp: craft,
-            inputs: vec![ing(herb(t), 3)],
+            inputs: vec![ing(herb(t), 2)],
         });
 
         // ---- Alchemy: the four weapon oils (the martial lever of the

--- a/late-ssh/src/app/door/lateania/crafting_test.rs
+++ b/late-ssh/src/app/door/lateania/crafting_test.rs
@@ -41,9 +41,9 @@ fn every_craft_skill_has_recipes_and_indices_are_stable() {
             );
         }
     }
-    // 10 recipes per tier x 6 tiers (Wildbound added the sixth), plus two
-    // masterwork sinks.
-    assert_eq!(recipes().len(), 62);
+    // 14 recipes per tier x 6 tiers (Wildbound added the sixth tier, the
+    // world resist/weak pass the four weapon oils), plus two masterwork sinks.
+    assert_eq!(recipes().len(), 86);
 }
 
 #[test]

--- a/late-ssh/src/app/door/lateania/damage.rs
+++ b/late-ssh/src/app/door/lateania/damage.rs
@@ -67,6 +67,118 @@ impl Defense {
     }
 }
 
+/// The themed vocabulary of the world resist/weak pass (THUNDERSMITH.md
+/// section 13). Every generated zone names one theme, and the zone's regular
+/// mobs inherit the theme's profile; bosses keep their own. The set is closed
+/// and the mapping exhaustive, so the whole pass is auditable as data: a theme
+/// can never place Physical in either slot (a zone-wide Physical resist would
+/// tax the seven Physical-locked classes with no counterplay, and nothing is
+/// ever weak to Physical), it always carries a weakness (weak-forward: the
+/// right school is a reward, walls are events), and resists exist on a
+/// minority of themes only.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ZoneTheme {
+    /// Burnt, magma-born country: shrugs off Fire, fears Frost.
+    Ashen,
+    /// Sun-cracked heat without the fire-born flesh: fears Frost.
+    Sunscorched,
+    /// Ice-locked country: shrugs off Frost, fears Fire.
+    Frozen,
+    /// Green, growing, burnable country: fears Fire.
+    Verdant,
+    /// Open water and wet ground, a conductor: fears Lightning.
+    Tidal,
+    /// The cold drowned deep: shrugs off Frost, fears Lightning.
+    Drowned,
+    /// Storm-born country: shrugs off Lightning, unravels to Arcane.
+    Storm,
+    /// Song, echo, and standing wards: unravels to Arcane.
+    Resonant,
+    /// The walking dead: shrug off Shadow, wither under Holy.
+    Undead,
+    /// Ghosts and hauntings without barrow-flesh: wither under Holy.
+    Haunted,
+    /// God-cults and the profaned divine: shrug off Holy, fear Shadow.
+    Profane,
+    /// Glamour and fae light: the dark undoes it, fears Shadow.
+    Fae,
+    /// Living beasts and vermin: flesh that poison kills, fears Poison.
+    Beastwild,
+    /// Spore, rot, and venom: shrugs off Poison, burns well, fears Fire.
+    Fungal,
+    /// Bloodless made things: shrug off Poison, overload under Lightning.
+    Construct,
+    /// Glass, shard, and crystal: shatters under Lightning.
+    Crystal,
+}
+
+impl ZoneTheme {
+    /// The school this theme's regulars resist, if any. Never Physical.
+    pub const fn resist(self) -> Option<DamageType> {
+        match self {
+            Self::Ashen => Some(DamageType::Fire),
+            Self::Sunscorched => None,
+            Self::Frozen => Some(DamageType::Frost),
+            Self::Verdant => None,
+            Self::Tidal => None,
+            Self::Drowned => Some(DamageType::Frost),
+            Self::Storm => Some(DamageType::Lightning),
+            Self::Resonant => None,
+            Self::Undead => Some(DamageType::Shadow),
+            Self::Haunted => None,
+            Self::Profane => Some(DamageType::Holy),
+            Self::Fae => None,
+            Self::Beastwild => None,
+            Self::Fungal => Some(DamageType::Poison),
+            Self::Construct => Some(DamageType::Poison),
+            Self::Crystal => None,
+        }
+    }
+
+    /// The school this theme's regulars are weak to. Always present
+    /// (weak-forward), never Physical.
+    pub const fn weak(self) -> Option<DamageType> {
+        match self {
+            Self::Ashen => Some(DamageType::Frost),
+            Self::Sunscorched => Some(DamageType::Frost),
+            Self::Frozen => Some(DamageType::Fire),
+            Self::Verdant => Some(DamageType::Fire),
+            Self::Tidal => Some(DamageType::Lightning),
+            Self::Drowned => Some(DamageType::Lightning),
+            Self::Storm => Some(DamageType::Arcane),
+            Self::Resonant => Some(DamageType::Arcane),
+            Self::Undead => Some(DamageType::Holy),
+            Self::Haunted => Some(DamageType::Holy),
+            Self::Profane => Some(DamageType::Shadow),
+            Self::Fae => Some(DamageType::Shadow),
+            Self::Beastwild => Some(DamageType::Poison),
+            Self::Fungal => Some(DamageType::Fire),
+            Self::Construct => Some(DamageType::Lightning),
+            Self::Crystal => Some(DamageType::Lightning),
+        }
+    }
+
+    /// Every theme, for census tests over the vocabulary itself.
+    pub const ALL: [ZoneTheme; 16] = [
+        Self::Ashen,
+        Self::Sunscorched,
+        Self::Frozen,
+        Self::Verdant,
+        Self::Tidal,
+        Self::Drowned,
+        Self::Storm,
+        Self::Resonant,
+        Self::Undead,
+        Self::Haunted,
+        Self::Profane,
+        Self::Fae,
+        Self::Beastwild,
+        Self::Fungal,
+        Self::Construct,
+        Self::Crystal,
+    ];
+}
+
 /// A mob's full damage profile: the type it deals, plus up to one resisted and
 /// one weak school. Built as data on each MobSpawn.
 #[derive(Clone, Copy, Debug)]

--- a/late-ssh/src/app/door/lateania/items.rs
+++ b/late-ssh/src/app/door/lateania/items.rs
@@ -8,6 +8,7 @@
 use std::sync::OnceLock;
 
 use super::classes::Class;
+use super::damage::DamageType;
 
 /// Where an item can be worn. Consumables and valuables have no slot.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -1286,10 +1287,11 @@ pub fn materials() -> &'static [Item] {
 // ---- Crafted goods -------------------------------------------------------
 //
 // Crafting turns raw materials into refined intermediates (ingots, planks,
-// leather) and finished goods (weapons, armor, potions, poisons, food). IDs live
-// in 4200..4500, clear of the raw materials (4000..4100). Recipes in
-// `crafting.rs` reference these ids by the const helpers below; `item` resolves
-// them like any other. Five tiers each, mirroring the material tiers.
+// leather) and finished goods (weapons, armor, potions, poisons, oils, food).
+// IDs live in 4200..4600, clear of the raw materials (4000..4100) and below the
+// Sunderlakes fish (4600..). Recipes in `crafting.rs` reference these ids by
+// the const helpers below; `item` resolves them like any other. Six tiers each,
+// mirroring the material tiers.
 
 pub const CRAFTED_BASE: u32 = 4200;
 
@@ -1327,11 +1329,37 @@ pub const fn food_id(tier: u32) -> u32 {
 pub const fn masterwork_id(n: u32) -> u32 {
     CRAFTED_BASE + 180 + n
 }
+/// Weapon oils, the martial school lever of the world resist/weak pass
+/// (CONTEXT.md, "The world resist/weak pass" section): a flat, charge-limited rider added to the
+/// Physical auto, one school per family. `school` indexes `OIL_SCHOOLS`.
+pub const fn oil_id(school: u32, tier: u32) -> u32 {
+    CRAFTED_BASE + 300 + school * 20 + tier
+}
+
+/// The four oil schools, in `oil_id` family order. Deliberately not all seven:
+/// Shadow, Arcane, and Poison stay caster-and-poison-flavored lanes.
+pub const OIL_SCHOOLS: [DamageType; 4] = [
+    DamageType::Fire,
+    DamageType::Frost,
+    DamageType::Holy,
+    DamageType::Lightning,
+];
 
 /// The tier of a poison item id, if `id` is one (used to route it to the
 /// weapon-coating action instead of the normal consumable path).
 pub fn poison_tier(id: u32) -> Option<u32> {
     (0..6).find(|&t| poison_id(t) == id)
+}
+
+/// The school and tier of a weapon-oil item id, if `id` is one (used to route
+/// it to the weapon-coating action, same as `poison_tier`).
+pub fn oil_school_tier(id: u32) -> Option<(DamageType, u32)> {
+    for (s, school) in OIL_SCHOOLS.iter().enumerate() {
+        if let Some(t) = (0..6).find(|&t| oil_id(s as u32, t) == id) {
+            return Some((*school, t));
+        }
+    }
+    None
 }
 
 /// The tier of a cooked-food item id, if `id` is one (food grants a well-fed
@@ -1412,6 +1440,48 @@ const POISON_NAMES: [&str; 6] = [
     "Wyrm Venom",
     "Voidvenom",
 ];
+/// Oil names per `OIL_SCHOOLS` family, six tiers each.
+const OIL_NAMES: [[&str; 6]; 4] = [
+    [
+        "Sparkseed Oil",
+        "Emberbrand Oil",
+        "Firebrand Oil",
+        "Pyreheart Oil",
+        "Dragonfire Oil",
+        "Sunflare Oil",
+    ],
+    [
+        "Chillrime Oil",
+        "Rimefrost Oil",
+        "Winterbite Oil",
+        "Glacierheart Oil",
+        "Deepfrost Oil",
+        "Worldwinter Oil",
+    ],
+    [
+        "Blessed Oil",
+        "Consecrated Oil",
+        "Radiant Oil",
+        "Sanctified Oil",
+        "Dawnflame Oil",
+        "Godlight Oil",
+    ],
+    [
+        "Sparkcharged Oil",
+        "Stormkissed Oil",
+        "Thunderlaced Oil",
+        "Stormheart Oil",
+        "Levinbrand Oil",
+        "Skysunder Oil",
+    ],
+];
+const OIL_DESCS: [&str; 4] = [
+    "A vial of ember-laced oil, meant to set a blade alight.",
+    "A vial of rime-cold oil, meant to frost a blade's edge.",
+    "A vial of consecrated oil, meant to bless a blade.",
+    "A vial of storm-charged oil, meant to make a blade crackle.",
+];
+
 const FOOD_NAMES: [&str; 6] = [
     "Grilled Bream",
     "Pan-Seared Trout",
@@ -1457,6 +1527,7 @@ fn build_crafted() -> Vec<Item> {
     const POTION_HEAL: [i32; 6] = [25, 45, 75, 120, 180, 270];
     const POTION_PRICE: [i64; 6] = [20, 45, 90, 160, 260, 400];
     const POISON_PRICE: [i64; 6] = [15, 40, 80, 140, 220, 350];
+    const OIL_PRICE: [i64; 6] = [20, 50, 100, 170, 260, 400];
     const FOOD_HEAL: [i32; 6] = [20, 35, 55, 85, 130, 195];
     const FOOD_REST: [i32; 6] = [10, 20, 35, 55, 85, 130];
     const FOOD_PRICE: [i64; 6] = [15, 35, 70, 120, 190, 300];
@@ -1550,6 +1621,15 @@ fn build_crafted() -> Vec<Item> {
             FINAL_RARITY[t],
             POISON_PRICE[t],
         ));
+        for s in 0..4usize {
+            out.push(utility(
+                oil_id(s as u32, tu),
+                OIL_NAMES[s][t],
+                OIL_DESCS[s],
+                FINAL_RARITY[t],
+                OIL_PRICE[t],
+            ));
+        }
         out.push(consumable(
             food_id(tu),
             FOOD_NAMES[t],

--- a/late-ssh/src/app/door/lateania/items_test.rs
+++ b/late-ssh/src/app/door/lateania/items_test.rs
@@ -61,13 +61,13 @@ fn every_equippable_item_carries_real_stats() {
 fn crafted_goods_form_a_clean_catalog() {
     assert_eq!(
         crafted().len(),
-        62,
-        "ten crafted kinds x six tiers, plus two masterwork sinks"
+        86,
+        "fourteen crafted kinds (ten plus the four oil families) x six tiers, plus two masterwork sinks"
     );
     for c in crafted() {
         assert!(
-            c.id >= CRAFTED_BASE && c.id < CRAFTED_BASE + 300,
-            "crafted item {} sits in the 4200 band",
+            c.id >= CRAFTED_BASE && c.id < CRAFTED_BASE + 400,
+            "crafted item {} sits in the 4200..4600 band",
             c.id
         );
         assert!(c.sell_price() >= 1, "crafted goods are worth something");
@@ -621,4 +621,22 @@ fn generated_loot_covers_the_previously_dropped_gear_slots() {
             );
         }
     }
+}
+
+#[test]
+fn oil_ids_roundtrip_school_and_tier() {
+    // `use_item` routes a vial to the coating action purely by id; a drifted
+    // id table would silently turn an oil into an unusable trinket.
+    for (s, school) in OIL_SCHOOLS.iter().enumerate() {
+        for t in 0..6u32 {
+            let id = oil_id(s as u32, t);
+            assert_eq!(
+                oil_school_tier(id),
+                Some((*school, t)),
+                "oil id {id} must map back to its school and tier"
+            );
+            assert!(item(id).is_some(), "oil id {id} resolves to a real item");
+        }
+    }
+    assert_eq!(oil_school_tier(poison_id(2)), None, "poisons are not oils");
 }

--- a/late-ssh/src/app/door/lateania/persist.rs
+++ b/late-ssh/src/app/door/lateania/persist.rs
@@ -216,6 +216,13 @@ pub struct SavedMobDot {
     pub owner: Uuid,
     pub damage: i32,
     pub remaining_ticks: u8,
+    /// True for a weapon-coat wound, which keeps one refreshing stack per
+    /// attacker rather than stacking (see `svc::DotSource`). Defaulting to
+    /// false hydrates pre-coat saves as ability stacks, which is what they
+    /// were; without it a reload would untag a live coat and let a second
+    /// stack open beside it.
+    #[serde(default)]
+    pub from_coat: bool,
 }
 
 fn one() -> i32 {

--- a/late-ssh/src/app/door/lateania/persist_test.rs
+++ b/late-ssh/src/app/door/lateania/persist_test.rs
@@ -125,6 +125,7 @@ fn world_state_round_trips_through_json() {
             owner,
             damage: 5,
             remaining_ticks: 3,
+            from_coat: false,
         }],
     );
     let json = world.to_json();

--- a/late-ssh/src/app/door/lateania/stats.rs
+++ b/late-ssh/src/app/door/lateania/stats.rs
@@ -59,6 +59,21 @@ pub enum Score {
     Charisma,
 }
 
+impl Score {
+    /// The three-letter label every attribute row is written with, and the one
+    /// place a score's short name is spelled.
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Strength => "STR",
+            Self::Dexterity => "DEX",
+            Self::Constitution => "CON",
+            Self::Intelligence => "INT",
+            Self::Wisdom => "WIS",
+            Self::Charisma => "CHA",
+        }
+    }
+}
+
 /// The D&D ability modifier for a score: floor((score - 10) / 2). div_euclid
 /// floors toward negative infinity, so a score of 7 correctly yields -2.
 pub fn modifier(score: i32) -> i32 {
@@ -116,16 +131,22 @@ impl AbilityScores {
         modifier(self.score(class.primary_score()))
     }
 
-    /// The six scores in display order: (short label, value, modifier).
+    /// The six scores in display order: (short label, value, modifier). Labels
+    /// come from `Score::label` so a row and a class's key ability can never
+    /// disagree about what a score is called.
     pub fn rows(&self) -> [(&'static str, i32, i32); 6] {
         [
-            ("STR", self.strength, modifier(self.strength)),
-            ("DEX", self.dexterity, modifier(self.dexterity)),
-            ("CON", self.constitution, modifier(self.constitution)),
-            ("INT", self.intelligence, modifier(self.intelligence)),
-            ("WIS", self.wisdom, modifier(self.wisdom)),
-            ("CHA", self.charisma, modifier(self.charisma)),
+            Score::Strength,
+            Score::Dexterity,
+            Score::Constitution,
+            Score::Intelligence,
+            Score::Wisdom,
+            Score::Charisma,
         ]
+        .map(|which| {
+            let value = self.score(which);
+            (which.label(), value, modifier(value))
+        })
     }
 }
 

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -993,6 +993,8 @@ pub struct PlayerView {
     pub empower: i32,
     /// True while the player is stunned (skipping their actions).
     pub stunned: bool,
+    /// The active weapon coat as a display line ("fire coat x8"), if any.
+    pub coat: Option<String>,
     pub abilities: Vec<AbilityView>,
     pub inventory: Vec<InvView>,
     pub shop: Option<ShopView>,
@@ -1122,6 +1124,7 @@ impl PlayerView {
             shield: 0,
             empower: 0,
             stunned: false,
+            coat: None,
             abilities: Vec::new(),
             inventory: Vec::new(),
             shop: None,
@@ -2311,9 +2314,12 @@ struct PlayerState {
     last_broadcast: Option<Instant>,
     /// Riding the companion (Wildbound mounts). Session-only.
     mounted: bool,
-    /// A weapon coated with poison: (damage per tick, strikes remaining). Each
-    /// landed melee hit leaves a poison DoT and spends one charge. Transient.
-    weapon_poison: Option<(i32, u8)>,
+    /// A coated weapon: the coat's school, damage per tick, and strikes
+    /// remaining. The poison vials and the four alchemy oils share this one
+    /// slot, so applying any coat replaces the last. Each landed melee hit
+    /// leaves a DoT of the coat's school (through the foe's resist/weak
+    /// profile) and spends one charge. Transient.
+    weapon_coat: Option<(DamageType, i32, u8)>,
     /// The friendly NPC the player is currently escorting, if any (transient).
     escort: Option<EscortState>,
     /// Transient warning gate for the start-room Frontier entrance.
@@ -3210,12 +3216,21 @@ const TAME_COOLDOWN: Duration = Duration::from_secs(30);
 /// self-limiting (only co-located players hear it); a global channel needs a
 /// brake or one voice can flood every log in Lateania.
 const BROADCAST_COOLDOWN: Duration = Duration::from_secs(10);
-/// Poison damage per tick applied by a coated weapon, by poison tier (0..5).
-const POISON_PER_TICK: [i32; 5] = [4, 8, 14, 22, 34];
+/// Poison damage per tick applied by a coated weapon, by poison tier (0..6).
+/// Voidvenom (tier 5) continues the curve; it used to silently clamp to the
+/// tier-4 value despite costing 350g.
+const POISON_PER_TICK: [i32; 6] = [4, 8, 14, 22, 34, 50];
 /// Strikes a single weapon-coating lasts before the poison is spent.
 const POISON_CHARGES: u8 = 5;
-/// Ticks each poisoned strike festers in the foe.
+/// Ticks each coated strike (poison or oil) festers in the foe.
 const POISON_DOT_TICKS: u8 = 3;
+/// Oil damage per tick, by oil tier (0..6). Sized half again above the poison
+/// curve: the oil is the deliberate zone-prep coat of the world resist/weak
+/// pass, the poison the cheap burst vial anyone can mix.
+const OIL_PER_TICK: [i32; 6] = [6, 12, 21, 33, 51, 76];
+/// Strikes a single oil coating lasts. Several fights' worth, so choosing an
+/// oil is a route decision made at the zone gate, not per-fight busywork.
+const OIL_CHARGES: u8 = 12;
 /// Ticks a cooked meal's well-fed regen lasts.
 const WELL_FED_TICKS: u8 = 8;
 
@@ -3363,7 +3378,7 @@ impl WorldState {
             rpg_mode: true,
             last_broadcast: None,
             mounted: false,
-            weapon_poison: None,
+            weapon_coat: None,
             escort: None,
             frontier_descent_pending: false,
             resurrection_cap: 0,
@@ -6871,9 +6886,15 @@ impl WorldState {
 
     fn use_item(&mut self, user_id: Uuid, item_id: u32) {
         let Some(it) = item(item_id) else { return };
-        // Poisons aren't drunk - they coat your weapon.
+        // Poisons and oils aren't drunk - they coat your weapon.
         if let Some(tier) = super::items::poison_tier(item_id) {
-            self.coat_weapon(user_id, item_id, tier);
+            let per_tick = POISON_PER_TICK[(tier as usize).min(POISON_PER_TICK.len() - 1)];
+            self.coat_weapon(user_id, item_id, DamageType::Poison, per_tick, POISON_CHARGES);
+            return;
+        }
+        if let Some((school, tier)) = super::items::oil_school_tier(item_id) {
+            let per_tick = OIL_PER_TICK[(tier as usize).min(OIL_PER_TICK.len() - 1)];
+            self.coat_weapon(user_id, item_id, school, per_tick, OIL_CHARGES);
             return;
         }
         let ItemKind::Consumable { heal, restore } = it.kind else {
@@ -6917,9 +6938,17 @@ impl WorldState {
         self.dirty = true;
     }
 
-    /// Coat the player's weapon with a poison: each landed melee hit will leave a
-    /// poison DoT until the charges run out. Consumes the vial.
-    fn coat_weapon(&mut self, user_id: Uuid, item_id: u32, tier: u32) {
+    /// Coat the player's weapon with a poison or an oil: each landed melee hit
+    /// will leave a DoT of the coat's school until the charges run out. One
+    /// coat slot: applying a new coat replaces the old. Consumes the vial.
+    fn coat_weapon(
+        &mut self,
+        user_id: Uuid,
+        item_id: u32,
+        school: DamageType,
+        per_tick: i32,
+        charges: u8,
+    ) {
         let has = self
             .players
             .get(&user_id)
@@ -6928,18 +6957,17 @@ impl WorldState {
         if !has {
             return;
         }
-        let per_tick = POISON_PER_TICK[(tier as usize).min(POISON_PER_TICK.len() - 1)];
-        let name = item(item_id).map(|i| i.name).unwrap_or("poison");
+        let name = item(item_id).map(|i| i.name).unwrap_or("coating");
         if let Some(p) = self.players.get_mut(&user_id) {
             if let Some(pos) = p.inventory.iter().position(|i| *i == item_id) {
                 p.inventory.remove(pos);
             }
-            p.weapon_poison = Some((per_tick, POISON_CHARGES));
+            p.weapon_coat = Some((school, per_tick, charges));
         }
         self.log_to(
             user_id,
             LogKind::Combat,
-            format!("You coat your weapon with {name} ({POISON_CHARGES} strikes)."),
+            format!("You coat your weapon with {name} ({charges} strikes)."),
         );
         self.dirty = true;
     }
@@ -7365,26 +7393,22 @@ impl WorldState {
                 self.kill_mob(user_id, mob_id);
                 continue;
             }
-            // A poison-coated weapon leaves a festering DoT in the struck foe and
-            // spends one charge (the target is the player's current mob).
-            let poison = self.players.get(&user_id).and_then(|p| p.weapon_poison);
-            if let Some((per_tick, charges)) = poison {
-                self.seed_mob_dot(
-                    user_id,
-                    per_tick,
-                    DamageType::Poison,
-                    POISON_DOT_TICKS,
-                    "Your poison",
-                );
+            // A coated weapon (poison or oil) leaves a festering DoT of the
+            // coat's school in the struck foe, through the foe's resist/weak
+            // profile, and spends one charge (the target is the player's
+            // current mob).
+            let coat = self.players.get(&user_id).and_then(|p| p.weapon_coat);
+            if let Some((school, per_tick, charges)) = coat {
+                self.seed_mob_dot(user_id, per_tick, school, POISON_DOT_TICKS, coat_source(school));
                 if let Some(p) = self.players.get_mut(&user_id) {
                     let left = charges.saturating_sub(1);
-                    p.weapon_poison = (left > 0).then_some((per_tick, left));
+                    p.weapon_coat = (left > 0).then_some((school, per_tick, left));
                 }
                 if charges <= 1 {
                     self.log_to(
                         user_id,
                         LogKind::System,
-                        "The last of the poison is spent.".to_string(),
+                        "The last of the coating is spent.".to_string(),
                     );
                 }
             }
@@ -7562,6 +7586,31 @@ impl WorldState {
             self.strike_pvp_target(attacker_id, victim_id, atk, DamageType::Physical, "a rival");
             if self.players.get(&victim_id).is_some_and(|v| v.dead) {
                 continue;
+            }
+            // A coated weapon works in a duel exactly as against a mob: the
+            // landed swing seeds a DoT of the coat's school on the rival
+            // (through their armor each tick, via the pvp dot pass) and
+            // spends a charge.
+            let coat = self.players.get(&attacker_id).and_then(|p| p.weapon_coat);
+            if let Some((school, per_tick, charges)) = coat {
+                self.seed_pvp_dot(
+                    attacker_id,
+                    per_tick,
+                    school,
+                    POISON_DOT_TICKS,
+                    coat_source(school),
+                );
+                if let Some(p) = self.players.get_mut(&attacker_id) {
+                    let left = charges.saturating_sub(1);
+                    p.weapon_coat = (left > 0).then_some((school, per_tick, left));
+                }
+                if charges <= 1 {
+                    self.log_to(
+                        attacker_id,
+                        LogKind::System,
+                        "The last of the coating is spent.".to_string(),
+                    );
+                }
             }
             // A living, fighting companion piles onto the same target, same as
             // it does against a mob - biting through `strike_pvp_target` so it
@@ -9633,6 +9682,9 @@ impl WorldState {
                     shield: player.shield,
                     empower: player.empower,
                     stunned: player.stunned > 0,
+                    coat: player
+                        .weapon_coat
+                        .map(|(school, _, charges)| format!("{} coat x{charges}", school.label())),
                     abilities,
                     inventory,
                     shop,
@@ -9717,6 +9769,20 @@ impl WorldState {
 }
 
 // ---- Free helpers: titles, tags, gold, and the log buffer ----------------
+
+/// The combat-log voice of a weapon coat's school ("Your burning oil ...").
+fn coat_source(school: DamageType) -> &'static str {
+    match school {
+        DamageType::Poison => "Your poison",
+        DamageType::Fire => "Your burning oil",
+        DamageType::Frost => "Your freezing oil",
+        DamageType::Holy => "Your blessed oil",
+        DamageType::Lightning => "Your crackling oil",
+        DamageType::Shadow => "Your darkened oil",
+        DamageType::Arcane => "Your humming oil",
+        DamageType::Physical => "Your coating",
+    }
+}
 
 /// A short combat-log suffix announcing a resist or weakness, empty for normal.
 fn defense_tag(defense: Defense, _dtype: DamageType) -> &'static str {

--- a/late-ssh/src/app/door/lateania/svc.rs
+++ b/late-ssh/src/app/door/lateania/svc.rs
@@ -3153,6 +3153,40 @@ struct MobInstance {
     summon_cooldown: u8,
 }
 
+/// Where a damage-over-time stack came from. The two behave differently on
+/// re-application and the difference is load-bearing: an ability DoT is one
+/// wound per cast and stacks, because a cooldown rations how often it can be
+/// cast. A weapon coat re-seeds on *every* landed strike, at the same cadence
+/// the DoT itself ticks, so stacking it would multiply the coat's rider by its
+/// duration (a 3-tick DoT reseeded every tick pays three times over). A coat
+/// therefore keeps exactly one stack per attacker and refreshes it in place.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DotSource {
+    Ability,
+    Coat,
+}
+
+/// One live damage-over-time stack on a mob. `per_tick` already has the
+/// target's resist/weak baked in (see `seed_mob_dot`).
+#[derive(Clone, Copy, Debug)]
+struct MobDot {
+    owner: Uuid,
+    per_tick: i32,
+    remaining: u8,
+    source: DotSource,
+}
+
+/// One live damage-over-time stack on a player. Unlike `MobDot` this carries
+/// its school live, since every tick re-applies the victim's armor.
+#[derive(Clone, Copy, Debug)]
+struct PvpDot {
+    owner: Uuid,
+    per_tick: i32,
+    school: DamageType,
+    remaining: u8,
+    source: DotSource,
+}
+
 struct WorldState {
     room_id: Uuid,
     world: World,
@@ -3163,15 +3197,15 @@ struct WorldState {
     mobs: HashMap<u32, MobInstance>,
     /// mob id -> stun ticks remaining.
     mob_stuns: HashMap<u32, u8>,
-    /// mob id -> active damage-over-time stacks (owner, per-tick, remaining).
-    mob_dots: HashMap<u32, Vec<(Uuid, i32, u8)>>,
+    /// mob id -> active damage-over-time stacks.
+    mob_dots: HashMap<u32, Vec<MobDot>>,
     /// Pvp equivalents of `mob_stuns`/`mob_dots`, keyed by the victim's user
     /// id instead of a mob id (see `strike_pvp_target`/`seed_pvp_dot`). Each
     /// dot stack also carries its `DamageType`, since (unlike a mob's baked-in
     /// resist/weak) a player's `strike_player` needs the real school on every
     /// tick to apply the right armor reduction.
     pvp_stuns: HashMap<Uuid, u8>,
-    pvp_dots: HashMap<Uuid, Vec<(Uuid, i32, DamageType, u8)>>,
+    pvp_dots: HashMap<Uuid, Vec<PvpDot>>,
     /// Kills accumulated during a tick, drained for the activity feed.
     pending_kills: Vec<KillOutcome>,
     generation: u64,
@@ -3216,21 +3250,47 @@ const TAME_COOLDOWN: Duration = Duration::from_secs(30);
 /// self-limiting (only co-located players hear it); a global channel needs a
 /// brake or one voice can flood every log in Lateania.
 const BROADCAST_COOLDOWN: Duration = Duration::from_secs(10);
+/// The auto-attack bar a tier-`t` coat is measured against: `attack()` for a
+/// character at that tier's crafting gate wearing that tier's crafted weapon.
+/// Measured from the engine, not guessed - `the_attack_bar_still_matches_a_real
+/// _character` rebuilds a real player at each gate and pins every entry. The
+/// coat curves below and the world pass's grind-rate budget are both written as
+/// a share of this, so neither can drift away from what a fight actually looks
+/// like (they once did: the oil rider was certified at 15% of output while
+/// really running three to six times that).
+#[cfg(test)]
+pub(super) const TIER_ATTACK_BAR: [i32; 6] = [12, 31, 52, 77, 106, 148];
+/// Character level at each crafting tier's gate, the level `TIER_ATTACK_BAR` is
+/// measured at (mirrors `crafting::LEVEL_REQ`).
+#[cfg(test)]
+pub(super) const TIER_GATE_LEVEL: [i32; 6] = [1, 8, 16, 26, 38, 55];
 /// Poison damage per tick applied by a coated weapon, by poison tier (0..6).
-/// Voidvenom (tier 5) continues the curve; it used to silently clamp to the
-/// tier-4 value despite costing 350g.
-const POISON_PER_TICK: [i32; 6] = [4, 8, 14, 22, 34, 50];
+/// The burst half of the coat family: about 30% of the auto bar but only
+/// `POISON_CHARGES` strikes of it, so a vial is roughly three quarters of an
+/// oil's damage packed into half the window. Cheap, and the right answer when
+/// the fight will be over quickly.
+pub(super) const POISON_PER_TICK: [i32; 6] = [3, 9, 15, 23, 32, 45];
 /// Strikes a single weapon-coating lasts before the poison is spent.
-const POISON_CHARGES: u8 = 5;
-/// Ticks each coated strike (poison or oil) festers in the foe.
-const POISON_DOT_TICKS: u8 = 3;
-/// Oil damage per tick, by oil tier (0..6). Sized half again above the poison
-/// curve: the oil is the deliberate zone-prep coat of the world resist/weak
-/// pass, the poison the cheap burst vial anyone can mix.
-const OIL_PER_TICK: [i32; 6] = [6, 12, 21, 33, 51, 76];
+pub(super) const POISON_CHARGES: u8 = 5;
+/// Ticks each coated strike (poison or oil) festers in the foe. A coat re-seeds
+/// every landed strike and refreshes rather than stacks (see `DotSource`), so
+/// this is the wound's lifetime after the last swing, not a multiplier on it.
+pub(super) const POISON_DOT_TICKS: u8 = 3;
+/// Oil damage per tick, by oil tier (0..6). The sustain half: about a fifth of
+/// the auto bar, held for `OIL_CHARGES` strikes, which is the whole of a boss
+/// fight. Sized so a coated character gains roughly 15% of total output, the
+/// figure the world pass's routed budget is written against.
+pub(super) const OIL_PER_TICK: [i32; 6] = [2, 6, 10, 15, 21, 30];
 /// Strikes a single oil coating lasts. Several fights' worth, so choosing an
 /// oil is a route decision made at the zone gate, not per-fight busywork.
-const OIL_CHARGES: u8 = 12;
+pub(super) const OIL_CHARGES: u8 = 12;
+/// Share of a character's output that comes from the Physical auto-attack at
+/// band gear; the rest is abilities in the class's school mix. The routed
+/// grind-rate budget in `world_test.rs` splits output this way, and the coat
+/// rider converts through it (a rider worth 20% of the auto is worth
+/// `0.20 * AUTO_SHARE` of total output).
+#[cfg(test)]
+pub(super) const AUTO_SHARE: f64 = 0.75;
 /// Ticks a cooked meal's well-fed regen lasts.
 const WELL_FED_TICKS: u8 = 8;
 
@@ -3523,7 +3583,7 @@ impl WorldState {
         self.players.remove(&user_id);
         let before: usize = self.mob_dots.values().map(Vec::len).sum();
         for stacks in self.mob_dots.values_mut() {
-            stacks.retain(|(owner, _, _)| *owner != user_id);
+            stacks.retain(|dot| dot.owner != user_id);
         }
         self.mob_dots.retain(|_, stacks| !stacks.is_empty());
         let after: usize = self.mob_dots.values().map(Vec::len).sum();
@@ -3859,16 +3919,15 @@ impl WorldState {
             .mob_dots
             .iter()
             .flat_map(|(mob_id, stacks)| {
-                stacks
-                    .iter()
-                    .filter_map(|(owner, damage, remaining_ticks)| {
-                        (*remaining_ticks > 0).then_some(SavedMobDot {
-                            mob_id: *mob_id,
-                            owner: *owner,
-                            damage: *damage,
-                            remaining_ticks: *remaining_ticks,
-                        })
+                stacks.iter().filter_map(|dot| {
+                    (dot.remaining > 0).then_some(SavedMobDot {
+                        mob_id: *mob_id,
+                        owner: dot.owner,
+                        damage: dot.per_tick,
+                        remaining_ticks: dot.remaining,
+                        from_coat: dot.source == DotSource::Coat,
                     })
+                })
             })
             .collect::<Vec<_>>();
         mob_dots.sort_by_key(|dot| (dot.mob_id, dot.owner));
@@ -3908,11 +3967,16 @@ impl WorldState {
         self.mob_dots.clear();
         for dot in &saved.mob_dots {
             if dot.remaining_ticks > 0 && self.mobs.contains_key(&dot.mob_id) {
-                self.mob_dots.entry(dot.mob_id).or_default().push((
-                    dot.owner,
-                    dot.damage,
-                    dot.remaining_ticks,
-                ));
+                self.mob_dots.entry(dot.mob_id).or_default().push(MobDot {
+                    owner: dot.owner,
+                    per_tick: dot.damage,
+                    remaining: dot.remaining_ticks,
+                    source: if dot.from_coat {
+                        DotSource::Coat
+                    } else {
+                        DotSource::Ability
+                    },
+                });
             }
         }
 
@@ -5988,6 +6052,7 @@ impl WorldState {
                         tick,
                         ability.damage_type,
                         ability.duration,
+                        DotSource::Ability,
                         ability.name,
                     );
                 } else {
@@ -5996,6 +6061,7 @@ impl WorldState {
                         tick,
                         ability.damage_type,
                         ability.duration,
+                        DotSource::Ability,
                         ability.name,
                     );
                 }
@@ -6123,6 +6189,7 @@ impl WorldState {
         per_tick: i32,
         dtype: DamageType,
         duration: u8,
+        origin: DotSource,
         source: &str,
     ) {
         let Some(mob_id) = self.players.get(&user_id).and_then(|p| p.target) else {
@@ -6134,16 +6201,40 @@ impl WorldState {
             .get(&mob_id)
             .map(|m| m.spawn.profile.apply(per_tick, dtype).0)
             .unwrap_or(per_tick);
-        self.mob_dots
-            .entry(mob_id)
-            .or_default()
-            .push((user_id, scaled, duration));
+        let stacks = self.mob_dots.entry(mob_id).or_default();
+        // A coat refreshes its own single wound; an ability opens a new one.
+        let existing = match origin {
+            DotSource::Coat => stacks
+                .iter_mut()
+                .find(|d| d.owner == user_id && d.source == DotSource::Coat),
+            DotSource::Ability => None,
+        };
+        let opened = match existing {
+            Some(dot) => {
+                dot.per_tick = scaled;
+                dot.remaining = duration;
+                false
+            }
+            None => {
+                stacks.push(MobDot {
+                    owner: user_id,
+                    per_tick: scaled,
+                    remaining: duration,
+                    source: origin,
+                });
+                true
+            }
+        };
         self.mark_world_dirty();
-        self.log_to(
-            user_id,
-            LogKind::Combat,
-            format!("{source} festers in the foe ({} damage).", dtype.label()),
-        );
+        // Only the wound opening is worth a line. A coat re-seeds every swing,
+        // so logging refreshes would bury the fight in its own upkeep.
+        if opened {
+            self.log_to(
+                user_id,
+                LogKind::Combat,
+                format!("{source} festers in the foe ({} damage).", dtype.label()),
+            );
+        }
         self.dirty = true;
     }
 
@@ -6158,20 +6249,45 @@ impl WorldState {
         per_tick: i32,
         dtype: DamageType,
         duration: u8,
+        origin: DotSource,
         source: &str,
     ) {
         let Some(victim_id) = self.players.get(&user_id).and_then(|p| p.pvp_target) else {
             return;
         };
-        self.pvp_dots
-            .entry(victim_id)
-            .or_default()
-            .push((user_id, per_tick, dtype, duration));
-        self.log_to(
-            user_id,
-            LogKind::Combat,
-            format!("{source} festers in your rival ({} damage).", dtype.label()),
-        );
+        let stacks = self.pvp_dots.entry(victim_id).or_default();
+        // Same one-wound-per-coat rule as `seed_mob_dot`.
+        let existing = match origin {
+            DotSource::Coat => stacks
+                .iter_mut()
+                .find(|d| d.owner == user_id && d.source == DotSource::Coat),
+            DotSource::Ability => None,
+        };
+        let opened = match existing {
+            Some(dot) => {
+                dot.per_tick = per_tick;
+                dot.school = dtype;
+                dot.remaining = duration;
+                false
+            }
+            None => {
+                stacks.push(PvpDot {
+                    owner: user_id,
+                    per_tick,
+                    school: dtype,
+                    remaining: duration,
+                    source: origin,
+                });
+                true
+            }
+        };
+        if opened {
+            self.log_to(
+                user_id,
+                LogKind::Combat,
+                format!("{source} festers in your rival ({} damage).", dtype.label()),
+            );
+        }
         self.dirty = true;
     }
 
@@ -6289,6 +6405,7 @@ impl WorldState {
                         per_tick,
                         DamageType::Physical,
                         3,
+                        DotSource::Ability,
                         &format!("Your {pet_name}'s Rend"),
                     );
                 }
@@ -7180,14 +7297,14 @@ impl WorldState {
             let mut total = 0;
             let mut owner = None;
             if let Some(stacks) = self.mob_dots.get_mut(&mob_id) {
-                for (uid, per, rem) in stacks.iter_mut() {
-                    if *rem > 0 {
-                        total += *per;
-                        *rem -= 1;
-                        owner = Some(*uid);
+                for dot in stacks.iter_mut() {
+                    if dot.remaining > 0 {
+                        total += dot.per_tick;
+                        dot.remaining -= 1;
+                        owner = Some(dot.owner);
                     }
                 }
-                stacks.retain(|(_, _, rem)| *rem > 0);
+                stacks.retain(|dot| dot.remaining > 0);
                 if stacks.is_empty() {
                     self.mob_dots.remove(&mob_id);
                 }
@@ -7399,7 +7516,14 @@ impl WorldState {
             // current mob).
             let coat = self.players.get(&user_id).and_then(|p| p.weapon_coat);
             if let Some((school, per_tick, charges)) = coat {
-                self.seed_mob_dot(user_id, per_tick, school, POISON_DOT_TICKS, coat_source(school));
+                self.seed_mob_dot(
+                    user_id,
+                    per_tick,
+                    school,
+                    POISON_DOT_TICKS,
+                    DotSource::Coat,
+                    coat_source(school),
+                );
                 if let Some(p) = self.players.get_mut(&user_id) {
                     let left = charges.saturating_sub(1);
                     p.weapon_coat = (left > 0).then_some((school, per_tick, left));
@@ -7598,6 +7722,7 @@ impl WorldState {
                     per_tick,
                     school,
                     POISON_DOT_TICKS,
+                    DotSource::Coat,
                     coat_source(school),
                 );
                 if let Some(p) = self.players.get_mut(&attacker_id) {
@@ -7674,13 +7799,13 @@ impl WorldState {
         for victim_id in pvp_dot_victims {
             let mut ticks: Vec<(Uuid, i32, DamageType)> = Vec::new();
             if let Some(stacks) = self.pvp_dots.get_mut(&victim_id) {
-                for (attacker_id, per, dtype, rem) in stacks.iter_mut() {
-                    if *rem > 0 {
-                        ticks.push((*attacker_id, *per, *dtype));
-                        *rem -= 1;
+                for dot in stacks.iter_mut() {
+                    if dot.remaining > 0 {
+                        ticks.push((dot.owner, dot.per_tick, dot.school));
+                        dot.remaining -= 1;
                     }
                 }
-                stacks.retain(|(_, _, _, rem)| *rem > 0);
+                stacks.retain(|dot| dot.remaining > 0);
                 if stacks.is_empty() {
                     self.pvp_dots.remove(&victim_id);
                 }
@@ -8636,6 +8761,7 @@ impl WorldState {
                         per_tick,
                         DamageType::Physical,
                         3,
+                        DotSource::Ability,
                         &format!("Your {pet_name}'s Rend"),
                     );
                 }

--- a/late-ssh/src/app/door/lateania/svc_test.rs
+++ b/late-ssh/src/app/door/lateania/svc_test.rs
@@ -380,6 +380,122 @@ fn an_oil_coats_the_weapon_with_its_school_and_replaces_the_last_coat() {
 }
 
 #[test]
+fn the_attack_bar_still_matches_a_real_character() {
+    // TIER_ATTACK_BAR is the yardstick the coat curves and the world pass's
+    // grind-rate budget are both written against, so it has to be measured
+    // rather than remembered: rebuild a real character at each crafting gate,
+    // wearing that tier's crafted weapon, and ask the engine what it swings for.
+    for t in 0..6usize {
+        let lvl = TIER_GATE_LEVEL[t];
+        let mut s = world();
+        s.join(uid(1));
+        s.choose_class(uid(1), Class::Warrior);
+        let p = s.players.get_mut(&uid(1)).unwrap();
+        p.level = lvl;
+        p.base_attack = Class::Warrior.stats_at(lvl).attack;
+        // Ability scores are rolled 4d6-drop-lowest at character creation, so
+        // the bar is measured at the flat 10s (a +0 modifier). A yardstick that
+        // moved with the dice would not be a yardstick.
+        p.scores = super::super::stats::AbilityScores::default();
+        p.equipped
+            .insert(Slot::Weapon, super::super::items::smith_weapon_id(t as u32));
+        assert_eq!(
+            p.attack(),
+            TIER_ATTACK_BAR[t],
+            "tier {t} (level {lvl}): the bar moved, so every coat share moved with it"
+        );
+    }
+}
+
+#[test]
+fn the_coat_curves_stay_inside_their_share_of_the_bar() {
+    // The balance contract for weapon coats, in the only terms that mean
+    // anything: what fraction of a real swing the rider is worth. An oil
+    // sustains about a fifth of the auto for a whole fight; a poison bursts
+    // about a third of it for a handful of strikes. Both are held to a band,
+    // and both are held to it at *every* tier, so the curves can never quietly
+    // outgrow the attack curve the way they did before.
+    for t in 0..6usize {
+        let bar = TIER_ATTACK_BAR[t] as f64;
+        let oil = OIL_PER_TICK[t] as f64 / bar;
+        let poison = POISON_PER_TICK[t] as f64 / bar;
+        assert!(
+            (0.15..=0.22).contains(&oil),
+            "tier {t}: oil rider is {oil:.3} of the bar, outside the sustain band"
+        );
+        assert!(
+            (0.24..=0.32).contains(&poison),
+            "tier {t}: poison rider is {poison:.3} of the bar, outside the burst band"
+        );
+        assert!(
+            POISON_PER_TICK[t] > OIL_PER_TICK[t],
+            "tier {t}: poison must hit harder per tick than oil, or it is dead content"
+        );
+    }
+    // And the shape that keeps them from being the same item: the poison
+    // bursts, the oil lasts. A coat wound is live for its charges plus the
+    // trailing POISON_DOT_TICKS after the final swing.
+    let ticks = |charges: u8| (charges + POISON_DOT_TICKS - 1) as f64;
+    let oil_total = ticks(OIL_CHARGES) * OIL_PER_TICK[5] as f64;
+    let poison_total = ticks(POISON_CHARGES) * POISON_PER_TICK[5] as f64;
+    assert!(
+        poison_total < oil_total,
+        "the cheap vial must not out-total the prepared coat"
+    );
+    assert!(
+        poison_total / oil_total > 0.6,
+        "but it must stay a real alternative, not a strictly worse one"
+    );
+}
+
+#[test]
+fn a_coat_keeps_one_refreshing_wound_however_many_swings_land() {
+    // A coat re-seeds on every landed strike, at the very cadence its DoT
+    // ticks. If each strike opened its own wound, POISON_DOT_TICKS of them
+    // would be live at once and the rider would be paid three times over -
+    // which is not the bar the grind-rate budget is written against. One
+    // wound per attacker, refreshed, is the contract.
+    let (mut s, mob_id) = engaged_with(MobBehavior::Brute);
+    // A neutral foe: `engaged_with` grabs whichever mob the map hands over
+    // first, and this test is about how many wounds a coat opens, not about
+    // what the foe's profile does to the number on each one.
+    if let Some(m) = s.mobs.get_mut(&mob_id) {
+        m.spawn.profile = DamageProfile::new(DamageType::Physical, None, None);
+    }
+    s.players.get_mut(&uid(1)).unwrap().weapon_coat = Some((DamageType::Fire, 10, OIL_CHARGES));
+    for _ in 0..5 {
+        s.tick();
+    }
+    let stacks = s.mob_dots.get(&mob_id).map(Vec::as_slice).unwrap_or(&[]);
+    assert_eq!(stacks.len(), 1, "five landed swings, one coat wound");
+    assert_eq!(stacks[0].per_tick, 10, "ticking for the rider exactly once");
+    let view = s.snapshot().players[&uid(1)].clone();
+    let foe = view
+        .mobs
+        .iter()
+        .find(|m| m.id == mob_id)
+        .expect("the foe is on the panel");
+    assert_eq!(
+        foe.dot_stacks, 1,
+        "and the panel shows one wound, not a growing pile"
+    );
+}
+
+#[test]
+fn ability_dots_still_stack_on_top_of_a_coat() {
+    // The other half of the rule: an ability DoT is one wound per cast and
+    // keeps stacking (its cooldown is what rations it), and it stacks
+    // alongside the coat's single wound rather than refreshing it.
+    let (mut s, mob_id) = engaged_with(MobBehavior::Brute);
+    s.players.get_mut(&uid(1)).unwrap().weapon_coat = Some((DamageType::Fire, 10, OIL_CHARGES));
+    s.tick();
+    s.seed_mob_dot(uid(1), 7, DamageType::Poison, 3, DotSource::Ability, "Venom");
+    s.seed_mob_dot(uid(1), 7, DamageType::Poison, 3, DotSource::Ability, "Venom");
+    let stacks = s.mob_dots.get(&mob_id).map(Vec::as_slice).unwrap_or(&[]);
+    assert_eq!(stacks.len(), 3, "one coat wound plus two ability wounds");
+}
+
+#[test]
 fn an_oiled_strike_rides_the_zone_profile() {
     // Against a foe weak to Fire, a fire oil's DoT seeds at 1.5x per tick;
     // against one that resists it, at half. The multiplier is baked in by
@@ -394,7 +510,7 @@ fn an_oiled_strike_rides_the_zone_profile() {
         .mob_dots
         .get(&mob_id)
         .and_then(|d| d.first())
-        .map(|(_, per_tick, _)| *per_tick);
+        .map(|dot| dot.per_tick);
     assert_eq!(seeded, Some(15), "weak to fire: 10 per tick seeds as 15");
 }
 
@@ -4235,8 +4351,12 @@ fn the_top_poison_tier_is_no_longer_a_clone_of_the_fourth() {
     s.use_item(uid(1), vial);
     assert_eq!(
         s.players[&uid(1)].weapon_coat,
-        Some((DamageType::Poison, 50, POISON_CHARGES)),
-        "tier 5 continues the per-tick curve past tier 4's 34"
+        Some((DamageType::Poison, POISON_PER_TICK[5], POISON_CHARGES)),
+        "tier 5 continues the per-tick curve instead of clamping to tier 4's"
+    );
+    assert!(
+        POISON_PER_TICK[5] > POISON_PER_TICK[4],
+        "and the curve really does keep climbing at the top"
     );
 }
 
@@ -4270,8 +4390,8 @@ fn a_coated_weapon_works_in_a_duel_too() {
     assert!(
         s.pvp_dots
             .get(&uid(2))
-            .is_some_and(|d| d.iter().any(|(owner, per_tick, dtype, _)| {
-                *owner == uid(1) && *per_tick == 10 && *dtype == DamageType::Fire
+            .is_some_and(|d| d.iter().any(|dot| {
+                dot.owner == uid(1) && dot.per_tick == 10 && dot.school == DamageType::Fire
             })),
         "the landed duel swing seeds the coat's school DoT on the rival"
     );
@@ -4280,4 +4400,29 @@ fn a_coated_weapon_works_in_a_duel_too() {
         Some(OIL_CHARGES - 1),
         "the duel swing spends one coat charge"
     );
+    // And the one-wound rule holds in a duel too. It matters more here than
+    // against a mob: a pvp dot is *not* pre-scaled, so each tick is charged
+    // against the victim's armor live, and a stacking coat would have made a
+    // 12-charge vial worth a third of an endgame duel all by itself.
+    // Both duellists need the hit points to still be trading blows five
+    // swings in, or the wound count below only proves someone died.
+    for id in [uid(1), uid(2)] {
+        let p = s.players.get_mut(&id).unwrap();
+        p.base_max_hp = 4000;
+        p.hp = p.max_hp();
+    }
+    for _ in 0..4 {
+        s.tick();
+    }
+    assert!(
+        s.players[&uid(1)].pvp_target == Some(uid(2)),
+        "the duel is still running"
+    );
+    let stacks = s.pvp_dots.get(&uid(2)).map(Vec::as_slice).unwrap_or(&[]);
+    assert_eq!(
+        stacks.iter().filter(|d| d.owner == uid(1)).count(),
+        1,
+        "five landed duel swings, one coat wound"
+    );
 }
+

--- a/late-ssh/src/app/door/lateania/svc_test.rs
+++ b/late-ssh/src/app/door/lateania/svc_test.rs
@@ -331,17 +331,22 @@ fn a_poison_coats_the_weapon_instead_of_being_drunk() {
     s.players.get_mut(&uid(1)).unwrap().inventory.push(poison);
     s.use_item(uid(1), poison);
     let p = &s.players[&uid(1)];
-    assert!(p.weapon_poison.is_some(), "the weapon is coated");
+    assert_eq!(
+        p.weapon_coat.map(|(school, _, _)| school),
+        Some(DamageType::Poison),
+        "the weapon is coated with poison"
+    );
     assert!(!p.inventory.contains(&poison), "the vial is used up");
 }
 
 #[test]
 fn a_coated_weapon_poisons_the_foe_and_spends_a_charge() {
     let (mut s, mob_id) = engaged_with(MobBehavior::Brute);
-    s.players.get_mut(&uid(1)).unwrap().weapon_poison = Some((10, POISON_CHARGES));
+    s.players.get_mut(&uid(1)).unwrap().weapon_coat =
+        Some((DamageType::Poison, 10, POISON_CHARGES));
     s.tick();
     assert_eq!(
-        s.players[&uid(1)].weapon_poison.map(|(_, c)| c),
+        s.players[&uid(1)].weapon_coat.map(|(_, _, c)| c),
         Some(POISON_CHARGES - 1),
         "a landed strike spends one poison charge"
     );
@@ -349,6 +354,48 @@ fn a_coated_weapon_poisons_the_foe_and_spends_a_charge() {
         s.mob_dots.get(&mob_id).is_some_and(|d| !d.is_empty()),
         "the struck foe is left with a poison DoT"
     );
+}
+
+#[test]
+fn an_oil_coats_the_weapon_with_its_school_and_replaces_the_last_coat() {
+    let mut s = world();
+    s.join(uid(1));
+    s.choose_class(uid(1), Class::Warrior);
+    let poison = super::super::items::poison_id(2);
+    let oil = super::super::items::oil_id(0, 2); // Firebrand Oil
+    {
+        let p = s.players.get_mut(&uid(1)).unwrap();
+        p.inventory.push(poison);
+        p.inventory.push(oil);
+    }
+    s.use_item(uid(1), poison);
+    s.use_item(uid(1), oil);
+    let p = &s.players[&uid(1)];
+    assert_eq!(
+        p.weapon_coat,
+        Some((DamageType::Fire, OIL_PER_TICK[2], OIL_CHARGES)),
+        "the oil takes the one coat slot, replacing the poison"
+    );
+    assert!(!p.inventory.contains(&oil), "the vial is used up");
+}
+
+#[test]
+fn an_oiled_strike_rides_the_zone_profile() {
+    // Against a foe weak to Fire, a fire oil's DoT seeds at 1.5x per tick;
+    // against one that resists it, at half. The multiplier is baked in by
+    // seed_mob_dot, so the coat is a real matchup lever, not flat flavor.
+    let (mut s, mob_id) = engaged_with(MobBehavior::Brute);
+    if let Some(m) = s.mobs.get_mut(&mob_id) {
+        m.spawn.profile = DamageProfile::new(DamageType::Physical, None, Some(DamageType::Fire));
+    }
+    s.players.get_mut(&uid(1)).unwrap().weapon_coat = Some((DamageType::Fire, 10, OIL_CHARGES));
+    s.tick();
+    let seeded = s
+        .mob_dots
+        .get(&mob_id)
+        .and_then(|d| d.first())
+        .map(|(_, per_tick, _)| *per_tick);
+    assert_eq!(seeded, Some(15), "weak to fire: 10 per tick seeds as 15");
 }
 
 #[test]
@@ -4149,4 +4196,61 @@ fn every_quest_target_and_zone_is_real() {
             "frontier zone {z} entrance missing"
         );
     }
+}
+
+#[test]
+fn the_top_poison_tier_is_no_longer_a_clone_of_the_fourth() {
+    let mut s = world();
+    s.join(uid(1));
+    s.choose_class(uid(1), Class::Warrior);
+    let vial = super::super::items::poison_id(5); // Voidvenom
+    s.players.get_mut(&uid(1)).unwrap().inventory.push(vial);
+    s.use_item(uid(1), vial);
+    assert_eq!(
+        s.players[&uid(1)].weapon_coat,
+        Some((DamageType::Poison, 50, POISON_CHARGES)),
+        "tier 5 continues the per-tick curve past tier 4's 34"
+    );
+}
+
+#[test]
+fn the_active_coat_shows_on_the_player_view() {
+    let mut s = world();
+    s.join(uid(1));
+    s.choose_class(uid(1), Class::Warrior);
+    s.players.get_mut(&uid(1)).unwrap().weapon_coat = Some((DamageType::Fire, 21, 8));
+    let view = s.snapshot().players[&uid(1)].clone();
+    assert_eq!(
+        view.coat.as_deref(),
+        Some("fire coat x8"),
+        "the battle panels read the coat from the view"
+    );
+}
+
+#[test]
+fn a_coated_weapon_works_in_a_duel_too() {
+    let mut s = world();
+    s.join(uid(1));
+    s.choose_class(uid(1), Class::Warrior);
+    s.join(uid(2));
+    s.choose_class(uid(2), Class::Warrior);
+    let pvp_room = any_pvp_room(&s.world);
+    s.players.get_mut(&uid(1)).unwrap().room = pvp_room;
+    s.players.get_mut(&uid(2)).unwrap().room = pvp_room;
+    s.engage_player(uid(1), uid(2));
+    s.players.get_mut(&uid(1)).unwrap().weapon_coat = Some((DamageType::Fire, 10, OIL_CHARGES));
+    s.tick();
+    assert!(
+        s.pvp_dots
+            .get(&uid(2))
+            .is_some_and(|d| d.iter().any(|(owner, per_tick, dtype, _)| {
+                *owner == uid(1) && *per_tick == 10 && *dtype == DamageType::Fire
+            })),
+        "the landed duel swing seeds the coat's school DoT on the rival"
+    );
+    assert_eq!(
+        s.players[&uid(1)].weapon_coat.map(|(_, _, c)| c),
+        Some(OIL_CHARGES - 1),
+        "the duel swing spends one coat charge"
+    );
 }

--- a/late-ssh/src/app/door/lateania/svc_test.rs
+++ b/late-ssh/src/app/door/lateania/svc_test.rs
@@ -4166,6 +4166,33 @@ fn the_long_road_matches_the_real_gates_and_tracks_titles() {
 }
 
 #[test]
+fn physical_walls_never_gate_the_long_road_past_the_treant() {
+    // This is a solo game: a Physical-locked class must be able to walk the
+    // whole mandatory road without another player. Physical-resist bosses may
+    // guard optional prizes, but on the Long Road only the Elder Treant wears
+    // one - and he sits at the low band where a tier-0 oil's flat rider
+    // out-punches the resist, so he teaches the coat instead of gating on it.
+    let w = seed_world();
+    for m in LONG_ROAD {
+        let spawn = w
+            .spawns
+            .iter()
+            .find(|sp| sp.name == m.boss)
+            .expect("road boss exists");
+        if m.boss == "the Elder Treant" {
+            assert_eq!(spawn.profile.resist, Some(DamageType::Physical));
+            continue;
+        }
+        assert_ne!(
+            spawn.profile.resist,
+            Some(DamageType::Physical),
+            "{} resists Physical on the mandatory road",
+            m.boss
+        );
+    }
+}
+
+#[test]
 fn every_quest_target_and_zone_is_real() {
     let w = seed_world();
     for q in STARTER_QUESTS {

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -1886,7 +1886,7 @@ fn draw_world_map(frame: &mut Frame, area: Rect, state: &State, view: &PlayerVie
 fn draw_class_select(frame: &mut Frame, area: Rect, view: &PlayerView, cursor: usize) {
     let cursor = cursor.min(Class::ALL.len() - 1);
     let chosen = Class::ALL[cursor];
-    let accent = class_accent(chosen.name());
+    let accent = class_accent(Some(chosen));
     let mut lines = vec![
         Line::from(Span::styled(
             "~ LATEANIA ~",
@@ -1912,7 +1912,7 @@ fn draw_class_select(frame: &mut Frame, area: Rect, view: &PlayerView, cursor: u
     ];
     // The rolled scores in the same rated rows as the character sheet, with the
     // highlighted class's primary score glowing in its accent.
-    lines.extend(attribute_lines(view, primary_label(chosen.name()), accent));
+    lines.extend(attribute_lines(view, primary_label(Some(chosen)), accent));
     lines.push(Line::raw(""));
     // One compact row per class; the highlighted one is expanded directly below
     // its row so cursor-following scroll keeps the choice and its details together.
@@ -3752,7 +3752,7 @@ fn map_cell_span(cell: MapCell) -> Span<'static> {
 /// A class portrait and vitals bars on the left, ability scores as dot ratings
 /// in the middle, and combat/derived stats, trait, titles, and XP on the right.
 fn draw_character_sheet(frame: &mut Frame, area: Rect, view: &PlayerView) {
-    let accent = class_accent(&view.class_name);
+    let accent = class_accent(Class::from_key(&view.class_key));
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(theme::BORDER()))
@@ -3783,12 +3783,7 @@ fn draw_character_sheet(frame: &mut Frame, area: Rect, view: &PlayerView) {
 
 /// Left column: portrait, identity headline, and vitals as filled meters.
 fn sheet_identity(view: &PlayerView, accent: Color) -> Vec<Line<'static>> {
-    let mut lines = composed_portrait(
-        &view.class_key,
-        &view.class_name,
-        &view.appearance_idx,
-        accent,
-    );
+    let mut lines = composed_portrait(&view.class_key, &view.appearance_idx, accent);
     lines.push(Line::raw(""));
     lines.push(Line::from(Span::styled(
         format!("Lv {} {}", view.level, view.class_name),
@@ -3899,7 +3894,11 @@ fn attribute_lines(view: &PlayerView, primary: &str, accent: Color) -> Vec<Line<
 }
 
 fn sheet_attributes(view: &PlayerView, accent: Color) -> Vec<Line<'static>> {
-    let mut lines = attribute_lines(view, primary_label(&view.class_name), accent);
+    let mut lines = attribute_lines(
+        view,
+        primary_label(Class::from_key(&view.class_key)),
+        accent,
+    );
     lines.push(Line::raw(""));
     lines.push(section("Trait"));
     lines.push(Line::from(Span::styled(
@@ -4169,22 +4168,15 @@ fn roster_row(
     Line::from(spans)
 }
 
-/// The short ability-score label of a class's primary score, for highlighting.
-fn primary_label(class_name: &str) -> &'static str {
-    match class_name {
-        "Warrior" => "STR",
-        "Mage" => "INT",
-        "Cleric" => "WIS",
-        "Rogue" | "Ranger" => "DEX",
-        _ => "",
+/// The attribute row a class's key ability lands on, so the sheet and the
+/// selection screen glow the score that actually feeds its attack bonus. Read
+/// off the class itself: a new class cannot silently render with no attribute
+/// highlighted. Empty for a player who has not picked a class yet.
+fn primary_label(class: Option<Class>) -> &'static str {
+    match class {
+        Some(class) => class.primary_score().label(),
+        None => "",
     }
-}
-
-/// The display name for a stable class key (empty string if unknown).
-fn class_name_of(class_key: &str) -> String {
-    Class::from_key(class_key)
-        .map(|c| c.name().to_string())
-        .unwrap_or_default()
 }
 
 /// A three-letter class abbreviation, for roster rows too narrow for the full
@@ -4213,37 +4205,59 @@ fn class_abbrev(class_key: &str) -> &'static str {
     }
 }
 
-/// The accent colour that tints a class's portrait and headline.
-fn class_accent(class_name: &str) -> Color {
-    match class_name {
-        "Warrior" => theme::AMBER(),
-        "Mage" => theme::MENTION(),
-        "Cleric" => theme::BADGE_GOLD(),
-        "Rogue" => theme::ERROR(),
-        "Ranger" => theme::SUCCESS(),
-        "Beastlord" => theme::SUCCESS(),
-        "Skald" => theme::AMBER_GLOW(),
-        "Runemaster" => theme::MENTION(),
-        "Valewalker" => theme::SUCCESS(),
-        "Spiritmaster" => theme::MENTION(),
-        _ => theme::TEXT_BRIGHT(),
+/// The colour a class is drawn in: its portrait tint, its key attribute, the
+/// stars on its rated rows. Every class names one, so no calling reads as a
+/// colourless "generic adventurer". Unclassed players get plain bright text.
+fn class_accent(class: Option<Class>) -> Color {
+    let Some(class) = class else {
+        return theme::TEXT_BRIGHT();
+    };
+    match class {
+        Class::Warrior => theme::AMBER(),
+        Class::Mage => theme::MENTION(),
+        Class::Cleric => theme::BADGE_GOLD(),
+        Class::Rogue => theme::ERROR(),
+        Class::Ranger => theme::SUCCESS(),
+        Class::Druid => theme::SUCCESS(),
+        Class::Necromancer => theme::MENTION(),
+        Class::Bard => theme::AMBER_GLOW(),
+        Class::Monk => theme::BADGE_GOLD(),
+        Class::Paladin => theme::BADGE_GOLD(),
+        Class::Warlock => theme::ERROR(),
+        Class::Berserker => theme::AMBER(),
+        Class::Beastlord => theme::SUCCESS(),
+        Class::Skald => theme::AMBER_GLOW(),
+        Class::Runemaster => theme::MENTION(),
+        Class::Valewalker => theme::SUCCESS(),
+        Class::Spiritmaster => theme::MENTION(),
     }
 }
 
-/// A single-glyph class emblem shown beneath the portrait bust.
-fn class_emblem(class_name: &str) -> &'static str {
-    match class_name {
-        "Warrior" => "⚔ Warrior",
-        "Mage" => "✦ Mage",
-        "Cleric" => "✚ Cleric",
-        "Rogue" => "† Rogue",
-        "Ranger" => "➹ Ranger",
-        "Beastlord" => "❦ Beastlord",
-        "Skald" => "♪ Skald",
-        "Runemaster" => "ᛟ Runemaster",
-        "Valewalker" => "⚑ Valewalker",
-        "Spiritmaster" => "✵ Spiritmaster",
-        _ => "Adventurer",
+/// The mark a class stands under: a single glyph and its name, shown beneath
+/// the portrait bust. Every calling names its own, and no two share a glyph, so
+/// a bust reads as that class at a glance. Unclassed players are Adventurers.
+fn class_emblem(class: Option<Class>) -> &'static str {
+    let Some(class) = class else {
+        return "Adventurer";
+    };
+    match class {
+        Class::Warrior => "⚔ Warrior",
+        Class::Mage => "✦ Mage",
+        Class::Cleric => "✚ Cleric",
+        Class::Rogue => "† Rogue",
+        Class::Ranger => "➹ Ranger",
+        Class::Druid => "☘ Druid",
+        Class::Necromancer => "☠ Necromancer",
+        Class::Bard => "♫ Bard",
+        Class::Monk => "☯ Monk",
+        Class::Paladin => "✠ Paladin",
+        Class::Warlock => "☾ Warlock",
+        Class::Berserker => "☄ Berserker",
+        Class::Beastlord => "❦ Beastlord",
+        Class::Skald => "♪ Skald",
+        Class::Runemaster => "ᛟ Runemaster",
+        Class::Valewalker => "⚑ Valewalker",
+        Class::Spiritmaster => "✵ Spiritmaster",
     }
 }
 
@@ -4274,12 +4288,7 @@ fn eye_tint(idx: u8) -> Color {
 /// (build/hair/eyes/bearing) plus a class-flavoured headpiece, tinted with the
 /// class accent and per-feature colours. Falls back cleanly when indices are
 /// missing (old/absent selections). The class emblem is shown below the bust.
-fn composed_portrait(
-    class_key: &str,
-    class_name: &str,
-    sel: &[u8],
-    accent: Color,
-) -> Vec<Line<'static>> {
+fn composed_portrait(class_key: &str, sel: &[u8], accent: Color) -> Vec<Line<'static>> {
     // Pad/clamp the selection to a full field set.
     let mut idx = [0u8; appearance::N_FIELDS];
     for (i, slot) in idx.iter_mut().enumerate() {
@@ -4307,7 +4316,7 @@ fn composed_portrait(
         })
         .collect();
     lines.push(Line::from(Span::styled(
-        format!(" {}", class_emblem(class_name)),
+        format!(" {}", class_emblem(Class::from_key(class_key))),
         Style::default().fg(accent).add_modifier(Modifier::BOLD),
     )));
     lines
@@ -4324,8 +4333,8 @@ fn character_panel(view: &PlayerView) -> Vec<Line<'static>> {
     lines.push(Line::raw(""));
     lines.extend(attribute_lines(
         view,
-        primary_label(&view.class_name),
-        class_accent(&view.class_name),
+        primary_label(Class::from_key(&view.class_key)),
+        class_accent(Class::from_key(&view.class_key)),
     ));
     if view.resurrection_cap > 0 {
         lines.push(stat(
@@ -5325,10 +5334,9 @@ fn appearance_panel(view: &PlayerView, cursor: usize) -> Vec<Line<'static>> {
     // A live portrait of the current choices, so players can preview how each
     // change reshapes their character before committing.
     if view.classed {
-        let accent = class_accent(&view.class_name);
+        let accent = class_accent(Class::from_key(&view.class_key));
         lines.extend(composed_portrait(
             &view.class_key,
-            &view.class_name,
             &view.appearance_idx,
             accent,
         ));
@@ -6083,10 +6091,9 @@ fn follow_panel(
                 .get(&occ.user_id)
                 .cloned()
                 .unwrap_or_else(|| "adventurer".to_string());
-            let accent = class_accent(&class_name_of(&occ.class_key));
+            let accent = class_accent(Class::from_key(&occ.class_key));
             lines.extend(composed_portrait(
                 &occ.class_key,
-                &class_name_of(&occ.class_key),
                 &occ.appearance_idx,
                 accent,
             ));

--- a/late-ssh/src/app/door/lateania/ui.rs
+++ b/late-ssh/src/app/door/lateania/ui.rs
@@ -3579,6 +3579,9 @@ fn battle_side_panel(
     if view.empower > 0 {
         effects.push(format!("empowered +{}", view.empower));
     }
+    if let Some(coat) = &view.coat {
+        effects.push(coat.clone());
+    }
     if view.stunned {
         effects.push("stunned".to_string());
     }
@@ -5686,6 +5689,9 @@ fn battle_context(view: &PlayerView, width: usize) -> Option<Vec<Line<'static>>>
     }
     if view.empower > 0 {
         effects.push(format!("empowered +{}", view.empower));
+    }
+    if let Some(coat) = &view.coat {
+        effects.push(coat.clone());
     }
     if view.stunned {
         effects.push("stunned".to_string());

--- a/late-ssh/src/app/door/lateania/ui_test.rs
+++ b/late-ssh/src/app/door/lateania/ui_test.rs
@@ -1024,3 +1024,73 @@ fn the_land_map_only_offers_the_scroll_key_when_it_overflows() {
         .unwrap_or_default();
     assert!(short.contains("[ ] scroll"), "{short}");
 }
+
+#[test]
+fn every_class_glows_the_ability_that_drives_its_attack() {
+    // The character sheet marks one attribute row as the class's key ability -
+    // the score that feeds `attack_bonus`. The mapping used to be a hand-kept
+    // list of the first five classes, so a Berserker (STR) or a Bard (CHA) read
+    // as if no attribute mattered to them at all.
+    use crate::app::door::lateania::classes::Class;
+    use ratatui::style::Modifier;
+
+    for class in Class::ALL {
+        let mut view = crate::app::door::lateania::svc::empty_player_view();
+        view.classed = true;
+        view.class_name = class.name().to_string();
+        view.class_key = class.as_key().to_string();
+
+        let labels: Vec<&str> = view.scores.rows().iter().map(|(l, _, _)| *l).collect();
+        let glowing: Vec<String> = super::character_panel(&view)
+            .iter()
+            .filter_map(|line| {
+                let label = line.spans.first()?;
+                let name = label.content.trim().to_string();
+                if !labels.contains(&name.as_str()) {
+                    return None;
+                }
+                label
+                    .style
+                    .add_modifier
+                    .contains(Modifier::BOLD)
+                    .then_some(name)
+            })
+            .collect();
+
+        assert_eq!(
+            glowing,
+            vec![class.primary_score().label().to_string()],
+            "{} should glow exactly its key ability",
+            class.name()
+        );
+    }
+}
+
+#[test]
+fn every_class_wears_its_own_emblem_under_the_portrait() {
+    // Same stale-list bug as the key ability: the portrait emblem was a
+    // hand-kept map of ten class names, so the other seven callings stood under
+    // a nameless "Adventurer" bust. Each class also gets its own glyph - two
+    // callings sharing a mark makes the portrait say less than nothing.
+    use crate::app::door::lateania::classes::Class;
+
+    let mut seen: Vec<String> = Vec::new();
+    for class in Class::ALL {
+        let portrait =
+            super::composed_portrait(class.as_key(), &[0u8; 4], ratatui::style::Color::White);
+        let emblem = portrait.last().map(line_text).unwrap_or_default();
+        assert!(
+            emblem.contains(class.name()),
+            "{} stands under \"{}\"",
+            class.name(),
+            emblem.trim()
+        );
+        let glyph = emblem.trim().chars().next().expect("an emblem glyph");
+        assert!(
+            !seen.contains(&glyph.to_string()),
+            "{} reuses the {glyph} emblem",
+            class.name()
+        );
+        seen.push(glyph.to_string());
+    }
+}

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -21,7 +21,7 @@
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::OnceLock;
 
-use super::damage::{DamageProfile, DamageType};
+use super::damage::{DamageProfile, DamageType, ZoneTheme};
 use super::skills::{CraftSkill, GatherSkill};
 
 // ---- Core world types: directions, rooms, spawns, behaviour --------------
@@ -5570,6 +5570,11 @@ pub fn seed_world() -> World {
             ),
         },
         // ---- The Sunken Citadel (tier 7-8) ------------------------------
+        // Bloodless citadel constructs: they shrug off venom, not steel. A
+        // Physical resist on a regular is a zone-wide tax on the seven
+        // Physical-locked classes with no counterplay, so it lives on bosses
+        // only (the world resist/weak pass, rule 2 - enforced globally by
+        // `no_regular_resists_physical_and_nothing_is_weak_to_physical`).
         MobSpawn {
             id: 60,
             name: "a faceless sentinel",
@@ -5582,7 +5587,7 @@ pub fn seed_world() -> World {
             boss: false,
             profile: DamageProfile::new(
                 DamageType::Physical,
-                Some(DamageType::Physical),
+                Some(DamageType::Poison),
                 Some(DamageType::Arcane),
             ),
         },
@@ -5598,7 +5603,7 @@ pub fn seed_world() -> World {
             boss: false,
             profile: DamageProfile::new(
                 DamageType::Physical,
-                Some(DamageType::Physical),
+                Some(DamageType::Poison),
                 Some(DamageType::Arcane),
             ),
         },
@@ -6054,9 +6059,15 @@ fn extend_archipelago(
                     58 + tier * 4 + depth,
                 )
             };
-            let profile = match behavior {
-                MobBehavior::Caster(school) => DamageProfile::new(school, None, None),
-                _ => DamageProfile::new(DamageType::Physical, None, None),
+            let attack = match behavior {
+                MobBehavior::Caster(school) => school,
+                _ => DamageType::Physical,
+            };
+            let profile = if boss_mob {
+                DamageProfile::new(attack, None, None)
+            } else {
+                let theme = super::archipelago::ISLAND_THEMES[isle];
+                DamageProfile::new(attack, theme.resist(), theme.weak())
             };
             spawns.push(MobSpawn {
                 id: spawn_id,
@@ -7446,6 +7457,32 @@ pub fn is_reaches_room(id: RoomId) -> bool {
 /// Twenty zones of the Sundered Reaches: (zone, adjective, ground, landmark,
 /// creatures, three mob names, boss). Reuses `frontier_desc` for prose.
 #[allow(clippy::type_complexity)]
+/// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
+/// Reaches zone, in `REACHES_ZONES_DATA` order. Regulars inherit the theme's
+/// profile; zone bosses keep their own.
+const REACHES_ZONE_THEMES: [ZoneTheme; REACHES_ZONES] = [
+    ZoneTheme::Tidal,     // Saltmarsh Shallows
+    ZoneTheme::Tidal,     // Wreckers' Coast
+    ZoneTheme::Resonant,  // Weeping Cliffs
+    ZoneTheme::Verdant,   // Kelpwood Drowned
+    ZoneTheme::Fae,       // Sirens' Reef
+    ZoneTheme::Haunted,   // Sinking Isles
+    ZoneTheme::Storm,     // Stormwall Straits
+    ZoneTheme::Drowned,   // Brine Caverns
+    ZoneTheme::Haunted,   // Sunken Valmaris
+    ZoneTheme::Drowned,   // Pearl Abyss
+    ZoneTheme::Beastwild, // Coral Throne Reach
+    ZoneTheme::Crystal,   // Glass Currents
+    ZoneTheme::Beastwild, // Leviathan's Wake
+    ZoneTheme::Undead,    // Mourning Depths
+    ZoneTheme::Storm,     // Tempest Spire Reach
+    ZoneTheme::Beastwild, // Trench of Maws
+    ZoneTheme::Profane,   // Drowned Pantheon
+    ZoneTheme::Resonant,  // Black Maelstrom
+    ZoneTheme::Fae,       // Abyssal Court
+    ZoneTheme::Profane,   // Sundering Deep
+];
+
 const REACHES_ZONES_DATA: [(&str, &str, &str, &str, &str, [&str; 3], &str); 20] = [
     (
         "Saltmarsh Shallows",
@@ -7873,9 +7910,15 @@ fn extend_reaches(
                     56 + tier * 4 + depth,
                 )
             };
-            let profile = match behavior {
-                MobBehavior::Caster(school) => DamageProfile::new(school, None, None),
-                _ => DamageProfile::new(DamageType::Physical, None, None),
+            let attack = match behavior {
+                MobBehavior::Caster(school) => school,
+                _ => DamageType::Physical,
+            };
+            let profile = if boss_mob {
+                DamageProfile::new(attack, None, None)
+            } else {
+                let theme = REACHES_ZONE_THEMES[z];
+                DamageProfile::new(attack, theme.resist(), theme.weak())
             };
             spawns.push(MobSpawn {
                 id: spawn_id,
@@ -7991,6 +8034,33 @@ pub fn is_kaelmyr_room(id: RoomId) -> bool {
 /// mob names, boss). The tribe threading is carried in the mob/boss names and
 /// the landmarks; `kaelmyr_desc` supplies the paragraph prose.
 #[allow(clippy::type_complexity)]
+/// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
+/// Kaelmyr zone, in `KAELMYR_ZONES_DATA` order. Regulars inherit the theme's
+/// profile; zone bosses keep their own. The burnt continent leans Frost-weak
+/// on purpose: fear of the cold is the land's through-line.
+const KAELMYR_ZONE_THEMES: [ZoneTheme; KAELMYR_ZONES] = [
+    ZoneTheme::Sunscorched, // Cinderfall Shore
+    ZoneTheme::Sunscorched, // Emberkin Terraces
+    ZoneTheme::Ashen,       // Calder Vhael
+    ZoneTheme::Sunscorched, // Pyre-Roads
+    ZoneTheme::Beastwild,   // Sunless Vents
+    ZoneTheme::Haunted,     // Cinderbound Fields
+    ZoneTheme::Construct,   // Slagworks Ruin
+    ZoneTheme::Undead,      // Ashen Barrows
+    ZoneTheme::Crystal,     // Gloamwright Deeps
+    ZoneTheme::Crystal,     // Black Deserts
+    ZoneTheme::Crystal,     // Volcanoglass Reach
+    ZoneTheme::Ashen,       // Ashfall Wastes
+    ZoneTheme::Resonant,    // Stormheld Ascent
+    ZoneTheme::Storm,       // Thunderspires
+    ZoneTheme::Resonant,    // Cinder-Storms
+    ZoneTheme::Resonant,    // Hollowing
+    ZoneTheme::Profane,     // Choirhold Caverns
+    ZoneTheme::Tidal,       // Drowned Wound
+    ZoneTheme::Beastwild,   // Unquenched Throne
+    ZoneTheme::Profane,     // Sundering Wound
+];
+
 const KAELMYR_ZONES_DATA: [(&str, &str, &str, &str, &str, [&str; 3], &str); 20] = [
     (
         "Cinderfall Shore",
@@ -8474,9 +8544,15 @@ fn extend_kaelmyr(
                     116 + tier * 4 + depth,
                 )
             };
-            let profile = match behavior {
-                MobBehavior::Caster(school) => DamageProfile::new(school, None, None),
-                _ => DamageProfile::new(DamageType::Physical, None, None),
+            let attack = match behavior {
+                MobBehavior::Caster(school) => school,
+                _ => DamageType::Physical,
+            };
+            let profile = if boss_mob {
+                DamageProfile::new(attack, None, None)
+            } else {
+                let theme = KAELMYR_ZONE_THEMES[z];
+                DamageProfile::new(attack, theme.resist(), theme.weak())
             };
             spawns.push(MobSpawn {
                 id: spawn_id,
@@ -8602,6 +8678,26 @@ pub fn is_lakes_room(id: RoomId) -> bool {
 /// lean toward wildlife and lost things rather than horrors, and the notables
 /// are lake-guardians more than tyrants. `lakes_desc` supplies the prose.
 #[allow(clippy::type_complexity)]
+/// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
+/// Sunderlakes zone, in `LAKES_ZONES_DATA` order. Regulars inherit the
+/// theme's profile; zone notables keep their own.
+const LAKES_ZONE_THEMES: [ZoneTheme; LAKES_ZONES] = [
+    ZoneTheme::Tidal,     // Anglers' Dock
+    ZoneTheme::Beastwild, // Reed Labyrinth
+    ZoneTheme::Drowned,   // Sunken Grotto
+    ZoneTheme::Beastwild, // Isle Meres
+    ZoneTheme::Verdant,   // Willow Drowns
+    ZoneTheme::Drowned,   // Weeping Caverns
+    ZoneTheme::Verdant,   // Lily Reaches
+    ZoneTheme::Haunted,   // Drowned Orchard
+    ZoneTheme::Beastwild, // Glasswater Deep
+    ZoneTheme::Fae,       // Fenlight Marsh
+    ZoneTheme::Fae,       // Mirror Meres
+    ZoneTheme::Drowned,   // Fathom Caverns
+    ZoneTheme::Haunted,   // Drowned Valley
+    ZoneTheme::Beastwild, // Mere-Mother's Deep
+];
+
 const LAKES_ZONES_DATA: [(&str, &str, &str, &str, &str, [&str; 3], &str); 14] = [
     (
         "Anglers' Dock",
@@ -9013,7 +9109,12 @@ fn extend_lakes(
                         11 + tier + depth / 2,
                     )
                 };
-            let profile = DamageProfile::new(DamageType::Physical, None, None);
+            let profile = if boss_mob {
+                DamageProfile::new(DamageType::Physical, None, None)
+            } else {
+                let theme = LAKES_ZONE_THEMES[z];
+                DamageProfile::new(DamageType::Physical, theme.resist(), theme.weak())
+            };
             spawns.push(MobSpawn {
                 id: spawn_id,
                 name: mob_name,
@@ -9374,6 +9475,33 @@ pub fn region_atlas_entry(id: RoomId) -> Option<(&'static str, &'static str)> {
 /// the paragraph prose. Zone names must NOT start with "The " (the builder does
 /// not prepend it here, but keeps them clean for the leaked zone label).
 #[allow(clippy::type_complexity)]
+/// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
+/// Broceliande zone, in `BROCELIANDE_ZONES_DATA` order. Regulars inherit the
+/// theme's profile; zone notables keep their own. The Greenwood leans
+/// Fire-weak on purpose: burning the wood is the answer the country teaches.
+const BROCELIANDE_ZONE_THEMES: [ZoneTheme; BROCELIANDE_ZONES] = [
+    ZoneTheme::Beastwild, // Woodward's Holt
+    ZoneTheme::Verdant,   // Oakheart Grove
+    ZoneTheme::Fungal,    // Fernlight Hollow
+    ZoneTheme::Resonant,  // Druid's Circle
+    ZoneTheme::Beastwild, // Briarmaze Thicket
+    ZoneTheme::Fae,       // Whispering Fens
+    ZoneTheme::Haunted,   // Verdant Ruins
+    ZoneTheme::Fae,       // Moonshadow Glade
+    ZoneTheme::Beastwild, // Steaming Jungle
+    ZoneTheme::Verdant,   // Vine-Choked Deep
+    ZoneTheme::Undead,    // Standing Kings
+    ZoneTheme::Undead,    // Barrowgreen
+    ZoneTheme::Fae,       // Faerie Reaches
+    ZoneTheme::Beastwild, // Wyrmfern Hollows
+    ZoneTheme::Haunted,   // Greenmantle Keep
+    ZoneTheme::Verdant,   // Thornwyrd Maze
+    ZoneTheme::Fae,       // Cernunmoor
+    ZoneTheme::Fungal,    // Worldroot Deep
+    ZoneTheme::Resonant,  // Greenmarch Heart
+    ZoneTheme::Fae,       // World-Oak Crown
+];
+
 const BROCELIANDE_ZONES_DATA: [(&str, &str, &str, &str, &str, [&str; 3], &str); 20] = [
     (
         "Woodward's Holt",
@@ -9906,7 +10034,12 @@ fn extend_broceliande(
                         15 + tier + depth / 2,
                     )
                 };
-            let profile = DamageProfile::new(DamageType::Physical, None, None);
+            let profile = if boss_mob {
+                DamageProfile::new(DamageType::Physical, None, None)
+            } else {
+                let theme = BROCELIANDE_ZONE_THEMES[z];
+                DamageProfile::new(DamageType::Physical, theme.resist(), theme.weak())
+            };
             spawns.push(MobSpawn {
                 id: spawn_id,
                 name: mob_name,
@@ -10046,6 +10179,25 @@ const AELUNOR_CREATURES: [&str; 20] = [
 /// same shape as `BROCELIANDE_ZONES_DATA`. Zone names must NOT start with
 /// "The " (the builder does not prepend it).
 #[allow(clippy::type_complexity)]
+/// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
+/// Aelunor glade, in `AELUNOR_ZONES_DATA` order. Regulars inherit the theme's
+/// profile whatever affix they roll (the affix buys stats and loot, not a
+/// different school game); zone bosses keep their authored profile.
+const AELUNOR_ZONE_THEMES: [ZoneTheme; AELUNOR_ZONES] = [
+    ZoneTheme::Verdant,   // Silverleaf Eaves
+    ZoneTheme::Resonant,  // the Whispering Boughs
+    ZoneTheme::Verdant,   // Mossheart Glade
+    ZoneTheme::Fae,       // the Sunfall Canopy
+    ZoneTheme::Beastwild, // Thistledown Hollow
+    ZoneTheme::Resonant,  // the Elder Ring
+    ZoneTheme::Fae,       // Duskpetal Grove
+    ZoneTheme::Tidal,     // the Starlit Fen
+    ZoneTheme::Fungal,    // Wychroot Deeps
+    ZoneTheme::Fae,       // the Faerie Loom
+    ZoneTheme::Tidal,     // Moonwell Thicket
+    ZoneTheme::Resonant,  // the Heartwood Sanctum
+];
+
 const AELUNOR_ZONES_DATA: [(&str, &str, &str, &str, &str, [usize; 3], &str); 12] = [
     (
         "Silverleaf Eaves",
@@ -10412,7 +10564,9 @@ fn extend_aelunor(
             // local floor as the prize does, or a first-glade Legendary hands
             // a wanderer Epic-band gear off an ordinary fight.
             let elite = (rarity * rarity) as i32;
-            let profile = DamageProfile::new(DamageType::Physical, None, None);
+            let theme = AELUNOR_ZONE_THEMES[z];
+            let profile =
+                DamageProfile::new(DamageType::Physical, theme.resist(), theme.weak());
             spawns.push(MobSpawn {
                 id: spawn_id,
                 name: mob_name,
@@ -11258,6 +11412,32 @@ fn wildbound_named(creature: &str, tier: usize) -> &'static str {
 /// Per-zone flavour: name, adjective, ground noun, a landmark feature, the
 /// creatures that haunt it, three regular mob names, and the zone boss.
 #[allow(clippy::type_complexity)]
+/// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
+/// Frontier zone, in `FRONTIER_ZONES_DATA` order, derived from the zone's
+/// flavor. Regulars inherit the theme's profile; zone bosses keep their own.
+const FRONTIER_ZONE_THEMES: [ZoneTheme; FRONTIER_ZONES] = [
+    ZoneTheme::Ashen,       // Ashen Wastes
+    ZoneTheme::Tidal,       // Sunken Fens
+    ZoneTheme::Fae,         // Glimmerwood
+    ZoneTheme::Beastwild,   // Howling Steppe
+    ZoneTheme::Sunscorched, // Cinder Barrens
+    ZoneTheme::Tidal,       // Tideglass Coast
+    ZoneTheme::Undead,      // Bonewhite Reach
+    ZoneTheme::Haunted,     // Verdigris Ruins
+    ZoneTheme::Storm,       // Stormspire Highlands
+    ZoneTheme::Haunted,     // Umbral Depths
+    ZoneTheme::Sunscorched, // Saltglass Desert
+    ZoneTheme::Fungal,      // Fungal Hollow
+    ZoneTheme::Crystal,     // Clockwork Ruins
+    ZoneTheme::Beastwild,   // Bloodmarsh
+    ZoneTheme::Resonant,    // Singing Canyon
+    ZoneTheme::Frozen,      // Frostfang Tundra
+    ZoneTheme::Crystal,     // Obsidian Flats
+    ZoneTheme::Haunted,     // Driftbone Sea
+    ZoneTheme::Sunscorched, // Emberfall Caldera
+    ZoneTheme::Profane,     // Hollow Crown
+];
+
 const FRONTIER_ZONES_DATA: [(&str, &str, &str, &str, &str, [&str; 3], &str); 20] = [
     (
         "Ashen Wastes",
@@ -11573,6 +11753,7 @@ fn extend_frontier(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>
                     spawn_id += 1;
                 } else if idx.is_multiple_of(2) {
                     let ti = tier as i32;
+                    let theme = FRONTIER_ZONE_THEMES[z];
                     spawns.push(MobSpawn {
                         id: spawn_id,
                         name: mob_names[(idx as usize) % 3],
@@ -11583,7 +11764,11 @@ fn extend_frontier(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>
                         respawn_secs: 90,
                         loot: super::items::frontier_loot(z),
                         boss: false,
-                        profile: DamageProfile::new(DamageType::Physical, None, None),
+                        profile: DamageProfile::new(
+                            DamageType::Physical,
+                            theme.resist(),
+                            theme.weak(),
+                        ),
                     });
                     spawn_id += 1;
                 }
@@ -12167,7 +12352,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         90,
         false,
         COMMON_LOOT,
-        p(D::Fire, Some(D::Physical), Some(D::Frost)),
+        p(D::Fire, Some(D::Poison), Some(D::Frost)),
     );
     mob(
         spawns,
@@ -12296,7 +12481,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         120,
         false,
         COMMON_LOOT,
-        p(D::Frost, Some(D::Physical), Some(D::Fire)),
+        p(D::Frost, Some(D::Frost), Some(D::Fire)),
     );
     mob(
         spawns,
@@ -12386,7 +12571,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         144,
         false,
         COMMON_LOOT,
-        p(D::Shadow, Some(D::Physical), Some(D::Holy)),
+        p(D::Shadow, Some(D::Shadow), Some(D::Holy)),
     );
     mob(
         spawns,
@@ -12397,7 +12582,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         150,
         false,
         COMMON_LOOT,
-        p(D::Shadow, Some(D::Physical), Some(D::Holy)),
+        p(D::Shadow, Some(D::Shadow), Some(D::Holy)),
     );
     mob(
         spawns,
@@ -12408,7 +12593,7 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         156,
         false,
         COMMON_LOOT,
-        p(D::Physical, Some(D::Physical), Some(D::Arcane)),
+        p(D::Physical, Some(D::Shadow), Some(D::Arcane)),
     );
     mob(
         spawns,
@@ -12891,7 +13076,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         44,
         false,
         COMMON_LOOT,
-        p(D::Physical, Some(D::Physical), Some(D::Fire)),
+        p(D::Physical, Some(D::Poison), Some(D::Fire)),
     );
 
     // ---- Tasmania (7 rooms): the harbor capital (SAFE) ------------------
@@ -13043,7 +13228,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         70,
         false,
         COMMON_LOOT,
-        p(D::Physical, Some(D::Physical), Some(D::Lightning)),
+        p(D::Physical, Some(D::Frost), Some(D::Lightning)),
     );
     mob(
         spawns,
@@ -13414,7 +13599,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         74,
         false,
         COMMON_LOOT,
-        p(D::Poison, Some(D::Physical), Some(D::Fire)),
+        p(D::Poison, Some(D::Poison), Some(D::Fire)),
     );
     mob(
         spawns,
@@ -13678,7 +13863,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         74,
         false,
         COMMON_LOOT,
-        p(D::Shadow, Some(D::Physical), Some(D::Holy)),
+        p(D::Shadow, Some(D::Shadow), Some(D::Holy)),
     );
     mob(
         spawns,
@@ -13763,7 +13948,7 @@ fn extend_overworld(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn
         72,
         false,
         COMMON_LOOT,
-        p(D::Physical, Some(D::Physical), Some(D::Frost)),
+        p(D::Physical, Some(D::Poison), Some(D::Frost)),
     );
     mob(
         spawns,

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -7461,7 +7461,8 @@ pub fn is_reaches_room(id: RoomId) -> bool {
 #[allow(clippy::type_complexity)]
 /// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
 /// Reaches zone, in `REACHES_ZONES_DATA` order. Regulars inherit the theme's
-/// profile; zone bosses keep their own.
+/// profile; the zone boss wears the theme's weakness but never its resist
+/// (prep is a pure reward on the fight players provision for).
 const REACHES_ZONE_THEMES: [ZoneTheme; REACHES_ZONES] = [
     ZoneTheme::Tidal,     // Saltmarsh Shallows
     ZoneTheme::Tidal,     // Wreckers' Coast
@@ -8040,8 +8041,10 @@ pub fn is_kaelmyr_room(id: RoomId) -> bool {
 #[allow(clippy::type_complexity)]
 /// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
 /// Kaelmyr zone, in `KAELMYR_ZONES_DATA` order. Regulars inherit the theme's
-/// profile; zone bosses keep their own. The burnt continent leans Frost-weak
-/// on purpose: fear of the cold is the land's through-line.
+/// profile; the zone boss wears the theme's weakness but never its resist
+/// (prep is a pure reward on the fight players provision for).
+/// The burnt continent leans Frost-weak on purpose: fear of the cold is the
+/// land's through-line.
 const KAELMYR_ZONE_THEMES: [ZoneTheme; KAELMYR_ZONES] = [
     ZoneTheme::Sunscorched, // Cinderfall Shore
     ZoneTheme::Sunscorched, // Emberkin Terraces
@@ -8686,7 +8689,8 @@ pub fn is_lakes_room(id: RoomId) -> bool {
 #[allow(clippy::type_complexity)]
 /// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
 /// Sunderlakes zone, in `LAKES_ZONES_DATA` order. Regulars inherit the
-/// theme's profile; zone notables keep their own.
+/// theme's profile; the zone boss wears the theme's weakness but never its resist
+/// (prep is a pure reward on the fight players provision for).
 const LAKES_ZONE_THEMES: [ZoneTheme; LAKES_ZONES] = [
     ZoneTheme::Tidal,     // Anglers' Dock
     ZoneTheme::Beastwild, // Reed Labyrinth
@@ -9485,8 +9489,10 @@ pub fn region_atlas_entry(id: RoomId) -> Option<(&'static str, &'static str)> {
 #[allow(clippy::type_complexity)]
 /// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
 /// Broceliande zone, in `BROCELIANDE_ZONES_DATA` order. Regulars inherit the
-/// theme's profile; zone notables keep their own. The Greenwood leans
-/// Fire-weak on purpose: burning the wood is the answer the country teaches.
+/// theme's profile; the zone boss wears the theme's weakness but never its resist
+/// (prep is a pure reward on the fight players provision for).
+/// The Greenwood leans Fire-weak on purpose: burning the wood is the answer
+/// the country teaches.
 const BROCELIANDE_ZONE_THEMES: [ZoneTheme; BROCELIANDE_ZONES] = [
     ZoneTheme::Beastwild, // Woodward's Holt
     ZoneTheme::Verdant,   // Oakheart Grove
@@ -10192,10 +10198,11 @@ const AELUNOR_CREATURES: [&str; 20] = [
 /// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
 /// Aelunor glade, in `AELUNOR_ZONES_DATA` order. Regulars inherit the theme's
 /// profile whatever affix they roll (the affix buys stats and loot, not a
-/// different school game); zone bosses keep their authored profile.
+/// different school game); the glade bosses keep their own authored profile
+/// (Shadow, resisting Physical, weak to Holy - the region's own school game).
 const AELUNOR_ZONE_THEMES: [ZoneTheme; AELUNOR_ZONES] = [
     ZoneTheme::Verdant,   // Silverleaf Eaves
-    ZoneTheme::Resonant,  // the Whispering Boughs
+    ZoneTheme::Haunted,   // the Whispering Boughs
     ZoneTheme::Verdant,   // Mossheart Glade
     ZoneTheme::Fae,       // the Sunfall Canopy
     ZoneTheme::Beastwild, // Thistledown Hollow
@@ -11424,7 +11431,8 @@ fn wildbound_named(creature: &str, tier: usize) -> &'static str {
 #[allow(clippy::type_complexity)]
 /// The world resist/weak pass (spec: CONTEXT.md, same-named section): one theme per
 /// Frontier zone, in `FRONTIER_ZONES_DATA` order, derived from the zone's
-/// flavor. Regulars inherit the theme's profile; zone bosses keep their own.
+/// flavor. Regulars inherit the theme's profile; the zone boss wears the theme's weakness but never its resist
+/// (prep is a pure reward on the fight players provision for).
 const FRONTIER_ZONE_THEMES: [ZoneTheme; FRONTIER_ZONES] = [
     ZoneTheme::Ashen,       // Ashen Wastes
     ZoneTheme::Tidal,       // Sunken Fens

--- a/late-ssh/src/app/door/lateania/world.rs
+++ b/late-ssh/src/app/door/lateania/world.rs
@@ -6063,10 +6063,12 @@ fn extend_archipelago(
                 MobBehavior::Caster(school) => school,
                 _ => DamageType::Physical,
             };
+            // The boss wears the island's weakness but never its resist:
+            // prep is a pure reward on the fight players provision for.
+            let theme = super::archipelago::ISLAND_THEMES[isle];
             let profile = if boss_mob {
-                DamageProfile::new(attack, None, None)
+                DamageProfile::new(attack, None, theme.weak())
             } else {
-                let theme = super::archipelago::ISLAND_THEMES[isle];
                 DamageProfile::new(attack, theme.resist(), theme.weak())
             };
             spawns.push(MobSpawn {
@@ -7914,10 +7916,12 @@ fn extend_reaches(
                 MobBehavior::Caster(school) => school,
                 _ => DamageType::Physical,
             };
+            // The boss wears the zone's weakness but never its resist:
+            // prep is a pure reward on the fight players provision for.
+            let theme = REACHES_ZONE_THEMES[z];
             let profile = if boss_mob {
-                DamageProfile::new(attack, None, None)
+                DamageProfile::new(attack, None, theme.weak())
             } else {
-                let theme = REACHES_ZONE_THEMES[z];
                 DamageProfile::new(attack, theme.resist(), theme.weak())
             };
             spawns.push(MobSpawn {
@@ -8548,10 +8552,12 @@ fn extend_kaelmyr(
                 MobBehavior::Caster(school) => school,
                 _ => DamageType::Physical,
             };
+            // The boss wears the zone's weakness but never its resist:
+            // prep is a pure reward on the fight players provision for.
+            let theme = KAELMYR_ZONE_THEMES[z];
             let profile = if boss_mob {
-                DamageProfile::new(attack, None, None)
+                DamageProfile::new(attack, None, theme.weak())
             } else {
-                let theme = KAELMYR_ZONE_THEMES[z];
                 DamageProfile::new(attack, theme.resist(), theme.weak())
             };
             spawns.push(MobSpawn {
@@ -9109,10 +9115,12 @@ fn extend_lakes(
                         11 + tier + depth / 2,
                     )
                 };
+            // The boss wears the zone's weakness but never its resist:
+            // prep is a pure reward on the fight players provision for.
+            let theme = LAKES_ZONE_THEMES[z];
             let profile = if boss_mob {
-                DamageProfile::new(DamageType::Physical, None, None)
+                DamageProfile::new(DamageType::Physical, None, theme.weak())
             } else {
-                let theme = LAKES_ZONE_THEMES[z];
                 DamageProfile::new(DamageType::Physical, theme.resist(), theme.weak())
             };
             spawns.push(MobSpawn {
@@ -10034,10 +10042,12 @@ fn extend_broceliande(
                         15 + tier + depth / 2,
                     )
                 };
+            // The boss wears the zone's weakness but never its resist:
+            // prep is a pure reward on the fight players provision for.
+            let theme = BROCELIANDE_ZONE_THEMES[z];
             let profile = if boss_mob {
-                DamageProfile::new(DamageType::Physical, None, None)
+                DamageProfile::new(DamageType::Physical, None, theme.weak())
             } else {
-                let theme = BROCELIANDE_ZONE_THEMES[z];
                 DamageProfile::new(DamageType::Physical, theme.resist(), theme.weak())
             };
             spawns.push(MobSpawn {
@@ -11738,6 +11748,10 @@ fn extend_frontier(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>
                 }
                 if is_boss_room {
                     let ti = tier as i32;
+                    // The boss wears the zone's weakness but never its
+                    // resist: prep is a pure reward on the fight players
+                    // provision for.
+                    let theme = FRONTIER_ZONE_THEMES[z];
                     spawns.push(MobSpawn {
                         id: spawn_id,
                         name: boss,
@@ -11748,7 +11762,7 @@ fn extend_frontier(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>
                         respawn_secs: 600,
                         loot: super::items::frontier_loot(z),
                         boss: true,
-                        profile: DamageProfile::new(DamageType::Physical, None, None),
+                        profile: DamageProfile::new(DamageType::Physical, None, theme.weak()),
                     });
                     spawn_id += 1;
                 } else if idx.is_multiple_of(2) {
@@ -12818,7 +12832,9 @@ fn extend_world(rooms: &mut HashMap<RoomId, Room>, spawns: &mut Vec<MobSpawn>) {
         130,
         true,
         &[1006, 1110, 1111, 1201, 1301],
-        DamageProfile::physical(),
+        // Living flesh: the cheapest coat in the game (a tier-0 poison
+        // vial) answers the game's first boss - the earliest prep lesson.
+        DamageProfile::new(DamageType::Physical, None, Some(DamageType::Poison)),
     );
 }
 

--- a/late-ssh/src/app/door/lateania/world_test.rs
+++ b/late-ssh/src/app/door/lateania/world_test.rs
@@ -2222,3 +2222,347 @@ fn zone_level_bands_are_sane_and_cover_the_road() {
         .expect("home region listed");
     assert!(road.levels.is_some(), "the home region has hostile levels");
 }
+
+// ---- The world resist/weak pass (spec: CONTEXT.md, same-named section) -------------
+//
+// One theme per generated zone; regulars wear the theme's resist/weak, bosses
+// keep their authored profiles. The tests below pin the placement to the theme
+// tables, hold the school census inside declared bands, and run the routed
+// grind-rate model that keeps the pass meaningful without rebalancing anyone.
+
+/// Every themed region: name, theme table, base room id, and rooms per zone.
+/// A spawn's home maps back to its zone by `(home - base) / stride`.
+fn themed_regions() -> [(&'static str, &'static [ZoneTheme], u32, u32); 7] {
+    use super::super::archipelago;
+    [
+        (
+            "Frontier",
+            &FRONTIER_ZONE_THEMES,
+            FRONTIER_BASE,
+            FRONTIER_W * FRONTIER_H,
+        ),
+        (
+            "Reaches",
+            &REACHES_ZONE_THEMES,
+            REACHES_BASE,
+            REACHES_ZONE_STRIDE,
+        ),
+        (
+            "Kaelmyr",
+            &KAELMYR_ZONE_THEMES,
+            KAELMYR_BASE,
+            KAELMYR_ZONE_STRIDE,
+        ),
+        (
+            "Sunderlakes",
+            &LAKES_ZONE_THEMES,
+            LAKES_BASE,
+            LAKES_ZONE_STRIDE,
+        ),
+        (
+            "Broceliande",
+            &BROCELIANDE_ZONE_THEMES,
+            BROCELIANDE_BASE,
+            BROCELIANDE_ZONE_STRIDE,
+        ),
+        (
+            "Aelunor",
+            &AELUNOR_ZONE_THEMES,
+            AELUNOR_BASE,
+            AELUNOR_ZONE_STRIDE,
+        ),
+        (
+            "Archipelago",
+            &archipelago::ISLAND_THEMES,
+            archipelago::ARCH_BASE,
+            archipelago::ARCH_STRIDE,
+        ),
+    ]
+}
+
+fn zone_index(home: RoomId, base: u32, stride: u32, zones: usize) -> Option<usize> {
+    (home >= base && home < base + stride * zones as u32)
+        .then(|| ((home - base) / stride) as usize)
+}
+
+/// The seven schools a theme may name (Physical is banned from both slots).
+const THEMED_SCHOOLS: [DamageType; 7] = [
+    DamageType::Fire,
+    DamageType::Frost,
+    DamageType::Holy,
+    DamageType::Shadow,
+    DamageType::Poison,
+    DamageType::Arcane,
+    DamageType::Lightning,
+];
+
+#[test]
+fn every_generated_regular_wears_its_zone_theme() {
+    let world = seed_world();
+    let mut regulars = 0usize;
+    let mut bosses = 0usize;
+    for (region, themes, base, stride) in themed_regions() {
+        for spawn in &world.spawns {
+            let Some(z) = zone_index(spawn.home, base, stride, themes.len()) else {
+                continue;
+            };
+            if spawn.boss {
+                // Bosses deviate on purpose: the pass never touches an
+                // authored boss profile, so a crown fight is exactly what it
+                // was before the pass.
+                bosses += 1;
+                continue;
+            }
+            let theme = themes[z];
+            regulars += 1;
+            assert_eq!(
+                spawn.profile.resist,
+                theme.resist(),
+                "{region} zone {z}: {} wears the zone resist",
+                spawn.name
+            );
+            assert_eq!(
+                spawn.profile.weak,
+                theme.weak(),
+                "{region} zone {z}: {} wears the zone weakness",
+                spawn.name
+            );
+        }
+    }
+    assert!(
+        regulars > 2000,
+        "the pass covers the generated regions ({regulars} regulars seen)"
+    );
+    assert!(
+        bosses >= 100,
+        "the zone bosses were seen and skipped ({bosses})"
+    );
+}
+
+#[test]
+fn no_regular_resists_physical_and_nothing_is_weak_to_physical() {
+    let world = seed_world();
+    // Nothing in the whole world, authored or generated, boss or regular, is
+    // ever weak to Physical: the neutral auto-attack baseline never inflates.
+    for spawn in &world.spawns {
+        assert_ne!(
+            spawn.profile.weak,
+            Some(DamageType::Physical),
+            "{} must not be weak to Physical",
+            spawn.name
+        );
+    }
+    // No regular anywhere resists Physical: a Physical resist is a 50% tax on
+    // the seven Physical-locked classes with no counterplay, so it lives on
+    // bosses only, where "bring a caster, an oil, or the smith" is the point.
+    for spawn in world.spawns.iter().filter(|s| !s.boss) {
+        assert_ne!(
+            spawn.profile.resist,
+            Some(DamageType::Physical),
+            "regular {} must not resist Physical",
+            spawn.name
+        );
+    }
+    // The theme vocabulary itself can never emit Physical, and every theme
+    // carries a weakness (weak-forward).
+    for theme in ZoneTheme::ALL {
+        assert_ne!(theme.resist(), Some(DamageType::Physical), "{theme:?}");
+        assert_ne!(theme.weak(), Some(DamageType::Physical), "{theme:?}");
+        assert!(theme.weak().is_some(), "{theme:?} must carry a weakness");
+    }
+}
+
+#[test]
+fn the_school_census_stays_inside_its_declared_bands() {
+    let regions = themed_regions();
+    let total_zones: usize = regions.iter().map(|(_, t, _, _)| t.len()).sum();
+    let school_pos =
+        |d: DamageType| THEMED_SCHOOLS.iter().position(|s| *s == d).expect("themed school");
+
+    let mut weak = [0usize; 7];
+    let mut resist = [0usize; 7];
+    for (region, themes, _, _) in &regions {
+        let mut region_weak = [0usize; 7];
+        let mut region_resists = 0usize;
+        for theme in *themes {
+            let w = school_pos(theme.weak().expect("weak-forward"));
+            weak[w] += 1;
+            region_weak[w] += 1;
+            if let Some(r) = theme.resist() {
+                resist[school_pos(r)] += 1;
+                region_resists += 1;
+            }
+        }
+        // Walls are events: resist zones stay a rough third of a region at
+        // most, and no single school owns more than a quarter of a region's
+        // weaknesses, so every region offers several different answers.
+        assert!(
+            region_resists <= (themes.len() + 2) / 3,
+            "{region}: {region_resists} resist zones of {}",
+            themes.len()
+        );
+        let lanes = region_weak.iter().filter(|c| **c > 0).count();
+        assert!(
+            lanes >= 5,
+            "{region}: only {lanes} weak schools represented"
+        );
+        let max_lane = region_weak.iter().max().copied().unwrap_or(0);
+        assert!(
+            max_lane <= themes.len().div_ceil(4),
+            "{region}: one school owns {max_lane} of {} zones",
+            themes.len()
+        );
+    }
+    // Global bands per school. Holy keeps predators (rule 4: without resist
+    // zones the two Holy classes silently become the school winners), no
+    // school's weakness count runs away, and every school has a real lane.
+    for (i, school) in THEMED_SCHOOLS.iter().enumerate() {
+        assert!(
+            (10..=30).contains(&weak[i]),
+            "{school:?}: {} weak zones of {total_zones} is outside 10..=30",
+            weak[i]
+        );
+        assert!(
+            resist[i] <= 10,
+            "{school:?}: {} resist zones is past the band",
+            resist[i]
+        );
+    }
+    assert!(
+        resist[school_pos(DamageType::Holy)] >= 4,
+        "Holy needs its predators"
+    );
+    let total_resists: usize = resist.iter().sum();
+    assert!(
+        total_resists * 3 <= total_zones,
+        "{total_resists} resist zones of {total_zones}: walls must stay rare"
+    );
+}
+
+/// The per-class offensive school mix at the Lv45 anchor, read from the real
+/// ability roster: each Strike/DoT/Finisher unlocked by 45 contributes its
+/// total effect per cooldown tick, normalized to shares per school.
+fn class_school_mix(class: super::super::classes::Class) -> Vec<(DamageType, f64)> {
+    use super::super::abilities::{ABILITIES, AbilityEffect};
+    let mut weights: Vec<(DamageType, f64)> = Vec::new();
+    for a in ABILITIES {
+        if a.class != class || a.level_req > 45 {
+            continue;
+        }
+        let ticks = match a.effect {
+            AbilityEffect::Strike | AbilityEffect::Finisher => 1.0,
+            AbilityEffect::DamageOverTime => 1.0 + a.duration as f64,
+            _ => continue,
+        };
+        let dps = a.magnitude as f64 * ticks / a.cooldown_ticks.max(1) as f64;
+        match weights.iter_mut().find(|(d, _)| *d == a.damage_type) {
+            Some((_, w)) => *w += dps,
+            None => weights.push((a.damage_type, dps)),
+        }
+    }
+    let total: f64 = weights.iter().map(|(_, w)| w).sum();
+    for (_, w) in &mut weights {
+        *w /= total;
+    }
+    weights
+}
+
+#[test]
+fn the_world_pass_redistributes_grind_rates_but_never_rebalances_a_class() {
+    // The grind-rate model, from CONTEXT.md ("The world resist/weak pass"): at band
+    // gear every class is ~75% auto damage (always Physical, and regulars are
+    // never weak to or resistant against it), ~25% abilities in the class's
+    // school mix, and a weapon oil adds a flat rider worth ~15% of output in
+    // the coat's school. Before this pass every generated regular was
+    // (None, None), so the "before" rate is exactly 1.0 in every zone: each
+    // assertion below is a live before/after budget.
+    const AUTO: f64 = 0.75;
+    const ABILITIES_SHARE: f64 = 0.25;
+    const OIL_RIDER: f64 = 0.15;
+    let oil_schools = super::super::items::OIL_SCHOOLS;
+
+    let mult = |theme: ZoneTheme, school: DamageType| -> f64 {
+        if theme.weak() == Some(school) {
+            1.5
+        } else if theme.resist() == Some(school) {
+            0.5
+        } else {
+            1.0
+        }
+    };
+
+    let regions = themed_regions();
+    let mut routed_best: Vec<(super::super::classes::Class, f64)> = Vec::new();
+    for class in super::super::classes::Class::ALL {
+        let mix = class_school_mix(class);
+        let ability_mult = |theme: ZoneTheme| -> f64 {
+            mix.iter().map(|(d, w)| w * mult(theme, *d)).sum::<f64>()
+        };
+
+        // Uncoated redistribution budget: within a zone a class may swing up
+        // to +-15%, and its average across every themed zone stays within a
+        // few percent of the old all-neutral world. Redistribution yes,
+        // rebalancing no.
+        let mut rates: Vec<f64> = Vec::new();
+        for (region, themes, _, _) in &regions {
+            for (z, theme) in themes.iter().enumerate() {
+                let rate = AUTO + ABILITIES_SHARE * ability_mult(*theme);
+                assert!(
+                    (0.85..=1.15).contains(&rate),
+                    "{class:?} in {region} zone {z}: {rate:.3} is outside the +-15% band"
+                );
+                rates.push(rate);
+            }
+        }
+        let avg = rates.iter().sum::<f64>() / rates.len() as f64;
+        assert!(
+            (0.97..=1.03).contains(&avg),
+            "{class:?}: themed-zone average {avg:.3} moved past the budget"
+        );
+
+        // The routed model: a player picks the zone and the coat. Neutral
+        // play is a coated weapon on unthemed ground (1 + OIL_RIDER).
+        // Floor: in every region there is a zone-and-coat answer worth at
+        // least +5%, so the school game is worth playing everywhere, for
+        // everyone. The legacy poison coat is left out of the model; it only
+        // adds options, never removes one.
+        let mut global_best: f64 = 0.0;
+        for (region, themes, _, _) in &regions {
+            let mut region_best: f64 = 0.0;
+            for theme in *themes {
+                let coat_best = oil_schools
+                    .iter()
+                    .map(|s| mult(*theme, *s))
+                    .fold(0.0f64, f64::max);
+                let rate =
+                    AUTO + ABILITIES_SHARE * ability_mult(*theme) + OIL_RIDER * coat_best;
+                region_best = region_best.max(rate);
+            }
+            let edge = region_best / (1.0 + OIL_RIDER);
+            assert!(
+                edge >= 1.05,
+                "{class:?} in {region}: best routed edge {edge:.3} is under the +5% floor"
+            );
+            global_best = global_best.max(edge);
+        }
+        routed_best.push((class, global_best));
+    }
+
+    // Ceiling: nobody's best-case routing runs away. The two mono-Holy
+    // classes top the table by design (a Holy oil stacks with their own
+    // school in the Undead/Haunted lanes - the deliberate buff to today's
+    // weakest classes), and even they stay under +18%; the spread between
+    // the best- and worst-served class stays within 12 points.
+    let max = routed_best.iter().map(|(_, e)| *e).fold(0.0f64, f64::max);
+    let min = routed_best.iter().map(|(_, e)| *e).fold(f64::MAX, f64::min);
+    for (class, edge) in &routed_best {
+        assert!(
+            *edge <= 1.18,
+            "{class:?}: routed best {edge:.3} is past the +18% ceiling"
+        );
+    }
+    assert!(
+        max - min <= 0.12,
+        "routed spread {max:.3} - {min:.3} is past 12 points"
+    );
+}

--- a/late-ssh/src/app/door/lateania/world_test.rs
+++ b/late-ssh/src/app/door/lateania/world_test.rs
@@ -2373,6 +2373,25 @@ fn no_regular_resists_physical_and_nothing_is_weak_to_physical() {
 }
 
 #[test]
+fn every_boss_carries_a_weakness() {
+    // Bosses are the fights players actually prepare for, so the prep
+    // mechanic must exist there: every boss in the world names a weakness
+    // (weak-forward: pure reward - an unprepared fighter loses nothing,
+    // a provisioned one is paid). Resists stay rare authored events.
+    let world = seed_world();
+    let neutral: Vec<&str> = world
+        .spawns
+        .iter()
+        .filter(|s| s.boss && s.profile.weak.is_none())
+        .map(|s| s.name)
+        .collect();
+    assert!(
+        neutral.is_empty(),
+        "bosses without a weakness: {neutral:?}"
+    );
+}
+
+#[test]
 fn the_school_census_stays_inside_its_declared_bands() {
     let regions = themed_regions();
     let total_zones: usize = regions.iter().map(|(_, t, _, _)| t.len()).sum();

--- a/late-ssh/src/app/door/lateania/world_test.rs
+++ b/late-ssh/src/app/door/lateania/world_test.rs
@@ -2297,7 +2297,12 @@ const THEMED_SCHOOLS: [DamageType; 7] = [
 ];
 
 #[test]
-fn every_generated_regular_wears_its_zone_theme() {
+fn every_generated_zone_spawn_wears_its_zone_theme() {
+    // Aelunor's glade bosses are the one authored exception inside a themed
+    // region: they carry a hand-written Shadow/resist-Physical/weak-Holy
+    // profile that is the region's whole school game, so they are named here
+    // rather than silently skipped.
+    const AELUNOR: &str = "Aelunor";
     let world = seed_world();
     let mut regulars = 0usize;
     let mut bosses = 0usize;
@@ -2306,14 +2311,31 @@ fn every_generated_regular_wears_its_zone_theme() {
             let Some(z) = zone_index(spawn.home, base, stride, themes.len()) else {
                 continue;
             };
+            let theme = themes[z];
             if spawn.boss {
-                // Bosses deviate on purpose: the pass never touches an
-                // authored boss profile, so a crown fight is exactly what it
-                // was before the pass.
                 bosses += 1;
+                if region == AELUNOR {
+                    continue;
+                }
+                // A zone boss wears the zone's weakness and never its resist:
+                // the fight players provision for is where the prep mechanic
+                // has to exist, and a resist there would be a class tax with
+                // no counterplay. Asserted, not assumed - this branch used to
+                // `continue` on a comment claiming bosses were untouched,
+                // which stopped being true the moment they were.
+                assert_eq!(
+                    spawn.profile.resist, None,
+                    "{region} zone {z}: boss {} must not resist a school",
+                    spawn.name
+                );
+                assert_eq!(
+                    spawn.profile.weak,
+                    theme.weak(),
+                    "{region} zone {z}: boss {} wears the zone weakness",
+                    spawn.name
+                );
                 continue;
             }
-            let theme = themes[z];
             regulars += 1;
             assert_eq!(
                 spawn.profile.resist,
@@ -2335,7 +2357,7 @@ fn every_generated_regular_wears_its_zone_theme() {
     );
     assert!(
         bosses >= 100,
-        "the zone bosses were seen and skipped ({bosses})"
+        "the zone bosses were seen and checked ({bosses})"
     );
 }
 
@@ -2491,13 +2513,34 @@ fn the_world_pass_redistributes_grind_rates_but_never_rebalances_a_class() {
     // The grind-rate model, from CONTEXT.md ("The world resist/weak pass"): at band
     // gear every class is ~75% auto damage (always Physical, and regulars are
     // never weak to or resistant against it), ~25% abilities in the class's
-    // school mix, and a weapon oil adds a flat rider worth ~15% of output in
-    // the coat's school. Before this pass every generated regular was
-    // (None, None), so the "before" rate is exactly 1.0 in every zone: each
-    // assertion below is a live before/after budget.
-    const AUTO: f64 = 0.75;
-    const ABILITIES_SHARE: f64 = 0.25;
-    const OIL_RIDER: f64 = 0.15;
+    // school mix, and a weapon oil adds a flat rider in the coat's school.
+    // Before this pass every generated regular was (None, None), so the
+    // "before" rate is exactly 1.0 in every zone: each assertion below is a
+    // live before/after budget.
+    //
+    // The rider is *derived from the engine*, never declared here. It used to
+    // be a bare 0.15 and the real coat was worth three to six times that,
+    // which no assertion in this file could see. Now it is read off the real
+    // coat curve against the real attack bar (both pinned to a live character
+    // by svc_test), at the tier where the coat weighs heaviest - so if anyone
+    // retunes a coat, this budget moves with it.
+    use super::super::svc::{AUTO_SHARE, OIL_PER_TICK, TIER_ATTACK_BAR};
+    const AUTO: f64 = AUTO_SHARE;
+    const ABILITIES_SHARE: f64 = 1.0 - AUTO_SHARE;
+    // The rider a typical coated character carries: the coat curve's mean
+    // share of the attack bar, converted to a share of total output. The mean
+    // is the right input because the model asks what routing is worth to a
+    // player, not what the worst-rounded tier looks like - and no tier can
+    // hide behind it, because `the_coat_curves_stay_inside_their_share_of_the
+    // _bar` pins every tier to a tight band on the same two constants.
+    let oil_rider = (0..6)
+        .map(|t| OIL_PER_TICK[t] as f64 / TIER_ATTACK_BAR[t] as f64 * AUTO_SHARE)
+        .sum::<f64>()
+        / 6.0;
+    assert!(
+        oil_rider <= 0.16,
+        "the oil rider is worth {oil_rider:.3} of output: past what this budget was written for"
+    );
     let oil_schools = super::super::items::OIL_SCHOOLS;
 
     let mult = |theme: ZoneTheme, school: DamageType| -> f64 {
@@ -2540,7 +2583,7 @@ fn the_world_pass_redistributes_grind_rates_but_never_rebalances_a_class() {
         );
 
         // The routed model: a player picks the zone and the coat. Neutral
-        // play is a coated weapon on unthemed ground (1 + OIL_RIDER).
+        // play is a coated weapon on unthemed ground (1 + the rider).
         // Floor: in every region there is a zone-and-coat answer worth at
         // least +5%, so the school game is worth playing everywhere, for
         // everyone. The legacy poison coat is left out of the model; it only
@@ -2554,10 +2597,10 @@ fn the_world_pass_redistributes_grind_rates_but_never_rebalances_a_class() {
                     .map(|s| mult(*theme, *s))
                     .fold(0.0f64, f64::max);
                 let rate =
-                    AUTO + ABILITIES_SHARE * ability_mult(*theme) + OIL_RIDER * coat_best;
+                    AUTO + ABILITIES_SHARE * ability_mult(*theme) + oil_rider * coat_best;
                 region_best = region_best.max(rate);
             }
-            let edge = region_best / (1.0 + OIL_RIDER);
+            let edge = region_best / (1.0 + oil_rider);
             assert!(
                 edge >= 1.05,
                 "{class:?} in {region}: best routed edge {edge:.3} is under the +5% floor"


### PR DESCRIPTION
## Summary
- Damage schools now matter across the whole world, not just against the ~116 hand-authored spawns. Every generated zone (126 of them, across Frontier, Reaches, Kaelmyr, Sunderlakes, Broceliande, Aelunor and the Archipelago) names one `ZoneTheme`, and its regular mobs wear that theme's resist/weak. Every boss in the world now carries a weakness.
- Adds the martial answer to that: four Alchemy **weapon oil** families (Fire, Frost, Holy, Lightning), six tiers each, that coat the weapon and add a flat school rider to the Physical auto-attack. So the seven Physical-locked classes have a real matchup lever, not just casters.
- Removes the counterplay-free tax: no regular anywhere resists Physical any more, and nothing anywhere is weak to Physical. Twelve authored regulars that used to resist Physical were re-themed to a real school and kept their weakness.
- Data-only on the engine side. Resist still halves, weak still adds 50 percent, minimum damage is still 1, and `DamageProfile` keeps its one-resist-one-weak shape.

## Changes
- **`damage::ZoneTheme`**: a closed 16-variant enum (Ashen, Sunscorched, Frozen, Verdant, Tidal, Drowned, Storm, Resonant, Undead, Haunted, Profane, Fae, Beastwild, Fungal, Construct, Crystal), each mapping exhaustively to `(resist, weak)`. Physical can never appear in either slot and every theme carries a weakness.
- **Placement**: one theme table per generated region, beside its zone data and in the same order (`FRONTIER/REACHES/KAELMYR/LAKES/BROCELIANDE/AELUNOR_ZONE_THEMES` in `world.rs`, `ISLAND_THEMES` in `archipelago.rs`). Regulars inherit the theme at spawn build; generated zone bosses inherit the theme's **weak but never its resist**. Authored crowns keep their hand-picked profiles untouched.
- **Weapon oils**: 24 new crafted items (`items::oil_id`/`oil_school_tier`/`OIL_SCHOOLS`) and 24 new Alchemy recipes, each family's second ingredient tying its school to a gathering trade (ore for fire, deep fish for frost, timber resin for lightning, pure herbcraft for the blessed oil). Crafted-goods band widens from `4200..4500` to `4200..4600`, still below the fish catalog at 4600.
- **One coat slot**: `PlayerState::weapon_poison` becomes `weapon_coat = Some((school, per_tick, charges))`. Poisons and oils share it, so any new coat replaces the last. Each landed melee hit seeds a DoT of the coat's school through `seed_mob_dot`, which bakes the foe's resist/weak multiplier into the per-tick, so a matched oil is worth bringing. Oils last 12 strikes at half again the poison per-tick curve (zone-prep coat); poisons stay the 5-strike cheap burst vial.
- **Coats work in duels now.** The pvp auto-attack pass seeds a `pvp_dots` entry of the coat's school and spends a charge, mirroring the mob path. This was the one remaining pvp gap called out in the previous pass.
- **Fix: the top poison tier was a clone of the fourth.** `POISON_PER_TICK` was a 5-element array indexed by a 0..5 tier, so Voidvenom (tier 5, 350g) silently clamped to tier 4's 34 per tick. The curve now continues to 50.
- **UI**: the active coat shows in both battle surfaces' `you:` effects line as `fire coat x8`, via the new `PlayerView.coat`.
- Docs: the pass is specified in the Lateania `CONTEXT.md` ("The world resist/weak pass"), and `THUNDERSMITH.md` is revised against the landed world (the probe-for-information loop it was built on is dead now that zone themes are uniform and the traits line is public; its identity moves to provisioning and to the three schools oils deliberately do not cover).

## Behavior notes
- **No save state, no schema bump.** `weapon_coat` is transient, exactly as `weapon_poison` was. Existing saves and existing poison vials keep working.
- **Boss fights get easier, not harder.** Generated zone bosses gain a weakness and no resist. That is deliberate: a weakness is pure reward, an unprepared player loses nothing.
- **Physical-resist bosses are now a bounded, declared set of 14**: the Elder Treant (the road's teaching fight, where a 20g tier-0 oil already beats hitting a neutral boss dry), the Fallen Paladin (optional Sunken Citadel), and Aelunor's 12 zone bosses (optional region, weak Holy). This is a solo game with no grouping fallback, so the mandatory Long Road past the Treant must never demand a school a Physical-locked class cannot bring. Pinned by `physical_walls_never_gate_the_long_road_past_the_treant`.
- **Balance intent, test-enforced rather than asserted in prose.** Because every generated regular used to be `(None, None)`, the "before" grind rate is exactly 1.0 everywhere, so the budget assertions in `world_test.rs` are live before/after comparisons: per-zone swing within +-15 percent, per-class themed-zone average within +-3 percent, a >=+5 percent best zone-and-coat answer for every class in every region, a <=+18 percent routed ceiling with <=12 points of spread between best- and worst-served class. The two mono-Holy classes top that table by design (holy oil stacking with their own school in the Undead/Haunted lanes), which is the intended buff to the previously weakest two.
- **Re-theming a zone** means editing its table row and letting the census and budget tests judge it. Those tests, not the prose, are the contract.
- No pre-fight display of a zone's theme was added. The first swing stays the probe.

## Feature flags
- None.

## Screenshots / Video
- Not included in this draft; attach before review. The only visible change is the new coat entry in the battle panel effects line (`fire coat x8`).

## Testing
- Automated: tests added or updated, not executed as part of drafting this description. New in `world_test.rs`: `every_generated_regular_wears_its_zone_theme`, `no_regular_resists_physical_and_nothing_is_weak_to_physical`, `every_boss_carries_a_weakness`, `the_school_census_stays_inside_its_declared_bands`, `the_world_pass_redistributes_grind_rates_but_never_rebalances_a_class`. New in `svc_test.rs`: `an_oil_coats_the_weapon_with_its_school_and_replaces_the_last_coat`, `an_oiled_strike_rides_the_zone_profile`, `physical_walls_never_gate_the_long_road_past_the_treant`, `the_top_poison_tier_is_no_longer_a_clone_of_the_fourth`, `the_active_coat_shows_on_the_player_view`, `a_coated_weapon_works_in_a_duel_too`. New in `items_test.rs`: `oil_ids_roundtrip_school_and_tier`. Existing catalog counts updated in `items_test.rs` and `crafting_test.rs` (crafted goods 62 to 86, recipes 62 to 86).
- Manual: Not run. No in-game session was played as part of preparing this description.